### PR TITLE
Limit packaged gem files for release

### DIFF
--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -28,11 +28,7 @@ Gem::Specification.new do |spec|
       "config/importmap.tree_view.rb",
       "docs/**/*",
       "lib/**/*",
-      "spec/**/*",
-      ".rspec",
       "CHANGELOG.md",
-      "Gemfile",
-      "Rakefile",
       "README.md",
       "LICENSE*",
       "tree_view.gemspec"


### PR DESCRIPTION
## Summary

- Remove development-only files from packaged gem file list
  - `spec/**/*`
  - `.rspec`
  - `Gemfile`
  - `Rakefile`
- Keep runtime Rails assets, helpers, views, importmap config, docs, lib files, README, CHANGELOG, LICENSE, and gemspec

Closes #66

## Tests

- Not run locally; changes were applied through GitHub API.
