### PR TITLE
Add orphan node strategy support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,7 +12,8 @@
 tree = TreeView::Tree.new(
   records: items,
   parent_id_method: :parent_item_id,
-  id_method: :id
+  id_method: :id,
+  orphan_strategy: :ignore
 )
 ```
 
@@ -22,6 +23,7 @@ tree = TreeView::Tree.new(
 | `parent_id_method:` | yes | 親IDを返すメソッド名 |
 | `id_method:` | no | 自身のIDを返すメソッド名。既定値は `:id` |
 | `sorter:` | no | root / children の並び順を決めるcallable |
+| `orphan_strategy:` | no | records内に親が存在しないnodeの扱い。既定値は `:ignore` |
 
 ### resolver mode
 
@@ -62,6 +64,7 @@ tree = TreeView::Tree.new(adapter: adapter)
 | `descendant_counts` | node_keyごとの子孫数を返す |
 | `node_key_for(record)` | nodeを識別するkeyを返す |
 | `sort_items(items)` | sorterに従ってitemsを並び替える |
+| `orphan_items` | records内に親が存在しないnodeを返す |
 | `validate_unique_node_keys!` | node_key の重複を検出する開発時向けチェック |
 
 ### 並び順
@@ -79,6 +82,31 @@ TreeView::Tree.new(
 `sorter` は `call(items, tree)` できるオブジェクトを指定します。
 `sorter` の戻り値は `to_a` に応答する配列相当のオブジェクトにしてください。
 `nil` など配列相当ではない値を返した場合は、誤実装に気づきやすいよう `ArgumentError` を発生させます。
+
+### orphan node の扱い
+
+records mode では、`parent_id_method` が返す親IDが `nil` ではなく、かつ同じ `records` 内に親レコードが存在しないnodeを orphan node として扱います。
+
+```ruby
+tree = TreeView::Tree.new(
+  records: items,
+  parent_id_method: :parent_item_id,
+  orphan_strategy: :as_root
+)
+```
+
+| `orphan_strategy` | `root_items(nil)` の挙動 |
+|---|---|
+| `:ignore` | 通常rootのみを返す。既定値で、従来互換の挙動 |
+| `:as_root` | 通常rootに orphan node を加えて返す |
+| `:raise` | orphan node が存在する場合に `ArgumentError` を発生させる |
+
+`root_items(parent_id)` のように親IDを明示した場合は、orphan strategy の影響を受けず、従来どおり指定した親IDのchildrenを返します。
+
+`orphan_items` は、strategyに関係なく orphan node の一覧を返します。
+resolver mode / adapter mode では orphan strategy は `:ignore` のみ有効です。
+
+orphan node だけをrootとして表示する `:orphans_only` は、別Issueの後続拡張として扱います。
 
 ### node_key の重複検出
 

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -6,7 +6,16 @@ module TreeView
       items.sort_by { |item| tree.descendant_counts[tree.node_key_for(item)].to_i }
     end
 
-    attr_reader :records, :id_method, :parent_id_method, :roots, :children_resolver, :adapter, :sorter
+    VALID_ORPHAN_STRATEGIES = %i[ignore as_root raise].freeze
+
+    attr_reader :records,
+                :id_method,
+                :parent_id_method,
+                :roots,
+                :children_resolver,
+                :adapter,
+                :sorter,
+                :orphan_strategy
 
     def initialize(records: nil,
                    parent_id_method: nil,
@@ -15,7 +24,8 @@ module TreeView
                    children_resolver: nil,
                    node_key_resolver: nil,
                    adapter: nil,
-                   sorter: nil)
+                   sorter: nil,
+                   orphan_strategy: :ignore)
       @records = records
       @id_method = id_method
       @parent_id_method = parent_id_method
@@ -24,6 +34,7 @@ module TreeView
       @node_key_resolver = node_key_resolver
       @adapter = adapter
       @sorter = sorter || DEFAULT_SORTER
+      @orphan_strategy = normalize_orphan_strategy(orphan_strategy)
 
       validate_mode!
     end
@@ -67,6 +78,8 @@ module TreeView
         adapter.roots
       elsif resolver_mode?
         roots
+      elsif root_parent_id.nil?
+        root_items_for_nil_parent
       else
         Array(items_by_parent_id[root_parent_id])
       end
@@ -102,6 +115,15 @@ module TreeView
       sorted.to_a
     end
 
+    def orphan_items
+      return [] unless records_mode?
+
+      @orphan_items ||= records.select do |record|
+        parent_id = record.public_send(parent_id_method)
+        parent_id && !items_by_id.key?(parent_id)
+      end
+    end
+
     def validate_unique_node_keys!
       seen = {}
       duplicated_keys = []
@@ -132,6 +154,10 @@ module TreeView
       children_resolver.respond_to?(:call)
     end
 
+    def records_mode?
+      !adapter_mode? && !resolver_mode?
+    end
+
     def each_root_candidate
       return enum_for(:each_root_candidate) unless block_given?
 
@@ -146,14 +172,48 @@ module TreeView
       end
     end
 
+    def root_items_for_nil_parent
+      regular_roots = Array(items_by_parent_id[nil])
+
+      case orphan_strategy
+      when :ignore
+        regular_roots
+      when :as_root
+        regular_roots + orphan_items
+      when :raise
+        raise_if_orphans!
+        regular_roots
+      end
+    end
+
+    def raise_if_orphans!
+      return if orphan_items.empty?
+
+      orphan_keys = orphan_items.map { |item| node_key_for(item).inspect }.join(', ')
+      raise ArgumentError, "orphan nodes detected: #{orphan_keys}"
+    end
+
+    def items_by_id
+      @items_by_id ||= records.to_h { |record| [record.public_send(id_method), record] }
+    end
+
+    def normalize_orphan_strategy(value)
+      normalized_value = value.to_sym
+      return normalized_value if VALID_ORPHAN_STRATEGIES.include?(normalized_value)
+
+      raise ArgumentError, "orphan_strategy must be one of: #{VALID_ORPHAN_STRATEGIES.join(', ')}"
+    end
+
     def validate_mode!
       raise ArgumentError, "sorter must respond to call" unless sorter.respond_to?(:call)
 
       if adapter_mode?
         raise ArgumentError, 'adapter mode cannot be combined with records mode' if records || parent_id_method
         raise ArgumentError, 'adapter mode cannot be combined with roots/children_resolver mode' if roots.any? || children_resolver
+        raise ArgumentError, 'orphan_strategy is only supported in records mode' unless orphan_strategy == :ignore
       elsif resolver_mode?
         raise ArgumentError, 'roots must be provided when children_resolver is used' if roots.empty?
+        raise ArgumentError, 'orphan_strategy is only supported in records mode' unless orphan_strategy == :ignore
       else
         raise ArgumentError, 'records and parent_id_method are required in records mode' if records.nil? || parent_id_method.nil?
       end

--- a/spec/lib/tree_view/orphan_strategy_spec.rb
+++ b/spec/lib/tree_view/orphan_strategy_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+
+RSpec.describe "TreeView::Tree orphan strategy" do
+  OrphanNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+  OrphanCountry = Struct.new(:id, :name, :children)
+
+  def build_tree(records, **options)
+    TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, **options)
+  end
+
+  it "ignores orphan nodes by default" do
+    root = OrphanNode.new(id: 1, parent_item_id: nil, name: "root")
+    orphan = OrphanNode.new(id: 2, parent_item_id: 999, name: "orphan")
+    tree = build_tree([root, orphan])
+
+    expect(tree.root_items).to eq([root])
+  end
+
+  it "exposes orphan_items" do
+    root = OrphanNode.new(id: 1, parent_item_id: nil, name: "root")
+    child = OrphanNode.new(id: 2, parent_item_id: 1, name: "child")
+    orphan = OrphanNode.new(id: 3, parent_item_id: 999, name: "orphan")
+    tree = build_tree([root, child, orphan])
+
+    expect(tree.orphan_items).to eq([orphan])
+  end
+
+  it "includes orphan nodes as roots when orphan_strategy is as_root" do
+    root = OrphanNode.new(id: 1, parent_item_id: nil, name: "root")
+    orphan = OrphanNode.new(id: 2, parent_item_id: 999, name: "orphan")
+    tree = build_tree(
+      [root, orphan],
+      orphan_strategy: :as_root,
+      sorter: ->(items, _tree) { items.sort_by(&:id) }
+    )
+
+    expect(tree.root_items).to eq([root, orphan])
+  end
+
+  it "does not apply orphan_strategy to explicit parent lookups" do
+    root = OrphanNode.new(id: 1, parent_item_id: nil, name: "root")
+    child = OrphanNode.new(id: 2, parent_item_id: 1, name: "child")
+    orphan = OrphanNode.new(id: 3, parent_item_id: 999, name: "orphan")
+    tree = build_tree([root, child, orphan], orphan_strategy: :as_root)
+
+    expect(tree.root_items(1)).to eq([child])
+  end
+
+  it "raises a clear error when orphan_strategy is raise and orphan nodes exist" do
+    root = OrphanNode.new(id: 1, parent_item_id: nil, name: "root")
+    orphan = OrphanNode.new(id: 2, parent_item_id: 999, name: "orphan")
+    tree = build_tree([root, orphan], orphan_strategy: :raise)
+
+    expect do
+      tree.root_items
+    end.to raise_error(ArgumentError, /orphan nodes detected: 2/)
+  end
+
+  it "rejects invalid orphan_strategy values" do
+    expect do
+      build_tree([], orphan_strategy: :unknown)
+    end.to raise_error(ArgumentError, /orphan_strategy must be one of/)
+  end
+
+  it "rejects orphan_strategy outside records mode" do
+    expect do
+      TreeView::Tree.new(
+        roots: [OrphanCountry.new(1, "japan", [])],
+        children_resolver: ->(node) { node.children },
+        orphan_strategy: :as_root
+      )
+    end.to raise_error(ArgumentError, /orphan_strategy is only supported in records mode/)
+  end
+end


### PR DESCRIPTION
## Summary

- Add records-mode `orphan_strategy` support with `:ignore`, `:as_root`, and `:raise`
- Keep `:ignore` as the default to preserve existing behavior
- Add `TreeView::Tree#orphan_items` for detecting records whose parent is missing from the current records set
- Ensure `orphan_strategy` only affects `root_items(nil)` and not explicit `root_items(parent_id)` lookups
- Reject non-default `orphan_strategy` outside records mode
- Document the behavior and note that `:orphans_only` is split out to #25

Closes #15

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.