### PR TITLE
Add checkbox selection params parser

### DIFF
--- a/lib/tree_view.rb
+++ b/lib/tree_view.rb
@@ -4,6 +4,7 @@ require "tree_view/version"
 require "tree_view/configuration"
 require "tree_view/graph_adapter"
 require "tree_view/render_state"
+require "tree_view/selection_params"
 require "tree_view/toggle_scope"
 require "tree_view/traversal"
 require "tree_view/tree"
@@ -25,6 +26,10 @@ module TreeView
 
     def reset_configuration!
       @configuration = Configuration.new
+    end
+
+    def parse_selection_params(value)
+      SelectionParams.parse(value)
     end
   end
 end

--- a/lib/tree_view/selection_params.rb
+++ b/lib/tree_view/selection_params.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "json"
+
+module TreeView
+  module SelectionParams
+    module_function
+
+    def parse(value)
+      Array(value).filter_map do |entry|
+        next if entry.nil? || entry == ""
+
+        parse_entry(entry)
+      end
+    end
+
+    def parse_entry(entry)
+      return entry.to_h if entry.respond_to?(:to_h) && !entry.is_a?(String)
+      raise ArgumentError, "selection params entries must be JSON strings or Hash-like objects" unless entry.is_a?(String)
+
+      parsed = JSON.parse(entry)
+      return parsed if parsed.is_a?(Hash)
+
+      raise ArgumentError, "selection params entries must parse to JSON objects"
+    rescue JSON::ParserError => e
+      raise ArgumentError, "invalid selection params JSON: #{e.message}"
+    end
+  end
+end

--- a/spec/lib/tree_view/selection_params_spec.rb
+++ b/spec/lib/tree_view/selection_params_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe TreeView::SelectionParams do
+  describe ".parse" do
+    it "returns an empty array for nil and empty input" do
+      expect(described_class.parse(nil)).to eq([])
+      expect(described_class.parse([])).to eq([])
+      expect(described_class.parse([nil, ""])).to eq([])
+    end
+
+    it "parses JSON selection values" do
+      params = [
+        '{"key":1,"id":1,"type":"Document"}',
+        '{"key":2,"id":2,"type":"Folder"}'
+      ]
+
+      expect(described_class.parse(params)).to eq([
+        { "key" => 1, "id" => 1, "type" => "Document" },
+        { "key" => 2, "id" => 2, "type" => "Folder" }
+      ])
+    end
+
+    it "accepts a single JSON selection value" do
+      expect(described_class.parse('{"key":1,"id":1}')).to eq([
+        { "key" => 1, "id" => 1 }
+      ])
+    end
+
+    it "accepts hash-like entries" do
+      expect(described_class.parse([{ key: 1, id: 1 }])).to eq([
+        { key: 1, id: 1 }
+      ])
+    end
+
+    it "raises a clear error for invalid JSON" do
+      expect do
+        described_class.parse(["not-json"])
+      end.to raise_error(ArgumentError, /invalid selection params JSON/)
+    end
+
+    it "raises a clear error when JSON does not parse to an object" do
+      expect do
+        described_class.parse(["[1,2]"])
+      end.to raise_error(ArgumentError, /must parse to JSON objects/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `TreeView::SelectionParams.parse`
- Expose `TreeView.parse_selection_params`
- Support nil, empty, single JSON string, arrays, and hash-like entries
- Raise `ArgumentError` for invalid JSON and non-object JSON entries

Closes #76

## Tests

- Not run locally; changes were applied through GitHub API.
