### PR TITLE
Add main-only Rails version matrix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,35 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
 
+  rails_matrix:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rails: "7.0"
+            gemfile: gemfiles/rails_7_0.gemfile
+            ruby-version: "3.2"
+          - rails: "7.1"
+            gemfile: gemfiles/rails_7_1.gemfile
+            ruby-version: "3.2"
+          - rails: "7.2"
+            gemfile: gemfiles/rails_7_2.gemfile
+            ruby-version: "3.2"
+          - rails: "8.0"
+            gemfile: gemfiles/rails_8_0.gemfile
+            ruby-version: "3.3"
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - run: bundle exec rake
+
   javascript:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added `TreeView::RenderWindow` and opt-in windowed rendering through `tree_view_rows(render_state, window: { offset:, limit: })`.
 - Added `tree_view_window(render_state, offset:, limit:)` for pagination metadata around visible rows.
 - Added Standard Ruby linting to the development dependencies and CI.
+- Added Rails version matrix Gemfiles and a main-push-only Rails compatibility CI job.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,14 @@ npm install
 npm test
 ```
 
-GitHub Actionsでは、`main` へのpushとPull Requestで Ruby spec、Ruby lint、JavaScript tests、gem package確認を実行します。
+Rails互換性確認用のGemfileは `gemfiles/` 配下にあります。必要に応じて `BUNDLE_GEMFILE` を指定して実行します。
+
+```bash
+BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
+```
+
+GitHub Actionsでは、Pull RequestではRuby lintのみを実行し、`main` へのpushで Ruby spec、Rails version matrix、JavaScript tests、gem package確認を実行します。
 
 ## Release
 
@@ -179,6 +186,7 @@ GitHub Actionsでは、`main` へのpushとPull Requestで Ruby spec、Ruby lint
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - `bundle exec rake build`
+- Rails version matrix CI
 - `npm test`
 - README / docs / CHANGELOG の整合
 - gemspec metadata

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "railties", "~> 7.0.8"
+
+group :development, :test do
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+end

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "railties", "~> 7.1.5"
+
+group :development, :test do
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+end

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "railties", "~> 7.2.3"
+
+group :development, :test do
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+end

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "railties", "~> 8.0.4"
+
+group :development, :test do
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+end


### PR DESCRIPTION
## Summary

- Add Rails compatibility Gemfiles for Rails 7.0, 7.1, 7.2, and 8.0.
- Add a `rails_matrix` CI job that runs only on pushes to `main`.
- Keep pull request CI lightweight; PRs still run only `bundle exec standardrb`.
- Document the Rails matrix workflow in README and CHANGELOG.

## Testing

- PR CI: `bundle exec standardrb` succeeded.
- PR CI confirmed `spec`, `rails_matrix`, `javascript`, and `gem_package` are skipped on pull requests.
- Rails matrix CI will run after merge to `main`.