### PR TITLE
Add max_render_depth to RenderState

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -13,6 +13,7 @@ module TreeViewHelper
         mode: mode,
         collapsed: collapsed.nil? ? render_state.effective_initial_state == :collapsed : collapsed,
         max_initial_depth: render_state.max_initial_depth,
+        max_render_depth: render_state.max_render_depth,
         expanded_keys: render_state.expanded_keys,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder
@@ -48,6 +49,10 @@ module TreeViewHelper
 
   def tree_initial_depth_boundary?(depth, max_initial_depth)
     !max_initial_depth.nil? && depth >= max_initial_depth
+  end
+
+  def tree_render_children?(depth, max_render_depth)
+    max_render_depth.nil? || depth < max_render_depth
   end
 
   def tree_expanded_key?(item, tree, expanded_keys)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -2,9 +2,10 @@
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
+<% max_render_depth = local_assigns[:max_render_depth] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -3,9 +3,11 @@
 <% row_partial = local_assigns.fetch(:row_partial) %>
 <% collapsed = local_assigns.fetch(:collapsed, false) %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
+<% max_render_depth = local_assigns[:max_render_depth] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
 <% explicitly_expanded = tree_expanded_key?(item, tree, expanded_keys) %>
 <% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
+<% render_children = tree_render_children?(depth, max_render_depth) %>
 <% effectively_collapsed = !explicitly_expanded && (collapsed || depth_boundary) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
@@ -14,11 +16,11 @@
 <% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth) %>
 <% children = tree.children_for(item) %>
 <% descendant_count = tree.descendant_counts[tree.node_key_for(item)].to_i %>
-<% hidden_count = effectively_collapsed && descendant_count.positive? ? descendant_count : nil %>
+<% hidden_count = render_children && effectively_collapsed && descendant_count.positive? ? descendant_count : nil %>
 <%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
   <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode %>
   <%= render row_partial, item: item %>
 <% end %>
-<% unless effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+<% if render_children && !effectively_collapsed %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/docs/api.md
+++ b/docs/api.md
@@ -152,6 +152,7 @@ render_state = TreeView::RenderState.new(
   ui_config: tree_ui,
   initial_state: :expanded,
   max_initial_depth: 2,
+  max_render_depth: 2,
   expanded_keys: [root_key, child_key],
   row_class_builder: ->(item) { item.archived? ? "is-archived" : nil },
   row_data_builder: ->(item) { { status: item.status } }
@@ -166,6 +167,7 @@ render_state = TreeView::RenderState.new(
 | `ui_config:` | yes | `TreeView::UiConfig` |
 | `initial_state:` | no | `:expanded` または `:collapsed` |
 | `max_initial_depth:` | no | 初期表示時に展開描画する最大depth。rootは `0` |
+| `max_render_depth:` | no | 描画対象にする最大depth。rootは `0` |
 | `expanded_keys:` | no | 初期表示時に展開するnode_key配列 |
 | `row_class_builder:` | no | `tr` に付与するCSS classを返すcallable |
 | `row_data_builder:` | no | `tr` に付与するdata属性Hashを返すcallable |
@@ -176,6 +178,11 @@ render_state = TreeView::RenderState.new(
 `nil` の場合はdepth制限なし、`0` の場合はrootのみ、`1` の場合はrootとそのchildrenまでを初期HTMLに描画します。
 境界depthのnodeは collapsed 扱いになり、子孫がある場合は `hidden_count` が表示されます。
 `initial_state: :collapsed` の場合は全体collapsedが優先され、rootのみが初期表示されます。
+
+`max_render_depth` は `nil` または `0` 以上のIntegerを指定します。
+`nil` の場合は描画範囲のdepth制限なし、`0` の場合はrootのみ、`1` の場合はrootとそのchildrenまでを描画対象にします。
+`max_initial_depth` と異なり、`max_render_depth` は描画対象そのものを制限するため、境界より深いnodeは初期HTMLに出ず、`hidden_count` も表示されません。
+後から開閉操作で表示する対象としても扱わない用途を想定しています。
 
 `expanded_keys` には `tree.node_key_for(item)` と一致する値を指定します。
 該当nodeは `initial_state: :collapsed` や `max_initial_depth` の境界指定より優先して展開されます。

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -10,6 +10,7 @@ module TreeView
                 :ui_config,
                 :initial_state,
                 :max_initial_depth,
+                :max_render_depth,
                 :expanded_keys,
                 :row_class_builder,
                 :row_data_builder
@@ -21,6 +22,7 @@ module TreeView
                    ui_config:,
                    initial_state: nil,
                    max_initial_depth: nil,
+                   max_render_depth: nil,
                    expanded_keys: [],
                    row_class_builder: nil,
                    row_data_builder: nil)
@@ -29,7 +31,8 @@ module TreeView
       @row_partial = row_partial
       @ui_config = ui_config
       @initial_state = normalize_initial_state(initial_state)
-      @max_initial_depth = normalize_max_initial_depth(max_initial_depth)
+      @max_initial_depth = normalize_non_negative_integer(max_initial_depth, :max_initial_depth)
+      @max_render_depth = normalize_non_negative_integer(max_render_depth, :max_render_depth)
       @expanded_keys = Array(expanded_keys).freeze
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
@@ -54,11 +57,11 @@ module TreeView
       raise ArgumentError, "initial_state must be one of: #{VALID_INITIAL_STATES.join(', ')}"
     end
 
-    def normalize_max_initial_depth(value)
+    def normalize_non_negative_integer(value, name)
       return nil if value.nil?
       return value if value.is_a?(Integer) && value >= 0
 
-      raise ArgumentError, "max_initial_depth must be a non-negative Integer"
+      raise ArgumentError, "#{name} must be a non-negative Integer"
     end
 
     def validate_builder!(builder, name)

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -110,6 +110,25 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include('tree-toggle__hidden-count')
     end
 
+    it "limits rendered rows with max_render_depth without hidden count" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        max_render_depth: 1
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).not_to include('id="project_3"')
+      expect(rendered).not_to include('tree-toggle__hidden-count')
+    end
+
     it "expands nodes listed in expanded_keys" do
       tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
       render_state = TreeView::RenderState.new(

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -40,6 +40,30 @@ RSpec.describe TreeView::RenderState do
     end.to raise_error(ArgumentError, /max_initial_depth/)
   end
 
+  it "stores max_render_depth when given" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      max_render_depth: 2
+    )
+
+    expect(state.max_render_depth).to eq(2)
+  end
+
+  it "rejects invalid max_render_depth values" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        max_render_depth: -1
+      )
+    end.to raise_error(ArgumentError, /max_render_depth/)
+  end
+
   it "stores expanded_keys when given" do
     state = described_class.new(
       tree: tree,


### PR DESCRIPTION
## Summary

- Add `max_render_depth` to `TreeView::RenderState` as a per-screen render scope setting
- Treat root as depth `0` and validate that the value is `nil` or a non-negative Integer
- Stop recursive row rendering beyond the configured render depth
- Keep `max_render_depth` distinct from `max_initial_depth`: hidden descendants are not represented by `hidden_count`
- Add RenderState and integration specs
- Document the API in `docs/api.md`

Closes #30

## Notes

This PR intentionally implements only the max-depth side of root-based render scope. `min_depth` remains out of scope for this step.

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.