### PR TITLE
Build selection payload once per checkbox

### DIFF
--- a/app/views/tree_view/_tree_selection_cell.html.erb
+++ b/app/views/tree_view/_tree_selection_cell.html.erb
@@ -1,17 +1,19 @@
 <% selection_disabled = tree_selection_disabled?(item, selection_disabled_builder) %>
 <% selection_disabled_reason = tree_selection_disabled_reason(item, selection_disabled_reason_builder) %>
 <% selection_checked = tree_selection_checked?(item, tree, selection_selected_keys) %>
+<% selection_payload = tree_selection_payload(item, tree, selection_payload_builder) %>
+<% selection_value = JSON.generate(selection_payload) %>
 
 <td class="tree-selection-cell">
   <%= check_box_tag selection_checkbox_name,
-                    tree_selection_value(item, tree, selection_payload_builder),
+                    selection_value,
                     selection_checked,
                     id: tree_selection_checkbox_dom_id(item),
                     class: "tree-selection-checkbox",
                     disabled: selection_disabled,
                     title: selection_disabled_reason,
                     data: {
-                      tree_selection_payload: tree_selection_payload(item, tree, selection_payload_builder),
+                      tree_selection_payload: selection_payload,
                       tree_selection_disabled_reason: selection_disabled_reason
                     } %>
 </td>

--- a/spec/integration/tree_view_selection_integration_spec.rb
+++ b/spec/integration/tree_view_selection_integration_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe "TreeView selection integration" do
     expect(rendered).to include('&quot;type&quot;:')
   end
 
+  it "calls the selection payload builder once per rendered checkbox" do
+    called_item_ids = []
+
+    render_rows(
+      tree,
+      tree.root_items,
+      payload_builder: lambda do |item|
+        called_item_ids << item.id
+        { key: tree.node_key_for(item), id: item.id, type: item.class.name }
+      end
+    )
+
+    expect(called_item_ids).to eq([1, 2, 3])
+  end
+
   it "renders checked selection checkboxes for selected keys" do
     rendered = render_rows(tree, tree.root_items, selected_keys: [2])
 


### PR DESCRIPTION
## Summary

- Build each selection payload once in `_tree_selection_cell.html.erb`
- Reuse the same payload for the checkbox JSON value and data attribute
- Add an integration spec that verifies the payload builder is called once per rendered checkbox

Closes #61

## Tests

- Not run locally; changes were applied through GitHub API.
