### PR TITLE
Implement parent-child cascading checkbox selection

### DIFF
--- a/app/helpers/tree_view_state_helper.rb
+++ b/app/helpers/tree_view_state_helper.rb
@@ -3,12 +3,21 @@
 module TreeViewStateHelper
   def tree_view_state_data(render_state)
     controllers = ["tree-view-state"]
+    controllers << "tree-view-selection" if render_state.selection_enabled?
     controllers << "tree-view-transfer" if render_state.respond_to?(:row_event_payload_builder) && render_state.row_event_payload_builder
 
     data = { controller: controllers.join(" ") }
     if render_state.respond_to?(:tree_instance_key) && render_state.tree_instance_key.present?
       data[:tree_view_state_tree_instance_key_value] = render_state.tree_instance_key
     end
+
+    if render_state.selection_enabled?
+      data[:action] = append_tree_view_action(data[:action], "change->tree-view-selection#toggle")
+      data[:tree_view_selection_cascade_value] = true if render_state.selection_cascade?
+      data[:tree_view_selection_indeterminate_value] = true if render_state.selection_indeterminate?
+      data[:tree_view_selection_max_count_value] = render_state.selection_max_count if render_state.selection_max_count
+    end
+
     data
   end
 
@@ -18,6 +27,14 @@ module TreeViewStateHelper
       tree_view_state_node_key: tree.node_key_for(item),
       tree_view_state_expanded: expanded
     }
+  end
+
+  private
+
+  def append_tree_view_action(existing_action, action)
+    actions = existing_action.to_s.split
+    actions << action unless actions.include?(action)
+    actions.join(" ")
   end
 end
 

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -10,7 +10,7 @@ module TreeView
     VALID_INITIAL_EXPANSION_KEYS = %i[default max_depth expanded_keys collapsed_keys].freeze
     VALID_RENDER_SCOPE_KEYS = %i[max_depth max_leaf_distance].freeze
     VALID_TOGGLE_SCOPE_KEYS = %i[max_depth_from_root max_leaf_distance].freeze
-    VALID_SELECTION_KEYS = %i[enabled visibility payload_builder checkbox_name disabled_builder disabled_reason_builder selected_keys].freeze
+    VALID_SELECTION_KEYS = %i[enabled visibility payload_builder checkbox_name disabled_builder disabled_reason_builder selected_keys cascade indeterminate max_count].freeze
     VALID_SELECTION_VISIBILITIES = %i[all roots leaves none].freeze
     DEFAULT_SELECTION_CHECKBOX_NAME = "selected_nodes[]"
 
@@ -35,6 +35,9 @@ module TreeView
                 :selection_disabled_builder,
                 :selection_disabled_reason_builder,
                 :selection_selected_keys,
+                :selection_cascade,
+                :selection_indeterminate,
+                :selection_max_count,
                 :row_class_builder,
                 :row_data_builder,
                 :row_event_payload_builder,
@@ -68,6 +71,9 @@ module TreeView
                    selection_disabled_builder: nil,
                    selection_disabled_reason_builder: nil,
                    selection_selected_keys: nil,
+                   selection_cascade: nil,
+                   selection_indeterminate: nil,
+                   selection_max_count: nil,
                    selection: nil,
                    row_class_builder: nil,
                    row_data_builder: nil,
@@ -103,6 +109,9 @@ module TreeView
       @selection_disabled_builder = resolve_option(selection_disabled_builder, selection_options[:disabled_builder])
       @selection_disabled_reason_builder = resolve_option(selection_disabled_reason_builder, selection_options[:disabled_reason_builder])
       @selection_selected_keys = Array(resolve_option(selection_selected_keys, selection_options[:selected_keys])).freeze
+      @selection_cascade = normalize_boolean(resolve_option(selection_cascade, selection_options[:cascade]), :selection_cascade)
+      @selection_indeterminate = normalize_boolean(resolve_option(selection_indeterminate, selection_options[:indeterminate]), :selection_indeterminate)
+      @selection_max_count = normalize_optional_positive_integer(resolve_option(selection_max_count, selection_options[:max_count]), :selection_max_count)
       @row_class_builder = row_class_builder
       @row_data_builder = row_data_builder
       @row_event_payload_builder = row_event_payload_builder
@@ -130,6 +139,14 @@ module TreeView
 
     def selection_enabled?
       selection_enabled == true
+    end
+
+    def selection_cascade?
+      selection_cascade == true
+    end
+
+    def selection_indeterminate?
+      selection_indeterminate == true
     end
 
     # 画面固有指定があればそれを優先し、なければ global config を使う。
