### PR TITLE
Validate sorter return value

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,8 @@ TreeView::Tree.new(
 ```
 
 `sorter` は `call(items, tree)` できるオブジェクトを指定します。
+`sorter` の戻り値は `to_a` に応答する配列相当のオブジェクトにしてください。
+`nil` など配列相当ではない値を返した場合は、誤実装に気づきやすいよう `ArgumentError` を発生させます。
 
 ## TreeView::GraphAdapter
 

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -94,7 +94,12 @@ module TreeView
     end
 
     def sort_items(items)
-      Array(sorter.call(Array(items), self))
+      sorted = sorter.call(Array(items), self)
+      unless sorted.respond_to?(:to_a)
+        raise ArgumentError, "sorter must return an Array-like object, got: #{sorted.class}"
+      end
+
+      sorted.to_a
     end
 
     private

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -95,7 +95,7 @@ module TreeView
 
     def sort_items(items)
       sorted = sorter.call(Array(items), self)
-      unless sorted.respond_to?(:to_a)
+      if sorted.nil? || !sorted.respond_to?(:to_a)
         raise ArgumentError, "sorter must return an Array-like object, got: #{sorted.class}"
       end
 

--- a/spec/lib/tree_view/tree_spec.rb
+++ b/spec/lib/tree_view/tree_spec.rb
@@ -123,10 +123,15 @@ RSpec.describe TreeView::Tree do
 
     it "accepts array-like sorter return values" do
       root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")
+      array_like_items = Struct.new(:items) do
+        def to_a
+          items
+        end
+      end
       tree = described_class.new(
         records: [root],
         parent_id_method: :parent_item_id,
-        sorter: ->(items, _tree) { Set.new(items) }
+        sorter: ->(items, _tree) { array_like_items.new(items) }
       )
 
       expect(tree.sort_items([root])).to eq([root])

--- a/spec/lib/tree_view/tree_spec.rb
+++ b/spec/lib/tree_view/tree_spec.rb
@@ -107,6 +107,30 @@ RSpec.describe TreeView::Tree do
 
       expect(tree.sort_items(tree.children_for(root))).to eq([child_a, child_b])
     end
+
+    it "raises a clear error when sorter returns nil" do
+      root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")
+      tree = described_class.new(
+        records: [root],
+        parent_id_method: :parent_item_id,
+        sorter: ->(_items, _tree) { nil }
+      )
+
+      expect do
+        tree.sort_items([root])
+      end.to raise_error(ArgumentError, /sorter must return an Array-like object/)
+    end
+
+    it "accepts array-like sorter return values" do
+      root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")
+      tree = described_class.new(
+        records: [root],
+        parent_id_method: :parent_item_id,
+        sorter: ->(items, _tree) { Set.new(items) }
+      )
+
+      expect(tree.sort_items([root])).to eq([root])
+    end
   end
 
   describe "#node_key_for" do


### PR DESCRIPTION
## Summary

- Validate that `sorter` returns an Array-like object from `TreeView::Tree#sort_items`
- Raise a clear `ArgumentError` when `sorter` returns invalid values such as `nil`
- Add specs for invalid and Array-like sorter return values
- Document the sorter return contract in `docs/api.md`

Closes #21

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.