### PR TITLE
Move spec constants out of example groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -17,10 +20,13 @@ jobs:
           bundler-cache: true
       - run: bundle exec standardrb
 
-  spec_constant_patch:
+  spec_constant_apply:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
       - run: |
           ruby <<'RUBY'
           Dir.glob("spec/**/*_spec.rb").each do |path|
@@ -57,11 +63,14 @@ jobs:
             File.write(path, lines.join)
           end
           RUBY
-      - run: git diff -- spec .standard.yml > spec-constants.patch
-      - uses: actions/upload-artifact@v4
-        with:
-          name: spec-constants-patch
-          path: spec-constants.patch
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet; then
+            git add spec
+            git commit -m "Move spec constants out of example groups"
+            git push origin HEAD:${{ github.head_ref }}
+          fi
 
   spec:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,58 +16,6 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec standardrb
-
-  spec_constant_apply:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-      - run: |
-          ruby <<'RUBY'
-          Dir.glob("spec/**/*_spec.rb").each do |path|
-            text = File.read(path)
-            lines = text.lines
-            describe_index = lines.index { |line| line.start_with?("RSpec.describe ") }
-            next unless describe_index
-
-            extracted = []
-            changed = false
-            scan_index = describe_index + 1
-            while scan_index < lines.length
-              line = lines[scan_index]
-              if line.match?(/^\s*$/)
-                scan_index += 1
-                next
-              end
-              if line.match?(/^\s{2}[A-Z][A-Za-z0-9_]*\s*=\s*(Struct\.new|Class\.new)/)
-                extracted << line.sub(/^\s{2}/, "")
-                lines.delete_at(scan_index)
-                changed = true
-                next
-              end
-              break
-            end
-
-            next unless changed
-
-            insertion_index = describe_index
-            while insertion_index.positive? && lines[insertion_index - 1].match?(/^\s*$/)
-              insertion_index -= 1
-            end
-            lines.insert(insertion_index, *extracted, "\n")
-            File.write(path, lines.join)
-          end
-          RUBY
-      - run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if ! git diff --quiet; then
-            git add spec
-            git commit -m "Move spec constants out of example groups"
-            git push origin HEAD:${{ github.head_ref }}
-          fi
 
   spec:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,52 @@ jobs:
           bundler-cache: true
       - run: bundle exec standardrb
 
+  spec_constant_patch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: |
+          ruby <<'RUBY'
+          Dir.glob("spec/**/*_spec.rb").each do |path|
+            text = File.read(path)
+            lines = text.lines
+            describe_index = lines.index { |line| line.start_with?("RSpec.describe ") }
+            next unless describe_index
+
+            extracted = []
+            changed = false
+            scan_index = describe_index + 1
+            while scan_index < lines.length
+              line = lines[scan_index]
+              if line.match?(/^\s*$/)
+                scan_index += 1
+                next
+              end
+              if line.match?(/^\s{2}[A-Z][A-Za-z0-9_]*\s*=\s*(Struct\.new|Class\.new)/)
+                extracted << line.sub(/^\s{2}/, "")
+                lines.delete_at(scan_index)
+                changed = true
+                next
+              end
+              break
+            end
+
+            next unless changed
+
+            insertion_index = describe_index
+            while insertion_index.positive? && lines[insertion_index - 1].match?(/^\s*$/)
+              insertion_index -= 1
+            end
+            lines.insert(insertion_index, *extracted, "\n")
+            File.write(path, lines.join)
+          end
+          RUBY
+      - run: git diff -- spec .standard.yml > spec-constants.patch
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spec-constants-patch
+          path: spec-constants.patch
+
   spec:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -16,6 +19,27 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec standardrb
+
+  standard_fix:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - run: bundle exec standardrb --fix || true
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet; then
+            git add spec .standard.yml
+            git commit -m "Apply Standard Ruby formatting to specs"
+            git push origin HEAD:${{ github.head_ref }}
+          fi
 
   spec:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,27 +16,6 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec standardrb
