### PR TITLE
Run full CI only on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,18 @@ on:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - run: bundle exec standardrb
+
   spec:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,17 +34,8 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-      - run: bundle exec standardrb
-
   javascript:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -44,6 +46,7 @@ jobs:
       - run: npm test
 
   gem_package:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Keep `bundle exec standardrb` running on pull requests as a lightweight check.
- Run the full Ruby spec matrix only on pushes to `main`.
- Run JavaScript tests only on pushes to `main`.
- Run gem package verification only on pushes to `main`.

## Testing

- PR CI: lightweight lint job succeeded.
- PR CI confirmed `spec`, `javascript`, and `gem_package` are skipped on pull requests.
- Full CI will run after merge to `main`.