### PR TITLE
Add grouped RenderState options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -281,10 +281,49 @@ render_state = TreeView::RenderState.new(
 | `max_toggle_depth_from_root:` | no | root基準で、開閉操作時にまとめて扱う最大depth |
 | `max_toggle_leaf_distance:` | no | leaf基準で、開閉操作時にまとめて扱う最大leaf距離 |
 | `expanded_keys:` | no | 初期表示時に展開するnode_key配列 |
+| `initial_expansion:` | no | 初期展開状態をまとめるHash相当のオプション |
+| `render_scope:` | no | 描画対象範囲をまとめるHash相当のオプション |
+| `toggle_scope:` | no | 開閉操作範囲をまとめるHash相当のオプション |
 | `row_class_builder:` | no | `tr` に付与するCSS classを返すcallable |
 | `row_data_builder:` | no | `tr` に付与するdata属性Hashを返すcallable |
 
 `effective_initial_state` は、画面固有指定、global config、既定値の順で解決します。
+
+scope / expansion 系の設定は、従来の個別引数に加えて、以下の grouped option でも指定できます。
+個別引数と grouped option を同時に指定した場合は、後方互換性のため個別引数を優先します。
+未知のkeyを含む場合は、設定ミスに気づきやすいよう `ArgumentError` を発生させます。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "projects/tree_columns",
+  ui_config: tree_ui,
+  initial_expansion: {
+    default: :expanded,
+    max_depth: 2,
+    expanded_keys: [root_key, child_key]
+  },
+  render_scope: {
+    max_depth: 3,
+    max_leaf_distance: 2
+  },
+  toggle_scope: {
+    max_depth_from_root: 2,
+    max_leaf_distance: 1
+  }
+)
+```
+
+| grouped option | 許可key | 対応する個別引数 |
+|---|---|---|
+| `initial_expansion:` | `:default` | `initial_state:` |
+| `initial_expansion:` | `:max_depth` | `max_initial_depth:` |
+| `initial_expansion:` | `:expanded_keys` | `expanded_keys:` |
+| `render_scope:` | `:max_depth` | `max_render_depth:` |
+| `render_scope:` | `:max_leaf_distance` | `max_leaf_distance:` |
+| `toggle_scope:` | `:max_depth_from_root` | `max_toggle_depth_from_root:` |
+| `toggle_scope:` | `:max_leaf_distance` | `max_toggle_leaf_distance:` |
 
 `max_initial_depth` は `nil` または `0` 以上のIntegerを指定します。
 `nil` の場合はdepth制限なし、`0` の場合はrootのみ、`1` の場合はrootとそのchildrenまでを初期HTMLに描画します。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,6 +72,60 @@ tree_ui = TreeView::UiConfigBuilder.new(context: view_context, node_prefix: "ite
 
 `initial_state` は省略できます。省略した場合は global config、さらに未設定なら `:expanded` が使われます。
 
+### grouped optionで指定する
+
+描画範囲・初期展開・開閉範囲は、個別引数の代わりに概念単位でまとめて指定できます。
+
+```ruby
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: @tree_ui,
+  initial_expansion: {
+    default: :collapsed,
+    max_depth: 2,
+    expanded_keys: expanded_keys
+  },
+  render_scope: {
+    max_depth: 3,
+    max_leaf_distance: 2
+  },
+  toggle_scope: {
+    max_depth_from_root: 2,
+    max_leaf_distance: 1
+  }
+)
+```
+
+対応関係は以下です。
+
+| grouped option | 個別引数 | 意味 |
+|---|---|---|
+| `initial_expansion[:default]` | `initial_state` | 初期状態。`:expanded` / `:collapsed` |
+| `initial_expansion[:max_depth]` | `max_initial_depth` | 初期HTMLで展開描画する最大depth |
+| `initial_expansion[:expanded_keys]` | `expanded_keys` | 初期表示時に展開するnode_key配列 |
+| `render_scope[:max_depth]` | `max_render_depth` | root基準の描画対象最大depth |
+| `render_scope[:max_leaf_distance]` | `max_leaf_distance` | leaf基準の描画対象最大distance |
+| `toggle_scope[:max_depth_from_root]` | `max_toggle_depth_from_root` | root基準の開閉操作範囲 |
+| `toggle_scope[:max_leaf_distance]` | `max_toggle_leaf_distance` | leaf基準の開閉操作範囲 |
+
+個別引数とgrouped optionを同時に指定した場合は、後方互換性のため個別引数を優先します。
+
+```ruby
+TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: @tree_ui,
+  max_render_depth: 1,
+  render_scope: { max_depth: 3 }
+)
+# => max_render_depth は 1 として扱われる
+```
+
+未知のkeyを含む場合は、設定ミスに気づきやすいよう `ArgumentError` を発生させます。
+
 ## Controller例
 
 ```ruby

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -3,6 +3,9 @@
 module TreeView
   class RenderState
     VALID_INITIAL_STATES = Configuration::VALID_INITIAL_STATES
