### PR TITLE
Add collapsed keys for initial expansion

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -20,6 +20,7 @@ module TreeViewHelper
         max_toggle_depth_from_root: render_state.max_toggle_depth_from_root,
         max_toggle_leaf_distance: render_state.max_toggle_leaf_distance,
         expanded_keys: render_state.expanded_keys,
+        collapsed_keys: render_state.collapsed_keys,
         selection_enabled: render_state.selection_enabled?,
         selection_payload_builder: render_state.selection_payload_builder,
         selection_checkbox_name: render_state.selection_checkbox_name,
@@ -121,6 +122,10 @@ module TreeViewHelper
 
   def tree_expanded_key?(item, tree, expanded_keys)
     Array(expanded_keys).include?(tree.node_key_for(item))
+  end
+
+  def tree_collapsed_key?(item, tree, collapsed_keys)
+    Array(collapsed_keys).include?(tree.node_key_for(item))
   end
 
   def tree_depth_slots(depth)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -7,6 +7,7 @@
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
+<% collapsed_keys = local_assigns[:collapsed_keys] %>
 <% selection_enabled = local_assigns[:selection_enabled] %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
 <% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
@@ -16,5 +17,5 @@
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -8,6 +8,7 @@
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
+<% collapsed_keys = local_assigns[:collapsed_keys] %>
 <% selection_enabled = local_assigns[:selection_enabled] %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
 <% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
@@ -15,11 +16,12 @@
 <% selection_disabled_reason_builder = local_assigns[:selection_disabled_reason_builder] %>
 <% selection_selected_keys = local_assigns[:selection_selected_keys] %>
 <% explicitly_expanded = tree_expanded_key?(item, tree, expanded_keys) %>
+<% explicitly_collapsed = tree_collapsed_key?(item, tree, collapsed_keys) %>
 <% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
 <% render_children = tree_render_children?(depth, max_render_depth) %>
 <% render_self = tree_render_leaf_distance?(item, tree, max_leaf_distance) %>
 <% leaf_distance = tree_leaf_distance(item, tree) %>
