### PR TITLE
docs: add render scale notes

### DIFF
--- a/docs/render-scale.md
+++ b/docs/render-scale.md
@@ -1,0 +1,15 @@
+# Render scale
+
+TreeView keeps the default table rendering path simple and predictable.
+
+For large trees, prefer reducing rendered rows before adding browser-side windowing.
+
+Recommended first steps:
+
+- limit initial expansion with `max_initial_depth`
+- limit rendered depth with `max_render_depth`
+- focus near-leaf views with `max_leaf_distance`
+- use `path_tree_for` for search-result style views
+- use host-app pagination or lazy loading for very large child lists
+
+A future windowed renderer should be opt-in. It should preserve stable DOM IDs, selection payloads, current row state, and Turbo Stream targets.


### PR DESCRIPTION
## Summary

- Add `docs/render-scale.md`
- Document recommended approaches before introducing a windowed renderer
- Clarify that any future windowed renderer should be opt-in and preserve existing row behavior

## Related issue

- #169

## Testing

- Not run locally because repository cloning failed in this environment.
- Docs-only change; CI should run the repository default task on the PR.