### PR TITLE
Add orphans_only orphan strategy

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -100,13 +100,14 @@ tree = TreeView::Tree.new(
 | `:ignore` | 通常rootのみを返す。既定値で、従来互換の挙動 |
 | `:as_root` | 通常rootに orphan node を加えて返す |
 | `:raise` | orphan node が存在する場合に `ArgumentError` を発生させる |
+| `:orphans_only` | orphan node のみをrootとして返す |
 
 `root_items(parent_id)` のように親IDを明示した場合は、orphan strategy の影響を受けず、従来どおり指定した親IDのchildrenを返します。
 
 `orphan_items` は、strategyに関係なく orphan node の一覧を返します。
 resolver mode / adapter mode では orphan strategy は `:ignore` のみ有効です。
 
-orphan node だけをrootとして表示する `:orphans_only` は、別Issueの後続拡張として扱います。
+`:orphans_only` は、不正データ検出・メンテナンス画面向けに orphan node だけをrootとして表示したい場合に使います。orphan node のchildrenは通常どおり `children_for` で辿れます。
 
 ### node_key の重複検出
 

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -6,7 +6,7 @@ module TreeView
       items.sort_by { |item| tree.descendant_counts[tree.node_key_for(item)].to_i }
     end
 
-    VALID_ORPHAN_STRATEGIES = %i[ignore as_root raise].freeze
+    VALID_ORPHAN_STRATEGIES = %i[ignore as_root raise orphans_only].freeze
 
     attr_reader :records,
                 :id_method,
@@ -183,6 +183,8 @@ module TreeView
       when :raise
         raise_if_orphans!
         regular_roots
+      when :orphans_only
+        orphan_items
       end
     end
 

--- a/spec/lib/tree_view/orphan_strategy_spec.rb
+++ b/spec/lib/tree_view/orphan_strategy_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "TreeView::Tree orphan strategy" do
     expect(tree.root_items).to eq([root, orphan])
   end
 
+  it "returns only orphan nodes when orphan_strategy is orphans_only" do
+    root = OrphanNode.new(id: 1, parent_item_id: nil, name: "root")
+    child = OrphanNode.new(id: 2, parent_item_id: 1, name: "child")
+    orphan = OrphanNode.new(id: 3, parent_item_id: 999, name: "orphan")
+    orphan_child = OrphanNode.new(id: 4, parent_item_id: 3, name: "orphan-child")
+    tree = build_tree([root, child, orphan, orphan_child], orphan_strategy: :orphans_only)
+
+    expect(tree.root_items).to eq([orphan])
+    expect(tree.children_for(orphan)).to eq([orphan_child])
+  end
+
   it "does not apply orphan_strategy to explicit parent lookups" do
     root = OrphanNode.new(id: 1, parent_item_id: nil, name: "root")
     child = OrphanNode.new(id: 2, parent_item_id: 1, name: "child")


### PR DESCRIPTION
## Summary

- Add `orphan_strategy: :orphans_only` for records mode
- Return only orphan nodes from `root_items(nil)` when this strategy is selected
- Keep `children_for` behavior unchanged so orphan node children can still be traversed
- Add specs for `:orphans_only`
- Update `docs/api.md` with the new strategy

Closes #25

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.