### PR TITLE
Add selection checkbox visibility options

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -23,6 +23,7 @@ module TreeViewHelper
         expanded_keys: render_state.expanded_keys,
         collapsed_keys: render_state.collapsed_keys,
         selection_enabled: render_state.selection_enabled?,
+        selection_visibility: render_state.selection_visibility,
         selection_payload_builder: render_state.selection_payload_builder,
         selection_checkbox_name: render_state.selection_checkbox_name,
         selection_disabled_builder: render_state.selection_disabled_builder,
@@ -88,6 +89,21 @@ module TreeViewHelper
 
   def tree_selection_checked?(item, tree, selected_keys = nil)
     Array(selected_keys).include?(tree.node_key_for(item))
+  end
+
+  def tree_selection_visible?(item, tree, depth, visibility)
+    case visibility.to_sym
+    when :all
+      true
+    when :roots
+      depth.to_i.zero?
+    when :leaves
+      tree.children_for(item).empty?
+    when :none
+      false
+    else
+      raise ArgumentError, "selection visibility must be one of: all, roots, leaves, none"
+    end
   end
 
   def tree_initial_depth_boundary?(depth, max_initial_depth)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -9,6 +9,7 @@
 <% expanded_keys = local_assigns[:expanded_keys] %>
 <% collapsed_keys = local_assigns[:collapsed_keys] %>
 <% selection_enabled = local_assigns[:selection_enabled] %>
+<% selection_visibility = local_assigns.fetch(:selection_visibility, :all) %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
 <% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
 <% selection_disabled_builder = local_assigns[:selection_disabled_builder] %>
@@ -17,5 +18,5 @@
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -10,6 +10,7 @@
 <% expanded_keys = local_assigns[:expanded_keys] %>
 <% collapsed_keys = local_assigns[:collapsed_keys] %>
 <% selection_enabled = local_assigns[:selection_enabled] %>
+<% selection_visibility = local_assigns.fetch(:selection_visibility, :all) %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
 <% selection_checkbox_name = local_assigns[:selection_checkbox_name] %>
 <% selection_disabled_builder = local_assigns[:selection_disabled_builder] %>
@@ -33,12 +34,13 @@
 <% if render_self %>
   <%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data) do %>
     <% if selection_enabled %>
-      <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys %>
+      <% selection_visible = tree_selection_visible?(item, tree, depth, selection_visibility) %>
+      <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_visible: selection_visible, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys %>
     <% end %>
     <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
     <%= render row_partial, item: item %>
   <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_selection_cell.html.erb
+++ b/app/views/tree_view/_tree_selection_cell.html.erb
@@ -1,20 +1,24 @@
-<% selection_disabled = tree_selection_disabled?(item, selection_disabled_builder) %>
-<% selection_disabled_reason = tree_selection_disabled_reason(item, selection_disabled_reason_builder) %>
-<% selection_checked = tree_selection_checked?(item, tree, selection_selected_keys) %>
-<% selection_payload = tree_selection_payload(item, tree, selection_payload_builder) %>
-<% selection_value = JSON.generate(selection_payload) %>
+<% selection_visible = local_assigns.fetch(:selection_visible, true) %>
 
 <td class="tree-selection-cell">
-  <%= check_box_tag selection_checkbox_name,
-                    selection_value,
-                    selection_checked,
-                    id: tree_selection_checkbox_dom_id(item),
-                    class: "tree-selection-checkbox",
-                    disabled: selection_disabled,
-                    title: selection_disabled_reason,
-                    aria: { label: tree_context_menu_label(item) },
-                    data: {
-                      tree_selection_payload: selection_payload,
-                      tree_selection_disabled_reason: selection_disabled_reason
-                    } %>
+  <% if selection_visible %>
+    <% selection_disabled = tree_selection_disabled?(item, selection_disabled_builder) %>
+    <% selection_disabled_reason = tree_selection_disabled_reason(item, selection_disabled_reason_builder) %>
+    <% selection_checked = tree_selection_checked?(item, tree, selection_selected_keys) %>
+    <% selection_payload = tree_selection_payload(item, tree, selection_payload_builder) %>
+    <% selection_value = JSON.generate(selection_payload) %>
+
+    <%= check_box_tag selection_checkbox_name,
+                      selection_value,
+                      selection_checked,
+                      id: tree_selection_checkbox_dom_id(item),
+                      class: "tree-selection-checkbox",
+                      disabled: selection_disabled,
+                      title: selection_disabled_reason,
+                      aria: { label: tree_context_menu_label(item) },
+                      data: {
+                        tree_selection_payload: selection_payload,
+                        tree_selection_disabled_reason: selection_disabled_reason
+                      } %>
+  <% end %>
 </td>

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -6,7 +6,8 @@ module TreeView
     VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys collapsed_keys].freeze
     VALID_RENDER_SCOPE_KEYS = %i[max_depth max_leaf_distance].freeze
     VALID_TOGGLE_SCOPE_KEYS = %i[max_depth_from_root max_leaf_distance].freeze
