### PR TITLE
Add integration spec for TreeView UI configs and mark integration task complete

### DIFF
--- a/context.md
+++ b/context.md
@@ -65,4 +65,4 @@
 - [x] static tree 用の API / partial を追加する
 - [x] gem に無関係な sample app view 残骸を取り除く
 - [x] container 上で `bundle exec rspec` を回せる最小 Docker 構成を追加する
-- [ ] 必要なら dummy app か integration spec を追加する
+- [x] 必要なら dummy app か integration spec を追加する

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe "TreeView integration" do
+  TestNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+  let(:root) { TestNode.new(id: 1, parent_item_id: nil, name: "root") }
+  let(:child) { TestNode.new(id: 2, parent_item_id: 1, name: "child") }
+  let(:nodes) { [root, child] }
+
+  describe "static host app usage" do
+    it "builds static UiConfig and render state without toggle paths" do
+      builder = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project")
+      ui = builder.build_static
+      tree = TreeView::Tree.new(records: nodes, parent_id_method: :parent_item_id)
+
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: ui
+      )
+
+      expect(render_state.effective_initial_state).to eq(:expanded)
+      expect(ui.node_dom_id(root)).to eq("project_1")
+      expect(ui.hide_descendants_path(root, 0)).to be_nil
+      expect(ui.show_descendants_path(root, 0)).to be_nil
+      expect(ui.toggle_all_path(state: :collapsed)).to be_nil
+    end
+  end
+
+  describe "turbo host app usage" do
+    it "builds full UiConfig and exposes toggle paths" do
+      builder = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project")
+      ui = builder.build(
+        hide_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/hide?depth=#{depth}&scope=#{scope}" },
+        show_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/show?depth=#{depth}&scope=#{scope}" },
+        toggle_all_path_builder: ->(state) { "/projects/toggle_all?state=#{state}" }
+      )
+
+      expect(ui.hide_descendants_path(root, 2, scope: "all")).to eq("/projects/1/hide?depth=2&scope=all")
+      expect(ui.show_descendants_path(root, 2, scope: "children")).to eq("/projects/1/show?depth=2&scope=children")
+      expect(ui.toggle_all_path(state: :expanded)).to eq("/projects/toggle_all?state=expanded")
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Add an integration spec to validate static and turbo `UiConfig` behaviors and ensure toggle-path builders are wired correctly.
- Update project checklist to reflect that a dummy app or integration spec has been added.

### Description
- Added `spec/integration/tree_view_integration_spec.rb` which defines `TestNode` fixtures and integration examples for static and turbo host usages of `TreeView::UiConfigBuilder`, `TreeView::Tree`, and `TreeView::RenderState`.
- The spec verifies that static builds produce no toggle paths (`hide_descendants_path`, `show_descendants_path`, `toggle_all_path` return `nil`) and that turbo builds expose correct path strings from provided builders.
- Updated `context.md` to mark the task `必要なら dummy app か integration spec を追加する` as completed.

### Testing
- Ran the integration examples via `bundle exec rspec` and the new `spec/integration/tree_view_integration_spec.rb` passed.
- No other automated test failures were observed when running the test suite with the added spec.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6fd07c00c832fb96f3c3e0cd3cf20)