### PR TITLE
Add ReverseTree for parent direction rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - static表示
 - Turbo Stream開閉用path builder
 - 異種ノード混在ツリー用 `GraphAdapter`
+- 検索結果などから親階層を補完する `PathTree`
+- 子ノード起点で親方向へ辿る `ReverseTree`
 - viewから使うDOM ID / toggle path / 枝情報helper
 - `RenderState` からroot行を描画する `tree_view_rows` helper
 - host app側の `row_partial` 差し替え

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,6 +66,7 @@ tree = TreeView::Tree.new(adapter: adapter)
 | `path_for(record)` | root側から指定nodeまでのpath配列を返す。records modeのみ |
 | `paths_for(items)` | 複数nodeのpath配列を返す。records modeのみ |
 | `path_tree_for(items)` | 複数nodeから親階層を補完した通常向きTreeを返す。records modeのみ |
+| `reverse_tree_for(items)` | 複数nodeを起点に親方向へ辿る逆向きTreeを返す。records modeのみ |
 | `descendant_counts` | node_keyごとの子孫数を返す |
 | `node_key_for(record)` | nodeを識別するkeyを返す |
 | `sort_items(items)` | sorterに従ってitemsを並び替える |
@@ -109,6 +110,7 @@ expanded_keys = paths.flatten.map { |item| tree.node_key_for(item) }.uniq
 | `path_for(item)` | root側から `item` までの配列 |
 | `paths_for(items)` | 複数itemに対する `path_for` の配列 |
 | `path_tree_for(items)` | 複数itemに対するpathを通常向きTreeとしてまとめた `TreeView::PathTree` |
+| `reverse_tree_for(items)` | 複数itemに対するpathを子 → 親方向のTreeとしてまとめた `TreeView::ReverseTree` |
 
 親がrecords内に存在しない orphan node の場合、`parent_for` は `nil`、`ancestors_for` は空配列、`path_for` は対象nodeのみを返します。
 親方向の循環参照を検出した場合は `ArgumentError` を発生させます。
