### PR TITLE
Add node key uniqueness validation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,7 @@ tree = TreeView::Tree.new(adapter: adapter)
 | `descendant_counts` | node_keyごとの子孫数を返す |
 | `node_key_for(record)` | nodeを識別するkeyを返す |
 | `sort_items(items)` | sorterに従ってitemsを並び替える |
+| `validate_unique_node_keys!` | node_key の重複を検出する開発時向けチェック |
 
 ### 並び順
 
@@ -78,6 +79,19 @@ TreeView::Tree.new(
 `sorter` は `call(items, tree)` できるオブジェクトを指定します。
 `sorter` の戻り値は `to_a` に応答する配列相当のオブジェクトにしてください。
 `nil` など配列相当ではない値を返した場合は、誤実装に気づきやすいよう `ArgumentError` を発生させます。
+
+### node_key の重複検出
+
+`validate_unique_node_keys!` は、開発時・テスト時に node_key の重複を明示的に検出するための optional API です。
+
+```ruby
+tree.validate_unique_node_keys!
+```
+
+node_key が重複している場合は、対象キーが分かる `ArgumentError` を発生させます。
+本番描画時に常に検証するものではなく、必要な画面やテストで明示的に呼び出す想定です。
+
+このAPIは node_key の重複検出のみを扱います。DOM ID の衝突検出は今後の拡張対象です。
 
 ## TreeView::GraphAdapter
 
@@ -160,6 +174,7 @@ viewから使う補助helperです。
 
 | メソッド | 説明 |
 |---|---|
+| `tree_view_rows(render_state)` | `RenderState` からroot行を描画する |
 | `tree_node_dom_id(item_or_id)` | nodeのDOM IDを返す |
 | `tree_button_dom_id(item)` | toggle cell用DOM IDを返す |
 | `tree_show_button_dom_id(item)` | show button用DOM IDを返す |

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -102,6 +102,26 @@ module TreeView
       sorted.to_a
     end
 
+    def validate_unique_node_keys!
+      seen = {}
+      duplicated_keys = []
+
+      each_root_candidate do |item|
+        node_key = node_key_for(item)
+        if seen.key?(node_key)
+          duplicated_keys << node_key unless duplicated_keys.include?(node_key)
+        else
+          seen[node_key] = true
+        end
+      end
+
+      if duplicated_keys.any?
+        raise ArgumentError, "duplicate node_key detected: #{duplicated_keys.map(&:inspect).join(', ')}"
+      end
+
+      true
+    end
+
     private
 
     def adapter_mode?

--- a/spec/lib/tree_view/tree_spec.rb
+++ b/spec/lib/tree_view/tree_spec.rb
@@ -151,6 +151,39 @@ RSpec.describe TreeView::Tree do
     end
   end
 
+  describe "#validate_unique_node_keys!" do
+    it "returns true when node keys are unique" do
+      root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")
+      child = ItemNode.new(id: 2, parent_item_id: 1, name: "child")
+      tree = described_class.new(records: [root, child], parent_id_method: :parent_item_id)
+
+      expect(tree.validate_unique_node_keys!).to eq(true)
+    end
+
+    it "raises a clear error when records mode has duplicate node keys" do
+      root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")
+      duplicate_root = ItemNode.new(id: 1, parent_item_id: nil, name: "duplicate-root")
+      tree = described_class.new(records: [root, duplicate_root], parent_id_method: :parent_item_id)
+
+      expect do
+        tree.validate_unique_node_keys!
+      end.to raise_error(ArgumentError, /duplicate node_key detected: 1/)
+    end
+
+    it "raises a clear error when resolver mode has duplicate node keys" do
+      country = CountryNode.new(1, "japan", [])
+      duplicate_country = CountryNode.new(1, "duplicate", [])
+      tree = described_class.new(
+        roots: [country, duplicate_country],
+        children_resolver: ->(node) { node.public_send(node.members.last) }
+      )
+
+      expect do
+        tree.validate_unique_node_keys!
+      end.to raise_error(ArgumentError, /duplicate node_key detected/)
+    end
+  end
+
   describe "validation" do
     it "rejects mixing adapter mode with records mode" do
       adapter = TreeView::GraphAdapter.new(


### PR DESCRIPTION
## Summary

- Add `TreeView::Tree#validate_unique_node_keys!` as an optional development/test-time check
- Detect duplicate `node_key` values and raise a clear `ArgumentError` with the duplicated keys
- Add specs for unique keys and duplicate key failures in records/resolver mode
- Document the API and clarify that DOM ID collision detection is left for future expansion

Closes #19

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.