### PR TITLE
Add tree_view_rows helper for RenderState

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Turbo Stream開閉用path builder
 - 異種ノード混在ツリー用 `GraphAdapter`
 - viewから使うDOM ID / toggle path / 枝情報helper
+- `RenderState` からroot行を描画する `tree_view_rows` helper
 - host app側の `row_partial` 差し替え
 
 ## 含まないもの
@@ -81,16 +82,12 @@ view:
 ```erb
 <table class="tree-view-table">
   <tbody>
-    <%= render partial: "tree_view/tree_row",
-      collection: @render_state.root_items,
-      as: :item,
-      locals: {
-        tree: @render_state.tree,
-        row_partial: @render_state.row_partial
-      } %>
+    <%= tree_view_rows(@render_state) %>
   </tbody>
 </table>
 ```
+
+既存どおり `tree_view/tree_row` partial を直接renderすることもできます。
 
 row partial:
 

--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -1,4 +1,23 @@
 module TreeViewHelper
+  def tree_view_rows(render_state, mode: nil, collapsed: nil)
+    previous_tree_ui = @tree_ui
+    @tree_ui = render_state.ui_config
+
+    render(
+      partial: "tree_view/tree_row",
+      collection: render_state.root_items,
+      as: :item,
+      locals: {
+        tree: render_state.tree,
+        row_partial: render_state.row_partial,
+        mode: mode,
+        collapsed: collapsed.nil? ? render_state.effective_initial_state == :collapsed : collapsed
+      }
+    )
+  ensure
+    @tree_ui = previous_tree_ui
+  end
+
   def tree_node_dom_id(item_or_id, ui: @tree_ui)
     resolved_ui(ui).node_dom_id(item_or_id)
   end

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,9 @@
 
 ## 基本構成
 
-`tree_view` は、host app 側で取得したrecordsを `TreeView::Tree` に渡し、`TreeView::RenderState` と `tree_view/tree_row` partial を使って描画します。
+`tree_view` は、host app 側で取得したrecordsを `TreeView::Tree` に渡し、`TreeView::RenderState` と `tree_view_rows` helper を使って描画します。
+
+既存どおり `tree_view/tree_row` partial を直接renderすることもできます。
 
 ## 通常Tree
 
@@ -107,15 +109,27 @@ end
     </tr>
   </thead>
   <tbody>
-    <%= render partial: "tree_view/tree_row",
-      collection: @render_state.root_items,
-      as: :item,
-      locals: {
-        tree: @render_state.tree,
-        row_partial: @render_state.row_partial
-      } %>
+    <%= tree_view_rows(@render_state) %>
   </tbody>
 </table>
+```
+
+`mode:` や `collapsed:` を明示したい場合は、helper引数で上書きできます。
+
+```erb
+<%= tree_view_rows(@render_state, mode: :static, collapsed: false) %>
+```
+
+既存のpartial直接render方式も維持されています。
+
+```erb
+<%= render partial: "tree_view/tree_row",
+  collection: @render_state.root_items,
+  as: :item,
+  locals: {
+    tree: @render_state.tree,
+    row_partial: @render_state.row_partial
+  } %>
 ```
 
 ## Row partial例（ERB）
@@ -140,13 +154,7 @@ table.tree-view-table
       th name
       th owner
   tbody
-    = render partial: "tree_view/tree_row",
-      collection: @render_state.root_items,
-      as: :item,
-      locals: {
-        tree: @render_state.tree,
-        row_partial: @render_state.row_partial
-      }
+    = tree_view_rows(@render_state)
 ```
 
 ```slim
@@ -160,14 +168,7 @@ td = item.owner_name
 `mode:` を明示する場合は、`:static` または `:turbo` のみ指定できます。
 
 ```erb
-<%= render partial: "tree_view/tree_row",
-  collection: @render_state.root_items,
-  as: :item,
-  locals: {
-    tree: @render_state.tree,
-    row_partial: @render_state.row_partial,
-    mode: :static
-  } %>
+<%= tree_view_rows(@render_state, mode: :static) %>
 ```
 
 不正なmodeを指定すると `ArgumentError` になります。

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include("project_1:root")
       expect(rendered).to include("tree-toggle__level")
     end
+
+    it "renders root rows through tree_view_rows helper" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).to include("project_1:root")
+      expect(rendered).to include("project_2:child")
+    end
+
+    it "respects RenderState initial_state when rendering through tree_view_rows" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        initial_state: :collapsed
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).not_to include('id="project_2"')
+      expect(rendered).to include('tree-toggle__hidden-count')
+    end
   end
 
   describe "turbo host app usage" do


### PR DESCRIPTION
## Summary

- Add `tree_view_rows(render_state)` helper to render root rows directly from `TreeView::RenderState`
- Keep existing `tree_view/tree_row` partial rendering supported
- Respect `RenderState#effective_initial_state` for collapsed initial rendering
- Add integration specs for helper rendering and collapsed initial state
- Update README and usage docs with the simpler helper usage

Closes #20

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.