### PR TITLE
Refactor tree traversals to avoid recursive stack growth

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -281,42 +281,64 @@ module TreeViewHelper
   end
 
   def tree_max_depth(tree)
-    memo = {}
+    max_depth = 0
+    seen_depths = {}
+    stack = tree.root_items.reverse.map { |root| [root, 0, {}] }
 
-    walk = lambda do |node, depth|
+    until stack.empty?
+      node, depth, ancestor_keys = stack.pop
       node_key = tree.node_key_for(node)
-      previous = memo[node_key]
-      return previous if previous && previous >= depth
+      raise ArgumentError, "cycle detected in tree for node #{node_key.inspect}" if ancestor_keys[node_key]
 
-      memo[node_key] = depth
-      children = tree.children_for(node)
-      return depth if children.empty?
+      previous_depth = seen_depths[node_key]
+      next if previous_depth && previous_depth >= depth
 
-      children.map { |child| walk.call(child, depth + 1) }.max
+      seen_depths[node_key] = depth
+      max_depth = depth if depth > max_depth
+
+      next_ancestor_keys = ancestor_keys.merge(node_key => true)
+      tree.children_for(node).reverse_each do |child|
+        stack << [child, depth + 1, next_ancestor_keys]
+      end
     end
 
-    tree.root_items.map { |root| walk.call(root, 0) }.max.to_i
+    max_depth
   end
 
   def tree_leaf_distances(tree)
     @tree_leaf_distance_maps ||= {}
     @tree_leaf_distance_maps[tree.object_id] ||= begin
       distances = {}
+      stack = tree.root_items.reverse.map { |root| [root, false, {}] }
 
-      walk = lambda do |node|
+      until stack.empty?
+        node, expanded, ancestor_keys = stack.pop
         node_key = tree.node_key_for(node)
-        return distances[node_key] if distances.key?(node_key)
 
-        children = tree.children_for(node)
-        distances[node_key] = if children.empty?
-                                0
-                              else
-                                child_distances = children.map { |child| walk.call(child) }.compact
-                                child_distances.empty? ? nil : child_distances.min + 1
-                              end
+        if expanded
+          children = tree.children_for(node)
+          distances[node_key] = if children.empty?
+                                  0
+                                else
+                                  child_distances = children.map { |child| distances[tree.node_key_for(child)] }.compact
+                                  child_distances.empty? ? nil : child_distances.min + 1
+                                end
+          next
+        end
+
+        next if distances.key?(node_key)
+        raise ArgumentError, "cycle detected in tree for node #{node_key.inspect}" if ancestor_keys[node_key]
+
+        next_ancestor_keys = ancestor_keys.merge(node_key => true)
+        stack << [node, true, ancestor_keys]
+        tree.children_for(node).reverse_each do |child|
+          child_key = tree.node_key_for(child)
+          raise ArgumentError, "cycle detected in tree for node #{child_key.inspect}" if next_ancestor_keys[child_key]
+
+          stack << [child, false, next_ancestor_keys] unless distances.key?(child_key)
+        end
       end
 
-      tree.root_items.each { |root| walk.call(root) }
       distances
     end
   end
@@ -325,13 +347,19 @@ module TreeViewHelper
     @tree_branch_maps ||= {}
     @tree_branch_maps[tree.object_id] ||= begin
       branch_map = {}
+      stack = [[tree.root_items, 0, [], {}]]
 
-      walk = lambda do |nodes, depth, ancestor_last_states|
+      until stack.empty?
+        nodes, depth, ancestor_last_states, ancestor_keys = stack.pop
         sorted_nodes = tree.sort_items(nodes)
+        child_frames = []
 
         sorted_nodes.each_with_index do |node, index|
+          node_key = tree.node_key_for(node)
+          raise ArgumentError, "cycle detected in tree for node #{node_key.inspect}" if ancestor_keys[node_key]
+
           is_last = index == sorted_nodes.length - 1
