### PR TITLE
fix: improve builder error diagnostics

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -65,12 +65,12 @@ module TreeViewHelper
     Array(builder&.call(item)).flatten.compact_blank
   end
 
-  def tree_row_data(item, builder = nil)
+  def tree_row_data(item, builder = nil, tree: nil)
     data = builder&.call(item)
     return {} if data.nil?
     return data.to_h if data.respond_to?(:to_h)
 
-    raise ArgumentError, "row_data_builder must return a Hash-like object"
+    raise ArgumentError, "row_data_builder must return a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
   end
 
   def tree_hidden_count_message(hidden_count, builder = nil)
@@ -89,7 +89,7 @@ module TreeViewHelper
     payload = builder ? builder.call(item) : default_tree_selection_payload(item, tree)
     return payload.to_h if payload.respond_to?(:to_h)
 
-    raise ArgumentError, "selection_payload_builder must return a Hash-like object"
+    raise ArgumentError, "selection_payload_builder must return a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
   end
 
   def tree_selection_value(item, tree, builder = nil)
@@ -245,6 +245,16 @@ module TreeViewHelper
       id: item.respond_to?(:id) ? item.id : tree.node_key_for(item),
       type: item.class.name
     }
+  end
+
+  def tree_diagnostic_node_label(item, tree = nil)
+    return "node_key=#{tree.node_key_for(item).inspect}" if tree
+
+    if item.respond_to?(:id)
+      "item_id=#{item.id.inspect}"
+    else
+      "item=#{item.inspect}"
+    end
   end
 
   def tree_max_depth(tree)

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -31,7 +31,7 @@
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
 <% row_classes = tree_row_classes(item, row_class_builder) %>
-<% row_data = tree_row_data(item, row_data_builder).merge(tree_depth: depth).merge(tree_state_row_data(item, tree, expanded: !effectively_collapsed)) %>
+<% row_data = tree_row_data(item, row_data_builder, tree: tree).merge(tree_depth: depth).merge(tree_state_row_data(item, tree, expanded: !effectively_collapsed)) %>
 <% children = tree.children_for(item) %>
 <% row_aria = { level: depth + 1, selected: tree_selection_checked?(item, tree, selection_selected_keys) } %>
 <% row_aria[:expanded] = !effectively_collapsed if children.any? %>

--- a/spec/helpers/tree_view_builder_diagnostics_spec.rb
+++ b/spec/helpers/tree_view_builder_diagnostics_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe "TreeView builder diagnostics" do
+  DiagnosticNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+  let(:helper_host_class) do
+    Class.new do
+      include TreeViewHelper
+    end
+  end
+
+  let(:helper) { helper_host_class.new }
+  let(:node) { DiagnosticNode.new(id: 42, parent_item_id: nil, name: "sample") }
+  let(:tree) { TreeView::Tree.new(records: [node], parent_id_method: :parent_item_id) }
+
+  it "includes item id when row_data_builder returns an invalid value without tree context" do
+    expect do
+      helper.tree_row_data(node, ->(_item) { "invalid" })
+    end.to raise_error(ArgumentError, /row_data_builder.*item_id=42/)
+  end
+
+  it "includes node key when row_data_builder returns an invalid value with tree context" do
+    expect do
+      helper.tree_row_data(node, ->(_item) { "invalid" }, tree: tree)
+    end.to raise_error(ArgumentError, /row_data_builder.*node_key=42/)
+  end
+
+  it "includes node key when selection_payload_builder returns an invalid value" do
+    expect do
+      helper.tree_selection_payload(node, tree, ->(_item) { "invalid" })
+    end.to raise_error(ArgumentError, /selection_payload_builder.*node_key=42/)
+  end
+end


### PR DESCRIPTION
## Summary

- Include item/node context when `row_data_builder` returns a non hash-like value
- Include node context when `selection_payload_builder` returns a non hash-like value
- Pass tree context from row rendering so row data errors can report `node_key`
- Add helper specs for diagnostic messages

## Related issue

- #187

## Testing

- Not run locally because repository cloning failed with DNS resolution error in this environment.
- CI should run the repository default task on the PR.