### PR TITLE
Add static HTML mock for default TreeView rendering

### DIFF
--- a/docs/mockups/default-tree.css
+++ b/docs/mockups/default-tree.css
@@ -1,0 +1,5 @@
+.tree-root { list-style-type: none; padding-left: 20px; }
+.tree-node { padding: 2px 5px; }
+.tree-node.selected { background-color: #cce5ff; }
+.tree-node.expanded > ul { display: block; }
+.tree-node > ul { display: none; }

--- a/docs/mockups/default-tree.html
+++ b/docs/mockups/default-tree.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Default TreeView Mock</title>
+<link rel="stylesheet" href="default-tree.css">
+</head>
+<body>
+  <ul class="tree-root">
+    <li class="tree-node root expanded">
+      Root Node
+      <ul>
+        <li class="tree-node child">
+          Child Node 1
+        </li>
+        <li class="tree-node child selected">
+          Child Node 2 (selected)
+        </li>
+      </ul>
+    </li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
Add static HTML (`default-tree.html`) and CSS (`default-tree.css`) to allow verification of the standard TreeView DOM structure without Rails or ERB environment. Linked from docs/README.md, separate from demo/playground app.