### PR TITLE
Improve static tree count text

### DIFF
--- a/app/views/tree_view/_tree_toggle_content_static.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_static.html.erb
@@ -16,7 +16,7 @@
   <div class="tree-toggle__control">
     <span class="tree-toggle__level"><%= tree_toggle_label(depth) %></span>
     <% if hidden_count %>
-      <span class="tree-toggle__hidden-count"><%= hidden_count %></span>
+      <span class="tree-toggle__hidden-count"><%= hidden_count %><span class="visually-hidden"> descendants</span></span>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Add auxiliary text after the static count number
- Keep the visible count unchanged

Part of #79

## Tests

- Not run locally.
