### PR TITLE
feat: add optional badge hook

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -37,7 +37,8 @@ module TreeViewHelper
         hidden_message_builder: render_state.hidden_message_builder,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder,
-        depth_label_builder: render_state.depth_label_builder
+        depth_label_builder: render_state.depth_label_builder,
+        badge_builder: render_state.badge_builder
       }
     )
   ensure
@@ -83,6 +84,28 @@ module TreeViewHelper
     return nil unless builder
 
     builder.call(item, depth).presence
+  end
+
+  def tree_node_badge(item, builder = nil, tree: nil)
+    value = builder&.call(item)
+    return nil if value.nil?
+
+    if value.respond_to?(:to_h)
+      badge = value.to_h.symbolize_keys
+      text = badge[:text] || badge[:label]
+      return nil if text.blank?
+
+      {
+        text: text,
+        class: Array(badge[:class]).flatten.compact_blank,
+        title: badge[:title],
+        data: badge[:data].respond_to?(:to_h) ? badge[:data].to_h : {}
+      }
+    else
+      { text: value, class: [], title: nil, data: {} }
+    end
+  rescue NoMethodError
+    raise ArgumentError, "badge_builder must return text or a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
   end
 
   def tree_selection_payload(item, tree, builder = nil)

--- a/app/helpers/tree_view_row_actions_helper.rb
+++ b/app/helpers/tree_view_row_actions_helper.rb
@@ -37,7 +37,8 @@ module TreeViewRowActionsHelper
         hidden_message_builder: render_state.hidden_message_builder,
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder,
-        depth_label_builder: render_state.depth_label_builder
+        depth_label_builder: render_state.depth_label_builder,
+        badge_builder: render_state.badge_builder
       }
     )
   ensure

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -1,6 +1,7 @@
 <% sorted_items = tree.sort_items(items) %>
 <% row_class_builder = local_assigns[:row_class_builder] %>
 <% row_data_builder = local_assigns[:row_data_builder] %>
+<% badge_builder = local_assigns[:badge_builder] %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
 <% max_render_depth = local_assigns[:max_render_depth] %>
 <% max_leaf_distance = local_assigns[:max_leaf_distance] %>
@@ -21,5 +22,5 @@
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, row_actions_partial: local_assigns[:row_actions_partial], mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, current_key: current_key, depth_label_builder: depth_label_builder, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder, render_state: local_assigns[:render_state] %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, tree: tree, row_partial: row_partial, row_actions_partial: local_assigns[:row_actions_partial], badge_builder: badge_builder, mode: tree_toggle_mode(local_assigns[:mode]), max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, current_key: current_key, depth_label_builder: depth_label_builder, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder, render_state: local_assigns[:render_state] %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -2,6 +2,7 @@
 <% depth = local_assigns.fetch(:depth, branch_info[:depth]) %>
 <% row_partial = local_assigns.fetch(:row_partial) %>
 <% row_actions_partial = local_assigns[:row_actions_partial] %>
+<% badge_builder = local_assigns[:badge_builder] %>
 <% collapsed = local_assigns.fetch(:collapsed, false) %>
 <% max_initial_depth = local_assigns[:max_initial_depth] %>
 <% max_render_depth = local_assigns[:max_render_depth] %>
@@ -44,7 +45,7 @@
       <% selection_visible = tree_selection_visible?(item, tree, depth, selection_visibility) %>
       <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_visible: selection_visible, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys %>
     <% end %>
-    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, depth_label_builder: depth_label_builder, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
+    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, depth_label_builder: depth_label_builder, badge_builder: badge_builder, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
     <%= render row_partial, item: item %>
     <% if row_actions_partial %>
       <%= render row_actions_partial, item: item, tree: tree, render_state: local_assigns[:render_state] %>
@@ -52,5 +53,5 @@
   <% end %>
 <% end %>
 <% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, row_actions_partial: row_actions_partial, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, current_key: current_key, depth_label_builder: depth_label_builder, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder, render_state: local_assigns[:render_state] %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, tree: tree, row_partial: row_partial, row_actions_partial: row_actions_partial, badge_builder: badge_builder, mode: mode, max_initial_depth: max_initial_depth, max_render_depth: max_render_depth, max_leaf_distance: max_leaf_distance, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, expanded_keys: expanded_keys, collapsed_keys: collapsed_keys, current_key: current_key, depth_label_builder: depth_label_builder, selection_enabled: selection_enabled, selection_visibility: selection_visibility, selection_payload_builder: selection_payload_builder, selection_checkbox_name: selection_checkbox_name, selection_disabled_builder: selection_disabled_builder, selection_disabled_reason_builder: selection_disabled_reason_builder, selection_selected_keys: selection_selected_keys, hidden_message_builder: hidden_message_builder, row_class_builder: row_class_builder, row_data_builder: row_data_builder, render_state: local_assigns[:render_state] %>
 <% end %>

