### PR TITLE
Complete current and highlighted row support

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -26,6 +26,7 @@ module TreeViewHelper
         max_toggle_leaf_distance: render_state.max_toggle_leaf_distance,
         expanded_keys: render_state.expanded_keys,
         collapsed_keys: render_state.collapsed_keys,
+        current_key: render_state.current_key,
         selection_enabled: render_state.selection_enabled?,
         selection_visibility: render_state.selection_visibility,
         selection_payload_builder: render_state.selection_payload_builder,

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -8,6 +8,7 @@
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
 <% collapsed_keys = local_assigns[:collapsed_keys] %>
+<% current_key = local_assigns[:current_key] %>
 <% selection_enabled = local_assigns[:selection_enabled] %>
 <% selection_visibility = local_assigns.fetch(:selection_visibility, :all) %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
@@ -19,5 +20,5 @@
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, current_key: current_key, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -9,6 +9,7 @@
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% expanded_keys = local_assigns[:expanded_keys] %>
 <% collapsed_keys = local_assigns[:collapsed_keys] %>
+<% current_key = local_assigns[:current_key] %>
 <% selection_enabled = local_assigns[:selection_enabled] %>
 <% selection_visibility = local_assigns.fetch(:selection_visibility, :all) %>
 <% selection_payload_builder = local_assigns[:selection_payload_builder] %>
@@ -29,10 +30,10 @@
 <% row_data_builder = local_assigns[:row_data_builder] %>
 <% row_classes = tree_row_classes(item, row_class_builder) %>
 <% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth).merge(tree_state_row_data(item, tree, expanded: !effectively_collapsed)) %>
-<% row_aria = tree_row_aria(item, tree, depth: depth, expanded: !effectively_collapsed, selected: tree_selection_checked?(item, tree, selection_selected_keys)) %>
 <% children = tree.children_for(item) %>
 <% row_aria = { level: depth + 1, selected: tree_selection_checked?(item, tree, selection_selected_keys) } %>
 <% row_aria[:expanded] = !effectively_collapsed if children.any? %>
+<% row_aria[:current] = "page" if current_key == tree.node_key_for(item) %>
 <% descendant_count = tree.descendant_counts[tree.node_key_for(item)].to_i %>
 <% hidden_count = render_children && effectively_collapsed && descendant_count.positive? && render_self ? descendant_count : nil %>
 <% if render_self %>
@@ -46,5 +47,5 @@
   <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, current_key: current_key, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder %>
 <% end %>

--- a/docs/host-app-extension-points.md
+++ b/docs/host-app-extension-points.md
@@ -7,6 +7,8 @@ Host applications can customize row output with these extension points:
 - `row_partial`
 - `row_class_builder`
 - `row_data_builder`
+- `current_key`
+- `highlighted_keys`
 
 ## Row partial
 
@@ -37,3 +39,33 @@ TreeView::RenderState.new(
 ```
 
 TreeView should not own application-specific row policies. Keep those decisions in the host application and use TreeView only for tree rendering structure.
+
+## Current and highlighted rows
+
+Use `current_key` when one row represents the currently displayed page or selected node.
+Use `highlighted_keys` when one or more rows should be emphasized, such as search hits.
+
+```ruby
+TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  current_key: tree.node_key_for(current_document),
+  highlighted_keys: matched_documents.map { |document| tree.node_key_for(document) },
+  row_class_builder: ->(item) { ["document-row"] }
+)
+```
+
+Current rows receive these classes:
+
+- `is-current`
+- `tree-view-row--current`
+
+Highlighted rows receive these classes:
+
+- `is-highlighted`
+- `tree-view-row--highlighted`
+
+`row_class_builder` classes are preserved and combined with TreeView's current/highlighted row classes.
+Current rows also receive `aria-current="page"` so assistive technologies can identify the active row.

--- a/lib/tree_view/render_state_row_state.rb
+++ b/lib/tree_view/render_state_row_state.rb
@@ -2,6 +2,9 @@
 
 module TreeView
   module RenderStateRowState
+    CURRENT_ROW_CLASSES = ["is-current", "tree-view-row--current"].freeze
+    HIGHLIGHTED_ROW_CLASSES = ["is-highlighted", "tree-view-row--highlighted"].freeze
+
     attr_reader :current_key, :highlighted_keys
 
     def initialize(**options)
@@ -28,8 +31,8 @@ module TreeView
       lambda do |item|
         node_key = tree.node_key_for(item)
         classes = Array(original_row_class_builder&.call(item)).flatten.compact
-        classes << "is-current" if current_key == node_key
-        classes << "is-highlighted" if highlighted_keys.include?(node_key)
+        classes.concat(CURRENT_ROW_CLASSES) if current_key == node_key
+        classes.concat(HIGHLIGHTED_ROW_CLASSES) if highlighted_keys.include?(node_key)
         classes
       end
     end

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -104,8 +104,9 @@ RSpec.describe "TreeView integration" do
 
       rendered = view.tree_view_rows(render_state)
 
-      expect(rendered).to include('class="host-child is-current"')
-      expect(rendered).to include('class="host-grandchild is-highlighted"')
+      expect(rendered).to include('class="host-child is-current tree-view-row--current"')
+      expect(rendered).to include('aria-current="page"')
+      expect(rendered).to include('class="host-grandchild is-highlighted tree-view-row--highlighted"')
       expect(rendered).to include('class="host-root"')
     end
 


### PR DESCRIPTION
## Summary

- Add semantic CSS classes for current and highlighted rows while preserving the existing `is-current` / `is-highlighted` classes
- Render `aria-current="page"` on the current row
- Propagate `current_key` through recursive row rendering
- Update integration specs and extension-point docs

Closes #145

## Tests

- Not run locally: this environment could not clone from GitHub because DNS resolution for `github.com` failed, so changes were made through the GitHub connector API.
- Added/updated integration expectations; please let GitHub Actions run the full suite.