### PR TITLE
Document ToggleScope mode as metadata

### DIFF
--- a/lib/tree_view/toggle_scope.rb
+++ b/lib/tree_view/toggle_scope.rb
@@ -8,6 +8,10 @@ module TreeView
                 :current_leaf_distance,
                 :max_leaf_distance
 
+    # mode is intentionally carried as request/path metadata.
+    # The current expansion boundary is determined by depth and leaf distance,
+    # while builders may still need the original mode value when constructing
+    # URLs or params for host applications.
     def initialize(mode:, current_depth:, max_depth_from_root: nil, current_leaf_distance: nil, max_leaf_distance: nil)
       @mode = mode.to_sym
       @current_depth = current_depth

--- a/spec/lib/tree_view/toggle_scope_spec.rb
+++ b/spec/lib/tree_view/toggle_scope_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe TreeView::ToggleScope do
     expect(scope.within_scope?).to eq(false)
   end
 
+  it "keeps mode as metadata without changing boundary decisions" do
+    all_scope = described_class.new(mode: :all, current_depth: 1, max_depth_from_root: 3)
+    child_scope = described_class.new(mode: :children, current_depth: 1, max_depth_from_root: 3)
+
+    expect(child_scope.mode).to eq(:children)
+    expect(child_scope.toggle_depth).to eq(all_scope.toggle_depth)
+    expect(child_scope.within_scope?).to eq(all_scope.within_scope?)
+  end
+
   it "returns max depth while current depth is inside root-based scope" do
     scope = described_class.new(mode: :all, current_depth: 1, max_depth_from_root: 3)
 


### PR DESCRIPTION
## Summary

- Document that `ToggleScope#mode` is carried as request/path metadata
- Keep scope boundary decisions based on depth and leaf distance
- Add a spec showing different modes do not change boundary decisions

Closes #65

## Tests

- Not run locally; changes were applied through GitHub API.
