### PR TITLE
Add gem package verification to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,15 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec rake
+
+  gem_package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - run: gem build tree_view.gemspec
+      - run: gem install tree_view-*.gem
+      - run: ruby -e "require 'tree_view'"


### PR DESCRIPTION
## Summary

- Add a CI job that builds the gem from the gemspec
- Install the generated gem artifact
- Verify the installed gem can be required

Closes #74

## Tests

- Not run locally; this PR adds CI verification.
