### PR TITLE
Require Ruby 3.2 or newer

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,10 @@
 # 導入手順
 
+## 必要環境
+
+- Ruby 3.2 以上
+- Rails 7.0 以上
+
 ## Gemfile
 
 host app の `Gemfile` に追加します。

--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Reusable tree traversal, render state, helpers, partials, and Rails integration points for tree-style UIs."
   spec.homepage = "https://github.com/matsuo-haruhito/tree_view-rails"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
## Summary

- Raise the gemspec Ruby requirement to Ruby 3.2+
- Document the supported Ruby and Rails versions in installation docs
- Align the gemspec support range with the CI matrix that runs on Ruby 3.2 and 3.3

Closes #107

## Tests

- Not run locally; changes were applied through GitHub API.
