### PR TITLE
Add English docs index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Clarified public API, semi-public API, internal helper module, and JavaScript entrypoint compatibility policy.
 - Clarified that releases are normally managed by tags on `main`, with release branches reserved for parallel maintenance.
 - Added a documentation i18n audit covering language status, translation priority, and release readiness.
+- Added English documentation index content to `docs/README.md`.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Clarified that releases are normally managed by tags on `main`, with release branches reserved for parallel maintenance.
 - Added a documentation i18n audit covering language status, translation priority, and release readiness.
 - Added English documentation index content to `docs/README.md`.
+- Added Japanese summaries to `docs/public-api.md` and `docs/release.md`.
 
 ### Tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,84 +4,130 @@
 
 README は利用者向けの短い入口に留め、設計思想・導入手順・API仕様・開発方針はこの `docs/` 配下に分けて管理します。
 
-## ドキュメントの言語対応
+This directory contains detailed `tree_view` documentation.
+
+The top-level README stays as a short user-facing entry point. Design policy, installation details, API references, and maintenance guidance live under `docs/`.
+
+## ドキュメントの言語対応 / Documentation language status
 
 `0.1.0` リリース前に、ドキュメントの日英対応状況を明示的に管理します。
 
-- [Documentation i18n audit](i18n-audit.md): 各ドキュメントの言語状態、優先度、翻訳方針
+Before the `0.1.0` release, documentation language coverage is tracked explicitly.
+
+- [Documentation i18n audit](i18n-audit.md): 各ドキュメントの言語状態、優先度、翻訳方針 / language status, priority, and translation policy for each document
 
 現時点では、すべてのドキュメントが完全な日英併記になっているわけではありません。利用者向けの入口、導入、最小利用例、使い方、API仕様から優先的に日英対応を進めます。
 
-## 利用者向け
+Not every document is fully bilingual yet. Bilingual coverage is prioritized for user-facing entry points, installation, minimal usage, usage, and API references first.
+
+## 利用者向け / For users
 
 TreeViewをhost Rails appに組み込む人は、まず以下を確認してください。
 
-| ドキュメント | 内容 |
-|---|---|
-| [導入手順](installation.md) | Gemfile、CSS、importmap、Propshaft / Sprockets、開発環境 |
-| [最小利用例](minimal-usage.md) | host app での controller、view、row partial の最小構成 |
-| [使い方](usage.md) | 通常Tree、static表示、Turbo表示、RenderState、view実装例 |
-| [Cookbook](cookbook.md) | 既存APIを組み合わせた代表的な利用パターン |
-| [用語集](glossary.md) | TreeView固有の概念、コード上の表現、責務の整理 |
-| [Selection](selection.md) | checkbox selection、visibility、送信値 parse |
-| [Breadcrumb helper](breadcrumb.md) | 現在nodeや任意nodeの親階層pathをパンくずとして描画するhelper |
-| [Depth labels](depth-labels.md) | node depthを任意のラベルとして表示するhook |
-| [Row status](row-status.md) | 行全体のdisabled / readonly状態を表すhook |
-| [Node keys](node-keys.md) | 異種nodeや複数TreeViewで衝突しにくいnode_key生成helper |
-| [Tree diagnostics helpers](tree-diagnostics.md) | expanded keys、統計、orphan診断などの構造確認API |
-| [Lazy Loading](lazy-loading.md) | 子ノードを必要なタイミングで読み込むための hook と data 属性 |
-| [Windowed Rendering](windowed-rendering.md) | 表示対象行をoffset / limitで一部だけ描画する opt-in API |
-| [API仕様](api.md) | 主要オブジェクト、引数、挙動、制約 |
+If you are integrating TreeView into a host Rails app, start with these documents.
 
