### PR TITLE
Document main tag release policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Clarified large-tree performance hardening boundaries between TreeView gem support and host app responsibilities.
 - Added windowed rendering documentation.
 - Clarified public API, semi-public API, internal helper module, and JavaScript entrypoint compatibility policy.
+- Clarified that releases are normally managed by tags on `main`, with release branches reserved for parallel maintenance.
 
 ### Tests
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,6 +16,41 @@ While the gem is still before `1.0.0`, breaking changes may happen in minor vers
 - update `docs/public-api.md` when the public surface changes
 - prefer compatibility shims when the maintenance cost is small
 
+## Release branch and tag policy
+
+`main` is the release source of truth.
+
+By default, releases are managed by Git tags on `main`, not long-lived release branches.
+
+Recommended tag format:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The release flow is:
+
+1. Open a release preparation PR against `main`.
+2. Update `lib/tree_view/version.rb`.
+3. Move relevant `CHANGELOG.md` entries from `Unreleased` into a dated version section.
+4. Merge the release preparation PR into `main`.
+5. Confirm the main-push full CI is green.
+6. Tag the exact green `main` commit with `vX.Y.Z`.
+7. Create a GitHub Release from that tag when appropriate.
+8. Publish the gem when appropriate.
+
+Do not create a `release/*` branch for normal patch or minor releases.
+
+Introduce a `release/x.y` branch only when parallel maintenance is needed, for example:
+
+- `main` is already accepting breaking changes for the next line.
+- an older minor line needs a bugfix release.
+- a release candidate must be frozen for an extended verification window.
+- multiple supported release lines need security or compatibility patches.
+
+When release branches are introduced, document the branch policy in this file and keep tag names globally unique.
+
 ## Initial release target
 
 The initial `0.1.0` release should include a coherent, documented baseline rather than every planned feature.
@@ -35,11 +70,23 @@ Issues that add optional UX enhancements, large-tree strategies, or richer brows
 
 ## Code and tests
 
+Local checks:
+
+- Run `bundle exec standardrb`
 - Run `bundle exec rake`
 - Run `bundle exec rake build`
-- Confirm the gem package CI job is green when available
-- Confirm packaged file list specs are green when available
-- Confirm the supported Ruby / Rails versions in `docs/installation.md` match `tree_view.gemspec`
+- Run `npm test`
+
+Main-push CI checks:
+
+- Ruby spec matrix is green.
+- Rails version matrix is green.
+- JavaScript tests are green through `npm ci`.
+- Gem package verification is green.
+
+Pull request CI is intentionally lightweight and currently runs Ruby lint only. Do not treat a pull request green check as a full release verification. The release tag should be placed only after the merge commit on `main` has completed full CI successfully.
+
+Confirm the supported Ruby / Rails versions in `docs/installation.md` match `tree_view.gemspec` and the Rails matrix Gemfiles.
 
 ## Documentation
 
@@ -62,6 +109,8 @@ For each release, add a dated entry to `CHANGELOG.md` with these groups when rel
 
 Include migration notes for breaking changes or deprecations.
 
+Before tagging, `CHANGELOG.md` should not leave release-bound user-visible changes only under `Unreleased`. Move them into the released version section.
+
 ## Gem package
 
 - Bump `TreeView::VERSION`
@@ -76,7 +125,7 @@ Include migration notes for breaking changes or deprecations.
   - `docs/**/*`
   - `LICENSE*`
 
-## Asset and importmap audit
+## Asset, importmap, and npm audit
 
 Before release, confirm the installation guide still matches the packaged files.
 
@@ -86,10 +135,12 @@ Before release, confirm the installation guide still matches the packaged files.
 - README and `docs/installation.md` show the recommended CSS import
 - README and `docs/installation.md` show the recommended importmap pin
 - Sprockets / Propshaft notes do not promise behavior that is not covered by the gem package
+- `package-lock.json` is committed when `package.json` changes
+- JavaScript CI uses `npm ci`, so lockfile updates should be part of dependency update PRs
 
 ## Repository
 
 - Ensure `main` is green before tagging
-- Tag the released version
+- Tag the released version on `main`
 - Create a GitHub release when appropriate
 - Link notable closed issues and merged PRs from the release notes


### PR DESCRIPTION
## Summary

- Document that `main` is the release source of truth.
- Clarify that normal releases are managed with `vX.Y.Z` tags on `main`.
- Reserve `release/x.y` branches for parallel maintenance or extended release candidate verification.
- Update the release checklist to reflect pull-request lightweight CI and main-push full CI.
- Document npm lockfile expectations for release checks.

## Testing

- PR CI: `bundle exec standardrb` succeeded.
- PR CI confirmed `spec`, `rails_matrix`, `javascript`, and `gem_package` are skipped on pull requests by design.
- Full CI will run after merge to `main` by design.