### PR TITLE
Add checkbox selection API

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module TreeViewHelper
   def tree_view_rows(render_state, mode: nil, collapsed: nil)
     previous_tree_ui = @tree_ui
@@ -18,6 +20,9 @@ module TreeViewHelper
         max_toggle_depth_from_root: render_state.max_toggle_depth_from_root,
         max_toggle_leaf_distance: render_state.max_toggle_leaf_distance,
         expanded_keys: render_state.expanded_keys,
+        selection_enabled: render_state.selection_enabled?,
+        selection_payload_builder: render_state.selection_payload_builder,
+        selection_checkbox_name: render_state.selection_checkbox_name,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder
       }
@@ -38,6 +43,10 @@ module TreeViewHelper
     resolved_ui(ui).show_button_dom_id(item)
   end
 
+  def tree_selection_checkbox_dom_id(item, ui: @tree_ui)
+    "#{tree_node_dom_id(item, ui: ui)}_selection"
+  end
+
   def tree_row_classes(item, builder = nil)
     Array(builder&.call(item)).flatten.compact_blank
   end
@@ -48,6 +57,17 @@ module TreeViewHelper
     return data.to_h if data.respond_to?(:to_h)
 
     raise ArgumentError, "row_data_builder must return a Hash-like object"
+  end
+
+  def tree_selection_payload(item, tree, builder = nil)
+    payload = builder ? builder.call(item) : default_tree_selection_payload(item, tree)
+    return payload.to_h if payload.respond_to?(:to_h)
+
+    raise ArgumentError, "selection_payload_builder must return a Hash-like object"
+  end
+
+  def tree_selection_value(item, tree, builder = nil)
+    JSON.generate(tree_selection_payload(item, tree, builder))
   end
 
   def tree_initial_depth_boundary?(depth, max_initial_depth)
@@ -153,6 +173,14 @@ module TreeViewHelper
 
   def default_tree_ui
     nil
+  end
+
+  def default_tree_selection_payload(item, tree)
+    {
+      key: tree.node_key_for(item),
+      id: item.respond_to?(:id) ? item.id : tree.node_key_for(item),
+      type: item.class.name
+    }
   end
 
   def tree_max_depth(tree)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -7,8 +7,11 @@
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
+<% selection_enabled = local_assigns[:selection_enabled] %>
+<% selection_payload_builder = local_assigns[:selection_payload_builder] %>
+<% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -8,6 +8,9 @@
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
+<% selection_enabled = local_assigns[:selection_enabled] %>
+<% selection_payload_builder = local_assigns[:selection_payload_builder] %>
+<% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
 <% explicitly_expanded = tree_expanded_key?(item, tree, expanded_keys) %>
 <% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
 <% render_children = tree_render_children?(depth, max_render_depth) %>
@@ -24,10 +27,13 @@
 <% hidden_count = render_children && effectively_collapsed && descendant_count.positive? && render_self ? descendant_count : nil %>
 <% if render_self %>
   <%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
+    <% if selection_enabled %>
+      <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name %>
+    <% end %>
     <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
     <%= render row_partial, item: item %>
   <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_selection_cell.html.erb
+++ b/app/views/tree_view/_tree_selection_cell.html.erb
@@ -1,0 +1,10 @@
+<td class="tree-selection-cell">
+  <%= check_box_tag selection_checkbox_name,
+                    tree_selection_value(item, tree, selection_payload_builder),
+                    false,
+                    id: tree_selection_checkbox_dom_id(item),
+                    class: "tree-selection-checkbox",
+                    data: {
+                      tree_selection_payload: tree_selection_payload(item, tree, selection_payload_builder)
+                    } %>
+</td>