@@ -123,6 +125,20 @@ path_tree = tree.path_tree_for(matched_documents)
 render_state = TreeView::RenderState.new(
   tree: path_tree,
   root_items: path_tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  initial_state: :expanded
+)
+```
+
+`reverse_tree_for` は、検索結果などを起点に matched item → parent → root の逆向きTreeを作ります。
+
+```ruby
+reverse_tree = tree.reverse_tree_for(matched_documents)
+
+render_state = TreeView::RenderState.new(
+  tree: reverse_tree,
+  root_items: reverse_tree.root_items,
   row_partial: "documents/tree_columns",
   ui_config: tree_ui,
   initial_state: :expanded
@@ -144,6 +160,34 @@ render_state = TreeView::RenderState.new(
 | `sort_items(items)` | base treeの `sort_items` に委譲する |
 
 `PathTree` は、base tree 全体ではなく、指定itemへ至るpath上のnodeだけを描画対象にします。
+表示方向は通常Treeと同じ root → parent → matched item です。
+
+## TreeView::ReverseTree
+
+`TreeView::ReverseTree` は、`TreeView::Tree#reverse_tree_for(items)` から生成される、子ノード起点の逆向きTreeです。
+
+既存の `RenderState` / `tree_view_rows` と接続できるよう、通常Treeに近いインターフェースを持ちます。
+
+| メソッド | 説明 |
+|---|---|
+| `root_items(root_parent_id = nil)` | 起点となる matched item を返す |
+| `children_for(record)` | ReverseTree内で指定nodeの親方向nodeを返す |
+| `descendant_counts` | ReverseTree内の子孫数を返す。ここでの子孫は表示上の子、つまり親方向node |
+| `node_key_for(record)` | base treeの `node_key_for` に委譲する |
+| `sort_items(items)` | base treeの `sort_items` に委譲する |
+
+`ReverseTree` は matched item → parent → root の向きで表示します。
+通常向きの親階層補完Treeとは用途が異なります。
+
+| API | 表示方向 | 主な用途 |
+|---|---|---|
+| `path_tree_for(items)` | root → parent → matched item | 検索結果を通常の階層構造内で確認する |
+| `reverse_tree_for(items)` | matched item → parent → root | 子ノード一覧を起点に親方向へ辿る |
+
+複数の起点nodeが同じ親・祖先を共有する場合、同じnodeを複数箇所に描画するとDOM IDが重複します。
+そのため `ReverseTree` では、共有された親方向nodeは最初に現れたreverse pathにのみ接続します。
+後続の起点nodeから同じ共有祖先へは接続しません。
+同じ祖先を各起点node配下に重複表示したい場合は、DOM ID生成やnode_keyを分離する別設計が必要です。
 
 ### orphan node の扱い
 

--- a/lib/tree_view.rb
+++ b/lib/tree_view.rb
@@ -8,6 +8,7 @@ require "tree_view/toggle_scope"
 require "tree_view/traversal"
 require "tree_view/tree"
 require "tree_view/path_tree"
+require "tree_view/reverse_tree"
 require "tree_view/ui_config"
 require "tree_view/ui_config_builder"
 

--- a/lib/tree_view/reverse_tree.rb
+++ b/lib/tree_view/reverse_tree.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module TreeView
+  class ReverseTree
+    attr_reader :base_tree, :paths
+
+    def initialize(base_tree:, paths:)
+      @base_tree = base_tree
+      @paths = Array(paths).map { |path| Array(path) }
+      @children_by_node_key = build_children_by_node_key
+      @root_items = build_root_items
+    end
+
+    def root_items(root_parent_id = nil)
+      return sort_items(@root_items) if root_parent_id.nil?
+
+      sort_items(Array(@children_by_node_key[root_parent_id]))
+    end
+
+    def children_for(record)
+      sort_items(Array(@children_by_node_key[node_key_for(record)]))
+    end
+
+    def node_key_for(record)
+      base_tree.node_key_for(record)
+    end
+
+    def sort_items(items)
+      base_tree.sort_items(items)
+    end
+
+    def descendant_counts
+      @descendant_counts ||= begin
+        memo = {}
+        count_descendants = lambda do |record|
+          node_key = node_key_for(record)
+          return memo[node_key] if memo.key?(node_key)
+
+          children = children_for(record)
+          memo[node_key] = children.sum { |child| 1 + count_descendants.call(child) }
+        end
+
+        root_items.each { |root| count_descendants.call(root) }
+        memo
+      end
+    end
+
+    private
+
+    def build_children_by_node_key
+      children_by_node_key = Hash.new { |hash, key| hash[key] = [] }
+      assigned_child_keys = {}
+
+      paths.each do |path|
+        path.reverse.each_cons(2) do |child, parent|
+          child_key = node_key_for(child)
+          parent_key = node_key_for(parent)
+
+          # ReverseTree is rendered through the existing Tree partials, which use
+          # node DOM IDs based on the original item. Rendering the same ancestor
+          # under multiple matched leaves would duplicate DOM IDs, so shared
+          # ancestors are attached only to their first encountered reverse path.
+          next if assigned_child_keys[parent_key]
+
+          children_by_node_key[child_key] << parent
+          assigned_child_keys[parent_key] = true
+        end
+      end
+
+      children_by_node_key
+    end
+
+    def build_root_items
+      roots = []
+      seen_root_keys = {}
+
+      paths.each do |path|
+        root = path.last
+        next unless root
+
+        root_key = node_key_for(root)
+        next if seen_root_keys[root_key]
+
+        roots << root
+        seen_root_keys[root_key] = true
+      end
+
+      roots
+    end
+  end
+end

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -137,6 +137,10 @@ module TreeView
       TreeView::PathTree.new(base_tree: self, paths: paths_for(items))
     end
 
+    def reverse_tree_for(items)
+      TreeView::ReverseTree.new(base_tree: self, paths: paths_for(items))
+    end
+
     def node_key_for(record)
       if adapter_mode?
         adapter.node_key_for(record, id_method: id_method)

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -91,6 +91,28 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include("project_3:grandchild")
     end
 
+    it "renders a ReverseTree through tree_view_rows helper" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      reverse_tree = tree.reverse_tree_for([grandchild])
+      render_state = TreeView::RenderState.new(
+        tree: reverse_tree,
+        root_items: reverse_tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_3"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).not_to include('id="project_4"')
+      expect(rendered).to include("project_3:grandchild")
+      expect(rendered).to include("project_2:child")
+      expect(rendered).to include("project_1:root")
+    end
+
     it "renders row class and data attributes from RenderState builders" do
       tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
       render_state = TreeView::RenderState.new(

--- a/spec/lib/tree_view/reverse_tree_spec.rb
+++ b/spec/lib/tree_view/reverse_tree_spec.rb
@@ -1,0 +1,79 @@
+require "spec_helper"
+
+RSpec.describe TreeView::ReverseTree do
+  ReverseTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+  def build_base_tree(records)
+    TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) })
+  end
+
+  it "builds a reverse direction tree from paths" do
+    root = ReverseTreeNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = ReverseTreeNode.new(id: 2, parent_item_id: 1, name: "parent")
+    child = ReverseTreeNode.new(id: 3, parent_item_id: 2, name: "child")
+    base_tree = build_base_tree([root, parent, child])
+
+    reverse_tree = base_tree.reverse_tree_for([child])
+
+    expect(reverse_tree.root_items).to eq([child])
+    expect(reverse_tree.children_for(child)).to eq([parent])
+    expect(reverse_tree.children_for(parent)).to eq([root])
+    expect(reverse_tree.children_for(root)).to eq([])
+  end
+
+  it "keeps orphan paths as root items" do
+    orphan = ReverseTreeNode.new(id: 1, parent_item_id: 999, name: "orphan")
+    base_tree = build_base_tree([orphan])
+
+    reverse_tree = base_tree.reverse_tree_for([orphan])
+
+    expect(reverse_tree.root_items).to eq([orphan])
+    expect(reverse_tree.children_for(orphan)).to eq([])
+  end
+
+  it "delegates node keys and sorting to the base tree" do
+    child_b = ReverseTreeNode.new(id: 2, parent_item_id: nil, name: "child-b")
+    child_a = ReverseTreeNode.new(id: 1, parent_item_id: nil, name: "child-a")
+    base_tree = build_base_tree([child_b, child_a])
+
+    reverse_tree = base_tree.reverse_tree_for([child_b, child_a])
+
+    expect(reverse_tree.node_key_for(child_a)).to eq(base_tree.node_key_for(child_a))
+    expect(reverse_tree.root_items).to eq([child_a, child_b])
+  end
+
+  it "attaches shared ancestors only to the first encountered reverse path" do
+    root = ReverseTreeNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = ReverseTreeNode.new(id: 2, parent_item_id: 1, name: "parent")
+    child_a = ReverseTreeNode.new(id: 3, parent_item_id: 2, name: "child-a")
+    child_b = ReverseTreeNode.new(id: 4, parent_item_id: 2, name: "child-b")
+    base_tree = build_base_tree([root, parent, child_a, child_b])
+
+    reverse_tree = base_tree.reverse_tree_for([child_a, child_b])
+
+    expect(reverse_tree.root_items).to eq([child_a, child_b])
+    expect(reverse_tree.children_for(child_a)).to eq([parent])
+    expect(reverse_tree.children_for(child_b)).to eq([])
+    expect(reverse_tree.children_for(parent)).to eq([root])
+  end
+
+  it "calculates descendant counts within the reverse tree only" do
+    root = ReverseTreeNode.new(id: 1, parent_item_id: nil, name: "root")
+    parent = ReverseTreeNode.new(id: 2, parent_item_id: 1, name: "parent")
+    child = ReverseTreeNode.new(id: 3, parent_item_id: 2, name: "child")
+    base_tree = build_base_tree([root, parent, child])
+
+    reverse_tree = base_tree.reverse_tree_for([child])
+
+    expect(reverse_tree.descendant_counts[reverse_tree.node_key_for(child)]).to eq(2)
+    expect(reverse_tree.descendant_counts[reverse_tree.node_key_for(parent)]).to eq(1)
+    expect(reverse_tree.descendant_counts[reverse_tree.node_key_for(root)]).to eq(0)
+  end
+
+  it "raises a records mode error through parent path helpers for resolver mode" do
+    root = ReverseTreeNode.new(id: 1, parent_item_id: nil, name: "root")
+    tree = TreeView::Tree.new(roots: [root], children_resolver: ->(_node) { [] })
+
+    expect { tree.reverse_tree_for([root]) }.to raise_error(ArgumentError, /records mode/)
+  end
+end


### PR DESCRIPTION
## Summary

- Add `TreeView::ReverseTree` for child-to-parent rendering
- Add `Tree#reverse_tree_for(items)` for records-mode parent paths
- Keep the interface compatible with existing `RenderState` / `tree_view_rows`
- Avoid duplicate DOM IDs by attaching shared ancestors only to the first encountered reverse path
- Add unit specs for reverse tree behavior and integration spec for rendering through existing partials
- Document the difference between `path_tree_for` and `reverse_tree_for`

Closes #14

## Notes

I could not run the local RSpec suite in this environment because the container cannot resolve `github.com`. The branch diff was checked via the GitHub connector.