### PR TITLE
Add row class and data attribute builders

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -11,7 +11,9 @@ module TreeViewHelper
         tree: render_state.tree,
         row_partial: render_state.row_partial,
         mode: mode,
-        collapsed: collapsed.nil? ? render_state.effective_initial_state == :collapsed : collapsed
+        collapsed: collapsed.nil? ? render_state.effective_initial_state == :collapsed : collapsed,
+        row_class_builder: render_state.row_class_builder,
+        row_data_builder: render_state.row_data_builder
       }
     )
   ensure
@@ -28,6 +30,18 @@ module TreeViewHelper
 
   def tree_show_button_dom_id(item, ui: @tree_ui)
     resolved_ui(ui).show_button_dom_id(item)
+  end
+
+  def tree_row_classes(item, builder = nil)
+    Array(builder&.call(item)).flatten.compact_blank
+  end
+
+  def tree_row_data(item, builder = nil)
+    data = builder&.call(item)
+    return {} if data.nil?
+    return data.to_h if data.respond_to?(:to_h)
+
+    raise ArgumentError, "row_data_builder must return a Hash-like object"
   end
 
   def tree_depth_slots(depth)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -1,6 +1,8 @@
 <% sorted_items = tree.sort_items(items) %>
+<% row_class_builder = local_assigns[:row_class_builder] %>
+<% row_data_builder = local_assigns[:row_data_builder] %>
 
-<% sorted_items.each_with_index do |child_item, index| %>
+<% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]) %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -3,13 +3,17 @@
 <% row_partial = local_assigns.fetch(:row_partial) %>
 <% collapsed = local_assigns.fetch(:collapsed, false) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
+<% row_class_builder = local_assigns[:row_class_builder] %>
+<% row_data_builder = local_assigns[:row_data_builder] %>
+<% row_classes = tree_row_classes(item, row_class_builder) %>
+<% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth) %>
 <% children = tree.children_for(item) %>
 <% descendant_count = tree.descendant_counts[tree.node_key_for(item)].to_i %>
 <% hidden_count = collapsed && descendant_count.positive? ? descendant_count : nil %>
-<tr id="<%= tree_node_dom_id(item) %>" data-tree-depth="<%= depth %>">
+<%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
   <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode %>
   <%= render row_partial, item: item %>
-</tr>
+<% end %>
 <% unless collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/docs/api.md
+++ b/docs/api.md
@@ -150,7 +150,9 @@ render_state = TreeView::RenderState.new(
   root_items: tree.root_items,
   row_partial: "projects/tree_columns",
   ui_config: tree_ui,
-  initial_state: :collapsed
+  initial_state: :collapsed,
+  row_class_builder: ->(item) { item.archived? ? "is-archived" : nil },
+  row_data_builder: ->(item) { { status: item.status } }
 )
 ```
 
@@ -161,8 +163,14 @@ render_state = TreeView::RenderState.new(
 | `row_partial:` | yes | host app側の列描画partial |
 | `ui_config:` | yes | `TreeView::UiConfig` |
 | `initial_state:` | no | `:expanded` または `:collapsed` |
+| `row_class_builder:` | no | `tr` に付与するCSS classを返すcallable |
+| `row_data_builder:` | no | `tr` に付与するdata属性Hashを返すcallable |
 
 `effective_initial_state` は、画面固有指定、global config、既定値の順で解決します。
+
+`row_class_builder` は文字列、配列、または `nil` を返せます。
+`row_data_builder` はHash相当の値、または `nil` を返せます。
+既存の `data-tree-depth` は常に維持されます。
 
 ## TreeView::UiConfig
 

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -4,15 +4,32 @@ module TreeView
   class RenderState
     VALID_INITIAL_STATES = Configuration::VALID_INITIAL_STATES
 
-    attr_reader :tree, :root_items, :row_partial, :ui_config, :initial_state
+    attr_reader :tree,
+                :root_items,
+                :row_partial,
+                :ui_config,
+                :initial_state,
+                :row_class_builder,
+                :row_data_builder
 
     # RenderState は「この画面ではどう描くか」を束ねる。
-    def initialize(tree:, root_items:, row_partial:, ui_config:, initial_state: nil)
+    def initialize(tree:,
+                   root_items:,
+                   row_partial:,
+                   ui_config:,
+                   initial_state: nil,
+                   row_class_builder: nil,
+                   row_data_builder: nil)
       @tree = tree
       @root_items = root_items
       @row_partial = row_partial
       @ui_config = ui_config
       @initial_state = normalize_initial_state(initial_state)
+      @row_class_builder = row_class_builder
+      @row_data_builder = row_data_builder
+
+      validate_builder!(row_class_builder, :row_class_builder)
+      validate_builder!(row_data_builder, :row_data_builder)
     end
 
     # 画面固有指定があればそれを優先し、なければ global config を使う。
@@ -29,6 +46,12 @@ module TreeView
       return normalized_value if VALID_INITIAL_STATES.include?(normalized_value)
 
       raise ArgumentError, "initial_state must be one of: #{VALID_INITIAL_STATES.join(', ')}"
+    end
+
+    def validate_builder!(builder, name)
+      return if builder.nil? || builder.respond_to?(:call)
+
+      raise ArgumentError, "#{name} must respond to call"
     end
   end
 end

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -67,6 +67,29 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include("project_2:child")
     end
 
+    it "renders row class and data attributes from RenderState builders" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        row_class_builder: ->(item) { ["tree-row", "is-#{item.name}"] },
+        row_data_builder: ->(item) { { node_name: item.name, node_id: item.id } }
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('class="tree-row is-root"')
+      expect(rendered).to include('class="tree-row is-child"')
+      expect(rendered).to include('data-node-name="root"')
+      expect(rendered).to include('data-node-name="child"')
+      expect(rendered).to include('data-node-id="1"')
+      expect(rendered).to include('data-tree-depth="0"')
+      expect(rendered).to include('data-tree-depth="1"')
+    end
+
     it "respects RenderState initial_state when rendering through tree_view_rows" do
       tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
       render_state = TreeView::RenderState.new(

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -16,6 +16,35 @@ RSpec.describe TreeView::RenderState do
     expect(state.ui_config).to eq(ui_config)
   end
 
+  it "stores row attribute builders when given" do
+    row_class_builder = ->(item) { item.name }
+    row_data_builder = ->(item) { { name: item.name } }
+
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      row_class_builder: row_class_builder,
+      row_data_builder: row_data_builder
+    )
+
+    expect(state.row_class_builder).to eq(row_class_builder)
+    expect(state.row_data_builder).to eq(row_data_builder)
+  end
+
+  it "rejects invalid row attribute builders" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        row_class_builder: :invalid
+      )
+    end.to raise_error(ArgumentError, /row_class_builder/)
+  end
+
   it "stores initial_state when given" do
     state = described_class.new(
       tree: tree,


### PR DESCRIPTION
## Summary

- Add `row_class_builder` and `row_data_builder` to `TreeView::RenderState`
- Apply generated CSS classes and data attributes to `tree_view/tree_row` `<tr>` elements
- Preserve existing `data-tree-depth` behavior
- Pass row attribute builders through recursive child rendering
- Add RenderState and integration specs
- Document row attribute builders in `docs/api.md`

Closes #17

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.