### PR TITLE
Add expanded_keys to RenderState

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -13,6 +13,7 @@ module TreeViewHelper
         mode: mode,
         collapsed: collapsed.nil? ? render_state.effective_initial_state == :collapsed : collapsed,
         max_initial_depth: render_state.max_initial_depth,
+        expanded_keys: render_state.expanded_keys,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder
       }
@@ -47,6 +48,10 @@ module TreeViewHelper
 
   def tree_initial_depth_boundary?(depth, max_initial_depth)
     !max_initial_depth.nil? && depth >= max_initial_depth
+  end
+
+  def tree_expanded_key?(item, tree, expanded_keys)
+    Array(expanded_keys).include?(tree.node_key_for(item))
   end
 
   def tree_depth_slots(depth)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -2,8 +2,9 @@
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
+<% expanded_keys = local_assigns[:expanded_keys] %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -3,8 +3,10 @@
 <% row_partial = local_assigns.fetch(:row_partial) %>
 <% collapsed = local_assigns.fetch(:collapsed, false) %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
+<% expanded_keys = local_assigns[:expanded_keys] %>
+<% explicitly_expanded = tree_expanded_key?(item, tree, expanded_keys) %>
 <% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
-<% effectively_collapsed = collapsed || depth_boundary %>
+<% effectively_collapsed = !explicitly_expanded && (collapsed || depth_boundary) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
@@ -18,5 +20,5 @@
   <%= render row_partial, item: item %>
 <% end %>
 <% unless effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/docs/api.md
+++ b/docs/api.md
@@ -152,6 +152,7 @@ render_state = TreeView::RenderState.new(
   ui_config: tree_ui,
   initial_state: :expanded,
   max_initial_depth: 2,
+  expanded_keys: [root_key, child_key],
   row_class_builder: ->(item) { item.archived? ? "is-archived" : nil },
   row_data_builder: ->(item) { { status: item.status } }
 )
@@ -165,6 +166,7 @@ render_state = TreeView::RenderState.new(
 | `ui_config:` | yes | `TreeView::UiConfig` |
 | `initial_state:` | no | `:expanded` または `:collapsed` |
 | `max_initial_depth:` | no | 初期表示時に展開描画する最大depth。rootは `0` |
+| `expanded_keys:` | no | 初期表示時に展開するnode_key配列 |
 | `row_class_builder:` | no | `tr` に付与するCSS classを返すcallable |
 | `row_data_builder:` | no | `tr` に付与するdata属性Hashを返すcallable |
 
@@ -174,6 +176,11 @@ render_state = TreeView::RenderState.new(
 `nil` の場合はdepth制限なし、`0` の場合はrootのみ、`1` の場合はrootとそのchildrenまでを初期HTMLに描画します。
 境界depthのnodeは collapsed 扱いになり、子孫がある場合は `hidden_count` が表示されます。
 `initial_state: :collapsed` の場合は全体collapsedが優先され、rootのみが初期表示されます。
+
+`expanded_keys` には `tree.node_key_for(item)` と一致する値を指定します。
+該当nodeは `initial_state: :collapsed` や `max_initial_depth` の境界指定より優先して展開されます。
+ただし、親が初期HTMLに描画されていない場合、子だけを `expanded_keys` に指定しても表示されません。
+対象ノードまで表示したい場合は、対象ノードだけではなく、その祖先nodeのkeyも一緒に指定してください。
 
 `row_class_builder` は文字列、配列、または `nil` を返せます。
 `row_data_builder` はHash相当の値、または `nil` を返せます。

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -10,6 +10,7 @@ module TreeView
                 :ui_config,
                 :initial_state,
                 :max_initial_depth,
+                :expanded_keys,
                 :row_class_builder,
                 :row_data_builder
 
@@ -20,6 +21,7 @@ module TreeView
                    ui_config:,
                    initial_state: nil,
                    max_initial_depth: nil,
+                   expanded_keys: [],
                    row_class_builder: nil,
                    row_data_builder: nil)
       @tree = tree
@@ -28,6 +30,7 @@ module TreeView
       @ui_config = ui_config
       @initial_state = normalize_initial_state(initial_state)
       @max_initial_depth = normalize_max_initial_depth(max_initial_depth)
+      @expanded_keys = Array(expanded_keys).freeze
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
 

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -110,6 +110,44 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include('tree-toggle__hidden-count')
     end
 
+    it "expands nodes listed in expanded_keys" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        initial_state: :collapsed,
+        expanded_keys: [tree.node_key_for(root), tree.node_key_for(child)]
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).to include('id="project_3"')
+    end
+
+    it "does not render descendants when only a hidden descendant is listed in expanded_keys" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        initial_state: :collapsed,
+        expanded_keys: [tree.node_key_for(child)]
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).not_to include('id="project_2"')
+      expect(rendered).not_to include('id="project_3"')
+    end
+
     it "respects RenderState initial_state when rendering through tree_view_rows" do
       tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
       render_state = TreeView::RenderState.new(

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe TreeView::RenderState do
     end.to raise_error(ArgumentError, /max_initial_depth/)
   end
 
+  it "stores expanded_keys when given" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      expanded_keys: [1, 2]
+    )
+
+    expect(state.expanded_keys).to eq([1, 2])
+  end
+
   it "stores row attribute builders when given" do
     row_class_builder = ->(item) { item.name }
     row_data_builder = ->(item) { { name: item.name } }


### PR DESCRIPTION
## Summary

- Add `expanded_keys` to `TreeView::RenderState` as a per-screen initial expansion setting
- Pass `expanded_keys` through `tree_view_rows` and recursive row rendering
- Expand rows whose `tree.node_key_for(item)` is included in `expanded_keys`
- Let `expanded_keys` override `initial_state: :collapsed` and `max_initial_depth` for rows that are already rendered
- Add specs for storing `expanded_keys`, expanding ancestor paths, and documenting the hidden descendant limitation
- Document that callers should include ancestor keys when they want a hidden descendant to appear initially

Closes #33

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.