### PR TITLE
Add PathTree for rendering parent-completed paths

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@ tree = TreeView::Tree.new(adapter: adapter)
 | `ancestors_for(record)` | root側から親までの祖先配列を返す。records modeのみ |
 | `path_for(record)` | root側から指定nodeまでのpath配列を返す。records modeのみ |
 | `paths_for(items)` | 複数nodeのpath配列を返す。records modeのみ |
+| `path_tree_for(items)` | 複数nodeから親階層を補完した通常向きTreeを返す。records modeのみ |
 | `descendant_counts` | node_keyごとの子孫数を返す |
 | `node_key_for(record)` | nodeを識別するkeyを返す |
 | `sort_items(items)` | sorterに従ってitemsを並び替える |
@@ -107,12 +108,42 @@ expanded_keys = paths.flatten.map { |item| tree.node_key_for(item) }.uniq
 | `ancestors_for(item)` | root側から親までの祖先配列 |
 | `path_for(item)` | root側から `item` までの配列 |
 | `paths_for(items)` | 複数itemに対する `path_for` の配列 |
+| `path_tree_for(items)` | 複数itemに対するpathを通常向きTreeとしてまとめた `TreeView::PathTree` |
 
 親がrecords内に存在しない orphan node の場合、`parent_for` は `nil`、`ancestors_for` は空配列、`path_for` は対象nodeのみを返します。
 親方向の循環参照を検出した場合は `ArgumentError` を発生させます。
 resolver mode / adapter mode では、これらの親方向helperは未対応です。
 
-親階層を補完した通常向きTreeをそのまま描画する `path_tree_for` 相当の機能は、後続Issue #40 で扱います。
+`path_tree_for` は、検索結果などを起点に root → ancestor → matched item の通常向きTreeを作ります。
+共通祖先や共通edgeは重複表示されません。
+
+```ruby
+path_tree = tree.path_tree_for(matched_documents)
+
+render_state = TreeView::RenderState.new(
+  tree: path_tree,
+  root_items: path_tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  initial_state: :expanded
+)
+```
+
+## TreeView::PathTree
+
+`TreeView::PathTree` は、`TreeView::Tree#path_tree_for(items)` から生成される、親階層補完済みの通常向きTreeです。
+
+既存の `RenderState` / `tree_view_rows` と接続できるよう、通常Treeに近いインターフェースを持ちます。
+
+| メソッド | 説明 |
+|---|---|
+| `root_items(root_parent_id = nil)` | PathTree内のroot nodeを返す |
+| `children_for(record)` | PathTree内で指定nodeのchildrenを返す |
+| `descendant_counts` | PathTree内の子孫数を返す |
+| `node_key_for(record)` | base treeの `node_key_for` に委譲する |
+| `sort_items(items)` | base treeの `sort_items` に委譲する |
+
+`PathTree` は、base tree 全体ではなく、指定itemへ至るpath上のnodeだけを描画対象にします。
 
 ### orphan node の扱い
 

--- a/lib/tree_view.rb
+++ b/lib/tree_view.rb
@@ -7,6 +7,7 @@ require "tree_view/render_state"
 require "tree_view/toggle_scope"
 require "tree_view/traversal"
 require "tree_view/tree"
+require "tree_view/path_tree"
 require "tree_view/ui_config"
 require "tree_view/ui_config_builder"
 

--- a/lib/tree_view/path_tree.rb
+++ b/lib/tree_view/path_tree.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module TreeView
+  class PathTree
+    attr_reader :base_tree, :paths
+
+    def initialize(base_tree:, paths:)
+      @base_tree = base_tree
+      @paths = Array(paths).map { |path| Array(path) }
+      @children_by_node_key = build_children_by_node_key
+      @root_items = build_root_items
+    end
+
+    def root_items(root_parent_id = nil)
+      return sort_items(@root_items) if root_parent_id.nil?
+
+      sort_items(Array(@children_by_node_key[root_parent_id]))
+    end
+
+    def children_for(record)
+      sort_items(Array(@children_by_node_key[node_key_for(record)]))
+    end
+
+    def node_key_for(record)
+      base_tree.node_key_for(record)
+    end
+
+    def sort_items(items)
+      base_tree.sort_items(items)
+    end
+
+    def descendant_counts
+      @descendant_counts ||= begin
+        memo = {}
+        count_descendants = lambda do |record|
+          node_key = node_key_for(record)
+          return memo[node_key] if memo.key?(node_key)
+
+          children = children_for(record)
+          memo[node_key] = children.sum { |child| 1 + count_descendants.call(child) }
+        end
+
+        root_items.each { |root| count_descendants.call(root) }
+        memo
+      end
+    end
+
+    private
+
+    def build_children_by_node_key
+      children_by_node_key = Hash.new { |hash, key| hash[key] = [] }
+      seen_edges = {}
+
+      paths.each do |path|
+        path.each_cons(2) do |parent, child|
+          parent_key = node_key_for(parent)
+          child_key = node_key_for(child)
+          edge_key = [parent_key, child_key]
+          next if seen_edges[edge_key]
+
+          children_by_node_key[parent_key] << child
+          seen_edges[edge_key] = true
+        end
+      end
+
+      children_by_node_key
+    end
+
+    def build_root_items
+      roots = []
+      seen_root_keys = {}
+
+      paths.each do |path|
+        root = path.first
+        next unless root
+
+        root_key = node_key_for(root)
+        next if seen_root_keys[root_key]
+
+        roots << root
+        seen_root_keys[root_key] = true
+      end
+
+      roots
+    end
+  end
+end

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -133,6 +133,10 @@ module TreeView
       Array(items).map { |item| path_for(item) }
     end
 
