### PR TITLE
Add lazy-loading support for TreeView nodes

### DIFF
--- a/lib/tree_view/lazy_loader.rb
+++ b/lib/tree_view/lazy_loader.rb
@@ -1,0 +1,17 @@
+module TreeView
+  class LazyLoader
+    # Implements on-demand child node fetching for TreeView
+    # Safe format for GitHub API
+    def initialize(fetch_callback)
+      @fetch_callback = fetch_callback
+      @loaded_nodes = {}
+    end
+
+    def load(node_id)
+      return @loaded_nodes[node_id] if @loaded_nodes.key?(node_id)
+      result = @fetch_callback.call(node_id)
+      @loaded_nodes[node_id] = result
+      result
+    end
+  end
+end


### PR DESCRIPTION
Implements the lazy-loading mechanism for TreeView nodes as described in docs/lazy-loading future extension. Allows fetching child nodes on demand.