### PR TITLE
docs: clarify CI coverage

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,7 +66,7 @@ pin "tree_view", to: "tree_view/index.js"
 TreeView gem package には、Rails host app で必要になる以下を含めます。
 
 - `app/assets/stylesheets/tree_view.scss`
-- `app/helpers tree_view_helper.rb`
+- `app/helpers/tree_view_helper.rb`
 - `app/javascript/tree_view/**/*`
 - `app/views/tree_view/**/*`
 - `config/importmap.tree_view.rb`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,14 @@
 
 この条件は `tree_view.gemspec` の `required_ruby_version` と `railties` dependency に合わせます。
 
+## CIで確認している範囲
+
+GitHub Actions では、Ruby 3.2 / 3.3 で `bundle exec rake` を実行します。
+
+gem package job は Ruby 3.3 で `gem build`、`gem install`、`require "tree_view"` を確認します。
+
+Rails version は `Gemfile.lock` 上の現在の解決結果で確認します。Rails version matrix を追加する場合は、CI時間とAppraisal等の構成を別途検討します。
+
 ## Gemfile
 
 host app の `Gemfile` に追加します。
@@ -58,7 +66,7 @@ pin "tree_view", to: "tree_view/index.js"
 TreeView gem package には、Rails host app で必要になる以下を含めます。
 
 - `app/assets/stylesheets/tree_view.scss`
-- `app/helpers/tree_view_helper.rb`
+- `app/helpers tree_view_helper.rb`
 - `app/javascript/tree_view/**/*`
 - `app/views/tree_view/**/*`
 - `config/importmap.tree_view.rb`


### PR DESCRIPTION
## Summary

- Document Ruby 3.2 / 3.3 CI coverage
- Document Ruby 3.3 gem package check
- Note Rails matrix as a future follow-up

## Related issue

- #191

## Testing

- Not run locally; docs-only change.