@@ -184,6 +201,13 @@ module TreeView
       return value if value.is_a?(Integer) && value >= 0
 
       raise ArgumentError, "#{name} must be a non-negative Integer"
+    end
+
+    def normalize_optional_positive_integer(value, name)
+      return nil if value.nil?
+      return value if value.is_a?(Integer) && value.positive?
+
+      raise ArgumentError, "#{name} must be a positive Integer"
     end
 
     def normalize_boolean(value, name)

--- a/spec/helpers/tree_view_state_helper_spec.rb
+++ b/spec/helpers/tree_view_state_helper_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe TreeViewStateHelper do
   end
 
   it "builds root data without a tree instance key" do
-    state = instance_double(TreeView::RenderState, tree_instance_key: nil, row_event_payload_builder: nil)
+    state = instance_double(TreeView::RenderState, tree_instance_key: nil, row_event_payload_builder: nil, selection_enabled?: false)
     helper = helper_host_class.new
 
     expect(helper.tree_view_state_data(state)).to eq(controller: "tree-view-state")
   end
 
   it "builds root data with a tree instance key" do
-    state = instance_double(TreeView::RenderState, tree_instance_key: "documents", row_event_payload_builder: nil)
+    state = instance_double(TreeView::RenderState, tree_instance_key: "documents", row_event_payload_builder: nil, selection_enabled?: false)
     helper = helper_host_class.new
 
     expect(helper.tree_view_state_data(state)).to eq(
@@ -27,10 +27,31 @@ RSpec.describe TreeViewStateHelper do
   end
 
   it "adds the transfer controller when row event payloads are configured" do
-    state = instance_double(TreeView::RenderState, tree_instance_key: nil, row_event_payload_builder: ->(_item) { {} })
+    state = instance_double(TreeView::RenderState, tree_instance_key: nil, row_event_payload_builder: ->(_item) { {} }, selection_enabled?: false)
     helper = helper_host_class.new
 
     expect(helper.tree_view_state_data(state)).to eq(controller: "tree-view-state tree-view-transfer")
+  end
+
+  it "adds the selection controller and cascade values when selection is configured" do
+    state = instance_double(
+      TreeView::RenderState,
+      tree_instance_key: nil,
+      row_event_payload_builder: nil,
+      selection_enabled?: true,
+      selection_cascade?: true,
+      selection_indeterminate?: true,
+      selection_max_count: 10
+    )
+    helper = helper_host_class.new
+
+    expect(helper.tree_view_state_data(state)).to eq(
+      controller: "tree-view-state tree-view-selection",
+      action: "change->tree-view-selection#toggle",
+      tree_view_selection_cascade_value: true,
+      tree_view_selection_indeterminate_value: true,
+      tree_view_selection_max_count_value: 10
+    )
   end
 
   it "builds row state data" do

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -289,13 +289,43 @@ RSpec.describe TreeView::RenderState do
       selection: {
         enabled: true,
         payload_builder: payload_builder,
-        checkbox_name: "documents[]"
+        checkbox_name: "documents[]",
+        cascade: true,
+        indeterminate: true,
+        max_count: 10
       }
     )
 
     expect(state.selection_enabled?).to eq(true)
     expect(state.selection_payload_builder).to eq(payload_builder)
     expect(state.selection_checkbox_name).to eq("documents[]")
+    expect(state.selection_cascade?).to eq(true)
+    expect(state.selection_indeterminate?).to eq(true)
+    expect(state.selection_max_count).to eq(10)
+  end
+
+  it "rejects invalid selection cascade options" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        selection: { enabled: true, cascade: "true" }
+      )
+    end.to raise_error(ArgumentError, /selection_cascade must be true or false/)
+  end
+
+  it "rejects invalid selection max count" do
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: ui_config,
+        selection: { enabled: true, max_count: 0 }
+      )
+    end.to raise_error(ArgumentError, /selection_max_count must be a positive Integer/)
   end
 
   it "uses the default selection checkbox name" do


### PR DESCRIPTION
## Summary

- Expose `selection[:cascade]`, `selection[:indeterminate]`, `selection[:max_count]` in `RenderState`
- Connect these values to the `tree-view-selection` Stimulus controller via `tree_view_state_data`
- Add integration spec verifying that `<tbody>` data attributes are correctly set

## Notes

This completes #245 by enabling the parent-child cascading checkbox functionality. Stimulus controller handles the interactive toggling and indeterminate states.

Closes #245