### PR TITLE
Validate UiConfig builders at initialization

### DIFF
--- a/lib/tree_view/ui_config.rb
+++ b/lib/tree_view/ui_config.rb
@@ -22,6 +22,13 @@ module TreeView
                    toggle_all_path_builder: nil,
                    indent_unit: '&ensp; &ensp; &ensp;',
                    scope_format: :string)
+      validate_builder!(node_dom_id_builder, :node_dom_id_builder)
+      validate_builder!(button_dom_id_builder, :button_dom_id_builder)
+      validate_builder!(show_button_dom_id_builder, :show_button_dom_id_builder)
+      validate_optional_builder!(hide_descendants_path_builder, :hide_descendants_path_builder)
+      validate_optional_builder!(show_descendants_path_builder, :show_descendants_path_builder)
+      validate_optional_builder!(toggle_all_path_builder, :toggle_all_path_builder)
+
       @node_dom_id_builder = node_dom_id_builder
       @button_dom_id_builder = button_dom_id_builder
       @show_button_dom_id_builder = show_button_dom_id_builder
@@ -73,6 +80,18 @@ module TreeView
     end
 
     private
+
+    def validate_builder!(builder, name)
+      return if builder.respond_to?(:call)
+
+      raise ArgumentError, "#{name} must respond to call"
+    end
+
+    def validate_optional_builder!(builder, name)
+      return if builder.nil?
+
+      validate_builder!(builder, name)
+    end
 
     def normalize_scope_format(value)
       normalized_value = value.to_sym

--- a/spec/lib/tree_view/ui_config_spec.rb
+++ b/spec/lib/tree_view/ui_config_spec.rb
@@ -1,11 +1,18 @@
 require "spec_helper"
 
 RSpec.describe TreeView::UiConfig do
+  def build_config(**overrides)
+    described_class.new(
+      {
+        node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+        button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+        show_button_dom_id_builder: ->(item_or_id) { "show_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
+      }.merge(overrides)
+    )
+  end
+
   it "calls DOM id and path builders" do
-    config = described_class.new(
-      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      show_button_dom_id_builder: ->(item_or_id) { "show_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+    config = build_config(
       hide_descendants_path_builder: ->(item, depth, scope) { "/hide/#{item.id}?depth=#{depth}&scope=#{scope}" },
       show_descendants_path_builder: ->(item, depth, scope) { "/show/#{item.id}?depth=#{depth}&scope=#{scope}" },
       toggle_all_path_builder: ->(state) { "/toggle?state=#{state}" }
@@ -24,11 +31,7 @@ RSpec.describe TreeView::UiConfig do
   end
 
   it "permits static configs without path builders" do
-    config = described_class.new(
-      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      show_button_dom_id_builder: ->(item_or_id) { "show_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
-    )
+    config = build_config
 
     item = Struct.new(:id).new(7)
 
@@ -37,5 +40,17 @@ RSpec.describe TreeView::UiConfig do
     expect(config.show_descendants_path(item, 3)).to be_nil
     expect(config.toggle_all_path(state: :collapsed)).to be_nil
     expect(config.static?).to eq(true)
+  end
+
+  it "raises a clear error when a required builder is not callable" do
+    expect do
+      build_config(node_dom_id_builder: "node")
+    end.to raise_error(ArgumentError, /node_dom_id_builder must respond to call/)
+  end
+
+  it "raises a clear error when an optional builder is not callable" do
+    expect do
+      build_config(hide_descendants_path_builder: "hide")
+    end.to raise_error(ArgumentError, /hide_descendants_path_builder must respond to call/)
   end
 end

--- a/spec/lib/tree_view/ui_config_spec.rb
+++ b/spec/lib/tree_view/ui_config_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe TreeView::UiConfig do
   def build_config(**overrides)
     described_class.new(
-      {
+      **{
         node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
         button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
         show_button_dom_id_builder: ->(item_or_id) { "show_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }


### PR DESCRIPTION
## Summary

- Validate required UiConfig builders during initialization
- Validate optional UiConfig path builders when provided
- Add specs for required and optional builder validation

Closes #63

## Tests

- Not run locally; changes were applied through GitHub API.

## Note

- This branch was created before the helper cache PR was merged, but it touches separate files and should be safe to merge after CI.
