### PR TITLE
Cover accessibility attributes in integration specs

### DIFF
--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -153,6 +153,8 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include('id="project_2"')
       expect(rendered).not_to include('id="project_3"')
       expect(rendered).to include('tree-toggle__hidden-count')
+      expect(rendered).to include('visually-hidden')
+      expect(rendered).to include(' descendants')
     end
 
     it "limits rendered rows with max_render_depth without hidden count" do
@@ -331,6 +333,8 @@ RSpec.describe "TreeView integration" do
       )
 
       expect(rendered).to include('/projects/1/hide?depth=0&amp;scope=all')
+      expect(rendered).to include('aria-expanded="true"')
+      expect(rendered).to include('aria-controls="project_1"')
     end
 
     it "passes object toggle scope when scope_format is object" do


### PR DESCRIPTION
## Summary

- Add integration expectations for static hidden count helper text
- Add integration expectations for turbo toggle state attributes
- Reuse existing integration specs instead of adding a new large spec file

Closes #91

## Tests

- Not run locally; changes were applied through GitHub API.