-## 保守者向け
+| ドキュメント / Document | 内容 / Description |
+|---|---|
+| [導入手順 / Installation](installation.md) | Gemfile、CSS、importmap、Propshaft / Sprockets、開発環境 / Gemfile, CSS, importmap, Propshaft / Sprockets, and development setup |
+| [最小利用例 / Minimal usage](minimal-usage.md) | host app での controller、view、row partial の最小構成 / Minimal controller, view, and row partial setup in a host app |
+| [使い方 / Usage](usage.md) | 通常Tree、static表示、Turbo表示、RenderState、view実装例 / Tree basics, static rendering, Turbo rendering, RenderState, and view examples |
+| [Cookbook](cookbook.md) | 既存APIを組み合わせた代表的な利用パターン / Common patterns composed from existing APIs |
+| [用語集 / Glossary](glossary.md) | TreeView固有の概念、コード上の表現、責務の整理 / TreeView concepts, code names, and responsibility boundaries |
+| [Selection](selection.md) | checkbox selection、visibility、送信値 parse / checkbox selection, visibility, and submitted value parsing |
+| [Breadcrumb helper](breadcrumb.md) | 現在nodeや任意nodeの親階層pathをパンくずとして描画するhelper / Helper for rendering ancestor paths as breadcrumbs |
+| [Depth labels](depth-labels.md) | node depthを任意のラベルとして表示するhook / Hook for displaying node depth labels |
+| [Row status](row-status.md) | 行全体のdisabled / readonly状態を表すhook / Hook for disabled / readonly row state |
+| [Node keys](node-keys.md) | 異種nodeや複数TreeViewで衝突しにくいnode_key生成helper / node_key helper for avoiding collisions across heterogeneous nodes or multiple TreeViews |
+| [Tree diagnostics helpers](tree-diagnostics.md) | expanded keys、統計、orphan診断などの構造確認API / Structure inspection APIs for expanded keys, stats, and orphan diagnostics |
+| [Lazy Loading](lazy-loading.md) | 子ノードを必要なタイミングで読み込むための hook と data 属性 / Hooks and data attributes for loading children on demand |
+| [Windowed Rendering](windowed-rendering.md) | 表示対象行をoffset / limitで一部だけ描画する opt-in API / Opt-in API for rendering visible rows by offset / limit |
+| [API仕様 / API reference](api.md) | 主要オブジェクト、引数、挙動、制約 / Main objects, arguments, behavior, and constraints |
+
+## 保守者向け / For maintainers
 
 TreeView gem自体を変更・releaseする人は、以下も確認してください。
 
-| ドキュメント | 内容 |
-|---|---|
-| [設計思想と責務範囲](design-policy.md) | gem が担う責務、含めるもの、含めないもの、設計判断 |
-| [Rendering boundaries](rendering-boundaries.md) | Rails helper / ERB による描画境界と host app 側の責務 |
-| [Persisted State](persisted-state.md) | 開閉状態の保存/復元に関する設計方針 |
-| [Lazy Loading](lazy-loading.md) | 子ノードを必要なタイミングで読み込むための設計方針 |
-| [Windowed Rendering](windowed-rendering.md) | RenderWindow と opt-in windowed rendering の設計方針 |
-| [Static HTML mock](mockups/default-tree.html) | gem標準の DOM 構造と CSS 適用状態を確認する静的モック |
-| [Public API](public-api.md) | host app が直接使ってよい API と互換性方針 |
-| [Release checklist](release.md) | release 前に確認するテスト、docs、gem package 作業 |
-| [開発・保守方針](development.md) | テスト、CI、ドキュメント更新、今後の作業 |
-| [Documentation i18n audit](i18n-audit.md) | 日英対応状況、翻訳優先度、翻訳方針 |
+If you are changing or releasing the TreeView gem itself, also read these documents.
 
