### PR TITLE
Normalize invalid option errors to ArgumentError

### DIFF
--- a/lib/tree_view/configuration.rb
+++ b/lib/tree_view/configuration.rb
@@ -18,9 +18,15 @@ module TreeView
     private
 
     def normalize_initial_state(value)
+      raise_invalid_initial_state! unless value.respond_to?(:to_sym)
+
       normalized_value = value.to_sym
       return normalized_value if VALID_INITIAL_STATES.include?(normalized_value)
 
+      raise_invalid_initial_state!
+    end
+
+    def raise_invalid_initial_state!
       raise ArgumentError, "initial_state must be one of: #{VALID_INITIAL_STATES.join(', ')}"
     end
   end

--- a/lib/tree_view/toggle_scope.rb
+++ b/lib/tree_view/toggle_scope.rb
@@ -13,7 +13,7 @@ module TreeView
     # while builders may still need the original mode value when constructing
     # URLs or params for host applications.
     def initialize(mode:, current_depth:, max_depth_from_root: nil, current_leaf_distance: nil, max_leaf_distance: nil)
-      @mode = mode.to_sym
+      @mode = normalize_mode(mode)
       @current_depth = current_depth
       @max_depth_from_root = max_depth_from_root
       @current_leaf_distance = current_leaf_distance
@@ -46,6 +46,14 @@ module TreeView
       return false if max_leaf_distance.nil? || current_leaf_distance.nil?
 
       current_leaf_distance < max_leaf_distance
+    end
+
+    private
+
+    def normalize_mode(value)
+      return value.to_sym if value.respond_to?(:to_sym)
+
+      raise ArgumentError, "mode must be symbol-like"
     end
   end
 end

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -253,9 +253,15 @@ module TreeView
     end
 
     def normalize_orphan_strategy(value)
+      raise_invalid_orphan_strategy! unless value.respond_to?(:to_sym)
+
       normalized_value = value.to_sym
       return normalized_value if VALID_ORPHAN_STRATEGIES.include?(normalized_value)
 
+      raise_invalid_orphan_strategy!
+    end
+
+    def raise_invalid_orphan_strategy!
       raise ArgumentError, "orphan_strategy must be one of: #{VALID_ORPHAN_STRATEGIES.join(', ')}"
     end
 

--- a/lib/tree_view/ui_config.rb
+++ b/lib/tree_view/ui_config.rb
@@ -94,9 +94,15 @@ module TreeView
     end
 
     def normalize_scope_format(value)
+      raise_invalid_scope_format! unless value.respond_to?(:to_sym)
+
       normalized_value = value.to_sym
       return normalized_value if SCOPE_FORMATS.include?(normalized_value)
 
+      raise_invalid_scope_format!
+    end
+
+    def raise_invalid_scope_format!
       raise ArgumentError, "scope_format must be one of: #{SCOPE_FORMATS.join(', ')}"
     end
   end

--- a/spec/lib/tree_view/configuration_spec.rb
+++ b/spec/lib/tree_view/configuration_spec.rb
@@ -15,5 +15,12 @@ RSpec.describe TreeView::Configuration do
 
       expect { config.initial_state = :invalid }.to raise_error(ArgumentError, /initial_state/)
     end
+
+    it "rejects non-symbolizable values with a clear error" do
+      config = described_class.new
+
+      expect { config.initial_state = nil }.to raise_error(ArgumentError, /initial_state must be one of/)
+      expect { config.initial_state = 1 }.to raise_error(ArgumentError, /initial_state must be one of/)
+    end
   end
 end

--- a/spec/lib/tree_view/orphan_strategy_spec.rb
+++ b/spec/lib/tree_view/orphan_strategy_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe "TreeView::Tree orphan strategy" do
     end.to raise_error(ArgumentError, /orphan_strategy must be one of/)
   end
 
+  it "rejects non-symbolizable orphan_strategy values with a clear error" do
+    expect do
+      build_tree([], orphan_strategy: nil)
+    end.to raise_error(ArgumentError, /orphan_strategy must be one of/)
+
+    expect do
+      build_tree([], orphan_strategy: 1)
+    end.to raise_error(ArgumentError, /orphan_strategy must be one of/)
+  end
+
   it "rejects orphan_strategy outside records mode" do
     expect do
       TreeView::Tree.new(

--- a/spec/lib/tree_view/toggle_scope_spec.rb
+++ b/spec/lib/tree_view/toggle_scope_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe TreeView::ToggleScope do
     expect(child_scope.within_scope?).to eq(all_scope.within_scope?)
   end
 
+  it "raises a clear error when mode is not symbolizable" do
+    expect do
+      described_class.new(mode: nil, current_depth: 1)
+    end.to raise_error(ArgumentError, /mode must be symbol-like/)
+
+    expect do
+      described_class.new(mode: 1, current_depth: 1)
+    end.to raise_error(ArgumentError, /mode must be symbol-like/)
+  end
+
   it "returns max depth while current depth is inside root-based scope" do
     scope = described_class.new(mode: :all, current_depth: 1, max_depth_from_root: 3)
 

--- a/spec/lib/tree_view/ui_config_spec.rb
+++ b/spec/lib/tree_view/ui_config_spec.rb
@@ -53,4 +53,14 @@ RSpec.describe TreeView::UiConfig do
       build_config(hide_descendants_path_builder: "hide")
     end.to raise_error(ArgumentError, /hide_descendants_path_builder must respond to call/)
   end
+
+  it "raises a clear error when scope_format is not symbolizable" do
+    expect do
+      build_config(scope_format: nil)
+    end.to raise_error(ArgumentError, /scope_format must be one of/)
+
+    expect do
+      build_config(scope_format: 1)
+    end.to raise_error(ArgumentError, /scope_format must be one of/)
+  end
 end


### PR DESCRIPTION
## Summary

- Normalize non-symbolizable `Configuration#initial_state` values to `ArgumentError`
- Normalize non-symbolizable `Tree#orphan_strategy` values to `ArgumentError`
- Normalize non-symbolizable `UiConfig#scope_format` values to `ArgumentError`
- Normalize non-symbolizable `ToggleScope#mode` values to `ArgumentError`
- Add specs for nil and integer inputs where applicable

Closes #64

## Tests

- Not run locally; changes were applied through GitHub API.
