### PR TITLE
Prepare v0.1.0 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## 0.1.0 - Initial release
+
+### Added
+
+- Core tree rendering primitives for Rails applications.
+- `TreeView::Tree` for parent-child records.
+- `TreeView::GraphAdapter` for graph-like or heterogeneous node structures.
+- `TreeView::PathTree` via `Tree#path_tree_for(items)` for rendering matched items with completed parent paths.
+- `TreeView::ReverseTree` via `Tree#reverse_tree_for(items)` for rendering child-to-parent paths.
+- `TreeView::RenderState` for screen-level rendering options.
+- `tree_view_rows(render_state)` helper.
+- Host app row partial support via `row_partial`.
+- Static tree rendering.
+- Turbo Stream path builder integration.
+- Initial expansion controls:
+  - `initial_state`
+  - `expanded_keys`
+  - `collapsed_keys`
+  - `max_initial_depth`
+- Render scope controls:
+  - `max_render_depth`
+  - `max_leaf_distance`
+- Toggle scope controls:
+  - `max_toggle_depth_from_root`
+  - `max_toggle_leaf_distance`
+- Grouped `RenderState` options:
+  - `initial_expansion`
+  - `render_scope`
+  - `toggle_scope`
+  - `selection`
+- Row attribute builders:
+  - `row_class_builder`
+  - `row_data_builder`
+- Checkbox selection support:
+  - JSON payload values
+  - custom checkbox name
+  - per-node disabled state
+  - disabled reason attributes
+  - initial selected state via `selected_keys`
+- Orphan handling strategies.
+- Optional node key uniqueness validation.
+- Japanese documentation under `docs/`.
+
+### Notes
+
+- This gem intentionally focuses on TreeView rendering primitives.
+- CRUD, authorization, business-specific actions, and selection side effects remain the responsibility of the host Rails application.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@
 - viewから使うDOM ID / toggle path / 枝情報helper
 - `RenderState` からroot行を描画する `tree_view_rows` helper
 - host app側の `row_partial` 差し替え
+- 初期展開制御
+  - `initial_state`
+  - `expanded_keys`
+  - `collapsed_keys`
+  - `max_initial_depth`
+- 描画範囲制御
+  - `max_render_depth`
+  - `max_leaf_distance`
+- 開閉操作範囲制御
+  - `max_toggle_depth_from_root`
+  - `max_toggle_leaf_distance`
+- 行属性カスタマイズ
+  - `row_class_builder`
+  - `row_data_builder`
+- checkbox selection
+  - JSON payload送信
+  - nodeごとのdisabled制御
+  - `selected_keys` による初期選択
 
 ## 含まないもの
 
@@ -30,6 +48,8 @@
 - 業務固有の文言やroute
 - Turbo Frame modal
 - 右クリックメニュー
+- checkbox selection後の削除・移動・関連付けなどの業務処理
+- 親子連動checkbox / indeterminate表示
 - demo data / seed
 
 ## Installation
@@ -111,6 +131,7 @@ row partial:
 | [docs/api.md](docs/api.md) | API仕様 |
 | [docs/design-policy.md](docs/design-policy.md) | 設計思想と責務範囲 |
 | [docs/development.md](docs/development.md) | 開発・保守方針 |
+| [CHANGELOG.md](CHANGELOG.md) | 変更履歴 |
 
 ## Development
 
@@ -121,6 +142,17 @@ bundle exec rake build
 ```
 
 GitHub Actionsでは、`main` へのpushとPull Requestで `bundle exec rake` を実行します。
+
+## Release
+
+現在の初期リリース想定versionは `0.1.0` です。
+
+リリース前には以下を確認します。
+
+- `bundle exec rspec`
+- `bundle exec rake build`
+- README / docs / CHANGELOG の整合
+- gemspec metadata
 
 ## License
 

--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/releases"
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   spec.files = Dir.chdir(__dir__) do
     Dir[
@@ -26,9 +26,11 @@ Gem::Specification.new do |spec|
       "app/javascript/tree_view/**/*",
       "app/views/tree_view/**/*",
       "config/importmap.tree_view.rb",
+      "docs/**/*",
       "lib/**/*",
       "spec/**/*",
       ".rspec",
+      "CHANGELOG.md",
       "Gemfile",
       "Rakefile",
       "README.md",


### PR DESCRIPTION
## Summary

- Update README with current v0.1.0 feature set
- Add `CHANGELOG.md` for the initial release
- Update gemspec metadata to point changelog URI to `CHANGELOG.md`
- Include `docs/**/*` and `CHANGELOG.md` in packaged files
- Confirm that `TreeView::VERSION` is already `0.1.0`

Closes #58

## Notes

Documentation and gemspec packaging metadata only. I did not run the local test suite in this environment.