+    VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys].freeze
+    VALID_RENDER_SCOPE_KEYS = %i[max_depth max_leaf_distance].freeze
+    VALID_TOGGLE_SCOPE_KEYS = %i[max_depth_from_root max_leaf_distance].freeze
 
     attr_reader :tree,
                 :root_items,
@@ -29,20 +32,27 @@ module TreeView
                    max_leaf_distance: nil,
                    max_toggle_depth_from_root: nil,
                    max_toggle_leaf_distance: nil,
-                   expanded_keys: [],
+                   expanded_keys: nil,
+                   initial_expansion: nil,
+                   render_scope: nil,
+                   toggle_scope: nil,
                    row_class_builder: nil,
                    row_data_builder: nil)
+      initial_expansion_options = normalize_options(initial_expansion, :initial_expansion, VALID_INITIAL_EXPANSION_KEYS)
+      render_scope_options = normalize_options(render_scope, :render_scope, VALID_RENDER_SCOPE_KEYS)
+      toggle_scope_options = normalize_options(toggle_scope, :toggle_scope, VALID_TOGGLE_SCOPE_KEYS)
+
       @tree = tree
       @root_items = root_items
       @row_partial = row_partial
       @ui_config = ui_config
-      @initial_state = normalize_initial_state(initial_state)
-      @max_initial_depth = normalize_non_negative_integer(max_initial_depth, :max_initial_depth)
-      @max_render_depth = normalize_non_negative_integer(max_render_depth, :max_render_depth)
-      @max_leaf_distance = normalize_non_negative_integer(max_leaf_distance, :max_leaf_distance)
-      @max_toggle_depth_from_root = normalize_non_negative_integer(max_toggle_depth_from_root, :max_toggle_depth_from_root)
-      @max_toggle_leaf_distance = normalize_non_negative_integer(max_toggle_leaf_distance, :max_toggle_leaf_distance)
-      @expanded_keys = Array(expanded_keys).freeze
+      @initial_state = normalize_initial_state(resolve_option(initial_state, initial_expansion_options[:default]))
+      @max_initial_depth = normalize_non_negative_integer(resolve_option(max_initial_depth, initial_expansion_options[:max_depth]), :max_initial_depth)
+      @max_render_depth = normalize_non_negative_integer(resolve_option(max_render_depth, render_scope_options[:max_depth]), :max_render_depth)
+      @max_leaf_distance = normalize_non_negative_integer(resolve_option(max_leaf_distance, render_scope_options[:max_leaf_distance]), :max_leaf_distance)
+      @max_toggle_depth_from_root = normalize_non_negative_integer(resolve_option(max_toggle_depth_from_root, toggle_scope_options[:max_depth_from_root]), :max_toggle_depth_from_root)
+      @max_toggle_leaf_distance = normalize_non_negative_integer(resolve_option(max_toggle_leaf_distance, toggle_scope_options[:max_leaf_distance]), :max_toggle_leaf_distance)
+      @expanded_keys = Array(resolve_option(expanded_keys, initial_expansion_options[:expanded_keys])).freeze
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
 
@@ -56,6 +66,23 @@ module TreeView
     end
 
     private
