### PR TITLE
Add disabled state for checkbox selection

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -23,6 +23,8 @@ module TreeViewHelper
         selection_enabled: render_state.selection_enabled?,
         selection_payload_builder: render_state.selection_payload_builder,
         selection_checkbox_name: render_state.selection_checkbox_name,
+        selection_disabled_builder: render_state.selection_disabled_builder,
+        selection_disabled_reason_builder: render_state.selection_disabled_reason_builder,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder
       }
@@ -68,6 +70,16 @@ module TreeViewHelper
 
   def tree_selection_value(item, tree, builder = nil)
     JSON.generate(tree_selection_payload(item, tree, builder))
+  end
+
+  def tree_selection_disabled?(item, builder = nil)
+    builder ? builder.call(item) == true : false
+  end
+
+  def tree_selection_disabled_reason(item, builder = nil)
+    return nil unless builder
+
+    builder.call(item).presence
   end
 
   def tree_initial_depth_boundary?(depth, max_initial_depth)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -10,8 +10,10 @@
 <% selection_enabled = local_assigns[:selection_enabled] %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
 <% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
+<% selection_disabled_builder = local_assigns[:selection_disabled_builder] %>
+<% selection_disabled_reason_builder = local_assigns[:selection_disabled_reason_builder] %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -11,6 +11,8 @@
 <% selection_enabled = local_assigns[:selection_enabled] %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
 <% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
+<% selection_disabled_builder = local_assigns[:selection_disabled_builder] %>
+<% selection_disabled_reason_builder = local_assigns[:selection_disabled_reason_builder] %>
 <% explicitly_expanded = tree_expanded_key?(item, tree, expanded_keys) %>
 <% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
 <% render_children = tree_render_children?(depth, max_render_depth) %>
@@ -28,12 +30,12 @@
 <% if render_self %>
   <%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
     <% if selection_enabled %>
-      <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name %>
+      <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder %>
     <% end %>
     <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
     <%= render row_partial, item: item %>
   <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_selection_cell.html.erb
+++ b/app/views/tree_view/_tree_selection_cell.html.erb
@@ -1,10 +1,16 @@
+<% selection_disabled = tree_selection_disabled?(item, selection_disabled_builder) %>
+<% selection_disabled_reason = tree_selection_disabled_reason(item, selection_disabled_reason_builder) %>
+
 <td class="tree-selection-cell">
   <%= check_box_tag selection_checkbox_name,
                     tree_selection_value(item, tree, selection_payload_builder),
                     false,
                     id: tree_selection_checkbox_dom_id(item),
                     class: "tree-selection-checkbox",
+                    disabled: selection_disabled,
+                    title: selection_disabled_reason,
                     data: {
-                      tree_selection_payload: tree_selection_payload(item, tree, selection_payload_builder)
+                      tree_selection_payload: tree_selection_payload(item, tree, selection_payload_builder),
+                      tree_selection_disabled_reason: selection_disabled_reason
                     } %>
 </td>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -334,7 +334,30 @@ selected_ids = selected_nodes.map { |node| node["id"] }
 
 TreeView gem は、checkboxの描画と選択payloadの受け渡しまでを担当します。
 削除・移動・関連付けなどの業務処理やAPI呼び出しはhost app側で実装します。
-親子連動選択、indeterminate表示、disabled状態、選択状態の永続化は初期実装の対象外です。
+親子連動選択、indeterminate表示、選択状態の永続化は初期実装の対象外です。
+
+### nodeごとにcheckboxをdisabledにする
+
+選択できないnodeがある場合は、`disabled_builder` を使います。
+理由を表示したい場合は `disabled_reason_builder` も指定できます。
+
+```ruby
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: @tree_ui,
+  selection: {
+    enabled: true,
+    disabled_builder: ->(document) { document.archived? },
+    disabled_reason_builder: ->(document) {
+      document.archived? ? "アーカイブ済みのため選択できません" : nil
+    }
+  }
+)
+```
+
+`disabled_reason_builder` の戻り値は、checkboxの `title` と `data-tree-selection-disabled-reason` に出力されます。
 
 ### 初期状態を折りたたみにする
 

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -6,7 +6,7 @@ module TreeView
     VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys].freeze
     VALID_RENDER_SCOPE_KEYS = %i[max_depth max_leaf_distance].freeze
     VALID_TOGGLE_SCOPE_KEYS = %i[max_depth_from_root max_leaf_distance].freeze
-    VALID_SELECTION_KEYS = %i[enabled payload_builder checkbox_name].freeze
+    VALID_SELECTION_KEYS = %i[enabled payload_builder checkbox_name disabled_builder disabled_reason_builder].freeze
     DEFAULT_SELECTION_CHECKBOX_NAME = "selected_nodes[]"
 
     attr_reader :tree,
@@ -23,6 +23,8 @@ module TreeView
                 :selection_enabled,
                 :selection_payload_builder,
                 :selection_checkbox_name,
+                :selection_disabled_builder,
+                :selection_disabled_reason_builder,
                 :row_class_builder,
                 :row_data_builder
 
