### PR TITLE
feat: add row event payload builder

### DIFF
--- a/app/helpers/tree_view_row_actions_helper.rb
+++ b/app/helpers/tree_view_row_actions_helper.rb
@@ -36,7 +36,7 @@ module TreeViewRowActionsHelper
         selection_selected_keys: render_state.selection_selected_keys,
         hidden_message_builder: render_state.hidden_message_builder,
         row_class_builder: render_state.row_class_builder,
-        row_data_builder: tree_view_row_data_with_key(render_state),
+        row_data_builder: tree_view_row_data_for_render(render_state),
         depth_label_builder: render_state.depth_label_builder,
         badge_builder: render_state.badge_builder || render_state.public_send("ico" + "n_builder")
       }
@@ -48,13 +48,21 @@ module TreeViewRowActionsHelper
 
   private
 
-  def tree_view_row_data_with_key(render_state)
-    return render_state.row_data_builder unless render_state.view_key
+  def tree_view_row_data_for_render(render_state)
+    return render_state.row_data_builder unless render_state.view_key || render_state.row_event_payload_builder
 
     lambda do |item|
       data = render_state.row_data_builder&.call(item)
       data = data.respond_to?(:to_h) ? data.to_h : {}
-      data.merge(view_key: render_state.view_key)
+      data = data.merge(view_key: render_state.view_key) if render_state.view_key
+
+      if render_state.row_event_payload_builder
+        payload = render_state.row_event_payload_builder.call(item)
+        payload = payload.to_h if payload.respond_to?(:to_h)
+        data = data.merge(row_event_payload: JSON.generate(payload))
+      end
+
+      data
     end
   end
 end

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -33,6 +33,7 @@ module TreeView
                 :selection_selected_keys,
                 :row_class_builder,
                 :row_data_builder,
+                :row_event_payload_builder,
                 :depth_label_builder,
                 :badge_builder,
                 :icon_builder
@@ -64,6 +65,7 @@ module TreeView
                    selection: nil,
                    row_class_builder: nil,
                    row_data_builder: nil,
+                   row_event_payload_builder: nil,
                    depth_label_builder: nil,
                    badge_builder: nil,
                    icon_builder: nil)
@@ -95,12 +97,14 @@ module TreeView
       @selection_selected_keys = Array(resolve_option(selection_selected_keys, selection_options[:selected_keys])).freeze
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
+      @row_event_payload_builder = row_event_payload_builder
       @depth_label_builder = depth_label_builder
       @badge_builder = badge_builder
       @icon_builder = icon_builder
 
       validate_builder!(row_class_builder, :row_class_builder)
       validate_builder!(row_data_builder, :row_data_builder)
+      validate_builder!(row_event_payload_builder, :row_event_payload_builder)
       validate_builder!(depth_label_builder, :depth_label_builder)
       validate_builder!(badge_builder, :badge_builder)
       validate_builder!(icon_builder, :icon_builder)

--- a/spec/lib/tree_view/row_event_payload_builder_spec.rb
+++ b/spec/lib/tree_view/row_event_payload_builder_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.describe "TreeView row event payload builder" do
+  let(:tree) { instance_double(TreeView::Tree) }
+  let(:ui_config) { instance_double(TreeView::UiConfig) }
+
+  it "stores a callable row event payload builder" do
+    builder = ->(item) { { id: item.id } }
+
+    state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      row_event_payload_builder: builder
+    )
+
+    expect(state.row_event_payload_builder).to eq(builder)
+  end
+
+  it "rejects invalid row event payload builders" do
+    expect do
+      TreeView::RenderState.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        row_event_payload_builder: :invalid
+      )
+    end.to raise_error(ArgumentError, /row_event_payload_builder/)
+  end
+end


### PR DESCRIPTION
## Summary

- Add optional `row_event_payload_builder` to `TreeView::RenderState`
- Validate the builder like other row hooks
- Merge generated row event payload into row data as JSON
- Add specs for storing and validating the option

## Related issue

- #157

## Testing

- Not run locally because repository cloning failed in this environment.
- CI should run the repository default task on the PR.