+
+    def resolve_option(individual_value, grouped_value)
+      individual_value.nil? ? grouped_value : individual_value
+    end
+
+    def normalize_options(value, name, valid_keys)
+      return {} if value.nil?
+      raise ArgumentError, "#{name} must respond to to_h" unless value.respond_to?(:to_h)
+
+      options = value.to_h.transform_keys(&:to_sym)
+      invalid_keys = options.keys - valid_keys
+      if invalid_keys.any?
+        raise ArgumentError, "#{name} contains unknown keys: #{invalid_keys.join(', ')}"
+      end
+
+      options
+    end
 
     def normalize_initial_state(value)
       return nil if value.nil?

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -148,6 +148,117 @@ RSpec.describe TreeView::RenderState do
     expect(state.expanded_keys).to eq([1, 2])
   end
 
+  it "stores grouped initial_expansion options" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      initial_expansion: {
+        default: :collapsed,
+        max_depth: 2,
+        expanded_keys: [1, 2]
+      }
+    )
+
+    expect(state.initial_state).to eq(:collapsed)
+    expect(state.max_initial_depth).to eq(2)
+    expect(state.expanded_keys).to eq([1, 2])
+  end
+
+  it "stores grouped render_scope options" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      render_scope: {
+        max_depth: 3,
+        max_leaf_distance: 2
+      }
+    )
+
+    expect(state.max_render_depth).to eq(3)
+    expect(state.max_leaf_distance).to eq(2)
+  end
+
+  it "stores grouped toggle_scope options" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      toggle_scope: {
+        max_depth_from_root: 3,
+        max_leaf_distance: 2
+      }
+    )
+
+    expect(state.max_toggle_depth_from_root).to eq(3)
+    expect(state.max_toggle_leaf_distance).to eq(2)
+  end
+
+  it "prefers individual options over grouped options" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      initial_state: :expanded,
+      max_initial_depth: 1,
+      max_render_depth: 1,
+      max_leaf_distance: 1,
+      max_toggle_depth_from_root: 1,
+      max_toggle_leaf_distance: 1,
+      expanded_keys: [9],
+      initial_expansion: {
+        default: :collapsed,
+        max_depth: 2,
+        expanded_keys: [1, 2]
+      },
+      render_scope: {
+        max_depth: 3,
+        max_leaf_distance: 2
+      },
+      toggle_scope: {
+        max_depth_from_root: 3,
+        max_leaf_distance: 2
+      }
+    )
+
+    expect(state.initial_state).to eq(:expanded)
+    expect(state.max_initial_depth).to eq(1)
+    expect(state.max_render_depth).to eq(1)
+    expect(state.max_leaf_distance).to eq(1)
+    expect(state.max_toggle_depth_from_root).to eq(1)
+    expect(state.max_toggle_leaf_distance).to eq(1)
+    expect(state.expanded_keys).to eq([9])
+  end
+
+  it "rejects unknown grouped option keys" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        render_scope: { max_depth: 2, unknown: true }
+      )
+    end.to raise_error(ArgumentError, /render_scope contains unknown keys: unknown/)
+  end
+
+  it "rejects non hash-like grouped options" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        toggle_scope: :invalid
+      )
+    end.to raise_error(ArgumentError, /toggle_scope must respond to to_h/)
+  end
+
   it "stores row attribute builders when given" do
     row_class_builder = ->(item) { item.name }
     row_data_builder = ->(item) { { name: item.name } }


### PR DESCRIPTION
## Summary

- Add grouped `RenderState` options:
  - `initial_expansion`
  - `render_scope`
  - `toggle_scope`
- Keep existing individual keyword arguments backward-compatible
- Prefer individual keyword arguments when both individual and grouped options are specified
- Validate unknown grouped option keys to catch typos
- Add RenderState specs for grouped options, precedence, and validation
- Document the grouped option API in `docs/api.md` and `docs/usage.md`

Closes #46

## Notes

I could not run the local RSpec suite in this environment because the container cannot resolve `github.com`. The branch diff was checked via the GitHub connector.