### PR TITLE
Clear helper render caches around tree row rendering

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -4,6 +4,7 @@ module TreeViewHelper
   def tree_view_rows(render_state, mode: nil, collapsed: nil)
     previous_tree_ui = @tree_ui
     @tree_ui = render_state.ui_config
+    clear_tree_view_render_caches!
 
     render(
       partial: "tree_view/tree_row",
@@ -32,6 +33,7 @@ module TreeViewHelper
       }
     )
   ensure
+    clear_tree_view_render_caches!
     @tree_ui = previous_tree_ui
   end
 
@@ -185,6 +187,11 @@ module TreeViewHelper
   end
 
   private
+
+  def clear_tree_view_render_caches!
+    @tree_leaf_distance_maps = {}
+    @tree_branch_maps = {}
+  end
 
   def resolved_ui(ui)
     resolved = ui || @tree_ui || default_tree_ui

--- a/spec/helpers/tree_view_helper_spec.rb
+++ b/spec/helpers/tree_view_helper_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe TreeViewHelper do
     end
   end
 
+  describe "tree render caches" do
+    it "clears cached leaf distance and branch maps" do
+      helper = helper_host_class.new(tree_ui: ui_config)
+
+      helper.instance_variable_set(:@tree_leaf_distance_maps, { 1 => { stale: true } })
+      helper.instance_variable_set(:@tree_branch_maps, { 1 => { stale: true } })
+
+      helper.send(:clear_tree_view_render_caches!)
+
+      expect(helper.instance_variable_get(:@tree_leaf_distance_maps)).to eq({})
+      expect(helper.instance_variable_get(:@tree_branch_maps)).to eq({})
+    end
+  end
+
   describe "tree_branch_info" do
     it "returns branch information for each node" do
       root_a = TestNode.new(id: 1, parent_item_id: nil, name: "root-a")


### PR DESCRIPTION
## Summary

- Clear TreeViewHelper leaf-distance and branch-map caches before and after `tree_view_rows`
- Add a helper spec for the cache clearing helper
- Keep cache lifetime scoped to a single row rendering pass to avoid stale structure data leaking between render states

Closes #62

## Tests

- Not run locally; changes were applied through GitHub API.
