### PR TITLE
Add state attributes to turbo hide toggle

### DIFF
--- a/app/views/tree_view/_tree_toggle_content_turbo.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_turbo.html.erb
@@ -25,7 +25,7 @@
         <%= tree_toggle_label(depth) %>
       <% end %>
     <% elsif children.any? && hide_path %>
-      <%= link_to hide_path, data: { turbo_stream: true }, class: 'btn btn-danger remove-button tree-toggle__action' do %>
+      <%= link_to hide_path, data: { turbo_stream: true }, class: 'btn btn-danger remove-button tree-toggle__action', aria: { expanded: true, controls: tree_node_dom_id(item) } do %>
         <%= tree_toggle_label(depth) %>
       <% end %>
     <% else %>


### PR DESCRIPTION
## Summary

- Add state attributes to the turbo hide control
- Keep the existing visible label and classes unchanged

Part of #79

## Tests

- Not run locally.