-<% effectively_collapsed = !explicitly_expanded && (collapsed || depth_boundary) %>
+<% effectively_collapsed = explicitly_collapsed || (!explicitly_expanded && (collapsed || depth_boundary)) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
@@ -38,5 +40,5 @@
   <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,7 +85,8 @@ tree_ui = TreeView::UiConfigBuilder.new(context: view_context, node_prefix: "ite
   initial_expansion: {
     default: :collapsed,
     max_depth: 2,
-    expanded_keys: expanded_keys
+    expanded_keys: expanded_keys,
+    collapsed_keys: collapsed_keys
   },
   render_scope: {
     max_depth: 3,
@@ -105,6 +106,7 @@ tree_ui = TreeView::UiConfigBuilder.new(context: view_context, node_prefix: "ite
 | `initial_expansion[:default]` | `initial_state` | 初期状態。`:expanded` / `:collapsed` |
 | `initial_expansion[:max_depth]` | `max_initial_depth` | 初期HTMLで展開描画する最大depth |
 | `initial_expansion[:expanded_keys]` | `expanded_keys` | 初期表示時に展開するnode_key配列 |
+| `initial_expansion[:collapsed_keys]` | `collapsed_keys` | 初期表示時に折りたたむnode_key配列 |
 | `render_scope[:max_depth]` | `max_render_depth` | root基準の描画対象最大depth |
 | `render_scope[:max_leaf_distance]` | `max_leaf_distance` | leaf基準の描画対象最大distance |
 | `toggle_scope[:max_depth_from_root]` | `max_toggle_depth_from_root` | root基準の開閉操作範囲 |
@@ -413,6 +415,27 @@ expanded_keys = path.map { |document| tree.node_key_for(document) }
   expanded_keys: expanded_keys
 )
 ```
+
+### `collapsed_keys` で特定nodeだけ初期折りたたみにする
+
+基本は展開しつつ、特定node配下だけ初期表示で閉じたい場合は `collapsed_keys` を指定します。
+
+```ruby
+large_folder = Document.find(params[:large_folder_id])
+
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: @tree_ui,
+  initial_state: :expanded,
+  collapsed_keys: [tree.node_key_for(large_folder)]
+)
+```
+
+`collapsed_keys` は `tree.node_key_for(item)` と照合されます。
+同じnode_keyを `expanded_keys` と `collapsed_keys` の両方に指定した場合は、矛盾として `ArgumentError` になります。
+親nodeが `collapsed_keys` に含まれている場合、その配下の子nodeを `expanded_keys` に入れても初期HTMLには表示されません。
 
 ### `max_initial_depth` で初期HTMLの展開範囲を制御する
 

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -3,7 +3,7 @@
 module TreeView
   class RenderState
     VALID_INITIAL_STATES = Configuration::VALID_INITIAL_STATES
-    VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys].freeze
+    VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys collapsed_keys].freeze
     VALID_RENDER_SCOPE_KEYS = %i[max_depth max_leaf_distance].freeze
     VALID_TOGGLE_SCOPE_KEYS = %i[max_depth_from_root max_leaf_distance].freeze
     VALID_SELECTION_KEYS = %i[enabled payload_builder checkbox_name disabled_builder disabled_reason_builder selected_keys].freeze
@@ -20,6 +20,7 @@ module TreeView
                 :max_toggle_depth_from_root,
                 :max_toggle_leaf_distance,
                 :expanded_keys,
+                :collapsed_keys,
                 :selection_enabled,
                 :selection_payload_builder,
                 :selection_checkbox_name,
@@ -41,6 +42,7 @@ module TreeView
                    max_toggle_depth_from_root: nil,
                    max_toggle_leaf_distance: nil,
                    expanded_keys: nil,
+                   collapsed_keys: nil,
                    initial_expansion: nil,
                    render_scope: nil,
                    toggle_scope: nil,
@@ -69,6 +71,7 @@ module TreeView
       @max_toggle_depth_from_root = normalize_non_negative_integer(resolve_option(max_toggle_depth_from_root, toggle_scope_options[:max_depth_from_root]), :max_toggle_depth_from_root)
       @max_toggle_leaf_distance = normalize_non_negative_integer(resolve_option(max_toggle_leaf_distance, toggle_scope_options[:max_leaf_distance]), :max_toggle_leaf_distance)
       @expanded_keys = Array(resolve_option(expanded_keys, initial_expansion_options[:expanded_keys])).freeze
+      @collapsed_keys = Array(resolve_option(collapsed_keys, initial_expansion_options[:collapsed_keys])).freeze
       @selection_enabled = normalize_boolean(resolve_option(selectable, selection_options[:enabled]), :selectable)
       @selection_payload_builder = resolve_option(selection_payload_builder, selection_options[:payload_builder])
       @selection_checkbox_name = resolve_option(selection_checkbox_name, selection_options[:checkbox_name]) || DEFAULT_SELECTION_CHECKBOX_NAME
@@ -83,6 +86,7 @@ module TreeView
       validate_builder!(@selection_payload_builder, :selection_payload_builder)
       validate_builder!(@selection_disabled_builder, :selection_disabled_builder)
       validate_builder!(@selection_disabled_reason_builder, :selection_disabled_reason_builder)
+      validate_expansion_key_conflicts!
     end
 
     def selection_enabled?
@@ -140,6 +144,13 @@ module TreeView
       return if builder.nil? || builder.respond_to?(:call)
 
       raise ArgumentError, "#{name} must respond to call"
+    end
+
+    def validate_expansion_key_conflicts!
+      conflicts = expanded_keys & collapsed_keys
+      return if conflicts.empty?
+
+      raise ArgumentError, "expanded_keys and collapsed_keys cannot include the same keys: #{conflicts.map(&:inspect).join(', ')}"
     end
   end
 end

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -238,6 +238,26 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include('id="project_3"')
     end
 
+    it "collapses nodes listed in collapsed_keys" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        initial_state: :expanded,
+        collapsed_keys: [tree.node_key_for(child)]
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
+      expect(rendered).not_to include('id="project_3"')
+      expect(rendered).to include('tree-toggle__hidden-count')
+    end
+
     it "does not render descendants when only a hidden descendant is listed in expanded_keys" do
       tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
       render_state = TreeView::RenderState.new(
@@ -254,6 +274,26 @@ RSpec.describe "TreeView integration" do
 
       expect(rendered).to include('id="project_1"')
       expect(rendered).not_to include('id="project_2"')
+      expect(rendered).not_to include('id="project_3"')
+    end
+
+    it "does not render descendants when parent is listed in collapsed_keys even if descendant is expanded" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        initial_state: :expanded,
+        collapsed_keys: [tree.node_key_for(child)],
+        expanded_keys: [tree.node_key_for(grandchild)]
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(rendered).to include('id="project_1"')
+      expect(rendered).to include('id="project_2"')
       expect(rendered).not_to include('id="project_3"')
     end
 

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -148,6 +148,18 @@ RSpec.describe TreeView::RenderState do
     expect(state.expanded_keys).to eq([1, 2])
   end
 
+  it "stores collapsed_keys when given" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      collapsed_keys: [1, 2]
+    )
+
+    expect(state.collapsed_keys).to eq([1, 2])
+  end
+
   it "stores grouped initial_expansion options" do
     state = described_class.new(
       tree: tree,
@@ -157,13 +169,28 @@ RSpec.describe TreeView::RenderState do
       initial_expansion: {
         default: :collapsed,
         max_depth: 2,
-        expanded_keys: [1, 2]
+        expanded_keys: [1, 2],
+        collapsed_keys: [3]
       }
     )
 
     expect(state.initial_state).to eq(:collapsed)
     expect(state.max_initial_depth).to eq(2)
     expect(state.expanded_keys).to eq([1, 2])
+    expect(state.collapsed_keys).to eq([3])
+  end
+
+  it "rejects conflicting expanded and collapsed keys" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        expanded_keys: [1, 2],
+        collapsed_keys: [2, 3]
+      )
+    end.to raise_error(ArgumentError, /expanded_keys and collapsed_keys/)
   end
 
   it "stores grouped render_scope options" do
@@ -344,10 +371,12 @@ RSpec.describe TreeView::RenderState do
       max_toggle_depth_from_root: 1,
       max_toggle_leaf_distance: 1,
       expanded_keys: [9],
+      collapsed_keys: [8],
       initial_expansion: {
         default: :collapsed,
         max_depth: 2,
-        expanded_keys: [1, 2]
+        expanded_keys: [1, 2],
+        collapsed_keys: [3]
       },
       render_scope: {
         max_depth: 3,
@@ -366,6 +395,7 @@ RSpec.describe TreeView::RenderState do
     expect(state.max_toggle_depth_from_root).to eq(1)
     expect(state.max_toggle_leaf_distance).to eq(1)
     expect(state.expanded_keys).to eq([9])
+    expect(state.collapsed_keys).to eq([8])
   end
 
   it "rejects unknown grouped option keys" do


### PR DESCRIPTION
## Summary

- Add `collapsed_keys` to `TreeView::RenderState`
- Add grouped option support via `initial_expansion[:collapsed_keys]`
- Treat duplicate keys in `expanded_keys` and `collapsed_keys` as an explicit configuration error
- Apply `collapsed_keys` during row rendering so selected nodes are initially collapsed
- Keep descendant `expanded_keys` hidden when an ancestor is collapsed
- Add RenderState specs and integration specs
- Document usage and precedence notes in `docs/usage.md`

Closes #53

## Behavior

- `expanded_keys` forces the listed node itself to expand
- `collapsed_keys` forces the listed node itself to collapse
- A node key cannot appear in both lists
- If a parent node is collapsed, descendants are not rendered in the initial HTML even if they are listed in `expanded_keys`

## Notes

I could not run the local RSpec suite in this environment because the container cannot resolve `github.com`. The branch diff was checked via the GitHub connector.