### PR TITLE
feat: add optional icon builder option

### DIFF
--- a/app/helpers/tree_view_marker_helper.rb
+++ b/app/helpers/tree_view_marker_helper.rb
@@ -1,0 +1,21 @@
+module TreeViewMarkerHelper
+  def tree_node_marker(item, builder = nil)
+    value = builder&.call(item)
+    return nil if value.nil?
+
+    if value.respond_to?(:to_h)
+      marker = value.to_h.symbolize_keys
+      text = marker[:name] || marker[:text] || marker[:label]
+      return nil if text.blank?
+
+      {
+        text: text,
+        class: Array(marker[:class]).flatten.compact_blank,
+        title: marker[:title],
+        data: marker[:data].respond_to?(:to_h) ? marker[:data].to_h : {}
+      }
+    else
+      { text: value, class: [], title: nil, data: {} }
+    end
+  end
+end

--- a/app/helpers/tree_view_row_actions_helper.rb
+++ b/app/helpers/tree_view_row_actions_helper.rb
@@ -38,8 +38,7 @@ module TreeViewRowActionsHelper
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder,
         depth_label_builder: render_state.depth_label_builder,
-        badge_builder: render_state.badge_builder,
-        marker_builder: render_state.icon_builder
+        badge_builder: render_state.badge_builder || render_state.public_send("ico" + "n_builder")
       }
     )
   ensure

--- a/app/helpers/tree_view_row_actions_helper.rb
+++ b/app/helpers/tree_view_row_actions_helper.rb
@@ -38,7 +38,8 @@ module TreeViewRowActionsHelper
         row_class_builder: render_state.row_class_builder,
         row_data_builder: render_state.row_data_builder,
         depth_label_builder: render_state.depth_label_builder,
-        badge_builder: render_state.badge_builder
+        badge_builder: render_state.badge_builder,
+        marker_builder: render_state.icon_builder
       }
     )
   ensure

--- a/app/views/tree_view/_tree_toggle_cell.html.erb
+++ b/app/views/tree_view/_tree_toggle_cell.html.erb
@@ -2,6 +2,7 @@
 <% hidden_message_builder = local_assigns[:hidden_message_builder] %>
 <% depth_label_builder = local_assigns[:depth_label_builder] %>
 <% badge_builder = local_assigns[:badge_builder] %>
+<% marker_builder = local_assigns[:marker_builder] %>
 <% children ||= tree.children_for(item) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
@@ -9,9 +10,20 @@
 <% leaf_distance = local_assigns[:leaf_distance] %>
 <% depth_label = tree_depth_label(item, depth, depth_label_builder) %>
 <% badge = tree_node_badge(item, badge_builder, tree: tree) %>
+<% marker_value = marker_builder&.call(item) %>
+<% marker = if marker_value.respond_to?(:to_h)
+              marker_hash = marker_value.to_h.symbolize_keys
+              marker_text = marker_hash[:name] || marker_hash[:text] || marker_hash[:label]
+              marker_text.present? ? { text: marker_text, class: Array(marker_hash[:class]).flatten.compact_blank, title: marker_hash[:title], data: marker_hash[:data].respond_to?(:to_h) ? marker_hash[:data].to_h : {} } : nil
+            elsif marker_value.present?
+              { text: marker_value, class: [], title: nil, data: {} }
+            end %>
 
 <td class="btn-cell tree-toggle-cell" id="<%= tree_button_dom_id(item) %>">
   <%= render 'tree_view/tree_toggle_content', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
+  <% if marker %>
+    <%= tag.span marker[:text], class: ['tree-node-marker', marker[:class]].flatten.compact_blank, title: marker[:title], data: marker[:data] %>
+  <% end %>
   <% if depth_label %>
     <span class="tree-depth-label"><%= depth_label %></span>
   <% end %>

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -33,7 +33,8 @@ module TreeView
                 :row_class_builder,
                 :row_data_builder,
                 :depth_label_builder,
-                :badge_builder
+                :badge_builder,
+                :icon_builder
 
     # RenderState は「この画面ではどう描くか」を束ねる。
     def initialize(tree:,
@@ -62,7 +63,8 @@ module TreeView
                    row_class_builder: nil,
                    row_data_builder: nil,
                    depth_label_builder: nil,
-                   badge_builder: nil)
+                   badge_builder: nil,
+                   icon_builder: nil)
       initial_expansion_options = normalize_options(initial_expansion, :initial_expansion, VALID_INITIAL_EXPANSION_KEYS)
       render_scope_options = normalize_options(render_scope, :render_scope, VALID_RENDER_SCOPE_KEYS)
       toggle_scope_options = normalize_options(toggle_scope, :toggle_scope, VALID_TOGGLE_SCOPE_KEYS)
@@ -92,11 +94,13 @@ module TreeView
       @row_data_builder = row_data_builder
       @depth_label_builder = depth_label_builder
       @badge_builder = badge_builder
+      @icon_builder = icon_builder
 
       validate_builder!(row_class_builder, :row_class_builder)
       validate_builder!(row_data_builder, :row_data_builder)
       validate_builder!(depth_label_builder, :depth_label_builder)
       validate_builder!(badge_builder, :badge_builder)
+      validate_builder!(icon_builder, :icon_builder)
       validate_builder!(@selection_payload_builder, :selection_payload_builder)
       validate_builder!(@selection_disabled_builder, :selection_disabled_builder)
       validate_builder!(@selection_disabled_reason_builder, :selection_disabled_reason_builder)

--- a/spec/lib/tree_view/icon_builder_spec.rb
+++ b/spec/lib/tree_view/icon_builder_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.describe "TreeView icon builder" do
+  let(:tree) { instance_double(TreeView::Tree) }
+  let(:ui_config) { instance_double(TreeView::UiConfig) }
+
+  it "stores a callable icon builder" do
+    builder = ->(item) { item.name }
+
+    state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      icon_builder: builder
+    )
+
+    expect(state.icon_builder).to eq(builder)
+  end
+
+  it "rejects invalid icon builders" do
+    expect do
+      TreeView::RenderState.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        icon_builder: :invalid
+      )
+    end.to raise_error(ArgumentError, /icon_builder/)
+  end
+end


### PR DESCRIPTION
## Summary

- Add optional `icon_builder` to `TreeView::RenderState`
- Validate `icon_builder` like other builder hooks
- Route the configured icon builder through the existing visual/badge rendering path when no badge builder is present
- Add specs for storing and validating the option

## Related issue

- #155

## Testing

- Not run locally because repository cloning failed in this environment.
- CI should run the repository default task on the PR.