-
-  standard_fix:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-      - run: bundle exec standardrb --fix || true
-      - run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if ! git diff --quiet; then
-            git add spec .standard.yml
-            git commit -m "Apply Standard Ruby formatting to specs"
-            git push origin HEAD:${{ github.head_ref }}
-          fi
 
   spec:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.standard.yml
+++ b/.standard.yml
@@ -2,5 +2,3 @@ ruby_version: 3.2
 ignore:
   - vendor/**/*
   - node_modules/**/*
-  - spec/**/*:
-    - Lint/ConstantDefinitionInBlock

--- a/spec/helpers/tree_view_badge_helper_spec.rb
+++ b/spec/helpers/tree_view_badge_helper_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+BadgeNode = Struct.new(:id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView badge helper" do
-  BadgeNode = Struct.new(:id, :name, keyword_init: true)
 
   let(:helper_host_class) do
     Class.new do

--- a/spec/helpers/tree_view_badge_helper_spec.rb
+++ b/spec/helpers/tree_view_badge_helper_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 BadgeNode = Struct.new(:id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView badge helper" do
-
   let(:helper_host_class) do
     Class.new do
       include TreeViewHelper

--- a/spec/helpers/tree_view_breadcrumb_helper_spec.rb
+++ b/spec/helpers/tree_view_breadcrumb_helper_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
 require "action_view"
+BreadcrumbNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeViewBreadcrumbHelper do
-  BreadcrumbNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:helper_host_class) do
     Class.new do

--- a/spec/helpers/tree_view_breadcrumb_helper_spec.rb
+++ b/spec/helpers/tree_view_breadcrumb_helper_spec.rb
@@ -2,9 +2,7 @@ require "spec_helper"
 require "action_view"
 BreadcrumbNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeViewBreadcrumbHelper do
-
   let(:helper_host_class) do
     Class.new do
       include ActionView::Helpers::TagHelper

--- a/spec/helpers/tree_view_builder_diagnostics_spec.rb
+++ b/spec/helpers/tree_view_builder_diagnostics_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 DiagnosticNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView builder diagnostics" do
-
   let(:helper_host_class) do
     Class.new do
       include TreeViewHelper

--- a/spec/helpers/tree_view_builder_diagnostics_spec.rb
+++ b/spec/helpers/tree_view_builder_diagnostics_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+DiagnosticNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView builder diagnostics" do
-  DiagnosticNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:helper_host_class) do
     Class.new do

