### PR TITLE
refactor: centralize render state builder validation

### DIFF
--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require "tree_view/render_state_builder_validation"
+
 module TreeView
   class RenderState
+    include TreeView::RenderStateBuilderValidation
+
     VALID_INITIAL_STATES = Configuration::VALID_INITIAL_STATES
     VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys collapsed_keys].freeze
     VALID_RENDER_SCOPE_KEYS = %i[max_depth max_leaf_distance].freeze
@@ -108,17 +112,19 @@ module TreeView
       @badge_builder = badge_builder
       @icon_builder = icon_builder
 
-      validate_builder!(row_class_builder, :row_class_builder)
-      validate_builder!(row_data_builder, :row_data_builder)
-      validate_builder!(row_event_payload_builder, :row_event_payload_builder)
-      validate_builder!(loading_builder, :loading_builder)
-      validate_builder!(error_builder, :error_builder)
-      validate_builder!(depth_label_builder, :depth_label_builder)
-      validate_builder!(badge_builder, :badge_builder)
-      validate_builder!(icon_builder, :icon_builder)
-      validate_builder!(@selection_payload_builder, :selection_payload_builder)
-      validate_builder!(@selection_disabled_builder, :selection_disabled_builder)
-      validate_builder!(@selection_disabled_reason_builder, :selection_disabled_reason_builder)
+      validate_builders!(
+        row_class_builder: row_class_builder,
+        row_data_builder: row_data_builder,
+        row_event_payload_builder: row_event_payload_builder,
+        loading_builder: loading_builder,
+        error_builder: error_builder,
+        depth_label_builder: depth_label_builder,
+        badge_builder: badge_builder,
+        icon_builder: icon_builder,
+        selection_payload_builder: @selection_payload_builder,
+        selection_disabled_builder: @selection_disabled_builder,
+        selection_disabled_reason_builder: @selection_disabled_reason_builder
+      )
       validate_expansion_key_conflicts!
     end
 

--- a/lib/tree_view/render_state_builder_validation.rb
+++ b/lib/tree_view/render_state_builder_validation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module TreeView
+  module RenderStateBuilderValidation
+    private
+
+    def validate_builders!(builders)
+      builders.each do |name, builder|
+        validate_builder!(builder, name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add a small RenderState builder validation helper
- Use it to group builder validation calls
- Preserve existing validation error behavior

## Related issue

- #179

## Testing

- Not run locally because repository cloning failed in this environment.
- CI should run the repository default task on the PR.