### PR TITLE
Add max_initial_depth to RenderState

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -12,6 +12,7 @@ module TreeViewHelper
         row_partial: render_state.row_partial,
         mode: mode,
         collapsed: collapsed.nil? ? render_state.effective_initial_state == :collapsed : collapsed,
+        max_initial_depth: render_state.max_initial_depth,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder
       }
@@ -42,6 +43,10 @@ module TreeViewHelper
     return data.to_h if data.respond_to?(:to_h)
 
     raise ArgumentError, "row_data_builder must return a Hash-like object"
+  end
+
+  def tree_initial_depth_boundary?(depth, max_initial_depth)
+    !max_initial_depth.nil? && depth >= max_initial_depth
   end
 
   def tree_depth_slots(depth)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -1,8 +1,9 @@
 <% sorted_items = tree.sort_items(items) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
+<% max_initial_depth = local_assigns[:max_initial_depth] %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -2,6 +2,9 @@
 <% depth = local_assigns.fetch(:depth, branch_info[:depth]) %>
 <% row_partial = local_assigns.fetch(:row_partial) %>
 <% collapsed = local_assigns.fetch(:collapsed, false) %>
+<% max_initial_depth = local_assigns[:max_initial_depth] %>
+<% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
+<% effectively_collapsed = collapsed || depth_boundary %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
@@ -9,11 +12,11 @@
 <% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth) %>
 <% children = tree.children_for(item) %>
 <% descendant_count = tree.descendant_counts[tree.node_key_for(item)].to_i %>
-<% hidden_count = collapsed && descendant_count.positive? ? descendant_count : nil %>
+<% hidden_count = effectively_collapsed && descendant_count.positive? ? descendant_count : nil %>
 <%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
   <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode %>
   <%= render row_partial, item: item %>
 <% end %>
-<% unless collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+<% unless effectively_collapsed %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/docs/api.md
+++ b/docs/api.md
@@ -150,7 +150,8 @@ render_state = TreeView::RenderState.new(
   root_items: tree.root_items,
   row_partial: "projects/tree_columns",
   ui_config: tree_ui,
-  initial_state: :collapsed,
+  initial_state: :expanded,
+  max_initial_depth: 2,
   row_class_builder: ->(item) { item.archived? ? "is-archived" : nil },
   row_data_builder: ->(item) { { status: item.status } }
 )
@@ -163,10 +164,16 @@ render_state = TreeView::RenderState.new(
 | `row_partial:` | yes | host app側の列描画partial |
 | `ui_config:` | yes | `TreeView::UiConfig` |
 | `initial_state:` | no | `:expanded` または `:collapsed` |
+| `max_initial_depth:` | no | 初期表示時に展開描画する最大depth。rootは `0` |
 | `row_class_builder:` | no | `tr` に付与するCSS classを返すcallable |
 | `row_data_builder:` | no | `tr` に付与するdata属性Hashを返すcallable |
 
 `effective_initial_state` は、画面固有指定、global config、既定値の順で解決します。
+
+`max_initial_depth` は `nil` または `0` 以上のIntegerを指定します。
+`nil` の場合はdepth制限なし、`0` の場合はrootのみ、`1` の場合はrootとそのchildrenまでを初期HTMLに描画します。
+境界depthのnodeは collapsed 扱いになり、子孫がある場合は `hidden_count` が表示されます。
+`initial_state: :collapsed` の場合は全体collapsedが優先され、rootのみが初期表示されます。
 
 `row_class_builder` は文字列、配列、または `nil` を返せます。
 `row_data_builder` はHash相当の値、または `nil` を返せます。

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -9,6 +9,7 @@ module TreeView
                 :row_partial,
                 :ui_config,
                 :initial_state,
+                :max_initial_depth,
                 :row_class_builder,
                 :row_data_builder
 
@@ -18,6 +19,7 @@ module TreeView
                    row_partial:,
                    ui_config:,
                    initial_state: nil,
+                   max_initial_depth: nil,
                    row_class_builder: nil,
                    row_data_builder: nil)
       @tree = tree
@@ -25,6 +27,7 @@ module TreeView
       @row_partial = row_partial
       @ui_config = ui_config
       @initial_state = normalize_initial_state(initial_state)
+      @max_initial_depth = normalize_max_initial_depth(max_initial_depth)
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
 
@@ -46,6 +49,13 @@ module TreeView
       return normalized_value if VALID_INITIAL_STATES.include?(normalized_value)
 
       raise ArgumentError, "initial_state must be one of: #{VALID_INITIAL_STATES.join(', ')}"
+    end
+
+    def normalize_max_initial_depth(value)
+      return nil if value.nil?
+      return value if value.is_a?(Integer) && value >= 0
+
+      raise ArgumentError, "max_initial_depth must be a non-negative Integer"
     end
 
     def validate_builder!(builder, name)

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "TreeView integration" do
 
   let(:root) { IntegrationNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { IntegrationNode.new(id: 2, parent_item_id: 1, name: "child") }
-  let(:nodes) { [root, child] }
+  let(:grandchild) { IntegrationNode.new(id: 3, parent_item_id: 2, name: "grandchild") }
+  let(:nodes) { [root, child, grandchild] }
   let(:tree) { TreeView::Tree.new(records: nodes, parent_id_method: :parent_item_id) }
   let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
   let(:host_view_dir) { Dir.mktmpdir("tree_view_host_views") }
@@ -88,6 +89,25 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include('data-node-id="1"')
       expect(rendered).to include('data-tree-depth="0"')
       expect(rendered).to include('data-tree-depth="1"')
+    end
+
+    it "limits initial child rendering with max_initial_depth" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        max_initial_depth: 1
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).not_to include('id="project_3"')
+      expect(rendered).to include('tree-toggle__hidden-count')
     end
 
     it "respects RenderState initial_state when rendering through tree_view_rows" do

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -16,6 +16,30 @@ RSpec.describe TreeView::RenderState do
     expect(state.ui_config).to eq(ui_config)
   end
 
+  it "stores max_initial_depth when given" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      max_initial_depth: 2
+    )
+
+    expect(state.max_initial_depth).to eq(2)
+  end
+
+  it "rejects invalid max_initial_depth values" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        max_initial_depth: "2"
+      )
+    end.to raise_error(ArgumentError, /max_initial_depth/)
+  end
+
   it "stores row attribute builders when given" do
     row_class_builder = ->(item) { item.name }
     row_data_builder = ->(item) { { name: item.name } }


### PR DESCRIPTION
## Summary

- Add `max_initial_depth` to `TreeView::RenderState` as a per-screen initial expansion setting
- Treat root as depth `0` and validate that the value is `nil` or a non-negative Integer
- Stop initial child rendering at the configured boundary depth
- Treat boundary nodes as collapsed and preserve `hidden_count` behavior
- Pass `max_initial_depth` through recursive row rendering
- Add RenderState and integration specs
- Document the API in `docs/api.md`

Closes #32

## Notes

This keeps the setting screen-local via `RenderState`, instead of adding another global config.

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.