### PR TITLE
Add cycle detection to path-derived descendant counts

### DIFF
--- a/lib/tree_view/path_tree.rb
+++ b/lib/tree_view/path_tree.rb
@@ -32,12 +32,21 @@ module TreeView
     def descendant_counts
       @descendant_counts ||= begin
         memo = {}
+        visiting = {}
+
         count_descendants = lambda do |record|
           node_key = node_key_for(record)
           return memo[node_key] if memo.key?(node_key)
+          raise ArgumentError, "cycle detected in path tree for node #{node_key.inspect}" if visiting[node_key]
 
+          visiting[node_key] = true
           children = children_for(record)
           memo[node_key] = children.sum { |child| 1 + count_descendants.call(child) }
+          visiting.delete(node_key)
+          memo[node_key]
+        rescue StandardError
+          visiting.delete(node_key)
+          raise
         end
 
         root_items.each { |root| count_descendants.call(root) }

--- a/lib/tree_view/reverse_tree.rb
+++ b/lib/tree_view/reverse_tree.rb
@@ -32,12 +32,21 @@ module TreeView
     def descendant_counts
       @descendant_counts ||= begin
         memo = {}
+        visiting = {}
+
         count_descendants = lambda do |record|
           node_key = node_key_for(record)
           return memo[node_key] if memo.key?(node_key)
+          raise ArgumentError, "cycle detected in reverse tree for node #{node_key.inspect}" if visiting[node_key]
 
+          visiting[node_key] = true
           children = children_for(record)
           memo[node_key] = children.sum { |child| 1 + count_descendants.call(child) }
+          visiting.delete(node_key)
+          memo[node_key]
+        rescue StandardError
+          visiting.delete(node_key)
+          raise
         end
 
         root_items.each { |root| count_descendants.call(root) }

--- a/spec/lib/tree_view/path_tree_spec.rb
+++ b/spec/lib/tree_view/path_tree_spec.rb
@@ -69,4 +69,15 @@ RSpec.describe TreeView::PathTree do
     expect(path_tree.descendant_counts[path_tree.node_key_for(parent)]).to eq(1)
     expect(path_tree.descendant_counts[path_tree.node_key_for(matched_child)]).to eq(0)
   end
+
+  it "raises a clear error when descendant count paths contain a cycle" do
+    node_a = PathTreeNode.new(id: 1, parent_item_id: 2, name: "node-a")
+    node_b = PathTreeNode.new(id: 2, parent_item_id: 1, name: "node-b")
+    base_tree = build_base_tree([node_a, node_b])
+    path_tree = described_class.new(base_tree: base_tree, paths: [[node_a, node_b, node_a]])
+
+    expect do
+      path_tree.descendant_counts
+    end.to raise_error(ArgumentError, /cycle detected in path tree/)
+  end
 end

--- a/spec/lib/tree_view/reverse_tree_spec.rb
+++ b/spec/lib/tree_view/reverse_tree_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe TreeView::ReverseTree do
     expect(reverse_tree.descendant_counts[reverse_tree.node_key_for(root)]).to eq(0)
   end
 
+  it "raises a clear error when descendant count paths contain a cycle" do
+    node_a = ReverseTreeNode.new(id: 1, parent_item_id: 2, name: "node-a")
+    node_b = ReverseTreeNode.new(id: 2, parent_item_id: 1, name: "node-b")
+    base_tree = build_base_tree([node_a, node_b])
+    reverse_tree = described_class.new(base_tree: base_tree, paths: [[node_a, node_b, node_a]])
+
+    expect do
+      reverse_tree.descendant_counts
+    end.to raise_error(ArgumentError, /cycle detected in reverse tree/)
+  end
+
   it "raises a records mode error through parent path helpers for resolver mode" do
     root = ReverseTreeNode.new(id: 1, parent_item_id: nil, name: "root")
     tree = TreeView::Tree.new(roots: [root], children_resolver: ->(_node) { [] })


### PR DESCRIPTION
## Summary

- Add visiting-node cycle detection to `PathTree#descendant_counts`
- Add visiting-node cycle detection to `ReverseTree#descendant_counts`
- Add specs ensuring cyclic path-derived trees raise `ArgumentError` instead of recursing indefinitely

Closes #60

## Tests

- Not run locally; changes were applied through GitHub API.
