### PR TITLE
Add state attributes to turbo show toggle

### DIFF
--- a/app/views/tree_view/_tree_toggle_content_turbo.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_turbo.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class="tree-toggle__control">
     <% if hidden_count && show_path %>
-      <%= link_to show_path, data: { turbo_stream: true }, class: 'btn btn-primary show-button tree-toggle__action', id: tree_show_button_dom_id(item) do %>
+      <%= link_to show_path, data: { turbo_stream: true }, class: 'btn btn-primary show-button tree-toggle__action', id: tree_show_button_dom_id(item), aria: { expanded: false, controls: tree_node_dom_id(item) } do %>
         <%= tree_toggle_label(depth) %>
       <% end %>
     <% elsif children.any? && hide_path %>


### PR DESCRIPTION
## Summary

- Add state attributes to the turbo show control
- Keep the existing visible label and classes unchanged

Part of #79

## Tests

- Not run locally.