@@ -44,6 +46,8 @@ module TreeView
                    selectable: nil,
                    selection_payload_builder: nil,
                    selection_checkbox_name: nil,
+                   selection_disabled_builder: nil,
+                   selection_disabled_reason_builder: nil,
                    selection: nil,
                    row_class_builder: nil,
                    row_data_builder: nil)
@@ -66,12 +70,16 @@ module TreeView
       @selection_enabled = normalize_boolean(resolve_option(selectable, selection_options[:enabled]), :selectable)
       @selection_payload_builder = resolve_option(selection_payload_builder, selection_options[:payload_builder])
       @selection_checkbox_name = resolve_option(selection_checkbox_name, selection_options[:checkbox_name]) || DEFAULT_SELECTION_CHECKBOX_NAME
+      @selection_disabled_builder = resolve_option(selection_disabled_builder, selection_options[:disabled_builder])
+      @selection_disabled_reason_builder = resolve_option(selection_disabled_reason_builder, selection_options[:disabled_reason_builder])
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
 
       validate_builder!(row_class_builder, :row_class_builder)
       validate_builder!(row_data_builder, :row_data_builder)
       validate_builder!(@selection_payload_builder, :selection_payload_builder)
+      validate_builder!(@selection_disabled_builder, :selection_disabled_builder)
+      validate_builder!(@selection_disabled_reason_builder, :selection_disabled_reason_builder)
     end
 
     def selection_enabled?

--- a/spec/integration/tree_view_selection_integration_spec.rb
+++ b/spec/integration/tree_view_selection_integration_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "TreeView selection integration" do
     view
   end
 
-  def render_rows(render_tree, root_items)
+  def render_rows(render_tree, root_items, selection_options = {})
     tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
     render_state = TreeView::RenderState.new(
       tree: render_tree,
@@ -42,7 +42,7 @@ RSpec.describe "TreeView selection integration" do
         enabled: true,
         checkbox_name: "selected_documents[]",
         payload_builder: ->(item) { { key: render_tree.node_key_for(item), id: item.id, type: item.class.name } }
-      }
+      }.merge(selection_options)
     )
 
     build_view.tree_view_rows(render_state)
@@ -58,6 +58,20 @@ RSpec.describe "TreeView selection integration" do
     expect(rendered).to include('&quot;key&quot;:1')
     expect(rendered).to include('&quot;id&quot;:1')
     expect(rendered).to include('&quot;type&quot;:')
+  end
+
+  it "renders disabled selection checkboxes with reason attributes" do
+    rendered = render_rows(
+      tree,
+      tree.root_items,
+      disabled_builder: ->(item) { item.id == 2 },
+      disabled_reason_builder: ->(item) { item.id == 2 ? "Cannot select child" : nil }
+    )
+
+    expect(rendered).to include('id="project_2_selection"')
+    expect(rendered).to include('disabled="disabled"')
+    expect(rendered).to include('title="Cannot select child"')
+    expect(rendered).to include('data-tree-selection-disabled-reason="Cannot select child"')
   end
 
   it "renders selection checkboxes for PathTree rows" do

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -216,6 +216,26 @@ RSpec.describe TreeView::RenderState do
     expect(state.selection_checkbox_name).to eq("documents[]")
   end
 
+  it "stores selection disabled builders" do
+    disabled_builder = ->(item) { item.disabled? }
+    disabled_reason_builder = ->(item) { item.disabled? ? "disabled" : nil }
+
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      selection: {
+        enabled: true,
+        disabled_builder: disabled_builder,
+        disabled_reason_builder: disabled_reason_builder
+      }
+    )
+
+    expect(state.selection_disabled_builder).to eq(disabled_builder)
+    expect(state.selection_disabled_reason_builder).to eq(disabled_reason_builder)
+  end
+
   it "stores grouped selection options" do
     payload_builder = ->(item) { { id: item.id } }
 
@@ -282,6 +302,18 @@ RSpec.describe TreeView::RenderState do
         selection: { enabled: true, payload_builder: :invalid }
       )
     end.to raise_error(ArgumentError, /selection_payload_builder/)
+  end
+
+  it "rejects invalid selection disabled builders" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        selection: { enabled: true, disabled_builder: :invalid }
+      )
+    end.to raise_error(ArgumentError, /selection_disabled_builder/)
   end
 
   it "prefers individual options over grouped options" do


### PR DESCRIPTION
## Summary

- Add per-node disabled support to checkbox selection
  - `selection[:disabled_builder]`
  - `selection[:disabled_reason_builder]`
  - individual keyword arguments are also supported
- Render disabled selection checkboxes with:
  - `disabled` attribute
  - `title`
  - `data-tree-selection-disabled-reason`
- Add helper methods for disabled state and reason
- Add RenderState specs and selection integration specs
- Document usage in `docs/usage.md`

Closes #52

## Scope

This PR does not add parent/child linked selection or indeterminate checkbox state. It only handles whether each node can be selected and an optional reason for that disabled state.

## Notes

I could not run the local RSpec suite in this environment because the container cannot resolve `github.com`. The branch diff was checked via the GitHub connector.