### PR TITLE
feat: add view key for tree rows

### DIFF
--- a/app/helpers/tree_view_row_actions_helper.rb
+++ b/app/helpers/tree_view_row_actions_helper.rb
@@ -36,7 +36,7 @@ module TreeViewRowActionsHelper
         selection_selected_keys: render_state.selection_selected_keys,
         hidden_message_builder: render_state.hidden_message_builder,
         row_class_builder: render_state.row_class_builder,
-        row_data_builder: render_state.row_data_builder,
+        row_data_builder: tree_view_row_data_with_key(render_state),
         depth_label_builder: render_state.depth_label_builder,
         badge_builder: render_state.badge_builder || render_state.public_send("ico" + "n_builder")
       }
@@ -44,5 +44,17 @@ module TreeViewRowActionsHelper
   ensure
     clear_tree_view_render_caches!
     @tree_ui = previous_tree_ui
+  end
+
+  private
+
+  def tree_view_row_data_with_key(render_state)
+    return render_state.row_data_builder unless render_state.view_key
+
+    lambda do |item|
+      data = render_state.row_data_builder&.call(item)
+      data = data.respond_to?(:to_h) ? data.to_h : {}
+      data.merge(view_key: render_state.view_key)
+    end
   end
 end

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -15,6 +15,7 @@ module TreeView
                 :row_partial,
                 :row_actions_partial,
                 :ui_config,
+                :view_key,
                 :initial_state,
                 :max_initial_depth,
                 :max_render_depth,
@@ -42,6 +43,7 @@ module TreeView
                    row_partial:,
                    ui_config:,
                    row_actions_partial: nil,
+                   view_key: nil,
                    initial_state: nil,
                    max_initial_depth: nil,
                    max_render_depth: nil,
@@ -75,6 +77,7 @@ module TreeView
       @row_partial = row_partial
       @row_actions_partial = row_actions_partial
       @ui_config = ui_config
+      @view_key = view_key&.to_s
       @initial_state = normalize_initial_state(resolve_option(initial_state, initial_expansion_options[:default]))
       @max_initial_depth = normalize_non_negative_integer(resolve_option(max_initial_depth, initial_expansion_options[:max_depth]), :max_initial_depth)
       @max_render_depth = normalize_non_negative_integer(resolve_option(max_render_depth, render_scope_options[:max_depth]), :max_render_depth)

--- a/lib/tree_view/render_state_persisted_state.rb
+++ b/lib/tree_view/render_state_persisted_state.rb
@@ -12,7 +12,7 @@ module TreeView
     end
 
     def view_key
-      persisted_state&.view_key
+      super || persisted_state&.view_key
     end
   end
 end

--- a/spec/lib/tree_view/view_key_spec.rb
+++ b/spec/lib/tree_view/view_key_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe "TreeView view key" do
+  let(:tree) { instance_double(TreeView::Tree) }
+  let(:ui_config) { instance_double(TreeView::UiConfig) }
+
+  it "stores view key as a string" do
+    state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      view_key: :source
+    )
+
+    expect(state.view_key).to eq("source")
+  end
+
+  it "keeps view key nil when omitted" do
+    state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config
+    )
+
+    expect(state.view_key).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

- Add optional `view_key` to `TreeView::RenderState`
- Render `view_key` into row data attributes as `data-view-key`
- Preserve host-provided row data by merging the generated value
- Add specs for the RenderState option

## Related issue

- #176

## Testing

- Not run locally because repository cloning failed in this environment.
- CI should run the repository default task on the PR.