--- a/app/views/tree_view/_tree_toggle_cell.html.erb
+++ b/app/views/tree_view/_tree_toggle_cell.html.erb
@@ -1,16 +1,21 @@
 <% hidden_count = local_assigns[:hidden_count] %>
 <% hidden_message_builder = local_assigns[:hidden_message_builder] %>
 <% depth_label_builder = local_assigns[:depth_label_builder] %>
+<% badge_builder = local_assigns[:badge_builder] %>
 <% children ||= tree.children_for(item) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% leaf_distance = local_assigns[:leaf_distance] %>
 <% depth_label = tree_depth_label(item, depth, depth_label_builder) %>
+<% badge = tree_node_badge(item, badge_builder, tree: tree) %>
 
 <td class="btn-cell tree-toggle-cell" id="<%= tree_button_dom_id(item) %>">
   <%= render 'tree_view/tree_toggle_content', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
   <% if depth_label %>
     <span class="tree-depth-label"><%= depth_label %></span>
+  <% end %>
+  <% if badge %>
+    <%= tag.span badge[:text], class: ['tree-node-badge', badge[:class]].flatten.compact_blank, title: badge[:title], data: badge[:data] %>
   <% end %>
 </td>

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -32,7 +32,8 @@ module TreeView
                 :selection_selected_keys,
                 :row_class_builder,
                 :row_data_builder,
-                :depth_label_builder
+                :depth_label_builder,
+                :badge_builder
 
     # RenderState は「この画面ではどう描くか」を束ねる。
     def initialize(tree:,
@@ -60,7 +61,8 @@ module TreeView
                    selection: nil,
                    row_class_builder: nil,
                    row_data_builder: nil,
-                   depth_label_builder: nil)
+                   depth_label_builder: nil,
+                   badge_builder: nil)
       initial_expansion_options = normalize_options(initial_expansion, :initial_expansion, VALID_INITIAL_EXPANSION_KEYS)
       render_scope_options = normalize_options(render_scope, :render_scope, VALID_RENDER_SCOPE_KEYS)
       toggle_scope_options = normalize_options(toggle_scope, :toggle_scope, VALID_TOGGLE_SCOPE_KEYS)
@@ -89,10 +91,12 @@ module TreeView
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
       @depth_label_builder = depth_label_builder
+      @badge_builder = badge_builder
 
       validate_builder!(row_class_builder, :row_class_builder)
       validate_builder!(row_data_builder, :row_data_builder)
       validate_builder!(depth_label_builder, :depth_label_builder)
+      validate_builder!(badge_builder, :badge_builder)
       validate_builder!(@selection_payload_builder, :selection_payload_builder)
       validate_builder!(@selection_disabled_builder, :selection_disabled_builder)
       validate_builder!(@selection_disabled_reason_builder, :selection_disabled_reason_builder)

--- a/spec/helpers/tree_view_badge_helper_spec.rb
+++ b/spec/helpers/tree_view_badge_helper_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe "TreeView badge helper" do
+  BadgeNode = Struct.new(:id, :name, keyword_init: true)
+
+  let(:helper_host_class) do
+    Class.new do
+      include TreeViewHelper
+    end
+  end
+
+  let(:helper) { helper_host_class.new }
+  let(:node) { BadgeNode.new(id: 1, name: "root") }
+
+  it "builds badge data from plain text" do
+    badge = helper.tree_node_badge(node, ->(_item) { "2" })
+
+    expect(badge).to eq(text: "2", class: [], title: nil, data: {})
+  end
+
+  it "builds badge data from a hash-like value" do
+    badge = helper.tree_node_badge(
+      node,
+      ->(_item) { { text: "new", class: "is-new", title: "New" } }
+    )
+
+    expect(badge).to eq(text: "new", class: ["is-new"], title: "New", data: {})
+  end
+
+  it "returns nil when badge text is blank" do
+    expect(helper.tree_node_badge(node, ->(_item) { { text: "" } })).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

- Add optional `badge_builder` to `TreeView::RenderState`
- Render a badge next to toggle content when the builder returns a value
- Support plain text badges and hash-like badge data
- Add helper specs for badge data normalization

## Example

```ruby
TreeView::RenderState.new(
  tree: tree,
  root_items: tree.root_items,
  row_partial: "documents/tree_columns",
  ui_config: tree_ui,
  badge_builder: ->(item) { item.children_count }
)
```

## Related issue

- #154

## Testing

- Not run locally because repository cloning failed in this environment.
- CI should run the repository default task on the PR.