-          branch_map[tree.node_key_for(node)] = {
+          branch_map[node_key] = {
             depth: depth,
             ancestor_last_states: ancestor_last_states.dup,
             is_last: is_last
@@ -341,11 +369,12 @@ module TreeViewHelper
           next if children.empty?
 
           next_ancestor_last_states = depth.zero? ? ancestor_last_states : ancestor_last_states + [is_last]
-          walk.call(children, depth + 1, next_ancestor_last_states)
+          child_frames << [children, depth + 1, next_ancestor_last_states, ancestor_keys.merge(node_key => true)]
         end
+
+        child_frames.reverse_each { |frame| stack << frame }
       end
 
-      walk.call(tree.root_items, 0, [])
       branch_map
     end
   end

--- a/lib/tree_view/tree.rb
+++ b/lib/tree_view/tree.rb
@@ -48,25 +48,9 @@ module TreeView
     def descendant_counts
       @descendant_counts ||= begin
         memo = {}
-        visiting = {}
-
-        count_descendants = lambda do |record|
-          node_key = node_key_for(record)
-          return memo[node_key] if memo.key?(node_key)
-          raise ArgumentError, "cycle detected in tree for node #{node_key.inspect}" if visiting[node_key]
-
-          visiting[node_key] = true
-          children = children_for(record)
-          memo[node_key] = children.sum { |child| 1 + count_descendants.call(child) }
-          visiting.delete(node_key)
-          memo[node_key]
-        rescue StandardError
-          visiting.delete(node_key)
-          raise
-        end
 
         each_root_candidate do |root_candidate|
-          count_descendants.call(root_candidate)
+          count_descendants_iteratively(root_candidate, memo)
         end
 
         memo
@@ -269,6 +253,41 @@ module TreeView
           items.each { |item| yield item }
         end
       end
+    end
+
+    def count_descendants_iteratively(root, memo)
+      root_key = node_key_for(root)
+      return memo[root_key] if memo.key?(root_key)
+
+      visiting = {}
+      stack = [[root, false]]
+
+      until stack.empty?
+        item, expanded = stack.pop
+        key = node_key_for(item)
+
+        if expanded
+          visiting.delete(key)
+          children = children_for(item)
+          memo[key] = children.sum { |child| 1 + memo[node_key_for(child)].to_i }
+          next
+        end
+
+        next if memo.key?(key)
+        raise ArgumentError, "cycle detected in tree for node #{key.inspect}" if visiting[key]
+
+        visiting[key] = true
+        stack << [item, true]
+
+        children_for(item).reverse_each do |child|
+          child_key = node_key_for(child)
+          raise ArgumentError, "cycle detected in tree for node #{child_key.inspect}" if visiting[child_key]
+
+          stack << [child, false] unless memo.key?(child_key)
+        end
+      end
+
+      memo[root_key]
     end
 
     def each_reachable_node(root_nodes)

--- a/spec/lib/tree_view/large_tree_spec.rb
+++ b/spec/lib/tree_view/large_tree_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe "TreeView large tree baselines" do
     expect(counts[120]).to eq(0)
   end
 
+  it "counts descendants for a very deep chain without recursive stack growth" do
+    records = build_chain(1_500)
+    tree = TreeView::Tree.new(records: records, parent_id_method: :parent_item_id)
+
+    expect { tree.descendant_counts }.not_to raise_error
+    expect(tree.descendant_counts[1]).to eq(1_499)
+    expect(tree.descendant_counts[1_500]).to eq(0)
+  end
+
   it "counts descendants for a moderately wide tree" do
     records = build_wide_tree(250)
     tree = TreeView::Tree.new(records: records, parent_id_method: :parent_item_id)


### PR DESCRIPTION
## Summary

- Make `Tree#descendant_counts` use an explicit stack instead of recursive lambdas.
- Make helper-side `tree_max_depth`, `tree_leaf_distances`, and `tree_branch_map` use explicit stack traversal.
- Add a deep-chain regression spec for descendant counts.

## Notes

This is an initial implementation for #183. It keeps public APIs unchanged and focuses on the traversal paths called out in the issue.

Closes #183