-## 読む順番
+| ドキュメント / Document | 内容 / Description |
+|---|---|
+| [設計思想と責務範囲 / Design policy](design-policy.md) | gem が担う責務、含めるもの、含めないもの、設計判断 / Gem responsibilities, included scope, excluded scope, and design decisions |
+| [Rendering boundaries](rendering-boundaries.md) | Rails helper / ERB による描画境界と host app 側の責務 / Rendering boundaries between Rails helpers, ERB, and host app responsibilities |
+| [Persisted State](persisted-state.md) | 開閉状態の保存/復元に関する設計方針 / Design policy for saving and restoring expansion state |
+| [Lazy Loading](lazy-loading.md) | 子ノードを必要なタイミングで読み込むための設計方針 / Design policy for loading child nodes on demand |
+| [Windowed Rendering](windowed-rendering.md) | RenderWindow と opt-in windowed rendering の設計方針 / Design policy for RenderWindow and opt-in windowed rendering |
+| [Static HTML mock](mockups/default-tree.html) | gem標準の DOM 構造と CSS 適用状態を確認する静的モック / Static mock for checking the default DOM and CSS state |
+| [Public API](public-api.md) | host app が直接使ってよい API と互換性方針 / APIs host apps may use directly and compatibility policy |
+| [Release checklist](release.md) | release 前に確認するテスト、docs、gem package 作業 / Release tests, documentation, and gem package checklist |
+| [開発・保守方針 / Development](development.md) | テスト、CI、ドキュメント更新、今後の作業 / Tests, CI, documentation updates, and future work |
+| [Documentation i18n audit](i18n-audit.md) | 日英対応状況、翻訳優先度、翻訳方針 / Language status, translation priority, and translation policy |
+
+## 読む順番 / Reading order
 
 初めて使う場合は [導入手順](installation.md)、[最小利用例](minimal-usage.md)、[使い方](usage.md) の順に確認してください。
 
+For first-time usage, read [Installation](installation.md), [Minimal usage](minimal-usage.md), and [Usage](usage.md) in that order.
+
 既存APIの組み合わせ方を確認したい場合は [Cookbook](cookbook.md) を参照してください。
+
+For common combinations of existing APIs, see [Cookbook](cookbook.md).
 
 TreeView固有の用語や、コード上の名前との対応を確認したい場合は [用語集](glossary.md) を参照してください。
 
+For TreeView-specific terms and their code names, see [Glossary](glossary.md).
+
 selection checkbox を使う場合は [Selection](selection.md) を参照してください。
+
+For checkbox selection, see [Selection](selection.md).
 
 描画時のRails helper / ERB境界を確認したい場合は [Rendering boundaries](rendering-boundaries.md) を参照してください。
 
+For Rails helper / ERB rendering boundaries, see [Rendering boundaries](rendering-boundaries.md).
+
 現在nodeの親階層pathをパンくずとして表示したい場合は [Breadcrumb helper](breadcrumb.md) を参照してください。
+
+For breadcrumbs from an item's ancestor path, see [Breadcrumb helper](breadcrumb.md).
 
 node depthを画面上にラベル表示したい場合は [Depth labels](depth-labels.md) を参照してください。
 
+For displaying node depth labels, see [Depth labels](depth-labels.md).
+
 行全体をdisabled / readonlyとして表示したい場合は [Row status](row-status.md) を参照してください。
+
+For disabled / readonly row states, see [Row status](row-status.md).
 
 異種nodeや複数TreeViewでnode_key衝突を避けたい場合は [Node keys](node-keys.md) を参照してください。
 
+For avoiding node_key collisions across heterogeneous nodes or multiple TreeViews, see [Node keys](node-keys.md).
+
 検索結果の初期展開、ツリー規模の確認、不正な親IDの調査を行う場合は [Tree diagnostics helpers](tree-diagnostics.md) を参照してください。
+
+For initial expansion from search results, tree size inspection, or invalid parent ID diagnostics, see [Tree diagnostics helpers](tree-diagnostics.md).
 
 設計や拡張方針を確認したい場合は [設計思想と責務範囲](design-policy.md) を参照してください。
 
+For design and extension policy, see [Design policy](design-policy.md).
+
 開閉状態の保存/復元を検討する場合は [Persisted State](persisted-state.md) を参照してください。
+
+For saving and restoring expansion state, see [Persisted State](persisted-state.md).
 
 子ノードの追加読み込みを行う場合は [Lazy Loading](lazy-loading.md) を参照してください。
 
+For loading child nodes on demand, see [Lazy Loading](lazy-loading.md).
+
 大量ノードで一部の表示行だけを描画したい場合は [Windowed Rendering](windowed-rendering.md) を参照してください。
+
+For rendering only a window of visible rows in large trees, see [Windowed Rendering](windowed-rendering.md).
 
 APIの細かい仕様や、実装時の判断に迷った場合は [API仕様](api.md) と [Public API](public-api.md) を参照してください。
 
