### PR TITLE
Enhance drag and drop transfer events

### DIFF
--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -50,6 +50,28 @@ module TreeViewHelper
     raise ArgumentError, "row_data_builder must return a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
   end
 
+  def tree_row_transfer_data(item, tree, builder = nil)
+    return {} if builder.nil?
+
+    payload = tree_row_event_payload(item, tree, builder)
+    {
+      tree_transfer_payload: JSON.generate(payload),
+      tree_transfer_node_key: tree.node_key_for(item),
+      action: [
+        "dragstart->tree-view-transfer#start",
+        "dragover->tree-view-transfer#over",
+        "drop->tree-view-transfer#drop"
+      ].join(" ")
+    }
+  end
+
+  def tree_row_event_payload(item, tree, builder = nil)
+    payload = builder ? builder.call(item) : default_tree_row_event_payload(item, tree)
+    return payload.to_h if payload.respond_to?(:to_h)
+
+    raise ArgumentError, "row_event_payload_builder must return a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
+  end
+
   def tree_hidden_count_message(hidden_count, builder = nil)
     return hidden_count if builder.nil?
 
@@ -234,6 +256,14 @@ module TreeViewHelper
   end
 
   def default_tree_selection_payload(item, tree)
+    {
+      key: tree.node_key_for(item),
+      id: item.respond_to?(:id) ? item.id : tree.node_key_for(item),
+      type: item.class.name
+    }
+  end
+
+  def default_tree_row_event_payload(item, tree)
     {
       key: tree.node_key_for(item),
       id: item.respond_to?(:id) ? item.id : tree.node_key_for(item),

--- a/app/helpers/tree_view_state_helper.rb
+++ b/app/helpers/tree_view_state_helper.rb
@@ -2,7 +2,10 @@
 
 module TreeViewStateHelper
   def tree_view_state_data(render_state)
-    data = { controller: "tree-view-state" }
+    controllers = ["tree-view-state"]
+    controllers << "tree-view-transfer" if render_state.respond_to?(:row_event_payload_builder) && render_state.row_event_payload_builder
+
+    data = { controller: controllers.join(" ") }
     if render_state.respond_to?(:view_key) && render_state.view_key.present?
       data[:tree_view_state_view_key_value] = render_state.view_key
     end

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -301,33 +301,54 @@ export class TreeViewSelectionController extends Controller {
 export class TreeViewTransferController extends Controller {
   start(event) {
     const row = this.rowFromEvent(event)
-    if (!row) return
+    if (!row || row.dataset.treeTransferDisabled === "true") return
 
-    const payload = this.payloadFromRow(row)
-    if (event.dataTransfer && payload) event.dataTransfer.setData("application/json", JSON.stringify(payload))
+    const sourcePayload = this.payloadFromRow(row)
+    if (event.dataTransfer && sourcePayload) {
+      event.dataTransfer.effectAllowed = "move"
+      event.dataTransfer.setData("application/json", JSON.stringify(sourcePayload))
+      event.dataTransfer.setData("text/plain", JSON.stringify(sourcePayload))
+    }
 
-    this.dispatch("started", { detail: { payload, row } })
+    this.dispatchTransferEvent("drag-start", {
+      sourcePayload,
+      sourceRow: row
+    })
   }
 
   over(event) {
-    event.preventDefault()
     const row = this.rowFromEvent(event)
-    this.dispatch("over", { detail: { payload: this.payloadFromRow(row), row } })
+    if (!row || row.dataset.treeTransferDisabled === "true") return
+
+    event.preventDefault()
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move"
+
+    this.dispatchTransferEvent("drag-over", {
+      targetPayload: this.payloadFromRow(row),
+      targetRow: row,
+      position: this.dropPosition(event, row)
+    })
   }
 
   drop(event) {
-    event.preventDefault()
     const targetRow = this.rowFromEvent(event)
+    if (!targetRow || targetRow.dataset.treeTransferDisabled === "true") return
+
+    event.preventDefault()
     const sourcePayload = this.payloadFromEvent(event)
     const targetPayload = this.payloadFromRow(targetRow)
+    const position = this.dropPosition(event, targetRow)
 
-    this.dispatch("dropped", {
-      detail: {
-        source: sourcePayload,
-        target: targetPayload,
-        targetRow
-      }
+    this.dispatchTransferEvent("drop", {
+      sourcePayload,
+      targetPayload,
+      position,
+      targetRow
     })
+  }
+
+  dispatchTransferEvent(name, detail) {
+    this.dispatch(name, { detail })
   }
 
   rowFromEvent(event) {
@@ -351,7 +372,7 @@ export class TreeViewTransferController extends Controller {
   payloadFromEvent(event) {
     if (!event.dataTransfer) return null
 
-    const value = event.dataTransfer.getData("application/json")
+    const value = event.dataTransfer.getData("application/json") || event.dataTransfer.getData("text/plain")
     if (!value) return null
 
     try {
@@ -360,6 +381,19 @@ export class TreeViewTransferController extends Controller {
       this.dispatch("invalid-transfer", { detail: { value } })
       return null
     }
+  }
+
+  dropPosition(event, row) {
+    if (!row || typeof row.getBoundingClientRect !== "function") return "inside"
+
+    const rect = row.getBoundingClientRect()
+    if (!rect || rect.height === 0) return "inside"
+
+    const offset = event.clientY - rect.top
+    if (offset < rect.height / 3) return "before"
+    if (offset > (rect.height * 2) / 3) return "after"
+
+    return "inside"
   }
 }
 

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -14,14 +14,16 @@
 <% effectively_collapsed = explicitly_collapsed || (!explicitly_expanded && (render_context.collapsed? || depth_boundary)) %>
 <% mode = tree_toggle_mode(render_context.mode) %>
 <% row_classes = tree_row_classes(item, render_context.row_class_builder) %>
-<% row_data = tree_row_data(item, render_context.row_data_builder, tree: tree).merge(tree_depth: depth).merge(tree_state_row_data(item, tree, expanded: !effectively_collapsed)) %>
+<% transfer_data = tree_row_transfer_data(item, tree, render_context.row_event_payload_builder) %>
+<% row_data = tree_row_data(item, render_context.row_data_builder, tree: tree).merge(tree_depth: depth).merge(tree_state_row_data(item, tree, expanded: !effectively_collapsed)).merge(transfer_data) %>
+<% row_attrs = { id: tree_node_dom_id(item), class: row_classes.presence, data: row_data, aria: row_aria = { level: depth + 1, selected: tree_selection_checked?(item, tree, render_context.selection_selected_keys) } } %>
+<% row_attrs[:draggable] = true if transfer_data.present? %>
 <% children = row_context.children %>
-<% row_aria = { level: depth + 1, selected: tree_selection_checked?(item, tree, render_context.selection_selected_keys) } %>
 <% row_aria[:expanded] = !effectively_collapsed if children.any? %>
 <% row_aria[:current] = "page" if row_context.current? %>
 <% hidden_count = render_children && effectively_collapsed && row_context.descendant_count.positive? && render_self ? row_context.descendant_count : nil %>
 <% if render_self %>
-  <%= tag.tr(id: tree_node_dom_id(item), class: row_classes.presence, data: row_data, aria: row_aria) do %>
+  <%= tag.tr(**row_attrs) do %>
     <% if render_context.selection_enabled? %>
       <% selection_visible = tree_selection_visible?(item, tree, depth, render_context.selection_visibility) %>
       <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_visible: selection_visible, selection_payload_builder: render_context.selection_payload_builder, selection_checkbox_name: render_context.selection_checkbox_name, selection_disabled_builder: render_context.selection_disabled_builder, selection_disabled_reason_builder: render_context.selection_disabled_reason_builder, selection_selected_keys: render_context.selection_selected_keys %>

--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -1,0 +1,102 @@
+# Drag and drop events
+
+`tree_view` は、行同士のドラッグ&ドロップで host app が使いやすいpayloadと標準イベントを提供します。
+
+DB上の親子関係更新、並び順保存、業務固有のdrop可否判定は host app 側の責務です。`tree_view` は行payload、DOM data属性、ブラウザ標準drag/dropイベントの橋渡しだけを担当します。
+
+## 基本形
+
+`RenderState` に `row_event_payload_builder` を指定すると、各行にdrag/drop用のdata属性とactionが付与されます。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "items/tree_columns",
+  ui_config: tree_ui,
+  row_event_payload_builder: ->(item) {
+    {
+      key: tree.node_key_for(item),
+      id: item.id,
+      type: item.class.name
+    }
+  }
+)
+```
+
+root要素側には `tree_view_state_data(render_state)` を指定します。`row_event_payload_builder` がある場合、`tree-view-transfer` controller も自動で含まれます。
+
+```erb
+<table data-controller="tree-view-state tree-view-transfer">
+  <tbody>
+    <%= tree_view_rows(render_state) %>
+  </tbody>
+</table>
+```
+
+helperを使う場合は以下のようにできます。
+
+```erb
+<table data-<%= tag.attributes(tree_view_state_data(render_state)) %>>
+  <tbody>
+    <%= tree_view_rows(render_state) %>
+  </tbody>
+</table>
+```
+
+## Row attributes
+
+`row_event_payload_builder` を指定した行には、以下が付与されます。
+
+- `draggable="true"`
+- `data-tree-transfer-payload`
+- `data-tree-transfer-node-key`
+- `data-action="dragstart->tree-view-transfer#start dragover->tree-view-transfer#over drop->tree-view-transfer#drop"`
+
+`data-tree-transfer-payload` には `row_event_payload_builder` の戻り値をJSON化した文字列が入ります。
+
+## Events
+
+`tree-view-transfer` controller は以下のStimulus eventをdispatchします。
+
+| event | timing | detail |
+|---|---|---|
+| `tree-view-transfer:drag-start` | drag開始時 | `sourcePayload`, `sourceRow` |
+| `tree-view-transfer:drag-over` | drop候補上をdrag中 | `targetPayload`, `targetRow`, `position` |
+| `tree-view-transfer:drop` | drop時 | `sourcePayload`, `targetPayload`, `targetRow`, `position` |
+
+`position` はdrop位置の目安です。
+
+- `before`
+- `inside`
+- `after`
+
+```js
+document.addEventListener("tree-view-transfer:drop", (event) => {
+  const { sourcePayload, targetPayload, position } = event.detail
+
+  // host app側で親変更や並び順保存APIを呼ぶ
+})
+```
+
+## Payload validation
+
+`row_event_payload_builder` はHash相当の値を返してください。
+
+```ruby
+row_event_payload_builder: ->(item) { { id: item.id } }
+```
+
+Hash相当ではない値を返した場合は、誤実装に気づきやすいよう `ArgumentError` を発生させます。
+
+## Out of scope
+
+以下は `tree_view` では扱いません。
+
+- DB更新
+- 並び順保存
+- drop可否判定
+- drop後の画面更新API
+- 複雑なdrag/drop UIライブラリへの依存
+
+host app 側では、payload内の `id` / `type` / `key` などを使って保存処理を実装してください。

--- a/lib/tree_view/render_context.rb
+++ b/lib/tree_view/render_context.rb
@@ -25,6 +25,7 @@ module TreeView
       :hidden_message_builder,
       :row_class_builder,
       :row_data_builder,
+      :row_event_payload_builder,
       :depth_label_builder,
       :badge_builder,
       keyword_init: true
@@ -65,6 +66,7 @@ module TreeView
           hidden_message_builder: local_assigns[:hidden_message_builder],
           row_class_builder: local_assigns[:row_class_builder],
           row_data_builder: local_assigns[:row_data_builder],
+          row_event_payload_builder: local_assigns[:row_event_payload_builder],
           depth_label_builder: local_assigns[:depth_label_builder],
           badge_builder: local_assigns[:badge_builder]
         ),
@@ -171,6 +173,10 @@ module TreeView
 
     def row_data_builder
       render_state.row_data_builder
+    end
+
+    def row_event_payload_builder
+      render_state.row_event_payload_builder
     end
 
     def depth_label_builder

--- a/spec/helpers/tree_view_state_helper_spec.rb
+++ b/spec/helpers/tree_view_state_helper_spec.rb
@@ -10,20 +10,27 @@ RSpec.describe TreeViewStateHelper do
   end
 
   it "builds root data without a view key" do
-    state = instance_double(TreeView::RenderState, view_key: nil)
+    state = instance_double(TreeView::RenderState, view_key: nil, row_event_payload_builder: nil)
     helper = helper_host_class.new
 
     expect(helper.tree_view_state_data(state)).to eq(controller: "tree-view-state")
   end
 
   it "builds root data with a view key" do
-    state = instance_double(TreeView::RenderState, view_key: "documents")
+    state = instance_double(TreeView::RenderState, view_key: "documents", row_event_payload_builder: nil)
     helper = helper_host_class.new
 
     expect(helper.tree_view_state_data(state)).to eq(
       controller: "tree-view-state",
       tree_view_state_view_key_value: "documents"
     )
+  end
+
+  it "adds the transfer controller when row event payloads are configured" do
+    state = instance_double(TreeView::RenderState, view_key: nil, row_event_payload_builder: ->(_item) { {} })
+    helper = helper_host_class.new
+
+    expect(helper.tree_view_state_data(state)).to eq(controller: "tree-view-state tree-view-transfer")
   end
 
   it "builds row state data" do

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe "TreeView integration" do
       expect(rendered).to include("project_2:child")
     end
 
+    it "renders row transfer data when row event payload builder is configured" do
+      tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+      render_state = TreeView::RenderState.new(
+        tree: tree,
+        root_items: tree.root_items,
+        row_partial: "projects/tree_columns",
+        ui_config: tree_ui,
+        row_event_payload_builder: ->(item) { { id: item.id, name: item.name } }
+      )
+      view = build_view(tree_ui: nil)
+
+      rendered = view.tree_view_rows(render_state)
+
+      expect(view.tree_view_state_data(render_state)).to eq(controller: "tree-view-state tree-view-transfer")
+      expect(rendered).to include('draggable="draggable"')
+      expect(rendered).to include('data-tree-transfer-node-key="1"')
+      expect(rendered).to include('data-tree-transfer-payload="{&quot;id&quot;:1,&quot;name&quot;:&quot;root&quot;}"')
+      expect(rendered).to include('dragstart-&gt;tree-view-transfer#start')
+      expect(rendered).to include('dragover-&gt;tree-view-transfer#over')
+      expect(rendered).to include('drop-&gt;tree-view-transfer#drop')
+    end
+
     it "renders an empty state row when root items are empty and empty_message is given" do
       tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
       empty_tree = TreeView::Tree.new(records: [], parent_id_method: :parent_item_id)

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "TreeView integration" do
       rendered = view.tree_view_rows(render_state)
 
       expect(view.tree_view_state_data(render_state)).to eq(controller: "tree-view-state tree-view-transfer")
-      expect(rendered).to include('draggable="draggable"')
+      expect(rendered).to include('draggable="true"')
       expect(rendered).to include('data-tree-transfer-node-key="1"')
       expect(rendered).to include('data-tree-transfer-payload="{&quot;id&quot;:1,&quot;name&quot;:&quot;root&quot;}"')
       expect(rendered).to include('dragstart-&gt;tree-view-transfer#start')

--- a/spec/lib/tree_view/render_context_spec.rb
+++ b/spec/lib/tree_view/render_context_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe TreeView::RenderContext do
 
   it "delegates render configuration to render state" do
     row_class_builder = ->(_item) { ["row"] }
+    row_event_payload_builder = ->(_item) { { id: 1 } }
     state = build_state(
       max_initial_depth: 1,
       max_render_depth: 2,
@@ -27,6 +28,7 @@ RSpec.describe TreeView::RenderContext do
       selectable: true,
       selection: { visibility: :leaves, selected_keys: [3] },
       row_class_builder: row_class_builder,
+      row_event_payload_builder: row_event_payload_builder,
       badge_builder: ->(_item) { "badge" }
     )
 
@@ -48,6 +50,7 @@ RSpec.describe TreeView::RenderContext do
     expect(context.selection_visibility).to eq(:leaves)
     expect(context.selection_selected_keys).to eq([3])
     expect(context.row_class_builder).to eq(row_class_builder)
+    expect(context.row_event_payload_builder).to eq(row_event_payload_builder)
     expect(context.badge_builder.call(:item)).to eq("badge")
   end
 

--- a/spec/lib/tree_view/row_event_payload_builder_spec.rb
+++ b/spec/lib/tree_view/row_event_payload_builder_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 RSpec.describe "TreeView row event payload builder" do
+  RowEventNode = Struct.new(:id, :name, keyword_init: true)
+
   let(:tree) { instance_double(TreeView::Tree) }
   let(:ui_config) { instance_double(TreeView::UiConfig) }
 
@@ -28,5 +30,39 @@ RSpec.describe "TreeView row event payload builder" do
         row_event_payload_builder: :invalid
       )
     end.to raise_error(ArgumentError, /row_event_payload_builder/)
+  end
+
+  it "builds transfer data attributes from a hash-like event payload" do
+    helper = Object.new.extend(TreeViewHelper)
+    item = RowEventNode.new(id: 1, name: "root")
+    builder = ->(node) { { id: node.id, name: node.name } }
+
+    allow(tree).to receive(:node_key_for).with(item).and_return("node-1")
+
+    data = helper.tree_row_transfer_data(item, tree, builder)
+
+    expect(data[:tree_transfer_node_key]).to eq("node-1")
+    expect(JSON.parse(data[:tree_transfer_payload])).to eq("id" => 1, "name" => "root")
+    expect(data[:action]).to include("dragstart->tree-view-transfer#start")
+    expect(data[:action]).to include("dragover->tree-view-transfer#over")
+    expect(data[:action]).to include("drop->tree-view-transfer#drop")
+  end
+
+  it "returns empty transfer data when no builder is given" do
+    helper = Object.new.extend(TreeViewHelper)
+    item = RowEventNode.new(id: 1, name: "root")
+
+    expect(helper.tree_row_transfer_data(item, tree, nil)).to eq({})
+  end
+
+  it "raises a clear error when row event payload is not hash-like" do
+    helper = Object.new.extend(TreeViewHelper)
+    item = RowEventNode.new(id: 1, name: "root")
+
+    allow(tree).to receive(:node_key_for).with(item).and_return("node-1")
+
+    expect do
+      helper.tree_row_transfer_data(item, tree, ->(_node) { "invalid" })
+    end.to raise_error(ArgumentError, /row_event_payload_builder must return a Hash-like object/)
   end
 end


### PR DESCRIPTION
## Summary

- Wire `row_event_payload_builder` into row transfer data attributes.
- Mark rows as draggable when transfer payloads are configured.
- Add drag/drop actions for the existing `tree-view-transfer` controller.
- Standardize transfer event details with `sourcePayload`, `targetPayload`, `targetRow`, and `position`.
- Add `tree-view-transfer:drag-start`, `tree-view-transfer:drag-over`, and `tree-view-transfer:drop` events.
- Add specs for render context, helper payload validation, root controller data, and rendered row attributes.
- Add `docs/drag-and-drop.md`.

## Notes

This keeps persistence, sorting, parent updates, and business-specific drop validation out of the gem. Host apps can listen to `tree-view-transfer:drop` and call their own APIs.

Closes #156