--- a/spec/helpers/tree_view_helper_spec.rb
+++ b/spec/helpers/tree_view_helper_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+HelperTestNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeViewHelper do
-  HelperTestNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:ui_config) do
     TreeView::UiConfig.new(

--- a/spec/helpers/tree_view_helper_spec.rb
+++ b/spec/helpers/tree_view_helper_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 HelperTestNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeViewHelper do
-
   let(:ui_config) do
     TreeView::UiConfig.new(
       node_dom_id_builder: ->(item_or_id) { "item_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },

--- a/spec/helpers/tree_view_state_helper_spec.rb
+++ b/spec/helpers/tree_view_state_helper_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+StateHelperTestNode = Struct.new(:id, keyword_init: true)
+
 
 RSpec.describe TreeViewStateHelper do
-  StateHelperTestNode = Struct.new(:id, keyword_init: true)
 
   let(:helper_host_class) do
     Class.new do

--- a/spec/helpers/tree_view_state_helper_spec.rb
+++ b/spec/helpers/tree_view_state_helper_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 StateHelperTestNode = Struct.new(:id, keyword_init: true)
 
-
 RSpec.describe TreeViewStateHelper do
-
   let(:helper_host_class) do
     Class.new do
       include TreeViewStateHelper

--- a/spec/integration/toggle_leaf_distance_integration_spec.rb
+++ b/spec/integration/toggle_leaf_distance_integration_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 require "action_view"
 require "fileutils"
 require "tmpdir"
+ToggleLeafNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView leaf-based toggle scope integration" do
-  ToggleLeafNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { ToggleLeafNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { ToggleLeafNode.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/integration/toggle_leaf_distance_integration_spec.rb
+++ b/spec/integration/toggle_leaf_distance_integration_spec.rb
@@ -4,9 +4,7 @@ require "fileutils"
 require "tmpdir"
 ToggleLeafNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView leaf-based toggle scope integration" do
-
   let(:root) { ToggleLeafNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { ToggleLeafNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:grandchild) { ToggleLeafNode.new(id: 3, parent_item_id: 2, name: "grandchild") }

--- a/spec/integration/tree_view_demo_contract_spec.rb
+++ b/spec/integration/tree_view_demo_contract_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 require "action_view"
 require "fileutils"
 require "tmpdir"
+DemoMachineNode = Struct.new(:id, :name, :children, keyword_init: true)
+
 
 RSpec.describe "TreeView demo app integration contract" do
-  DemoMachineNode = Struct.new(:id, :name, :children, keyword_init: true)
 
   let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
   let(:host_view_dir) { Dir.mktmpdir("tree_view_demo_host_views") }

--- a/spec/integration/tree_view_demo_contract_spec.rb
+++ b/spec/integration/tree_view_demo_contract_spec.rb
@@ -4,9 +4,7 @@ require "fileutils"
 require "tmpdir"
 DemoMachineNode = Struct.new(:id, :name, :children, keyword_init: true)
 
-
 RSpec.describe "TreeView demo app integration contract" do
-
   let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
   let(:host_view_dir) { Dir.mktmpdir("tree_view_demo_host_views") }
 

--- a/spec/integration/tree_view_icon_builder_integration_spec.rb
+++ b/spec/integration/tree_view_icon_builder_integration_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 require "action_view"
 require "fileutils"
 require "tmpdir"
+IconNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView icon builder integration" do
-  IconNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { IconNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:tree) { TreeView::Tree.new(records: [root], parent_id_method: :parent_item_id) }

--- a/spec/integration/tree_view_icon_builder_integration_spec.rb
+++ b/spec/integration/tree_view_icon_builder_integration_spec.rb
@@ -4,9 +4,7 @@ require "fileutils"
 require "tmpdir"
 IconNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView icon builder integration" do
-
   let(:root) { IconNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:tree) { TreeView::Tree.new(records: [root], parent_id_method: :parent_item_id) }
   let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -5,9 +5,7 @@ require "fileutils"
 require "tmpdir"
 IntegrationNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView integration" do
-
   let(:root) { IntegrationNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { IntegrationNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:grandchild) { IntegrationNode.new(id: 3, parent_item_id: 2, name: "grandchild") }

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -3,9 +3,10 @@ require "action_view"
 require "bigdecimal"
 require "fileutils"
 require "tmpdir"
+IntegrationNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView integration" do
-  IntegrationNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { IntegrationNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { IntegrationNode.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/integration/tree_view_selection_integration_spec.rb
+++ b/spec/integration/tree_view_selection_integration_spec.rb
@@ -4,9 +4,7 @@ require "fileutils"
 require "tmpdir"
 SelectionNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView selection integration" do
-
   let(:root) { SelectionNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { SelectionNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:grandchild) { SelectionNode.new(id: 3, parent_item_id: 2, name: "grandchild") }

--- a/spec/integration/tree_view_selection_integration_spec.rb
+++ b/spec/integration/tree_view_selection_integration_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 require "action_view"
 require "fileutils"
 require "tmpdir"
+SelectionNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView selection integration" do
-  SelectionNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { SelectionNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { SelectionNode.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/integration/tree_view_windowed_rendering_spec.rb
+++ b/spec/integration/tree_view_windowed_rendering_spec.rb
@@ -6,9 +6,7 @@ require "fileutils"
 require "tmpdir"
 WindowNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView windowed rendering" do
-
   let(:root) { WindowNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { WindowNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:grandchild) { WindowNode.new(id: 3, parent_item_id: 2, name: "grandchild") }

--- a/spec/integration/tree_view_windowed_rendering_spec.rb
+++ b/spec/integration/tree_view_windowed_rendering_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 require "action_view"
 require "fileutils"
 require "tmpdir"
+WindowNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView windowed rendering" do
-  WindowNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { WindowNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { WindowNode.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/lib/tree_view/cycle_diagnostics_spec.rb
+++ b/spec/lib/tree_view/cycle_diagnostics_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 CycleNodeForSpec = Struct.new(:id, :parent_id, keyword_init: true)
 
-
 RSpec.describe "TreeView cycle diagnostics" do
-
   it "returns an empty report without cycles" do
     root = CycleNodeForSpec.new(id: 1, parent_id: nil)
     child = CycleNodeForSpec.new(id: 2, parent_id: 1)

--- a/spec/lib/tree_view/cycle_diagnostics_spec.rb
+++ b/spec/lib/tree_view/cycle_diagnostics_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+CycleNodeForSpec = Struct.new(:id, :parent_id, keyword_init: true)
+
 
 RSpec.describe "TreeView cycle diagnostics" do
-  CycleNodeForSpec = Struct.new(:id, :parent_id, keyword_init: true)
 
   it "returns an empty report without cycles" do
     root = CycleNodeForSpec.new(id: 1, parent_id: nil)

--- a/spec/lib/tree_view/dom_id_validator_spec.rb
+++ b/spec/lib/tree_view/dom_id_validator_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+DomIdTestNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::DomIdValidator do
-  DomIdTestNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { DomIdTestNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { DomIdTestNode.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/lib/tree_view/dom_id_validator_spec.rb
+++ b/spec/lib/tree_view/dom_id_validator_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 DomIdTestNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::DomIdValidator do
-
   let(:root) { DomIdTestNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { DomIdTestNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:nodes) { [root, child] }

--- a/spec/lib/tree_view/filtered_tree_spec.rb
+++ b/spec/lib/tree_view/filtered_tree_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+FilterNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::FilteredTree do
-  FilterNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { FilterNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { FilterNode.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/lib/tree_view/filtered_tree_spec.rb
+++ b/spec/lib/tree_view/filtered_tree_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 FilterNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::FilteredTree do
-
   let(:root) { FilterNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { FilterNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:grandchild) { FilterNode.new(id: 3, parent_item_id: 2, name: "grandchild") }

--- a/spec/lib/tree_view/graph_adapter_spec.rb
+++ b/spec/lib/tree_view/graph_adapter_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 GraphAdapterNode = Struct.new(:id, :children)
 
-
 RSpec.describe TreeView::GraphAdapter do
-
   it "provides roots, children, and node_key" do
     child = GraphAdapterNode.new(2, [])
     root = GraphAdapterNode.new(1, [child])

--- a/spec/lib/tree_view/graph_adapter_spec.rb
+++ b/spec/lib/tree_view/graph_adapter_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+GraphAdapterNode = Struct.new(:id, :children)
+
 
 RSpec.describe TreeView::GraphAdapter do
-  GraphAdapterNode = Struct.new(:id, :children)
 
   it "provides roots, children, and node_key" do
     child = GraphAdapterNode.new(2, [])

--- a/spec/lib/tree_view/large_tree_spec.rb
+++ b/spec/lib/tree_view/large_tree_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+BaselineNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView large tree baselines" do
-  BaselineNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   def build_chain(size)
     Array.new(size) do |index|

--- a/spec/lib/tree_view/large_tree_spec.rb
+++ b/spec/lib/tree_view/large_tree_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 BaselineNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView large tree baselines" do
-
   def build_chain(size)
     Array.new(size) do |index|
       BaselineNode.new(

--- a/spec/lib/tree_view/node_key_helper_spec.rb
+++ b/spec/lib/tree_view/node_key_helper_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+NodeKeyHelperSpecItem = Struct.new(:id, :parent_id, keyword_init: true)
+
 
 RSpec.describe "TreeView node key helper" do
-  NodeKeyHelperSpecItem = Struct.new(:id, :parent_id, keyword_init: true)
 
   it "builds a namespaced node key" do
     expect(TreeView.node_key("Document", 123)).to eq("Document:123")

--- a/spec/lib/tree_view/node_key_helper_spec.rb
+++ b/spec/lib/tree_view/node_key_helper_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 NodeKeyHelperSpecItem = Struct.new(:id, :parent_id, keyword_init: true)
 
-
 RSpec.describe "TreeView node key helper" do
-
   it "builds a namespaced node key" do
     expect(TreeView.node_key("Document", 123)).to eq("Document:123")
   end

--- a/spec/lib/tree_view/orphan_strategy_spec.rb
+++ b/spec/lib/tree_view/orphan_strategy_spec.rb
@@ -2,9 +2,7 @@ require "spec_helper"
 OrphanNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 OrphanCountry = Struct.new(:id, :name, :children)
 
-
 RSpec.describe "TreeView::Tree orphan strategy" do
-
   def build_tree(records, **options)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, **options)
   end

--- a/spec/lib/tree_view/orphan_strategy_spec.rb
+++ b/spec/lib/tree_view/orphan_strategy_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
+OrphanNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+OrphanCountry = Struct.new(:id, :name, :children)
+
 
 RSpec.describe "TreeView::Tree orphan strategy" do
-  OrphanNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
-  OrphanCountry = Struct.new(:id, :name, :children)
 
   def build_tree(records, **options)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, **options)

--- a/spec/lib/tree_view/path_helpers_spec.rb
+++ b/spec/lib/tree_view/path_helpers_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
+PathNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+PathCountry = Struct.new(:id, :name, :children)
+
 
 RSpec.describe "TreeView::Tree parent path helpers" do
-  PathNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
-  PathCountry = Struct.new(:id, :name, :children)
 
   def build_tree(records, **options)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, **options)

--- a/spec/lib/tree_view/path_helpers_spec.rb
+++ b/spec/lib/tree_view/path_helpers_spec.rb
@@ -2,9 +2,7 @@ require "spec_helper"
 PathNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 PathCountry = Struct.new(:id, :name, :children)
 
-
 RSpec.describe "TreeView::Tree parent path helpers" do
-
   def build_tree(records, **options)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, **options)
   end

--- a/spec/lib/tree_view/path_tree_spec.rb
+++ b/spec/lib/tree_view/path_tree_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+PathTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::PathTree do
-  PathTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   def build_base_tree(records)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) })

--- a/spec/lib/tree_view/path_tree_spec.rb
+++ b/spec/lib/tree_view/path_tree_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 PathTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::PathTree do
-
   def build_base_tree(records)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) })
   end

--- a/spec/lib/tree_view/render_traversal_spec.rb
+++ b/spec/lib/tree_view/render_traversal_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 RenderTraversalNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::RenderTraversal do
-
   def build_tree
     root_a = RenderTraversalNode.new(id: 1, parent_item_id: nil, name: "root-a")
     root_b = RenderTraversalNode.new(id: 2, parent_item_id: nil, name: "root-b")

--- a/spec/lib/tree_view/render_traversal_spec.rb
+++ b/spec/lib/tree_view/render_traversal_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+RenderTraversalNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::RenderTraversal do
-  RenderTraversalNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   def build_tree
     root_a = RenderTraversalNode.new(id: 1, parent_item_id: nil, name: "root-a")

--- a/spec/lib/tree_view/reverse_tree_spec.rb
+++ b/spec/lib/tree_view/reverse_tree_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 ReverseTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::ReverseTree do
-
   def build_base_tree(records)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) })
   end

--- a/spec/lib/tree_view/reverse_tree_spec.rb
+++ b/spec/lib/tree_view/reverse_tree_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+ReverseTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::ReverseTree do
-  ReverseTreeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   def build_base_tree(records)
     TreeView::Tree.new(records: records, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) })

--- a/spec/lib/tree_view/row_context_spec.rb
+++ b/spec/lib/tree_view/row_context_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 Node = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::RowContext do
-
   let(:root) { Node.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { Node.new(id: 2, parent_item_id: 1, name: "child") }
   let(:tree) { TreeView::Tree.new(records: [root, child], parent_id_method: :parent_item_id) }

--- a/spec/lib/tree_view/row_context_spec.rb
+++ b/spec/lib/tree_view/row_context_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+Node = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::RowContext do
-  Node = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { Node.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { Node.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/lib/tree_view/row_event_payload_builder_spec.rb
+++ b/spec/lib/tree_view/row_event_payload_builder_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 RowEventNode = Struct.new(:id, :name, keyword_init: true)
 
-
 RSpec.describe "TreeView row event payload builder" do
-
   let(:tree) { instance_double(TreeView::Tree) }
   let(:ui_config) { instance_double(TreeView::UiConfig) }
 

--- a/spec/lib/tree_view/row_event_payload_builder_spec.rb
+++ b/spec/lib/tree_view/row_event_payload_builder_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+RowEventNode = Struct.new(:id, :name, keyword_init: true)
+
 
 RSpec.describe "TreeView row event payload builder" do
-  RowEventNode = Struct.new(:id, :name, keyword_init: true)
 
   let(:tree) { instance_double(TreeView::Tree) }
   let(:ui_config) { instance_double(TreeView::UiConfig) }

--- a/spec/lib/tree_view/row_status_builder_spec.rb
+++ b/spec/lib/tree_view/row_status_builder_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+RowStatusSpecNode = Struct.new(:id, :parent_item_id, :name, :locked, :readonly, keyword_init: true)
+
 
 RSpec.describe "TreeView row status builders" do
-  RowStatusSpecNode = Struct.new(:id, :parent_item_id, :name, :locked, :readonly, keyword_init: true)
 
   let(:root) { RowStatusSpecNode.new(id: 1, parent_item_id: nil, name: "root", locked: true, readonly: false) }
   let(:child) { RowStatusSpecNode.new(id: 2, parent_item_id: 1, name: "child", locked: false, readonly: true) }

--- a/spec/lib/tree_view/row_status_builder_spec.rb
+++ b/spec/lib/tree_view/row_status_builder_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 RowStatusSpecNode = Struct.new(:id, :parent_item_id, :name, :locked, :readonly, keyword_init: true)
 
-
 RSpec.describe "TreeView row status builders" do
-
   let(:root) { RowStatusSpecNode.new(id: 1, parent_item_id: nil, name: "root", locked: true, readonly: false) }
   let(:child) { RowStatusSpecNode.new(id: 2, parent_item_id: 1, name: "child", locked: false, readonly: true) }
   let(:tree) { TreeView::Tree.new(records: [root, child], parent_id_method: :parent_item_id) }

--- a/spec/lib/tree_view/sorters_spec.rb
+++ b/spec/lib/tree_view/sorters_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+SortPresetNode = Struct.new(:id, :parent_id, :position, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::Sorters do
-  SortPresetNode = Struct.new(:id, :parent_id, :position, :name, keyword_init: true)
 
   it "sorts by one or more methods" do
     first = SortPresetNode.new(id: 1, parent_id: nil, position: 2, name: "B")

--- a/spec/lib/tree_view/sorters_spec.rb
+++ b/spec/lib/tree_view/sorters_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 SortPresetNode = Struct.new(:id, :parent_id, :position, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::Sorters do
-
   it "sorts by one or more methods" do
     first = SortPresetNode.new(id: 1, parent_id: nil, position: 2, name: "B")
     second = SortPresetNode.new(id: 2, parent_id: nil, position: 1, name: "C")

--- a/spec/lib/tree_view/state_store_spec.rb
+++ b/spec/lib/tree_view/state_store_spec.rb
@@ -1,30 +1,29 @@
 require "spec_helper"
-DummyRecord = Struct.new(:owner, :tree_instance_key, :expanded_keys) do
 
+DummyRecord = Struct.new(:owner, :tree_instance_key, :expanded_keys) do
+  def save!
+    true
+  end
+end
+
+class DummyModel
+  class << self
+    attr_accessor :record
+
+    def find_by(owner:, tree_instance_key:)
+      return nil unless record
+      return record if record.owner == owner && record.tree_instance_key == tree_instance_key
+
+      nil
+    end
+
+    def find_or_initialize_by(owner:, tree_instance_key:)
+      self.record ||= DummyRecord.new(owner, tree_instance_key, [])
+    end
+  end
+end
 
 RSpec.describe TreeView::StateStore do
-    def save!
-      true
-    end
-  end
-
-  class DummyModel
-    class << self
-      attr_accessor :record
-
-      def find_by(owner:, tree_instance_key:)
-        return nil unless record
-        return record if record.owner == owner && record.tree_instance_key == tree_instance_key
-
-        nil
-      end
-
-      def find_or_initialize_by(owner:, tree_instance_key:)
-        self.record ||= DummyRecord.new(owner, tree_instance_key, [])
-      end
-    end
-  end
-
   before do
     DummyModel.record = nil
   end

--- a/spec/lib/tree_view/state_store_spec.rb
+++ b/spec/lib/tree_view/state_store_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+DummyRecord = Struct.new(:owner, :tree_instance_key, :expanded_keys) do
+
 
 RSpec.describe TreeView::StateStore do
-  DummyRecord = Struct.new(:owner, :tree_instance_key, :expanded_keys) do
     def save!
       true
     end

--- a/spec/lib/tree_view/tree_spec.rb
+++ b/spec/lib/tree_view/tree_spec.rb
@@ -1,10 +1,11 @@
 require "spec_helper"
+ItemNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+CountryNode = Struct.new(:id, :name, :cities)
+CityNode = Struct.new(:id, :name, :recipes)
+RecipeNode = Struct.new(:id, :name, :steps)
+
 
 RSpec.describe TreeView::Tree do
-  ItemNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
-  CountryNode = Struct.new(:id, :name, :cities)
-  CityNode = Struct.new(:id, :name, :recipes)
-  RecipeNode = Struct.new(:id, :name, :steps)
 
   describe "#descendant_counts" do
     it "counts descendants in records mode" do

--- a/spec/lib/tree_view/tree_spec.rb
+++ b/spec/lib/tree_view/tree_spec.rb
@@ -4,9 +4,7 @@ CountryNode = Struct.new(:id, :name, :cities)
 CityNode = Struct.new(:id, :name, :recipes)
 RecipeNode = Struct.new(:id, :name, :steps)
 
-
 RSpec.describe TreeView::Tree do
-
   describe "#descendant_counts" do
     it "counts descendants in records mode" do
       root = ItemNode.new(id: 1, parent_item_id: nil, name: "root")

--- a/spec/lib/tree_view/visible_rows_spec.rb
+++ b/spec/lib/tree_view/visible_rows_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
+VisibleRowsNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
 
 RSpec.describe TreeView::VisibleRows do
-  VisibleRowsNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
   let(:root) { VisibleRowsNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { VisibleRowsNode.new(id: 2, parent_item_id: 1, name: "child") }

--- a/spec/lib/tree_view/visible_rows_spec.rb
+++ b/spec/lib/tree_view/visible_rows_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 VisibleRowsNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
 
-
 RSpec.describe TreeView::VisibleRows do
-
   let(:root) { VisibleRowsNode.new(id: 1, parent_item_id: nil, name: "root") }
   let(:child) { VisibleRowsNode.new(id: 2, parent_item_id: 1, name: "child") }
   let(:grandchild) { VisibleRowsNode.new(id: 3, parent_item_id: 2, name: "grandchild") }


### PR DESCRIPTION
## Summary

- Move spec-local test constants out of `RSpec.describe` example groups.
- Remove the temporary `Lint/ConstantDefinitionInBlock` exception from `.standard.yml`.
- Keep the regular CI workflow unchanged after using temporary cleanup jobs during preparation.

## Testing

- PR CI: `bundle exec standardrb` succeeded.
- `spec`, `javascript`, and `gem_package` are skipped on pull requests by design; full CI will run after merge to `main`.