### PR TITLE
feat: add error state hook

### DIFF
--- a/app/helpers/tree_view_row_actions_helper.rb
+++ b/app/helpers/tree_view_row_actions_helper.rb
@@ -49,7 +49,7 @@ module TreeViewRowActionsHelper
   private
 
   def tree_view_row_data_for_render(render_state)
-    return render_state.row_data_builder unless render_state.view_key || render_state.row_event_payload_builder || render_state.loading_builder
+    return render_state.row_data_builder unless render_state.view_key || render_state.row_event_payload_builder || render_state.loading_builder || render_state.error_builder
 
     lambda do |item|
       data = render_state.row_data_builder&.call(item)
@@ -62,7 +62,12 @@ module TreeViewRowActionsHelper
         data = data.merge(row_event_payload: JSON.generate(payload))
       end
 
-      data = data.merge(remote_state: "loading") if render_state.loading_builder&.call(item) == true
+      if render_state.error_builder&.call(item) == true
+        data = data.merge(remote_state: "error")
+      elsif render_state.loading_builder&.call(item) == true
+        data = data.merge(remote_state: "loading")
+      end
+
       data
     end
   end

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -35,6 +35,7 @@ module TreeView
                 :row_data_builder,
                 :row_event_payload_builder,
                 :loading_builder,
+                :error_builder,
                 :depth_label_builder,
                 :badge_builder,
                 :icon_builder
@@ -68,6 +69,7 @@ module TreeView
                    row_data_builder: nil,
                    row_event_payload_builder: nil,
                    loading_builder: nil,
+                   error_builder: nil,
                    depth_label_builder: nil,
                    badge_builder: nil,
                    icon_builder: nil)
@@ -101,6 +103,7 @@ module TreeView
       @row_data_builder = row_data_builder
       @row_event_payload_builder = row_event_payload_builder
       @loading_builder = loading_builder
+      @error_builder = error_builder
       @depth_label_builder = depth_label_builder
       @badge_builder = badge_builder
       @icon_builder = icon_builder
@@ -109,6 +112,7 @@ module TreeView
       validate_builder!(row_data_builder, :row_data_builder)
       validate_builder!(row_event_payload_builder, :row_event_payload_builder)
       validate_builder!(loading_builder, :loading_builder)
+      validate_builder!(error_builder, :error_builder)
       validate_builder!(depth_label_builder, :depth_label_builder)
       validate_builder!(badge_builder, :badge_builder)
       validate_builder!(icon_builder, :icon_builder)

--- a/spec/lib/tree_view/error_builder_spec.rb
+++ b/spec/lib/tree_view/error_builder_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.describe "TreeView error builder" do
+  let(:tree) { instance_double(TreeView::Tree) }
+  let(:ui_config) { instance_double(TreeView::UiConfig) }
+
+  it "stores a callable error builder" do
+    builder = ->(item) { item.error? }
+
+    state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      error_builder: builder
+    )
+
+    expect(state.error_builder).to eq(builder)
+  end
+
+  it "rejects invalid error builders" do
+    expect do
+      TreeView::RenderState.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        error_builder: :invalid
+      )
+    end.to raise_error(ArgumentError, /error_builder/)
+  end
+end


### PR DESCRIPTION
## Summary

- Add optional `error_builder` to `TreeView::RenderState`
- Validate the builder like other row hooks
- Merge error state into row data as `data-remote-state="error"`
- Prefer error state over loading state when both builders match
- Add specs for storing and validating the option

## Related issue

- #168

## Testing

- Not run locally because repository cloning failed in this environment.
- CI should run the repository default task on the PR.