+For detailed API behavior and implementation decisions, see [API reference](api.md) and [Public API](public-api.md).
+
 release 作業前には [Release checklist](release.md) を確認してください。
 
+Before release work, see [Release checklist](release.md).
+
 翻訳・日英対応の優先度を確認する場合は [Documentation i18n audit](i18n-audit.md) を参照してください。
+
+For translation priority and bilingual readiness, see [Documentation i18n audit](i18n-audit.md).

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -38,8 +38,8 @@ These should be understandable in both Japanese and English before tagging `v0.1
 
 | Document | Current status | Needed work |
 |---|---|---|
-| `README.md` | Japanese-first | Add or expand English overview, installation, quick start, and documentation index. |
-| `docs/README.md` | Japanese-first | Add English documentation index, reading order, and maintainer/user split. |
+| `README.md` | Bilingual | Keep Japanese and English entry content in sync. |
+| `docs/README.md` | Bilingual | Keep Japanese and English documentation index and reading order in sync. |
 | `docs/installation.md` | Needs audit | Ensure both languages cover Gemfile, CSS, importmap, Propshaft/Sprockets, Ruby/Rails requirements. |
 | `docs/minimal-usage.md` | Needs audit | Ensure both languages cover the smallest host app setup. |
 | `docs/usage.md` | Needs audit | Ensure both languages cover static rendering, Turbo rendering, RenderState, and row partials. |
@@ -92,10 +92,9 @@ These do not need prose translation unless comments or visible labels become rel
 
 ## Recommended next PRs
 
-1. Add English sections to `README.md` and `docs/README.md`.
-2. Add Japanese summaries to English-first policy docs: `docs/public-api.md` and `docs/release.md`.
-3. Add bilingual coverage to `docs/installation.md`, `docs/minimal-usage.md`, `docs/usage.md`, and `docs/api.md`.
-4. Work through P1 feature docs in small topic-based PRs.
+1. Add Japanese summaries to English-first policy docs: `docs/public-api.md` and `docs/release.md`.
+2. Add bilingual coverage to `docs/installation.md`, `docs/minimal-usage.md`, `docs/usage.md`, and `docs/api.md`.
+3. Work through P1 feature docs in small topic-based PRs.
 
 ## Release decision
 

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -44,8 +44,8 @@ These should be understandable in both Japanese and English before tagging `v0.1
 | `docs/minimal-usage.md` | Needs audit | Ensure both languages cover the smallest host app setup. |
 | `docs/usage.md` | Needs audit | Ensure both languages cover static rendering, Turbo rendering, RenderState, and row partials. |
 | `docs/api.md` | Needs audit | Ensure public API descriptions are available in both languages. |
-| `docs/public-api.md` | English-first | Add Japanese summary for public/semi-public/internal API policy. |
-| `docs/release.md` | English-first | Add Japanese summary for main-tag release policy and release checklist. |
+| `docs/public-api.md` | Bilingual summary | Expand Japanese details when the public API surface changes. |
+| `docs/release.md` | Bilingual summary | Expand Japanese details when the release process changes. |
 
 ### P1: important feature docs
 
@@ -92,9 +92,8 @@ These do not need prose translation unless comments or visible labels become rel
 
 ## Recommended next PRs
 
-1. Add Japanese summaries to English-first policy docs: `docs/public-api.md` and `docs/release.md`.
-2. Add bilingual coverage to `docs/installation.md`, `docs/minimal-usage.md`, `docs/usage.md`, and `docs/api.md`.
-3. Work through P1 feature docs in small topic-based PRs.
+1. Add bilingual coverage to `docs/installation.md`, `docs/minimal-usage.md`, `docs/usage.md`, and `docs/api.md`.
+2. Work through P1 feature docs in small topic-based PRs.
 
 ## Release decision
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -2,6 +2,41 @@
 
 This document describes which APIs host applications can rely on directly, which parts are intentionally internal, and how compatibility is handled.
 
