### PR TITLE
Add optional node key validation

### DIFF
--- a/lib/tree_view.rb
+++ b/lib/tree_view.rb
@@ -7,10 +7,13 @@ require "tree_view/render_state"
 require "tree_view/toggle_scope"
 require "tree_view/traversal"
 require "tree_view/tree"
+require "tree_view/node_key_validation"
 require "tree_view/path_tree"
 require "tree_view/reverse_tree"
 require "tree_view/ui_config"
 require "tree_view/ui_config_builder"
+
+TreeView::Tree.prepend(TreeView::NodeKeyValidation)
 
 module TreeView
   class << self

--- a/lib/tree_view/node_key_validation.rb
+++ b/lib/tree_view/node_key_validation.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module TreeView
+  module NodeKeyValidation
+    def initialize(*args, validate_node_keys: false, **kwargs, &block)
+      super(*args, **kwargs, &block)
+      validate_unique_node_keys! if validate_node_keys
+    end
+  end
+end

--- a/spec/lib/tree_view/tree_spec.rb
+++ b/spec/lib/tree_view/tree_spec.rb
@@ -182,6 +182,24 @@ RSpec.describe TreeView::Tree do
         tree.validate_unique_node_keys!
       end.to raise_error(ArgumentError, /duplicate node_key detected/)
     end
+
+    it "validates node keys during initialization when requested" do
+      root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")
+      duplicate_root = ItemNode.new(id: 1, parent_item_id: nil, name: "duplicate-root")
+
+      expect do
+        described_class.new(records: [root, duplicate_root], parent_id_method: :parent_item_id, validate_node_keys: true)
+      end.to raise_error(ArgumentError, /duplicate node_key detected: 1/)
+    end
+
+    it "keeps duplicate node keys allowed by default for backward compatibility" do
+      root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")
+      duplicate_root = ItemNode.new(id: 1, parent_item_id: nil, name: "duplicate-root")
+
+      expect do
+        described_class.new(records: [root, duplicate_root], parent_id_method: :parent_item_id)
+      end.not_to raise_error
+    end
   end
 
   describe "validation" do


### PR DESCRIPTION
## Summary

- Add an optional node key validation flag
- Keep duplicate node keys allowed by default for compatibility
- Add specs for opt-in validation and default compatibility

Closes #77

## Tests

- Not run locally; changes were applied through GitHub API.