-    VALID_SELECTION_KEYS = %i[enabled payload_builder checkbox_name disabled_builder disabled_reason_builder selected_keys].freeze
+    VALID_SELECTION_KEYS = %i[enabled visibility payload_builder checkbox_name disabled_builder disabled_reason_builder selected_keys].freeze
+    VALID_SELECTION_VISIBILITIES = %i[all roots leaves none].freeze
     DEFAULT_SELECTION_CHECKBOX_NAME = "selected_nodes[]"
 
     attr_reader :tree,
@@ -22,6 +23,7 @@ module TreeView
                 :expanded_keys,
                 :collapsed_keys,
                 :selection_enabled,
+                :selection_visibility,
                 :selection_payload_builder,
                 :selection_checkbox_name,
                 :selection_disabled_builder,
@@ -73,6 +75,7 @@ module TreeView
       @expanded_keys = Array(resolve_option(expanded_keys, initial_expansion_options[:expanded_keys])).freeze
       @collapsed_keys = Array(resolve_option(collapsed_keys, initial_expansion_options[:collapsed_keys])).freeze
       @selection_enabled = normalize_boolean(resolve_option(selectable, selection_options[:enabled]), :selectable)
+      @selection_visibility = normalize_selection_visibility(selection_options[:visibility])
       @selection_payload_builder = resolve_option(selection_payload_builder, selection_options[:payload_builder])
       @selection_checkbox_name = resolve_option(selection_checkbox_name, selection_options[:checkbox_name]) || DEFAULT_SELECTION_CHECKBOX_NAME
       @selection_disabled_builder = resolve_option(selection_disabled_builder, selection_options[:disabled_builder])
@@ -124,6 +127,20 @@ module TreeView
       return normalized_value if VALID_INITIAL_STATES.include?(normalized_value)
 
       raise ArgumentError, "initial_state must be one of: #{VALID_INITIAL_STATES.join(', ')}"
+    end
+
+    def normalize_selection_visibility(value)
+      return :all if value.nil?
+      raise_invalid_selection_visibility! unless value.respond_to?(:to_sym)
+
+      normalized_value = value.to_sym
+      return normalized_value if VALID_SELECTION_VISIBILITIES.include?(normalized_value)
+
+      raise_invalid_selection_visibility!
+    end
+
+    def raise_invalid_selection_visibility!
+      raise ArgumentError, "selection visibility must be one of: #{VALID_SELECTION_VISIBILITIES.join(', ')}"
     end
 
     def normalize_non_negative_integer(value, name)

--- a/spec/integration/tree_view_selection_integration_spec.rb
+++ b/spec/integration/tree_view_selection_integration_spec.rb
@@ -61,6 +61,37 @@ RSpec.describe "TreeView selection integration" do
     expect(rendered).to include('&quot;type&quot;:')
   end
 
+  it "renders selection checkboxes only for roots when visibility is roots" do
+    rendered = render_rows(tree, tree.root_items, visibility: :roots)
+
+    expect(rendered.scan('class="tree-selection-cell"').size).to eq(3)
+    expect(rendered).to include('id="project_1_selection"')
+    expect(rendered).not_to include('id="project_2_selection"')
+    expect(rendered).not_to include('id="project_3_selection"')
+  end
+
+  it "renders selection checkboxes only for leaves when visibility is leaves" do
+    rendered = render_rows(tree, tree.root_items, visibility: :leaves)
+
+    expect(rendered.scan('class="tree-selection-cell"').size).to eq(3)
+    expect(rendered).not_to include('id="project_1_selection"')
+    expect(rendered).not_to include('id="project_2_selection"')
+    expect(rendered).to include('id="project_3_selection"')
+  end
+
+  it "keeps empty selection cells when visibility is none" do
+    rendered = render_rows(tree, tree.root_items, visibility: :none)
+
+    expect(rendered.scan('class="tree-selection-cell"').size).to eq(3)
+    expect(rendered).not_to include('class="tree-selection-checkbox"')
+  end
+
+  it "rejects invalid selection visibility values" do
+    expect do
+      render_rows(tree, tree.root_items, visibility: :middle)
+    end.to raise_error(ArgumentError, /selection visibility must be one of/)
+  end
+
   it "calls the selection payload builder once per rendered checkbox" do
     called_item_ids = []
 


### PR DESCRIPTION
## Summary

- Add `selection[:visibility]` with `:all`, `:roots`, `:leaves`, and `:none`
- Keep selection cells rendered while selection is enabled to avoid table column shifts
- Render empty selection cells when a row is outside the configured visibility
- Add integration specs for roots, leaves, none, and invalid visibility values

Closes #87

## Tests

- Not run locally; changes were applied through GitHub API.
