### PR TITLE
Support current and highlighted row classes

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -29,6 +29,9 @@ module TreeViewHelper
         selection_disabled_builder: render_state.selection_disabled_builder,
         selection_disabled_reason_builder: render_state.selection_disabled_reason_builder,
         selection_selected_keys: render_state.selection_selected_keys,
+        current_key: render_state.current_key,
+        active_keys: render_state.active_keys,
+        highlighted_keys: render_state.highlighted_keys,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder
       }
@@ -54,8 +57,15 @@ module TreeViewHelper
     "#{tree_node_dom_id(item, ui: ui)}_selection"
   end
 
-  def tree_row_classes(item, builder = nil)
-    Array(builder&.call(item)).flatten.compact_blank
+  def tree_row_classes(item, builder = nil, tree: nil, current_key: nil, active_keys: nil, highlighted_keys: nil)
+    classes = Array(builder&.call(item)).flatten.compact_blank
+    return classes if tree.nil?
+
+    node_key = tree.node_key_for(item)
+    classes << "is-current" if !current_key.nil? && node_key == current_key
+    classes << "is-active" if Array(active_keys).include?(node_key)
+    classes << "is-highlighted" if Array(highlighted_keys).include?(node_key)
+    classes
   end
 
   def tree_row_data(item, builder = nil)

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -15,8 +15,11 @@
 <% selection_disabled_builder = local_assigns[:selection_disabled_builder] %>
 <% selection_disabled_reason_builder = local_assigns[:selection_disabled_reason_builder] %>
 <% selection_selected_keys = local_assigns[:selection_selected_keys] %>
+<% current_key = local_assigns[:current_key] %>
+<% active_keys = local_assigns[:active_keys] %>
+<% highlighted_keys = local_assigns[:highlighted_keys] %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, current_key: current_key, active_keys: active_keys, highlighted_keys: highlighted_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -16,6 +16,9 @@
 <% selection_disabled_builder = local_assigns[:selection_disabled_builder] %>
 <% selection_disabled_reason_builder = local_assigns[:selection_disabled_reason_builder] %>
 <% selection_selected_keys = local_assigns[:selection_selected_keys] %>
+<% current_key = local_assigns[:current_key] %>
+<% active_keys = local_assigns[:active_keys] %>
+<% highlighted_keys = local_assigns[:highlighted_keys] %>
 <% explicitly_expanded = tree_expanded_key?(item, tree, expanded_keys) %>
 <% explicitly_collapsed = tree_collapsed_key?(item, tree, collapsed_keys) %>
 <% depth_boundary = tree_initial_depth_boundary?(depth, max_initial_depth) %>
@@ -26,7 +29,7 @@
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
-<% row_classes = tree_row_classes(item, row_class_builder) %>
+<% row_classes = tree_row_classes(item, row_class_builder, tree: tree, current_key: current_key, active_keys: active_keys, highlighted_keys: highlighted_keys) %>
 <% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth) %>
 <% children = tree.children_for(item) %>
 <% descendant_count = tree.descendant_counts[tree.node_key_for(item)].to_i %>
@@ -42,5 +45,5 @@
   <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, current_key: current_key, active_keys: active_keys, highlighted_keys: highlighted_keys, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -29,6 +29,9 @@ module TreeView
                 :selection_disabled_builder,
                 :selection_disabled_reason_builder,
                 :selection_selected_keys,
+                :current_key,
+                :active_keys,
+                :highlighted_keys,
                 :row_class_builder,
                 :row_data_builder
 
@@ -55,6 +58,9 @@ module TreeView
                    selection_disabled_reason_builder: nil,
                    selection_selected_keys: nil,
                    selection: nil,
+                   current_key: nil,
+                   active_keys: nil,
+                   highlighted_keys: nil,
                    row_class_builder: nil,
                    row_data_builder: nil)
       initial_expansion_options = normalize_options(initial_expansion, :initial_expansion, VALID_INITIAL_EXPANSION_KEYS)
@@ -81,6 +87,9 @@ module TreeView
       @selection_disabled_builder = resolve_option(selection_disabled_builder, selection_options[:disabled_builder])
       @selection_disabled_reason_builder = resolve_option(selection_disabled_reason_builder, selection_options[:disabled_reason_builder])
       @selection_selected_keys = Array(resolve_option(selection_selected_keys, selection_options[:selected_keys])).freeze
+      @current_key = current_key
+      @active_keys = Array(active_keys).freeze
+      @highlighted_keys = Array(highlighted_keys).freeze
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
 

--- a/spec/helpers/tree_view_helper_spec.rb
+++ b/spec/helpers/tree_view_helper_spec.rb
@@ -87,6 +87,44 @@ RSpec.describe TreeViewHelper do
     end
   end
 
+  describe "tree_row_classes" do
+    it "adds current, active, and highlighted classes while preserving builder classes" do
+      helper = helper_host_class.new(tree_ui: ui_config)
+      item = TestNode.new(id: 42, parent_item_id: nil, name: "sample")
+      tree = instance_double(TreeView::Tree)
+      allow(tree).to receive(:node_key_for).with(item).and_return("node-42")
+
+      classes = helper.tree_row_classes(
+        item,
+        ->(_item) { ["custom-row"] },
+        tree: tree,
+        current_key: "node-42",
+        active_keys: ["node-42"],
+        highlighted_keys: ["node-42"]
+      )
+
+      expect(classes).to eq(["custom-row", "is-current", "is-active", "is-highlighted"])
+    end
+
+    it "does not add row state classes when keys do not match" do
+      helper = helper_host_class.new(tree_ui: ui_config)
+      item = TestNode.new(id: 42, parent_item_id: nil, name: "sample")
+      tree = instance_double(TreeView::Tree)
+      allow(tree).to receive(:node_key_for).with(item).and_return("node-42")
+
+      classes = helper.tree_row_classes(
+        item,
+        nil,
+        tree: tree,
+        current_key: "node-1",
+        active_keys: ["node-2"],
+        highlighted_keys: ["node-3"]
+      )
+
+      expect(classes).to eq([])
+    end
+  end
+
   describe "tree render caches" do
     it "clears cached leaf distance and branch maps" do
       helper = helper_host_class.new(tree_ui: ui_config)

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -160,6 +160,22 @@ RSpec.describe TreeView::RenderState do
     expect(state.collapsed_keys).to eq([1, 2])
   end
 
+  it "stores row state keys when given" do
+    state = described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      current_key: 1,
+      active_keys: [2, 3],
+      highlighted_keys: [4, 5]
+    )
+
+    expect(state.current_key).to eq(1)
+    expect(state.active_keys).to eq([2, 3])
+    expect(state.highlighted_keys).to eq([4, 5])
+  end
+
   it "stores grouped initial_expansion options" do
     state = described_class.new(
       tree: tree,


### PR DESCRIPTION
## Summary

Closed because #128 has already implemented and merged the same `current_key` / `highlighted_keys` row class support into `main`.

## Related Issues

- #111
- #112

No further action is needed from this PR.