--- a/docs/api.md
+++ b/docs/api.md
@@ -284,6 +284,10 @@ render_state = TreeView::RenderState.new(
 | `initial_expansion:` | no | 初期展開状態をまとめるHash相当のオプション |
 | `render_scope:` | no | 描画対象範囲をまとめるHash相当のオプション |
 | `toggle_scope:` | no | 開閉操作範囲をまとめるHash相当のオプション |
+| `selectable:` | no | checkbox選択を有効にするか。`true` / `false` |
+| `selection_payload_builder:` | no | checkbox valueに入れるpayload Hashを返すcallable |
+| `selection_checkbox_name:` | no | checkboxのname属性。既定値は `selected_nodes[]` |
+| `selection:` | no | checkbox selectionをまとめるHash相当のオプション |
 | `row_class_builder:` | no | `tr` に付与するCSS classを返すcallable |
 | `row_data_builder:` | no | `tr` に付与するdata属性Hashを返すcallable |
 
@@ -324,6 +328,39 @@ render_state = TreeView::RenderState.new(
 | `render_scope:` | `:max_leaf_distance` | `max_leaf_distance:` |
 | `toggle_scope:` | `:max_depth_from_root` | `max_toggle_depth_from_root:` |
 | `toggle_scope:` | `:max_leaf_distance` | `max_toggle_leaf_distance:` |
+
+`selection:` ではcheckbox selectionをまとめて指定できます。
+個別引数と `selection:` を同時に指定した場合は、後方互換性と明示性のため個別引数を優先します。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "projects/tree_columns",
+  ui_config: tree_ui,
+  selection: {
+    enabled: true,
+    checkbox_name: "selected_nodes[]",
+    payload_builder: ->(item) {
+      {
+        key: tree.node_key_for(item),
+        id: item.id,
+        type: item.class.name
+      }
+    }
+  }
+)
+```
+
+| selection key | 対応する個別引数 | 説明 |
+|---|---|---|
+| `:enabled` | `selectable:` | checkbox列を描画するか |
+| `:payload_builder` | `selection_payload_builder:` | checkbox valueに入れるpayload Hashを返すcallable |
+| `:checkbox_name` | `selection_checkbox_name:` | checkboxのname属性 |
+
+`selection_payload_builder` を省略した場合は、`key` / `id` / `type` を持つpayloadを生成します。
+checkboxの `value` にはJSON文字列が入ります。
+TreeView gem はcheckboxの描画と選択payloadの受け渡しまでを担当し、削除・移動・関連付けなどの一括処理はhost app側で実装します。
 
 `max_initial_depth` は `nil` または `0` 以上のIntegerを指定します。
 `nil` の場合はdepth制限なし、`0` の場合はrootのみ、`1` の場合はrootとそのchildrenまでを初期HTMLに描画します。
@@ -462,6 +499,9 @@ viewから使う補助helperです。
 | `tree_node_dom_id(item_or_id)` | nodeのDOM IDを返す |
 | `tree_button_dom_id(item)` | toggle cell用DOM IDを返す |
 | `tree_show_button_dom_id(item)` | show button用DOM IDを返す |
+| `tree_selection_checkbox_dom_id(item)` | selection checkbox用DOM IDを返す |
+| `tree_selection_payload(item, tree, builder = nil)` | selection checkbox用payload Hashを返す |
+| `tree_selection_value(item, tree, builder = nil)` | selection checkboxのvalue用JSON文字列を返す |
 | `tree_hide_descendants_path(item, display_depth, scope: 'all')` | 閉じるpathを返す |
 | `tree_show_descendants_path(item, toggle_depth, scope: 'all')` | 開くpathを返す |
 | `tree_toggle_all_path(state:)` | 全体開閉pathを返す |
@@ -492,6 +532,7 @@ TreeView本体は以下のpartialを提供します。
 
 - `tree_view/tree_row`
 - `tree_view/tree_children`
+- `tree_view/tree_selection_cell`
 - `tree_view/tree_toggle_cell`
 - `tree_view/tree_toggle_content`
 - `tree_view/tree_toggle_content_static`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -295,6 +295,47 @@ reverse_tree = base_tree.reverse_tree_for(matched_documents)
 | `path_tree_for(items)` | root → parent → matched item | 通常の階層構造内で検索結果を確認する |
 | `reverse_tree_for(items)` | matched item → parent → root | 子node一覧から親方向へ辿る |
 
+### 複数nodeをcheckboxで選択する
+
+TreeView上で複数nodeを選択し、host app側のcontrollerで一括処理したい場合は `selection:` を指定します。
+
+```ruby
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: @tree_ui,
+  selection: {
+    enabled: true,
+    checkbox_name: "selected_nodes[]",
+    payload_builder: ->(document) {
+      {
+        key: tree.node_key_for(document),
+        id: document.id,
+        type: document.class.name
+      }
+    }
+  }
+)
+```
+
+選択checkboxの `value` にはJSON文字列が入ります。
+
+```json
+{"key":1,"id":1,"type":"Document"}
+```
+
+host app側では、通常のformやTurbo formから送られた `params[:selected_nodes]` をparseして一括処理します。
+
+```ruby
+selected_nodes = Array(params[:selected_nodes]).map { |value| JSON.parse(value) }
+selected_ids = selected_nodes.map { |node| node["id"] }
+```
+
+TreeView gem は、checkboxの描画と選択payloadの受け渡しまでを担当します。
+削除・移動・関連付けなどの業務処理やAPI呼び出しはhost app側で実装します。
+親子連動選択、indeterminate表示、disabled状態、選択状態の永続化は初期実装の対象外です。
+
 ### 初期状態を折りたたみにする
 
 最初はrootだけ表示し、ユーザー操作で展開したい場合は `initial_state: :collapsed` を指定します。

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -6,6 +6,8 @@ module TreeView
     VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys].freeze
     VALID_RENDER_SCOPE_KEYS = %i[max_depth max_leaf_distance].freeze
     VALID_TOGGLE_SCOPE_KEYS = %i[max_depth_from_root max_leaf_distance].freeze
+    VALID_SELECTION_KEYS = %i[enabled payload_builder checkbox_name].freeze
+    DEFAULT_SELECTION_CHECKBOX_NAME = "selected_nodes[]"
 
     attr_reader :tree,
                 :root_items,
@@ -18,6 +20,9 @@ module TreeView
                 :max_toggle_depth_from_root,
                 :max_toggle_leaf_distance,
                 :expanded_keys,
+                :selection_enabled,
+                :selection_payload_builder,
+                :selection_checkbox_name,
                 :row_class_builder,
                 :row_data_builder
 
@@ -36,11 +41,16 @@ module TreeView
                    initial_expansion: nil,
                    render_scope: nil,
                    toggle_scope: nil,
+                   selectable: nil,
+                   selection_payload_builder: nil,
+                   selection_checkbox_name: nil,
+                   selection: nil,
                    row_class_builder: nil,
                    row_data_builder: nil)
       initial_expansion_options = normalize_options(initial_expansion, :initial_expansion, VALID_INITIAL_EXPANSION_KEYS)
       render_scope_options = normalize_options(render_scope, :render_scope, VALID_RENDER_SCOPE_KEYS)
       toggle_scope_options = normalize_options(toggle_scope, :toggle_scope, VALID_TOGGLE_SCOPE_KEYS)
+      selection_options = normalize_options(selection, :selection, VALID_SELECTION_KEYS)
 
       @tree = tree
       @root_items = root_items
@@ -53,11 +63,19 @@ module TreeView
       @max_toggle_depth_from_root = normalize_non_negative_integer(resolve_option(max_toggle_depth_from_root, toggle_scope_options[:max_depth_from_root]), :max_toggle_depth_from_root)
       @max_toggle_leaf_distance = normalize_non_negative_integer(resolve_option(max_toggle_leaf_distance, toggle_scope_options[:max_leaf_distance]), :max_toggle_leaf_distance)
       @expanded_keys = Array(resolve_option(expanded_keys, initial_expansion_options[:expanded_keys])).freeze
+      @selection_enabled = normalize_boolean(resolve_option(selectable, selection_options[:enabled]), :selectable)
+      @selection_payload_builder = resolve_option(selection_payload_builder, selection_options[:payload_builder])
+      @selection_checkbox_name = resolve_option(selection_checkbox_name, selection_options[:checkbox_name]) || DEFAULT_SELECTION_CHECKBOX_NAME
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
 
       validate_builder!(row_class_builder, :row_class_builder)
       validate_builder!(row_data_builder, :row_data_builder)
+      validate_builder!(selection_payload_builder, :selection_payload_builder)
+    end
+
+    def selection_enabled?
+      selection_enabled == true
     end
 
     # 画面固有指定があればそれを優先し、なければ global config を使う。
@@ -98,6 +116,13 @@ module TreeView
       return value if value.is_a?(Integer) && value >= 0
 
       raise ArgumentError, "#{name} must be a non-negative Integer"
+    end
+
+    def normalize_boolean(value, name)
+      return false if value.nil?
+      return value if value == true || value == false
+
+      raise ArgumentError, "#{name} must be true or false"
     end
 
     def validate_builder!(builder, name)

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -71,7 +71,7 @@ module TreeView
 
       validate_builder!(row_class_builder, :row_class_builder)
       validate_builder!(row_data_builder, :row_data_builder)
-      validate_builder!(selection_payload_builder, :selection_payload_builder)
+      validate_builder!(@selection_payload_builder, :selection_payload_builder)
     end
 
     def selection_enabled?

--- a/spec/integration/tree_view_selection_integration_spec.rb
+++ b/spec/integration/tree_view_selection_integration_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+require "action_view"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe "TreeView selection integration" do
+  SelectionNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+  let(:root) { SelectionNode.new(id: 1, parent_item_id: nil, name: "root") }
+  let(:child) { SelectionNode.new(id: 2, parent_item_id: 1, name: "child") }
+  let(:grandchild) { SelectionNode.new(id: 3, parent_item_id: 2, name: "grandchild") }
+  let(:tree) { TreeView::Tree.new(records: [root, child, grandchild], parent_id_method: :parent_item_id) }
+  let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
+  let(:host_view_dir) { Dir.mktmpdir("tree_view_host_views") }
+
+  before do
+    FileUtils.mkdir_p(File.join(host_view_dir, "projects"))
+    File.write(
+      File.join(host_view_dir, "projects", "_tree_columns.html.erb"),
+      '<td class="project-cell"><%= item.name %></td>'
+    )
+  end
+
+  after do
+    FileUtils.remove_entry(host_view_dir) if Dir.exist?(host_view_dir)
+  end
+
+  def build_view
+    view = ActionView::Base.with_empty_template_cache.with_view_paths([host_view_dir, gem_view_path], {}, nil)
+    view.extend(TreeViewHelper)
+    view
+  end
+
+  def render_rows(render_tree, root_items)
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+    render_state = TreeView::RenderState.new(
+      tree: render_tree,
+      root_items: root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      selection: {
+        enabled: true,
+        checkbox_name: "selected_documents[]",
+        payload_builder: ->(item) { { key: render_tree.node_key_for(item), id: item.id, type: item.class.name } }
+      }
+    )
+
+    build_view.tree_view_rows(render_state)
+  end
+
+  it "renders selection checkboxes with JSON payload values" do
+    rendered = render_rows(tree, tree.root_items)
+
+    expect(rendered).to include('class="tree-selection-cell"')
+    expect(rendered).to include('class="tree-selection-checkbox"')
+    expect(rendered).to include('name="selected_documents[]"')
+    expect(rendered).to include('id="project_1_selection"')
+    expect(rendered).to include('&quot;id&quot;:1')
+    expect(rendered).to include('&quot;type&quot;:&quot;TreeView selection integration::SelectionNode&quot;')
+  end
+
+  it "renders selection checkboxes for PathTree rows" do
+    path_tree = tree.path_tree_for([grandchild])
+
+    rendered = render_rows(path_tree, path_tree.root_items)
+
+    expect(rendered).to include('id="project_1_selection"')
+    expect(rendered).to include('id="project_2_selection"')
+    expect(rendered).to include('id="project_3_selection"')
+  end
+
+  it "renders selection checkboxes for ReverseTree rows" do
+    reverse_tree = tree.reverse_tree_for([grandchild])
+
+    rendered = render_rows(reverse_tree, reverse_tree.root_items)
+
+    expect(rendered).to include('id="project_3_selection"')
+    expect(rendered).to include('id="project_2_selection"')
+    expect(rendered).to include('id="project_1_selection"')
+  end
+end

--- a/spec/integration/tree_view_selection_integration_spec.rb
+++ b/spec/integration/tree_view_selection_integration_spec.rb
@@ -55,8 +55,9 @@ RSpec.describe "TreeView selection integration" do
     expect(rendered).to include('class="tree-selection-checkbox"')
     expect(rendered).to include('name="selected_documents[]"')
     expect(rendered).to include('id="project_1_selection"')
+    expect(rendered).to include('&quot;key&quot;:1')
     expect(rendered).to include('&quot;id&quot;:1')
-    expect(rendered).to include('&quot;type&quot;:&quot;TreeView selection integration::SelectionNode&quot;')
+    expect(rendered).to include('&quot;type&quot;:')
   end
 
   it "renders selection checkboxes for PathTree rows" do

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -198,6 +198,92 @@ RSpec.describe TreeView::RenderState do
     expect(state.max_toggle_leaf_distance).to eq(2)
   end
 
+  it "stores selection options" do
+    payload_builder = ->(item) { { id: item.id } }
+
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      selectable: true,
+      selection_payload_builder: payload_builder,
+      selection_checkbox_name: "documents[]"
+    )
+
+    expect(state.selection_enabled?).to eq(true)
+    expect(state.selection_payload_builder).to eq(payload_builder)
+    expect(state.selection_checkbox_name).to eq("documents[]")
+  end
+
+  it "stores grouped selection options" do
+    payload_builder = ->(item) { { id: item.id } }
+
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      selection: {
+        enabled: true,
+        payload_builder: payload_builder,
+        checkbox_name: "documents[]"
+      }
+    )
+
+    expect(state.selection_enabled?).to eq(true)
+    expect(state.selection_payload_builder).to eq(payload_builder)
+    expect(state.selection_checkbox_name).to eq("documents[]")
+  end
+
+  it "uses the default selection checkbox name" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      selectable: true
+    )
+
+    expect(state.selection_checkbox_name).to eq("selected_nodes[]")
+  end
+
+  it "rejects invalid selection options" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        selection: { enabled: true, unknown: true }
+      )
+    end.to raise_error(ArgumentError, /selection contains unknown keys: unknown/)
+  end
+
+  it "rejects invalid selectable values" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        selectable: "true"
+      )
+    end.to raise_error(ArgumentError, /selectable must be true or false/)
+  end
+
+  it "rejects invalid selection payload builders" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        selection: { enabled: true, payload_builder: :invalid }
+      )
+    end.to raise_error(ArgumentError, /selection_payload_builder/)
+  end
+
   it "prefers individual options over grouped options" do
     state = described_class.new(
       tree: tree,


### PR DESCRIPTION
## Summary

- Add checkbox selection options to `TreeView::RenderState`
  - `selectable`
  - `selection_payload_builder`
  - `selection_checkbox_name`
  - grouped `selection:` option
- Render a selection checkbox cell before the toggle cell when selection is enabled
- Store a JSON payload in each checkbox value so host apps can parse `params[:selected_nodes]`
- Add helper methods for selection checkbox DOM IDs and payload/value generation
- Support normal Tree, PathTree, and ReverseTree rendering
- Document the selection API and responsibility boundary in `docs/api.md` and `docs/usage.md`

Closes #48

## Scope

This PR intentionally keeps the gem responsibility limited to checkbox UI and selected payload delivery. Business actions such as delete, move, attach, publish, or API calls remain in the host Rails app.

Not included in this first implementation:

- parent/child linked selection
- indeterminate checkbox state
- disabled checkbox state
- persisted selection state

## Notes

I could not run the local RSpec suite in this environment because the container cannot resolve `github.com`. The branch diff was checked via the GitHub connector.