### PR TITLE
Add tree expansion state hook

### DIFF
--- a/app/helpers/tree_view_state_helper.rb
+++ b/app/helpers/tree_view_state_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module TreeViewStateHelper
+  def tree_view_state_data(render_state)
+    data = { controller: "tree-view-state" }
+    if render_state.respond_to?(:view_key) && render_state.view_key.present?
+      data[:tree_view_state_view_key_value] = render_state.view_key
+    end
+    data
+  end
+
+  def tree_state_row_data(item, tree, expanded:)
+    {
+      tree_view_state_target: "node",
+      tree_view_state_node_key: tree.node_key_for(item),
+      tree_view_state_expanded: expanded
+    }
+  end
+end

--- a/app/helpers/tree_view_state_helper.rb
+++ b/app/helpers/tree_view_state_helper.rb
@@ -17,3 +17,5 @@ module TreeViewStateHelper
     }
   end
 end
+
+TreeViewHelper.include(TreeViewStateHelper) if defined?(TreeViewHelper)

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -1,1 +1,59 @@
-export function registerTreeViewControllers(_application) {}
+import { Controller } from "@hotwired/stimulus"
+
+export class TreeViewStateController extends Controller {
+  static targets = ["node"]
+  static values = {
+    viewKey: String
+  }
+
+  connect() {
+    this.dispatchStateChanged()
+  }
+
+  expandedKeys() {
+    return this.nodeTargets
+      .filter((node) => node.dataset.treeViewStateExpanded === "true")
+      .map((node) => node.dataset.treeViewStateNodeKey)
+      .filter((key) => key && key.length > 0)
+  }
+
+  markExpanded(event) {
+    this.setExpandedFromEvent(event, true)
+  }
+
+  markCollapsed(event) {
+    this.setExpandedFromEvent(event, false)
+  }
+
+  refresh() {
+    this.dispatchStateChanged()
+  }
+
+  setExpandedFromEvent(event, expanded) {
+    const node = this.findNodeFromEvent(event)
+    if (!node) return
+
+    node.dataset.treeViewStateExpanded = expanded ? "true" : "false"
+    this.dispatchStateChanged()
+  }
+
+  findNodeFromEvent(event) {
+    const target = event.target
+    if (!target || !target.closest) return null
+
+    return target.closest("[data-tree-view-state-target~='node']")
+  }
+
+  dispatchStateChanged() {
+    this.dispatch("state-changed", {
+      detail: {
+        viewKey: this.hasViewKeyValue ? this.viewKeyValue : null,
+        expandedKeys: this.expandedKeys()
+      }
+    })
+  }
+}
+
+export function registerTreeViewControllers(application) {
+  application.register("tree-view-state", TreeViewStateController)
+}

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -28,7 +28,7 @@
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
 <% row_classes = tree_row_classes(item, row_class_builder) %>
-<% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth) %>
+<% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth).merge(tree_state_row_data(item, tree, expanded: !effectively_collapsed)) %>
 <% children = tree.children_for(item) %>
 <% descendant_count = tree.descendant_counts[tree.node_key_for(item)].to_i %>
 <% hidden_count = render_children && effectively_collapsed && descendant_count.positive? && render_self ? descendant_count : nil %>

--- a/lib/tree_view/engine.rb
+++ b/lib/tree_view/engine.rb
@@ -24,6 +24,7 @@ module TreeView
     initializer "tree_view.helpers" do
       ActiveSupport.on_load(:action_controller_base) do
         helper TreeViewHelper
+        helper TreeViewStateHelper
       end
     end
   end

--- a/spec/helpers/tree_view_state_helper_spec.rb
+++ b/spec/helpers/tree_view_state_helper_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.describe TreeViewStateHelper do
+  TestNode = Struct.new(:id, keyword_init: true)
+
+  let(:helper_host_class) do
+    Class.new do
+      include TreeViewStateHelper
+    end
+  end
+
+  it "builds root data without a view key" do
+    state = instance_double(TreeView::RenderState, view_key: nil)
+    helper = helper_host_class.new
+
+    expect(helper.tree_view_state_data(state)).to eq(controller: "tree-view-state")
+  end
+
+  it "builds root data with a view key" do
+    state = instance_double(TreeView::RenderState, view_key: "documents")
+    helper = helper_host_class.new
+
+    expect(helper.tree_view_state_data(state)).to eq(
+      controller: "tree-view-state",
+      tree_view_state_view_key_value: "documents"
+    )
+  end
+
+  it "builds row state data" do
+    item = TestNode.new(id: 1)
+    tree = instance_double(TreeView::Tree)
+    allow(tree).to receive(:node_key_for).with(item).and_return("node-1")
+    helper = helper_host_class.new
+
+    expect(helper.tree_state_row_data(item, tree, expanded: true)).to eq(
+      tree_view_state_target: "node",
+      tree_view_state_node_key: "node-1",
+      tree_view_state_expanded: true
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "bundler/setup"
 require "tree_view"
 require_relative "../app/helpers/tree_view_helper"
+require_relative "../app/helpers/tree_view_state_helper"
 
 RSpec.configure do |config|
   config.disable_monkey_patching!


### PR DESCRIPTION
## Summary

- Add `tree_view_state_data(render_state)` for host containers
- Add row data attributes for node keys and current expanded state
- Add `TreeViewStateController` with `expandedKeys()` and `state-changed` dispatch
- Register the controller from `registerTreeViewControllers(application)`
- Add helper specs

Closes #122

## Notes

This PR intentionally keeps persistence out of scope. It only exposes the browser-side state collection hook.

## Testing

- Not run locally. CI should run on this PR.