### PR TITLE
Add parent path helper APIs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -61,6 +61,10 @@ tree = TreeView::Tree.new(adapter: adapter)
 |---|---|
 | `root_items(root_parent_id = nil)` | root node を返す |
 | `children_for(record)` | 指定nodeのchildrenを返す |
+| `parent_for(record)` | 指定nodeの親を返す。records modeのみ |
+| `ancestors_for(record)` | root側から親までの祖先配列を返す。records modeのみ |
+| `path_for(record)` | root側から指定nodeまでのpath配列を返す。records modeのみ |
+| `paths_for(items)` | 複数nodeのpath配列を返す。records modeのみ |
 | `descendant_counts` | node_keyごとの子孫数を返す |
 | `node_key_for(record)` | nodeを識別するkeyを返す |
 | `sort_items(items)` | sorterに従ってitemsを並び替える |
@@ -82,6 +86,33 @@ TreeView::Tree.new(
 `sorter` は `call(items, tree)` できるオブジェクトを指定します。
 `sorter` の戻り値は `to_a` に応答する配列相当のオブジェクトにしてください。
 `nil` など配列相当ではない値を返した場合は、誤実装に気づきやすいよう `ArgumentError` を発生させます。
+
+### 親方向 path helper
+
+records mode では、検索結果や子ノード一覧から親階層を確認するための補助APIを使えます。
+
+```ruby
+tree = TreeView::Tree.new(
+  records: documents,
+  parent_id_method: :parent_document_id
+)
+
+paths = tree.paths_for(matched_documents)
+expanded_keys = paths.flatten.map { |item| tree.node_key_for(item) }.uniq
+```
+
+| メソッド | 戻り値 |
+|---|---|
+| `parent_for(item)` | `item` の親。親IDが `nil`、または親がrecords内に存在しない場合は `nil` |
+| `ancestors_for(item)` | root側から親までの祖先配列 |
+| `path_for(item)` | root側から `item` までの配列 |
+| `paths_for(items)` | 複数itemに対する `path_for` の配列 |
+
+親がrecords内に存在しない orphan node の場合、`parent_for` は `nil`、`ancestors_for` は空配列、`path_for` は対象nodeのみを返します。
+親方向の循環参照を検出した場合は `ArgumentError` を発生させます。
+resolver mode / adapter mode では、これらの親方向helperは未対応です。
+
+親階層を補完した通常向きTreeをそのまま描画する `path_tree_for` 相当の機能は、後続Issue #40 で扱います。
 
 ### orphan node の扱い
 

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -94,6 +94,45 @@ module TreeView
       Array(items_by_parent_id[record.public_send(id_method)])
     end
 
+    def parent_for(record)
+      ensure_records_path_helpers!
+
+      parent_id = record.public_send(parent_id_method)
+      return nil if parent_id.nil?
+
+      items_by_id[parent_id]
+    end
+
+    def ancestors_for(record)
+      ensure_records_path_helpers!
+
+      ancestors = []
+      visiting = {}
+      current = record
+
+      loop do
+        current_key = node_key_for(current)
+        raise ArgumentError, "cycle detected in parent path for node #{current_key.inspect}" if visiting[current_key]
+
+        visiting[current_key] = true
+        parent = parent_for(current)
+        break unless parent
+
+        ancestors.unshift(parent)
+        current = parent
+      end
+
+      ancestors
+    end
+
+    def path_for(record)
+      ancestors_for(record) + [record]
+    end
+
+    def paths_for(items)
+      Array(items).map { |item| path_for(item) }
+    end
+
     def node_key_for(record)
       if adapter_mode?
         adapter.node_key_for(record, id_method: id_method)
@@ -156,6 +195,12 @@ module TreeView
 
     def records_mode?
       !adapter_mode? && !resolver_mode?
+    end
+
+    def ensure_records_path_helpers!
+      return if records_mode?
+
+      raise ArgumentError, "parent path helpers are only supported in records mode"
     end
 
     def each_root_candidate

--- a/spec/lib/tree_view/path_helpers_spec.rb
+++ b/spec/lib/tree_view/path_helpers_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+RSpec.describe "TreeView::Tree parent path helpers" do
+  PathNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+  PathCountry = Struct.new(:id, :name, :children)
+
+  def build_tree(records)
+    TreeView::Tree.new(records: records, parent_id_method: :parent_item_id)
+  end
+
+  it "returns the parent record" do
+    root = PathNode.new(id: 1, parent_item_id: nil, name: "root")
+    child = PathNode.new(id: 2, parent_item_id: 1, name: "child")
+    tree = build_tree([root, child])
+
+    expect(tree.parent_for(child)).to eq(root)
+    expect(tree.parent_for(root)).to be_nil
+  end
+
+  it "returns nil when the parent is missing from records" do
+    orphan = PathNode.new(id: 2, parent_item_id: 999, name: "orphan")
+    tree = build_tree([orphan])
+
+    expect(tree.parent_for(orphan)).to be_nil
+    expect(tree.ancestors_for(orphan)).to eq([])
+    expect(tree.path_for(orphan)).to eq([orphan])
+  end
+
+  it "returns ancestors from root to parent" do
+    root = PathNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = PathNode.new(id: 2, parent_item_id: 1, name: "parent")
+    child = PathNode.new(id: 3, parent_item_id: 2, name: "child")
+    tree = build_tree([root, parent, child])
+
+    expect(tree.ancestors_for(child)).to eq([root, parent])
+  end
+
+  it "returns a path from root to item" do
+    root = PathNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = PathNode.new(id: 2, parent_item_id: 1, name: "parent")
+    child = PathNode.new(id: 3, parent_item_id: 2, name: "child")
+    tree = build_tree([root, parent, child])
+
+    expect(tree.path_for(child)).to eq([root, parent, child])
+  end
+
+  it "returns paths for multiple items" do
+    root = PathNode.new(id: 1, parent_item_id: nil, name: "root")
+    child_a = PathNode.new(id: 2, parent_item_id: 1, name: "child-a")
+    child_b = PathNode.new(id: 3, parent_item_id: 1, name: "child-b")
+    tree = build_tree([root, child_a, child_b])
+
+    expect(tree.paths_for([child_a, child_b])).to eq([[root, child_a], [root, child_b]])
+  end
+
+  it "detects cycles while walking parent paths" do
+    node_a = PathNode.new(id: 1, parent_item_id: 2, name: "a")
+    node_b = PathNode.new(id: 2, parent_item_id: 1, name: "b")
+    tree = build_tree([node_a, node_b])
+
+    expect do
+      tree.path_for(node_a)
+    end.to raise_error(ArgumentError, /cycle detected in parent path/)
+  end
+
+  it "rejects parent path helpers in resolver mode" do
+    country = PathCountry.new(1, "japan", [])
+    tree = TreeView::Tree.new(
+      roots: [country],
+      children_resolver: ->(node) { node.children }
+    )
+
+    expect do
+      tree.parent_for(country)
+    end.to raise_error(ArgumentError, /only supported in records mode/)
+  end
+end


### PR DESCRIPTION
## Summary

- Add records-mode parent path helper APIs:
  - `parent_for(item)`
  - `ancestors_for(item)`
  - `path_for(item)`
  - `paths_for(items)`
- Return `nil` / empty ancestors for missing parents, so orphan nodes can still produce a self-only path
- Detect cycles while walking parent paths and raise a clear `ArgumentError`
- Reject these helpers outside records mode with an explicit error
- Add specs for parent lookup, paths, orphan handling, cycle detection, and unsupported modes
- Document the APIs in `docs/api.md`

Closes #13

## Notes

`path_tree_for` / renderable path tree generation is intentionally split out to #40.

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.