+## 日本語サマリー
+
+このドキュメントは、host Rails app が直接依存してよいAPIと、gem内部の実装詳細を区別するための方針です。
+
+### 安定した公開入口
+
+host app が直接使ってよい主な入口は以下です。
+
+- `TreeView::Tree`
+- `TreeView::RenderState`
+- `TreeView::UiConfigBuilder`
+- `TreeView::VisibleRows`
+- `TreeView::RenderWindow`
+- `TreeView::PersistedState`
+- `TreeView::StateStore`
+- `tree_view_rows(render_state)`
+- `tree_view_rows(render_state, window: { offset:, limit: })`
+- `tree_view_window(render_state, offset:, limit:)`
+- `tree_view_breadcrumb(tree, item, ...)`
+- `tree_view/index.js` の `registerTreeViewControllers(application)` と exported controller classes
+
+### host app の拡張ポイント
+
+推奨される拡張ポイントは、documented option、builder、`row_partial`、path builder、selection payload builder、lazy loading hook などです。
+
+`TreeViewHelper::Rendering` や `TreeViewHelper::Selection` などの内部moduleは、整理のために分割された実装詳細です。host app はこれらを直接includeせず、`TreeViewHelper` と documented helper method に依存してください。
+
+### 互換性方針
+
+documented class、helper、option、JavaScript event、CSS/data hook の削除・rename・意味変更はbreaking changeとして扱います。
+
+一方、documented behaviorを変えない内部module分割、controller file layout変更、private method変更はbreaking changeではありません。
+
+breaking change が必要な場合は、`CHANGELOG.md` と関連docsにmigration noteを書き、可能な限り互換shimを用意します。
+
 ## Stable public entry points
 
 Host applications may use these entry points directly:

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,43 @@
 
 Before publishing a gem version, check the following items.
 
+## 日本語サマリー
+
+このドキュメントは、`tree_view` gemをリリースする前に確認する手順と方針をまとめたものです。
+
+### バージョン管理
+
+`tree_view` は semantic versioning を前提にします。
+
+- patch version: 挙動を変えないbug fixやdocs修正
+- minor version: 後方互換なAPI、option、hook、docs追加
+- major version: 意図的なbreaking change
+
+`1.0.0` 未満でも、breaking change は意図的に扱い、`CHANGELOG.md` と関連docsにmigration noteを書きます。
+
+### release branch / tag 方針
+
+通常のリリースでは、長期運用する `release/*` branch は作らず、`main` のgreenなcommitに `vX.Y.Z` tag を付けます。
+
+release flow:
+
+1. `main` 向けにrelease preparation PRを作る。
+2. `lib/tree_view/version.rb` を更新する。
+3. `CHANGELOG.md` の `Unreleased` を日付付きversion sectionへ移す。
+4. PRを `main` にmergeする。
+5. main-push full CIがgreenであることを確認する。
+6. greenな `main` commit に `vX.Y.Z` tag を付ける。
+7. 必要に応じてGitHub Releaseを作成する。
+8. 必要に応じてgem publishする。
+
+`release/x.y` branch は、複数minor lineの並行保守、長期RC検証、security/compatibility patchなどが必要になった時だけ導入します。
+
+### release前の確認
+
+Pull Request CIは軽量lintのみなので、release判定には使いません。release tagは、merge後の `main` でfull CIが成功したcommitにだけ付けます。
+
+release前には、Ruby spec matrix、Rails version matrix、JavaScript tests、gem package verification、docs/CHANGELOG整合、packaged filesを確認します。
+
 ## Versioning policy
 
 `tree_view` follows semantic versioning.


### PR DESCRIPTION
## Summary

- Add English content to `docs/README.md`.
- Keep the Japanese documentation index while adding English descriptions and reading order.
- Add Japanese summaries to `docs/public-api.md` and `docs/release.md`.
- Update `docs/i18n-audit.md` to mark `docs/README.md` as bilingual and policy docs as bilingual summaries.
- Update CHANGELOG.

## Testing

- PR CI: `bundle exec standardrb` succeeded.
- PR CI confirmed `spec`, `rails_matrix`, `javascript`, and `gem_package` are skipped on pull requests by design.
- Full CI will run after merge to `main` by design.