+    def path_tree_for(items)
+      TreeView::PathTree.new(base_tree: self, paths: paths_for(items))
+    end
+
     def node_key_for(record)
       if adapter_mode?
         adapter.node_key_for(record, id_method: id_method)

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "TreeView integration" do
   let(:root) { IntegrationNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { IntegrationNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:grandchild) { IntegrationNode.new(id: 3, parent_item_id: 2, name: "grandchild") }
-  let(:nodes) { [root, child, grandchild] }
+  let(:sibling) { IntegrationNode.new(id: 4, parent_item_id: 2, name: "sibling") }
+  let(:nodes) { [root, child, grandchild, sibling] }
   let(:tree) { TreeView::Tree.new(records: nodes, parent_id_method: :parent_item_id) }
   let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
   let(:host_view_dir) { Dir.mktmpdir("tree_view_host_views") }
@@ -66,6 +67,28 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include('id="project_2"')
       expect(rendered).to include("project_1:root")
       expect(rendered).to include("project_2:child")
+    end
+
+    it "renders a PathTree through tree_view_rows helper" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      path_tree = tree.path_tree_for([grandchild])
+      render_state = TreeView::RenderState.new(
+        tree: path_tree,
+        root_items: path_tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).to include('id="project_3"')
+      expect(rendered).not_to include('id="project_4"')
+      expect(rendered).to include("project_1:root")
+      expect(rendered).to include("project_2:child")
+      expect(rendered).to include("project_3:grandchild")
     end
 
     it "renders row class and data attributes from RenderState builders" do

--- a/spec/lib/tree_view/path_tree_spec.rb
+++ b/spec/lib/tree_view/path_tree_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+RSpec.describe TreeView::PathTree do
+  PathTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+  def build_base_tree(records)
+    TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) })
+  end
+
+  it "builds a normal direction tree from paths" do
+    root = PathTreeNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = PathTreeNode.new(id: 2, parent_item_id: 1, name: "parent")
+    child = PathTreeNode.new(id: 3, parent_item_id: 2, name: "child")
+    base_tree = build_base_tree([root, parent, child])
+
+    path_tree = base_tree.path_tree_for([child])
+
+    expect(path_tree.root_items).to eq([root])
+    expect(path_tree.children_for(root)).to eq([parent])
+    expect(path_tree.children_for(parent)).to eq([child])
+    expect(path_tree.children_for(child)).to eq([])
+  end
+
+  it "deduplicates shared ancestors and edges" do
+    root = PathTreeNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = PathTreeNode.new(id: 2, parent_item_id: 1, name: "parent")
+    child_a = PathTreeNode.new(id: 3, parent_item_id: 2, name: "child-a")
+    child_b = PathTreeNode.new(id: 4, parent_item_id: 2, name: "child-b")
+    base_tree = build_base_tree([root, parent, child_a, child_b])
+
+    path_tree = base_tree.path_tree_for([child_a, child_b])
+
+    expect(path_tree.root_items).to eq([root])
+    expect(path_tree.children_for(root)).to eq([parent])
+    expect(path_tree.children_for(parent)).to eq([child_a, child_b])
+  end
+
+  it "keeps orphan paths as root items" do
+    orphan = PathTreeNode.new(id: 1, parent_item_id: 999, name: "orphan")
+    base_tree = build_base_tree([orphan])
+
+    path_tree = base_tree.path_tree_for([orphan])
+
+    expect(path_tree.root_items).to eq([orphan])
+    expect(path_tree.children_for(orphan)).to eq([])
+  end
+
+  it "delegates node keys and sorting to the base tree" do
+    root_b = PathTreeNode.new(id: 2, parent_item_id: nil, name: "root-b")
+    root_a = PathTreeNode.new(id: 1, parent_item_id: nil, name: "root-a")
+    base_tree = build_base_tree([root_b, root_a])
+
+    path_tree = base_tree.path_tree_for([root_b, root_a])
+
+    expect(path_tree.node_key_for(root_a)).to eq(base_tree.node_key_for(root_a))
+    expect(path_tree.root_items).to eq([root_a, root_b])
+  end
+
+  it "calculates descendant counts within the path tree only" do
+    root = PathTreeNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = PathTreeNode.new(id: 2, parent_item_id: 1, name: "parent")
+    matched_child = PathTreeNode.new(id: 3, parent_item_id: 2, name: "matched-child")
+    excluded_child = PathTreeNode.new(id: 4, parent_item_id: 2, name: "excluded-child")
+    base_tree = build_base_tree([root, parent, matched_child, excluded_child])
+
+    path_tree = base_tree.path_tree_for([matched_child])
+
+    expect(path_tree.descendant_counts[path_tree.node_key_for(root)]).to eq(2)
+    expect(path_tree.descendant_counts[path_tree.node_key_for(parent)]).to eq(1)
+    expect(path_tree.descendant_counts[path_tree.node_key_for(matched_child)]).to eq(0)
+  end
+end


### PR DESCRIPTION
## Summary

- Add `TreeView::PathTree` for rendering parent-completed paths in normal root-to-leaf direction
- Add `TreeView::Tree#path_tree_for(items)` as a records-mode helper built on `paths_for`
- Deduplicate shared roots and parent-child edges across multiple paths
- Delegate `node_key_for` and `sort_items` to the base tree
- Calculate descendant counts within the path tree only
- Add unit specs for PathTree behavior
- Add an integration spec showing PathTree works with `RenderState` and `tree_view_rows`
- Document `path_tree_for` and `TreeView::PathTree` in `docs/api.md`

Closes #40

## Testing

- Not run locally; changes were made through the GitHub connector in this chat environment.