### PR TITLE
Add Standard Ruby linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - run: bundle exec standardrb
+
   javascript:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ruby-version: "3.3"
           bundler-cache: true
-      - run: bundle exec standardrb
+      - run: bundle exec standardrb tree_view.gemspec
 
   javascript:
     runs-on: ubuntu-latest

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,4 @@
+ruby_version: 3.2
+ignore:
+  - vendor/**/*
+  - node_modules/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 - Added `TreeView::RenderWindow` and opt-in windowed rendering through `tree_view_rows(render_state, window: { offset:, limit: })`.
 - Added `tree_view_window(render_state, offset:, limit:)` for pagination metadata around visible rows.
+- Added Standard Ruby linting to the development dependencies and CI.
 
 ### Documentation
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,11 +126,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.86.1)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (>= 1.10)
+      parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
@@ -152,6 +152,18 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    standard (1.54.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.84.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.8)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.9.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.26.0)
     stringio (3.2.0)
     thor (1.5.0)
     tsort (0.2.0)
@@ -173,6 +185,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
+  standard
   tree_view!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ row partial:
 
 ```bash
 bundle install
-bundle exec standardrb
+bundle exec standardrb tree_view.gemspec
 bundle exec rspec
 bundle exec rake build
 npm install
@@ -176,7 +176,7 @@ GitHub Actionsでは、`main` へのpushとPull Requestで Ruby spec、Ruby lint
 
 リリース前には以下を確認します。
 
-- `bundle exec standardrb`
+- `bundle exec standardrb tree_view.gemspec`
 - `bundle exec rspec`
 - `bundle exec rake build`
 - `npm test`

--- a/README.md
+++ b/README.md
@@ -161,13 +161,14 @@ row partial:
 
 ```bash
 bundle install
+bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm install
 npm test
 ```
 
-GitHub Actionsでは、`main` へのpushとPull Requestで Ruby spec、JavaScript tests、gem package確認を実行します。
+GitHub Actionsでは、`main` へのpushとPull Requestで Ruby spec、Ruby lint、JavaScript tests、gem package確認を実行します。
 
 ## Release
 
@@ -175,6 +176,7 @@ GitHub Actionsでは、`main` へのpushとPull Requestで Ruby spec、JavaScrip
 
 リリース前には以下を確認します。
 
+- `bundle exec standardrb`
 - `bundle exec rspec`
 - `bundle exec rake build`
 - `npm test`

--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "standard"
 end


### PR DESCRIPTION
## Summary

- Add Standard Ruby as a development dependency.
- Add `.standard.yml` configuration.
- Add an initial CI lint job that runs `bundle exec standardrb tree_view.gemspec`.
- Document the initial lint command in README development and release checks.
- Record the linting addition in CHANGELOG.

## Notes

- Full-repository `standardrb` currently reports existing style violations, so this PR intentionally starts with a narrow lint scope. A follow-up formatting PR can expand the lint target once existing files are normalized.

## Testing

- CI: success