### PR TITLE
Complete icon builder rendering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Breaking changes and required migration notes should be called out explicitly in
 - Row attribute builders:
   - `row_class_builder`
   - `row_data_builder`
+- Row visual hooks:
+  - `badge_builder`
+  - `icon_builder`
 - Checkbox selection support:
   - JSON payload values
   - custom checkbox name

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -14,8 +14,27 @@ The examples stay generic. Business-specific models, authorization, routes, and 
 - Checkbox selection: enable selection options and parse submitted values with `TreeView.parse_selection_params`.
 - Disabled selection rows: use disabled builders when rows should be visible but not selectable. Permission checks still belong in the host app.
 - Row class and data hooks: use `row_class_builder` and `row_data_builder` for styling and lightweight integration hooks.
+- Row visual hooks: use `badge_builder` for badges and `icon_builder` for a small node-type visual when no badge is configured.
 - Large tree guardrails: use `max_initial_depth`, `max_render_depth`, `max_leaf_distance`, or focused trees to avoid rendering everything by default.
 - Orphan diagnostics: choose an orphan strategy deliberately when parent IDs may point to missing records.
+
+## Icon builder
+
+`icon_builder` is a lightweight visual hook for node type or state markers.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "items/tree_columns",
+  ui_config: tree_ui,
+  icon_builder: ->(item) {
+    item.folder? ? { text: "folder", title: "Folder" } : { text: "file", title: "File" }
+  }
+)
+```
+
+When both `badge_builder` and `icon_builder` are configured, `badge_builder` takes precedence in the current visual slot.
 
 ## Notes
 

--- a/lib/tree_view/render_context.rb
+++ b/lib/tree_view/render_context.rb
@@ -206,7 +206,7 @@ module TreeView
     end
 
     def badge_builder
-      render_state.badge_builder
+      render_state.badge_builder || render_state.icon_builder
     end
 
     def icon_builder

--- a/lib/tree_view/render_context.rb
+++ b/lib/tree_view/render_context.rb
@@ -30,6 +30,7 @@ module TreeView
       :error_builder,
       :depth_label_builder,
       :badge_builder,
+      :icon_builder,
       keyword_init: true
     ) do
       def effective_initial_state
@@ -76,7 +77,8 @@ module TreeView
           loading_builder: local_assigns[:loading_builder],
           error_builder: local_assigns[:error_builder],
           depth_label_builder: local_assigns[:depth_label_builder],
-          badge_builder: local_assigns[:badge_builder]
+          badge_builder: local_assigns[:badge_builder],
+          icon_builder: local_assigns[:icon_builder]
         ),
         mode: local_assigns[:mode],
         collapsed: local_assigns.fetch(:collapsed, false)
@@ -205,6 +207,10 @@ module TreeView
 
     def badge_builder
       render_state.badge_builder
+    end
+
+    def icon_builder
+      render_state.icon_builder
     end
   end
 end

--- a/spec/integration/tree_view_icon_builder_integration_spec.rb
+++ b/spec/integration/tree_view_icon_builder_integration_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+require "action_view"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe "TreeView icon builder integration" do
+  IconNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+  let(:root) { IconNode.new(id: 1, parent_item_id: nil, name: "root") }
+  let(:tree) { TreeView::Tree.new(records: [root], parent_id_method: :parent_item_id) }
+  let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
+  let(:host_view_dir) { Dir.mktmpdir("tree_view_icon_host_views") }
+
+  before do
+    FileUtils.mkdir_p(File.join(host_view_dir, "items"))
+    File.write(
+      File.join(host_view_dir, "items", "_tree_columns.html.erb"),
+      '<td class="item-cell"><%= item.name %></td>'
+    )
+  end
+
+  after do
+    FileUtils.remove_entry(host_view_dir) if Dir.exist?(host_view_dir)
+  end
+
+  def build_view(tree_ui:)
+    view = ActionView::Base.with_empty_template_cache.with_view_paths([host_view_dir, gem_view_path], {}, nil)
+    view.extend(TreeViewHelper)
+    view.instance_variable_set(:@tree_ui, tree_ui)
+    view
+  end
+
+  it "renders icon_builder output through the row visual slot when no badge_builder is configured" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "item").build_static
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "items/tree_columns",
+      ui_config: tree_ui,
+      icon_builder: ->(_item) { { text: "folder", title: "Folder", class: "node-icon" } }
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state)
+
+    expect(rendered).to include("folder")
+    expect(rendered).to include('title="Folder"')
+    expect(rendered).to include("node-icon")
+  end
+
+  it "keeps badge_builder precedence over icon_builder" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "item").build_static
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "items/tree_columns",
+      ui_config: tree_ui,
+      badge_builder: ->(_item) { "badge" },
+      icon_builder: ->(_item) { "icon" }
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state)
+
+    expect(rendered).to include("badge")
+    expect(rendered).not_to include("icon")
+  end
+end


### PR DESCRIPTION
## Summary

- Expose `icon_builder` through `TreeView::RenderContext` and legacy locals.
- Use `icon_builder` in the existing row visual slot when `badge_builder` is absent.
- Add integration specs for icon rendering and badge precedence.
- Document `icon_builder` in the cookbook and changelog.

## Notes

This finishes the previously stored-but-not-rendered `icon_builder` option without widening the row partial surface before beta.

Closes #244