### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      rubocop:
+        patterns:
+          - "rubocop*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml`
- Enable weekly Dependabot updates for Bundler dependencies
- Enable weekly Dependabot updates for GitHub Actions
- Group RuboCop-related Bundler updates together

## Notes

- The schedule uses Monday 09:00 in Asia/Tokyo.
- The open PR limit is set to 5 for each ecosystem to avoid excessive noise.

## Testing

- Not run. Configuration-only change.