### PR TITLE
Add max_leaf_distance render scope

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -14,6 +14,7 @@ module TreeViewHelper
         collapsed: collapsed.nil? ? render_state.effective_initial_state == :collapsed : collapsed,
         max_initial_depth: render_state.max_initial_depth,
         max_render_depth: render_state.max_render_depth,
+        max_leaf_distance: render_state.max_leaf_distance,
         max_toggle_depth_from_root: render_state.max_toggle_depth_from_root,
         expanded_keys: render_state.expanded_keys,
         row_class_builder: render_state.row_class_builder,
@@ -54,6 +55,17 @@ module TreeViewHelper
 
   def tree_render_children?(depth, max_render_depth)
     max_render_depth.nil? || depth < max_render_depth
+  end
+
+  def tree_render_leaf_distance?(item, tree, max_leaf_distance)
+    return true if max_leaf_distance.nil?
+
+    distance = tree_leaf_distance(item, tree)
+    !distance.nil? && distance <= max_leaf_distance
+  end
+
+  def tree_leaf_distance(item, tree)
+    tree_leaf_distances(tree)[tree.node_key_for(item)]
   end
 
   def tree_toggle_scope(depth:, max_toggle_depth_from_root:, mode: :all, ui: @tree_ui)
@@ -156,6 +168,29 @@ module TreeViewHelper
     end
 
     tree.root_items.map { |root| walk.call(root, 0) }.max.to_i
+  end
+
+  def tree_leaf_distances(tree)
+    @tree_leaf_distance_maps ||= {}
+    @tree_leaf_distance_maps[tree.object_id] ||= begin
+      distances = {}
+
+      walk = lambda do |node|
+        node_key = tree.node_key_for(node)
+        return distances[node_key] if distances.key?(node_key)
+
+        children = tree.children_for(node)
+        distances[node_key] = if children.empty?
+                                0
+                              else
+                                child_distances = children.map { |child| walk.call(child) }.compact
+                                child_distances.empty? ? nil : child_distances.min + 1
+                              end
+      end
+
+      tree.root_items.each { |root| walk.call(root) }
+      distances
+    end
   end
 
   def tree_branch_map(tree)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -3,10 +3,11 @@
 <% row_data_builder = local_assigns[:row_data_builder] %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
 <% max_render_depth = local_assigns[:max_render_depth] %>
+<% max_leaf_distance = local_assigns[:max_leaf_distance] %>
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_toggle_depth_from_root: max_toggle_depth_from_root, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -4,11 +4,13 @@
 <% collapsed = local_assigns.fetch(:collapsed, false) %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
 <% max_render_depth = local_assigns[:max_render_depth] %>
+<% max_leaf_distance = local_assigns[:max_leaf_distance] %>
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
 <% explicitly_expanded = tree_expanded_key?(item, tree, expanded_keys) %>
 <% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
 <% render_children = tree_render_children?(depth, max_render_depth) %>
+<% render_self = tree_render_leaf_distance?(item, tree, max_leaf_distance) %>
 <% effectively_collapsed = !explicitly_expanded && (collapsed || depth_boundary) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
@@ -17,11 +19,13 @@
 <% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth) %>
 <% children = tree.children_for(item) %>
 <% descendant_count = tree.descendant_counts[tree.node_key_for(item)].to_i %>
