### PR TITLE
Add tree selection API

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -54,6 +54,53 @@ export class TreeViewStateController extends Controller {
   }
 }
 
+export class TreeViewSelectionController extends Controller {
+  selectedPayloads() {
+    return this.selectedCheckboxes()
+      .map((checkbox) => this.parsePayload(checkbox))
+      .filter((payload) => payload !== null)
+  }
+
+  submit(event) {
+    if (event) event.preventDefault()
+
+    this.dispatch("selected", {
+      detail: {
+        payloads: this.selectedPayloads()
+      }
+    })
+  }
+
+  refresh() {
+    this.dispatch("selected", {
+      detail: {
+        payloads: this.selectedPayloads()
+      }
+    })
+  }
+
+  selectedCheckboxes() {
+    return Array.from(
+      this.element.querySelectorAll(".tree-selection-checkbox:checked:not(:disabled)")
+    )
+  }
+
+  parsePayload(checkbox) {
+    try {
+      return JSON.parse(checkbox.value)
+    } catch (_error) {
+      this.dispatch("invalid-payload", {
+        detail: {
+          value: checkbox.value,
+          checkbox
+        }
+      })
+      return null
+    }
+  }
+}
+
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
+  application.register("tree-view-selection", TreeViewSelectionController)
 }

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -34,3 +34,36 @@ The checkbox value is a JSON string. Host apps can parse submitted values with:
 ```ruby
 selected_nodes = TreeView.parse_selection_params(params[:selected_nodes])
 ```
+
+## JavaScript selection API
+
+`tree-view-selection` can collect checked node payloads from rendered selection checkboxes.
+
+```erb
+<tbody data-controller="tree-view-selection">
+  <%= tree_view_rows(@render_state) %>
+</tbody>
+
+<button data-action="tree-view-selection#submit">
+  Process selected nodes
+</button>
+```
+
+When `submit` runs, the controller dispatches a `tree-view-selection:selected` event.
+
+```js
+document.addEventListener("tree-view-selection:selected", (event) => {
+  console.log(event.detail.payloads)
+})
+```
+
+The controller also exposes `selectedPayloads()` for direct JavaScript integration.
+
+```js
+const payloads = controller.selectedPayloads()
+```
+
+Only checked and enabled `.tree-selection-checkbox` elements are included.
+Invalid JSON values are skipped and reported through `tree-view-selection:invalid-payload`.
+
+TreeView only collects and exposes the selected payloads. Deleting, moving, relating, or sending them to an API remains the host app's responsibility.


### PR DESCRIPTION
## Summary

- Add `TreeViewSelectionController`
- Register `tree-view-selection`
- Add `selectedPayloads()`, `submit`, and `refresh`
- Document the JavaScript selection API

Closes #114

## Testing

- Not run locally. CI should run on this PR.