-<% hidden_count = render_children && effectively_collapsed && descendant_count.positive? ? descendant_count : nil %>
-<%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
-  <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root %>
-  <%= render row_partial, item: item %>
+<% hidden_count = render_children && effectively_collapsed && descendant_count.positive? && render_self ? descendant_count : nil %>
+<% if render_self %>
+  <%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
+    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root %>
+    <%= render row_partial, item: item %>
+  <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_toggle_depth_from_root: max_toggle_depth_from_root, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/docs/api.md
+++ b/docs/api.md
@@ -215,6 +215,7 @@ render_state = TreeView::RenderState.new(
   initial_state: :expanded,
   max_initial_depth: 2,
   max_render_depth: 2,
+  max_leaf_distance: 2,
   max_toggle_depth_from_root: 2,
   expanded_keys: [root_key, child_key],
   row_class_builder: ->(item) { item.archived? ? "is-archived" : nil },
@@ -231,6 +232,7 @@ render_state = TreeView::RenderState.new(
 | `initial_state:` | no | `:expanded` または `:collapsed` |
 | `max_initial_depth:` | no | 初期表示時に展開描画する最大depth。rootは `0` |
 | `max_render_depth:` | no | 描画対象にする最大depth。rootは `0` |
+| `max_leaf_distance:` | no | 描画対象にする最大leaf距離。leafは `0` |
 | `max_toggle_depth_from_root:` | no | root基準で、開閉操作時にまとめて扱う最大depth |
 | `expanded_keys:` | no | 初期表示時に展開するnode_key配列 |
 | `row_class_builder:` | no | `tr` に付与するCSS classを返すcallable |
@@ -247,6 +249,15 @@ render_state = TreeView::RenderState.new(
 `nil` の場合は描画範囲のdepth制限なし、`0` の場合はrootのみ、`1` の場合はrootとそのchildrenまでを描画対象にします。
 `max_initial_depth` と異なり、`max_render_depth` は描画対象そのものを制限するため、境界より深いnodeは初期HTMLに出ず、`hidden_count` も表示されません。
 後から開閉操作で表示する対象としても扱わない用途を想定しています。
+
+`max_leaf_distance` は `nil` または `0` 以上のIntegerを指定します。
+`nil` の場合はleaf距離による描画範囲制限なし、`0` の場合はleafのみ、`1` の場合はleafとその親までを描画対象にします。
+leaf distance は、leafを `0` として、leaf側からroot方向へ数えた距離です。
+複数leafを持つnodeでは、最短leaf距離を採用します。
+たとえば、あるnodeが一方のleafからは距離 `1`、別のleafからは距離 `3` の場合、そのnodeのleaf distanceは `1` です。
+`max_render_depth` がroot基準であるのに対し、`max_leaf_distance` はleaf基準です。
+`max_render_depth` と同様に描画対象そのものを制限するため、対象外nodeは初期HTMLに出ず、`hidden_count` も表示されません。
+ただし、対象外nodeの子孫に描画対象nodeが存在する場合があるため、行を省略しても子側の探索は継続します。
 
 `max_toggle_depth_from_root` は `nil` または `0` 以上のIntegerを指定します。
 `scope_format: :object` の `UiConfig` と組み合わせると、path builder の第3引数 `scope` に `TreeView::ToggleScope` が渡されます。

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -11,6 +11,7 @@ module TreeView
                 :initial_state,
                 :max_initial_depth,
                 :max_render_depth,
+                :max_leaf_distance,
                 :max_toggle_depth_from_root,
                 :expanded_keys,
                 :row_class_builder,
@@ -24,6 +25,7 @@ module TreeView
                    initial_state: nil,
                    max_initial_depth: nil,
                    max_render_depth: nil,
+                   max_leaf_distance: nil,
                    max_toggle_depth_from_root: nil,
                    expanded_keys: [],
                    row_class_builder: nil,
@@ -35,6 +37,7 @@ module TreeView
       @initial_state = normalize_initial_state(initial_state)
       @max_initial_depth = normalize_non_negative_integer(max_initial_depth, :max_initial_depth)
       @max_render_depth = normalize_non_negative_integer(max_render_depth, :max_render_depth)
+      @max_leaf_distance = normalize_non_negative_integer(max_leaf_distance, :max_leaf_distance)
       @max_toggle_depth_from_root = normalize_non_negative_integer(max_toggle_depth_from_root, :max_toggle_depth_from_root)
       @expanded_keys = Array(expanded_keys).freeze
       @row_class_builder = row_class_builder

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -152,6 +152,51 @@ RSpec.describe "TreeView integration" do
       expect(rendered).not_to include('tree-toggle__hidden-count')
     end
 
+    it "limits rendered rows with max_leaf_distance from leaves without hidden count" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        max_leaf_distance: 1
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).not_to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).to include('id="project_3"')
+      expect(rendered).to include('id="project_4"')
+      expect(rendered).not_to include('tree-toggle__hidden-count')
+    end
+
+    it "uses the shortest distance when a node has multiple leaves" do
+      short_leaf = IntegrationNode.new(id: 5, parent_item_id: 1, name: "short_leaf")
+      long_parent = IntegrationNode.new(id: 6, parent_item_id: 1, name: "long_parent")
+      long_child = IntegrationNode.new(id: 7, parent_item_id: 6, name: "long_child")
+      long_leaf = IntegrationNode.new(id: 8, parent_item_id: 7, name: "long_leaf")
+      mixed_tree = TreeView::Tree.new(records: [root, short_leaf, long_parent, long_child, long_leaf], parent_id_method: :parent_item_id)
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: mixed_tree,
+        root_items: mixed_tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        max_leaf_distance: 1
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_5"')
+      expect(rendered).not_to include('id="project_6"')
+      expect(rendered).to include('id="project_7"')
+      expect(rendered).to include('id="project_8"')
+    end
+
     it "expands nodes listed in expanded_keys" do
       tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
       render_state = TreeView::RenderState.new(

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -64,6 +64,30 @@ RSpec.describe TreeView::RenderState do
     end.to raise_error(ArgumentError, /max_render_depth/)
   end
 
+  it "stores max_leaf_distance when given" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      max_leaf_distance: 2
+    )
+
+    expect(state.max_leaf_distance).to eq(2)
+  end
+
+  it "rejects invalid max_leaf_distance values" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        max_leaf_distance: -1
+      )
+    end.to raise_error(ArgumentError, /max_leaf_distance/)
+  end
+
   it "stores max_toggle_depth_from_root when given" do
     state = described_class.new(
       tree: tree,


### PR DESCRIPTION
## Summary

- Add `max_leaf_distance` to `TreeView::RenderState` with non-negative Integer validation
- Calculate shortest leaf distance per node and filter rendered rows by leaf-side distance
- Keep leaf-distance filtered nodes out of `hidden_count`, consistent with `max_render_depth`
- Document the leaf-distance semantics in `docs/api.md`
- Add RenderState and integration specs, including shortest-distance behavior for nodes with multiple leaves

Closes #31

## Notes

I could not run the local RSpec suite in this environment because cloning from GitHub failed with DNS resolution for `github.com`. The branch diff was checked via the GitHub connector instead.