### PR TITLE
Introduce language-specific docs directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added Japanese summaries to `docs/public-api.md` and `docs/release.md`.
 - Added bilingual coverage to `docs/installation.md` and `docs/minimal-usage.md`.
 - Added bilingual summaries to `docs/usage.md` and a bilingual `docs/api-overview.md` entry point.
+- Started migrating documentation to language-specific `docs/ja/` and `docs/en/` directories.
 
 ### Tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,138 +1,30 @@
 # tree_view docs
 
-`tree_view` の詳細ドキュメントです。
+`tree_view` documentation is organized by language.
 
-README は利用者向けの短い入口に留め、設計思想・導入手順・API仕様・開発方針はこの `docs/` 配下に分けて管理します。
+`tree_view` のドキュメントは言語別に管理します。
 
-This directory contains detailed `tree_view` documentation.
+## Languages
 
-The top-level README stays as a short user-facing entry point. Design policy, installation details, API references, and maintenance guidance live under `docs/`.
+- [日本語ドキュメント](ja/README.md)
+- [English documentation](en/README.md)
 
-## ドキュメントの言語対応 / Documentation language status
+## Translation status
 
-`0.1.0` リリース前に、ドキュメントの日英対応状況を明示的に管理します。
+Documentation translation status and priorities are tracked in [Documentation i18n audit](i18n-audit.md).
 
-Before the `0.1.0` release, documentation language coverage is tracked explicitly.
+ドキュメントの日英対応状況と優先度は [Documentation i18n audit](i18n-audit.md) で管理します。
 
-- [Documentation i18n audit](i18n-audit.md): 各ドキュメントの言語状態、優先度、翻訳方針 / language status, priority, and translation policy for each document
+## Policy
 
-現時点では、すべてのドキュメントが完全な日英併記になっているわけではありません。利用者向けの入口、導入、最小利用例、使い方、API仕様から優先的に日英対応を進めます。
+- `docs/ja/` is the Japanese documentation tree and is the primary canonical source while Japanese coverage is more complete.
+- `docs/en/` is the English documentation tree.
+- Root-level docs are kept temporarily for compatibility during the migration.
+- New or substantially updated user-facing docs should be added under both `docs/ja/` and `docs/en/` when practical.
 
-Not every document is fully bilingual yet. Bilingual coverage is prioritized for user-facing entry points, installation, minimal usage, usage, and API references first.
+## 方針
 
-## 利用者向け / For users
-
-TreeViewをhost Rails appに組み込む人は、まず以下を確認してください。
-
-If you are integrating TreeView into a host Rails app, start with these documents.
-
-| ドキュメント / Document | 内容 / Description |
-|---|---|
-| [導入手順 / Installation](installation.md) | Gemfile、CSS、importmap、Propshaft / Sprockets、開発環境 / Gemfile, CSS, importmap, Propshaft / Sprockets, and development setup |
-| [最小利用例 / Minimal usage](minimal-usage.md) | host app での controller、view、row partial の最小構成 / Minimal controller, view, and row partial setup in a host app |
-| [使い方 / Usage](usage.md) | 通常Tree、static表示、Turbo表示、RenderState、view実装例 / Tree basics, static rendering, Turbo rendering, RenderState, and view examples |
-| [API概要 / API overview](api-overview.md) | 主要公開APIの概要 / Bilingual overview of the main public APIs |
-| [Cookbook](cookbook.md) | 既存APIを組み合わせた代表的な利用パターン / Common patterns composed from existing APIs |
-| [用語集 / Glossary](glossary.md) | TreeView固有の概念、コード上の表現、責務の整理 / TreeView concepts, code names, and responsibility boundaries |
-| [Selection](selection.md) | checkbox selection、visibility、送信値 parse / checkbox selection, visibility, and submitted value parsing |
-| [Breadcrumb helper](breadcrumb.md) | 現在nodeや任意nodeの親階層pathをパンくずとして描画するhelper / Helper for rendering ancestor paths as breadcrumbs |
-| [Depth labels](depth-labels.md) | node depthを任意のラベルとして表示するhook / Hook for displaying node depth labels |
-| [Row status](row-status.md) | 行全体のdisabled / readonly状態を表すhook / Hook for disabled / readonly row state |
-| [Node keys](node-keys.md) | 異種nodeや複数TreeViewで衝突しにくいnode_key生成helper / node_key helper for avoiding collisions across heterogeneous nodes or multiple TreeViews |
-| [Tree diagnostics helpers](tree-diagnostics.md) | expanded keys、統計、orphan診断などの構造確認API / Structure inspection APIs for expanded keys, stats, and orphan diagnostics |
-| [Lazy Loading](lazy-loading.md) | 子ノードを必要なタイミングで読み込むための hook と data 属性 / Hooks and data attributes for loading children on demand |
-| [Windowed Rendering](windowed-rendering.md) | 表示対象行をoffset / limitで一部だけ描画する opt-in API / Opt-in API for rendering visible rows by offset / limit |
-| [API仕様 / API reference](api.md) | 主要オブジェクト、引数、挙動、制約 / Main objects, arguments, behavior, and constraints |
-
-## 保守者向け / For maintainers
-
-TreeView gem自体を変更・releaseする人は、以下も確認してください。
-
-If you are changing or releasing the TreeView gem itself, also read these documents.
-
-| ドキュメント / Document | 内容 / Description |
-|---|---|
-| [設計思想と責務範囲 / Design policy](design-policy.md) | gem が担う責務、含めるもの、含めないもの、設計判断 / Gem responsibilities, included scope, excluded scope, and design decisions |
-| [Rendering boundaries](rendering-boundaries.md) | Rails helper / ERB による描画境界と host app 側の責務 / Rendering boundaries between Rails helpers, ERB, and host app responsibilities |
-| [Persisted State](persisted-state.md) | 開閉状態の保存/復元に関する設計方針 / Design policy for saving and restoring expansion state |
-| [Lazy Loading](lazy-loading.md) | 子ノードを必要なタイミングで読み込むための設計方針 / Design policy for loading child nodes on demand |
-| [Windowed Rendering](windowed-rendering.md) | RenderWindow と opt-in windowed rendering の設計方針 / Design policy for RenderWindow and opt-in windowed rendering |
-| [Static HTML mock](mockups/default-tree.html) | gem標準の DOM 構造と CSS 適用状態を確認する静的モック / Static mock for checking the default DOM and CSS state |
-| [Public API](public-api.md) | host app が直接使ってよい API と互換性方針 / APIs host apps may use directly and compatibility policy |
-| [Release checklist](release.md) | release 前に確認するテスト、docs、gem package 作業 / Release tests, documentation, and gem package checklist |
-| [開発・保守方針 / Development](development.md) | テスト、CI、ドキュメント更新、今後の作業 / Tests, CI, documentation updates, and future work |
-| [Documentation i18n audit](i18n-audit.md) | 日英対応状況、翻訳優先度、翻訳方針 / Language status, translation priority, and translation policy |
-
-## 読む順番 / Reading order
-
-初めて使う場合は [導入手順](installation.md)、[最小利用例](minimal-usage.md)、[使い方](usage.md) の順に確認してください。
-
-For first-time usage, read [Installation](installation.md), [Minimal usage](minimal-usage.md), and [Usage](usage.md) in that order.
-
-API全体の入口を確認したい場合は、まず [API概要](api-overview.md) を読み、細かい仕様は [API仕様](api.md) を参照してください。
-
-For a high-level API entry point, read [API overview](api-overview.md) first, then use [API reference](api.md) for details.
-
-既存APIの組み合わせ方を確認したい場合は [Cookbook](cookbook.md) を参照してください。
-
-For common combinations of existing APIs, see [Cookbook](cookbook.md).
-
-TreeView固有の用語や、コード上の名前との対応を確認したい場合は [用語集](glossary.md) を参照してください。
-
-For TreeView-specific terms and their code names, see [Glossary](glossary.md).
-
-selection checkbox を使う場合は [Selection](selection.md) を参照してください。
-
-For checkbox selection, see [Selection](selection.md).
-
-描画時のRails helper / ERB境界を確認したい場合は [Rendering boundaries](rendering-boundaries.md) を参照してください。
-
-For Rails helper / ERB rendering boundaries, see [Rendering boundaries](rendering-boundaries.md).
-
-現在nodeの親階層pathをパンくずとして表示したい場合は [Breadcrumb helper](breadcrumb.md) を参照してください。
-
-For breadcrumbs from an item's ancestor path, see [Breadcrumb helper](breadcrumb.md).
-
-node depthを画面上にラベル表示したい場合は [Depth labels](depth-labels.md) を参照してください。
-
-For displaying node depth labels, see [Depth labels](depth-labels.md).
-
-行全体をdisabled / readonlyとして表示したい場合は [Row status](row-status.md) を参照してください。
-
-For disabled / readonly row states, see [Row status](row-status.md).
-
-異種nodeや複数TreeViewでnode_key衝突を避けたい場合は [Node keys](node-keys.md) を参照してください。
-
-For avoiding node_key collisions across heterogeneous nodes or multiple TreeViews, see [Node keys](node-keys.md).
-
-検索結果の初期展開、ツリー規模の確認、不正な親IDの調査を行う場合は [Tree diagnostics helpers](tree-diagnostics.md) を参照してください。
-
-For initial expansion from search results, tree size inspection, or invalid parent ID diagnostics, see [Tree diagnostics helpers](tree-diagnostics.md).
-
-設計や拡張方針を確認したい場合は [設計思想と責務範囲](design-policy.md) を参照してください。
-
-For design and extension policy, see [Design policy](design-policy.md).
-
-開閉状態の保存/復元を検討する場合は [Persisted State](persisted-state.md) を参照してください。
-
-For saving and restoring expansion state, see [Persisted State](persisted-state.md).
-
-子ノードの追加読み込みを行う場合は [Lazy Loading](lazy-loading.md) を参照してください。
-
-For loading child nodes on demand, see [Lazy Loading](lazy-loading.md).
-
-大量ノードで一部の表示行だけを描画したい場合は [Windowed Rendering](windowed-rendering.md) を参照してください。
-
-For rendering only a window of visible rows in large trees, see [Windowed Rendering](windowed-rendering.md).
-
-APIの細かい仕様や、実装時の判断に迷った場合は [API仕様](api.md) と [Public API](public-api.md) を参照してください。
-
-For detailed API behavior and implementation decisions, see [API reference](api.md) and [Public API](public-api.md).
-
-release 作業前には [Release checklist](release.md) を確認してください。
-
-Before release work, see [Release checklist](release.md).
-
-翻訳・日英対応の優先度を確認する場合は [Documentation i18n audit](i18n-audit.md) を参照してください。
-
-For translation priority and bilingual readiness, see [Documentation i18n audit](i18n-audit.md).
+- `docs/ja/` は日本語ドキュメントです。日本語側の内容がより充実している間は、主なcanonical sourceとして扱います。
+- `docs/en/` は英語ドキュメントです。
+- 移行中の互換性のため、root直下の既存docsは一旦残します。
+- 利用者向けdocsを新規追加または大きく更新する場合は、可能な限り `docs/ja/` と `docs/en/` の両方に追加します。

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,46 @@
+# tree_view documentation
+
+This is the English documentation entry point for `tree_view`.
+
+The top-level README stays short. Detailed installation, usage, API, design, and release guidance lives under `docs/`.
+
+## Language status
+
+Documentation is being migrated to language-specific directories before the `0.1.0` release.
+
+- [Japanese documentation](../ja/README.md)
+- [Documentation i18n audit](../i18n-audit.md)
+
+Not every page has a complete English translation yet. English coverage is prioritized for entry points, installation, minimal usage, usage, and API overview first.
+
+## For users
+
+If you are integrating TreeView into a Rails host app, start with these documents.
+
+| Document | Description |
+|---|---|
+| [Installation](installation.md) | Gemfile, CSS, importmap, Propshaft / Sprockets, and development setup |
+| [Minimal usage](minimal-usage.md) | Minimal controller, view, and row partial setup in a host app |
+| [Usage](usage.md) | Tree basics, static rendering, Turbo rendering, RenderState, and view examples |
+| [API overview](api-overview.md) | Bilingual overview of the main public APIs |
+| [API reference](../api.md) | Detailed API reference; currently Japanese-first |
+| [Selection](../selection.md) | Checkbox selection, visibility, and submitted value parsing |
+| [Lazy Loading](../lazy-loading.md) | Hooks and data attributes for loading children on demand |
+| [Windowed Rendering](../windowed-rendering.md) | Opt-in API for rendering visible rows by offset / limit |
+
+## For maintainers
+
+| Document | Description |
+|---|---|
+| [Public API](../public-api.md) | APIs host apps may use directly and compatibility policy |
+| [Release checklist](../release.md) | Release tests, documentation, and gem package checklist |
+| [Design policy](../design-policy.md) | Gem responsibilities, included scope, excluded scope, and design decisions |
+| [Development](../development.md) | Tests, CI, documentation updates, and future work |
+
+## Reading order
+
+For first-time usage, read [Installation](installation.md), [Minimal usage](minimal-usage.md), and [Usage](usage.md) in that order.
+
+For a high-level API entry point, read [API overview](api-overview.md) first, then use [API reference](../api.md) for details.
+
+For translation priority and bilingual readiness, see [Documentation i18n audit](../i18n-audit.md).

--- a/docs/en/api-overview.md
+++ b/docs/en/api-overview.md
@@ -1,0 +1,172 @@
+# API overview
+
+This page gives an overview of the main public APIs. See [API reference](../api.md) for the full detailed reference.
+
+## Core objects
+
+| API | Description |
+|---|---|
+| `TreeView::Tree` | Builds and queries tree structures from records, resolvers, or adapters. |
+| `TreeView::RenderState` | Holds screen-level rendering state such as roots, row partial, UI config, expansion, selection, and render scope. |
+| `TreeView::UiConfig` | Stores DOM ID and path-building behavior for static or Turbo rendering. |
+| `TreeView::UiConfigBuilder` | Builds `UiConfig` objects from a Rails view context. |
+| `TreeView::VisibleRows` | Flattens currently visible rows from a render state. |
+| `TreeView::RenderWindow` | Slices visible rows by `offset` and `limit` and exposes pagination metadata. |
+| `TreeView::PersistedState` | Represents persisted expansion state. |
+| `TreeView::StateStore` | Loads and saves persisted state through a host app model. |
+
+## Tree construction
+
+### records mode
+
+Use records mode when each item has an ID and a parent ID.
+
+```ruby
+tree = TreeView::Tree.new(
+  records: documents,
+  parent_id_method: :parent_document_id
+)
+```
+
+Important options:
+
+| Option | Description |
+|---|---|
+| `records:` | Items to render as a tree. |
+| `parent_id_method:` | Method name that returns the parent ID. |
+| `id_method:` | Method name that returns the item ID. Defaults to `:id`. |
+| `sorter:` | Callable used for root and child ordering. |
+| `orphan_strategy:` | Strategy for records whose parent is missing from the record set. |
+
+### resolver mode
+
+Use resolver mode when children come from a callable instead of parent IDs.
+
+```ruby
+tree = TreeView::Tree.new(
+  roots: roots,
+  children_resolver: ->(node) { node.children }
+)
+```
+
+### adapter mode
+
+Use adapter mode for heterogeneous or graph-like structures.
+
+```ruby
+adapter = TreeView::GraphAdapter.new(
+  roots: roots,
+  children_resolver: ->(node) { node.children },
+  node_key_resolver: ->(node) { [node.class.name, node.id] }
+)
+
+tree = TreeView::Tree.new(adapter: adapter)
+```
+
+## Rendering
+
+The recommended rendering entrypoint is `tree_view_rows(render_state)`.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui
+)
+```
+
+```erb
+<tbody>
+  <%= tree_view_rows(@render_state) %>
+</tbody>
+```
+
+For windowed rendering, pass a window hash:
+
+```erb
+<%= tree_view_rows(@render_state, window: { offset: 0, limit: 50 }) %>
+```
+
+For pagination metadata, use `tree_view_window`:
+
+```ruby
+window = tree_view_window(@render_state, offset: 0, limit: 50)
+window.has_next?
+```
+
+## RenderState option groups
+
+`RenderState` accepts both legacy flat keyword options and grouped options.
+
+| Group | Description |
+|---|---|
+| `initial_expansion:` | Default expansion, max initial depth, expanded keys, and collapsed keys. |
+| `render_scope:` | Depth and leaf-distance limits for what is rendered. |
+| `toggle_scope:` | Depth and leaf-distance limits passed to toggle path builders. |
+| `selection:` | Checkbox selection behavior and payload options. |
+| `lazy_loading:` | Remote children state and scope options. |
+
+Flat keyword options take precedence when both forms are provided.
+
+## Selection
+
+TreeView can render checkbox selection, but the host app owns the business action.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  selection: {
+    enabled: true,
+    checkbox_name: "selected_nodes[]",
+    visibility: :leaves
+  }
+)
+```
+
+Use `TreeView.parse_selection_params` to parse submitted JSON values when appropriate.
+
+## Path helpers
+
+Records mode provides helpers for inspecting parent paths.
+
+| API | Description |
+|---|---|
+| `parent_for(item)` | Returns the parent item. |
+| `ancestors_for(item)` | Returns ancestors from root to parent. |
+| `path_for(item)` | Returns the path from root to item. |
+| `paths_for(items)` | Returns paths for multiple items. |
+| `path_tree_for(items)` | Builds a root-to-match `PathTree`. |
+| `reverse_tree_for(items)` | Builds a match-to-root `ReverseTree`. |
+
+## Public helper entrypoints
+
+| Helper | Description |
+|---|---|
+| `tree_view_rows` | Render TreeView rows from a render state. |
+| `tree_view_window` | Build a render window and expose metadata. |
+| `tree_node_dom_id` | Build a node DOM ID through `UiConfig`. |
+| `tree_selection_value` | Build a JSON checkbox value. |
+| `tree_view_breadcrumb` | Render an ancestor breadcrumb. |
+
+## JavaScript entrypoint
+
+The public JavaScript entrypoint is `tree_view/index.js`.
+
+```js
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+Exported controller classes are documented as the stable entrypoints. Individual controller file layout is internal.
+
+## More detail
+
+- Full API reference: [api.md](../api.md)
+- Public API compatibility policy: [public-api.md](../public-api.md)
+- Minimal usage: [minimal-usage.md](minimal-usage.md)
+- Main usage guide: [usage.md](usage.md)

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -1,0 +1,161 @@
+# Installation
+
+This page explains how to install `tree_view` in a Rails host app.
+
+## Requirements
+
+- Ruby 3.2 or later
+- Rails 7.0 or later
+
+These requirements should stay aligned with `required_ruby_version` and the `railties` dependency in `tree_view.gemspec`.
+
+## CI coverage
+
+On pull requests, GitHub Actions intentionally runs only lightweight Ruby lint.
+
+On pushes to `main`, full CI runs:
+
+- Ruby spec matrix
+- Rails version matrix
+- JavaScript tests through `npm ci`
+- gem package verification
+
+Release tags should be placed only on `main` commits whose full CI has passed.
+
+## Gemfile
+
+Add the gem to the host app's `Gemfile`.
+
+```ruby
+gem "tree_view", git: "https://github.com/matsuo-haruhito/tree_view-rails.git"
+```
+
+Then run `bundle install` as usual.
+
+```bash
+bundle install
+```
+
+## CSS import
+
+Import the TreeView CSS from the host app stylesheet.
+
+```scss
+@import "tree_view";
+```
+
+Example:
+
+```scss
+/* app/assets/stylesheets/application.scss */
+@import "tree_view";
+```
+
+## JavaScript / importmap
+
+Add the TreeView importmap pin when the JavaScript controllers are needed.
+
+```ruby
+pin "tree_view", to: "tree_view/index.js"
+```
+
+Example:
+
+```ruby
+# config/importmap.rb
+pin "tree_view", to: "tree_view/index.js"
+```
+
+Static rendering works without dedicated TreeView JavaScript. Turbo Stream expand/collapse behavior primarily depends on the host app's Turbo setup and path builders.
+
+JavaScript controllers are used for browser-side integration hooks such as state tracking, keyboard navigation, selection cascade, transfer events, and remote loading state.
+
+## Packaged files
+
+The gem package should include the files needed by Rails host apps:
+
+- `app/assets/stylesheets/tree_view.scss`
+- `app/helpers/tree_view_helper.rb`
+- `app/helpers/tree_view_helper/**/*`
+- `app/javascript/tree_view/**/*`
+- `app/views/tree_view/**/*`
+- `config/importmap.tree_view.rb`
+- `lib/**/*`
+- `README.md`
+- `CHANGELOG.md`
+- `docs/**/*`
+
+When installation behavior changes, keep this list aligned with the packaged file list in `tree_view.gemspec`.
+
+## Propshaft
+
+TreeView can be used with Rails 8 + Propshaft.
+
+The recommended setup is to explicitly import CSS and add the importmap pin from the host app.
+
+```scss
+@import "tree_view";
+```
+
+```ruby
+pin "tree_view", to: "tree_view/index.js"
+```
+
+In Propshaft apps, follow the host app's asset loading policy and make the CSS/importmap integration explicit.
+
+## Sprockets
+
+The engine keeps Sprockets-compatible asset hooks.
+
+- Add `app/javascript` to asset paths
+- Add `tree_view.css` and `tree_view/index.js` to precompile targets
+
+However, explicit CSS/importmap setup in the host app remains the recommended integration path.
+
+## Asset / importmap audit checklist
+
+When asset or JavaScript paths change, check these items before release:
+
+- `tree_view.gemspec` includes CSS, JavaScript, and importmap files
+- README installation examples match this file
+- the package checklist in `docs/en/release.md` or `docs/release.md` is updated
+- static rendering still works without JavaScript
+- JavaScript-dependent features document their importmap pin and data attributes
+
+## Development setup
+
+For local Ruby:
+
+```bash
+bundle install
+bundle exec standardrb
+bundle exec rspec
+bundle exec rake build
+npm install
+npm test
+```
+
+Rails compatibility Gemfiles live under `gemfiles/`.
+
+```bash
+BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
+```
+
+For Docker:
+
+```bash
+cp .env.example .env
+docker compose build
+docker compose run --rm app bundle install
+docker compose run --rm app bundle exec rspec
+docker compose run --rm app bundle exec rake build
+```
+
+Use `.devcontainer/devcontainer.json` for VS Code Dev Containers.
+
+## CI
+
+GitHub Actions runs only `bundle exec standardrb` on pull requests.
+
+On pushes to `main`, GitHub Actions runs Ruby specs, the Rails version matrix, JavaScript tests, and gem package verification.

--- a/docs/en/minimal-usage.md
+++ b/docs/en/minimal-usage.md
@@ -1,0 +1,96 @@
+# Minimal host app usage
+
+This page shows the smallest practical setup for rendering a tree from records in a Rails host app.
+
+## Goal
+
+The minimal setup has three parts:
+
+1. Build a `TreeView::Tree` in the controller.
+2. Build a static `TreeView::UiConfig` with `TreeView::UiConfigBuilder`.
+3. Render rows from `TreeView::RenderState` in the view.
+
+## Controller
+
+```ruby
+class DocumentsController < ApplicationController
+  def index
+    documents = Document.order(:name).to_a
+
+    tree = TreeView::Tree.new(
+      records: documents,
+      parent_id_method: :parent_document_id
+    )
+
+    tree_ui = TreeView::UiConfigBuilder.new(
+      context: view_context,
+      node_prefix: "document"
+    ).build_static
+
+    @render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "documents/tree_columns",
+      ui_config: tree_ui
+    )
+  end
+end
+```
+
+Pass the Active Record objects you want to render as `records`.
+
+Use `parent_id_method` to tell TreeView which method returns the parent ID. This example uses `Document#parent_document_id`.
+
+`node_prefix` is used for DOM IDs and related helpers. Use a distinct prefix when rendering multiple TreeViews on the same page.
+
+## View
+
+```erb
+<table class="tree-view-table">
+  <tbody>
+    <%= tree_view_rows(@render_state) %>
+  </tbody>
+</table>
+```
+
+`tree_view_rows(@render_state)` renders tree rows starting from the root rows.
+
+## Row partial
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td><%= item.name %></td>
+```
+
+`row_partial` points to the host app partial that renders the custom columns inside the TreeView row.
+
+The partial receives `item`.
+
+## With selection
+
+```ruby
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  selection: {
+    enabled: true,
+    visibility: :leaves
+  }
+)
+```
+
+Set `selection.enabled` to `true` to enable checkbox selection.
+
+`visibility: :leaves` renders checkboxes only for leaf nodes.
+
+See [Selection](../selection.md) for details.
+
+## Next steps
+
+- [Installation](installation.md)
+- [Usage](usage.md)
+- [API overview](api-overview.md)
+- [API reference](../api.md)
+- [Selection](../selection.md)

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -1,6 +1,15 @@
 # Documentation i18n audit
 
-This document tracks the documentation language status before the `0.1.0` release.
+This document tracks documentation language status before the `0.1.0` release.
+
+## Current structure
+
+Documentation is moving to language-specific directories.
+
+- `docs/ja/`: Japanese documentation tree
+- `docs/en/`: English documentation tree
+- `docs/README.md`: language selector
+- root-level docs such as `docs/usage.md` and `docs/api.md`: kept temporarily for compatibility during migration
 
 ## Goal
 
@@ -8,82 +17,84 @@ The documentation should be usable by both Japanese and English readers.
 
 For the initial release, the priority is:
 
-1. Make the documentation inventory explicit.
-2. Mark which documents are already bilingual, Japanese-first, English-first, or not yet translated.
-3. Keep canonical behavior/API descriptions in sync while translations are added.
-4. Prioritize user-facing installation, usage, and API documents before maintainer-only process docs.
+1. Keep the language-specific structure explicit.
+2. Keep Japanese and English entry points easy to find.
+3. Move or rewrite user-facing docs into both `docs/ja/` and `docs/en/` gradually.
+4. Keep canonical behavior/API descriptions in sync while translations are added.
+5. Prefer translating user-facing documents before maintainer-only documents.
 
 ## Language status labels
 
 | Status | Meaning |
 |---|---|
-| Bilingual | Japanese and English content are both present enough for practical use. |
-| Japanese-first | Japanese is the canonical or more complete version; English should be added or expanded. |
-| English-first | English is the canonical or more complete version; Japanese should be added or expanded. |
+| Split | Separate Japanese and English files exist under `docs/ja/` and `docs/en/`. |
+| Japanese canonical | Japanese is currently the more complete canonical source. |
+| English canonical | English is currently the more complete canonical source. |
 | Bilingual summary | Both languages have a usable summary, but one language may still contain the complete canonical detail. |
+| Pending split | Existing root-level doc still needs language-specific copies. |
 | Technical asset | Not a prose document that needs translation, such as HTML/CSS mock assets. |
 
 ## Translation policy
 
+- Prefer separate files under `docs/ja/` and `docs/en/` for prose docs.
 - Keep code examples identical across languages unless a translated comment is more helpful.
-- Prefer one file per topic for now, with Japanese and English sections in the same document, instead of creating separate `ja/` and `en/` trees.
-- When behavior changes, update the canonical section first, then update the translated section in the same PR when practical.
-- If a PR cannot update both languages, add a short note to this audit or the relevant document so the gap remains visible.
-- Prefer translating user-facing documents before maintainer-only documents.
+- When behavior changes, update the canonical language first, then update the translation in the same PR when practical.
+- If a PR cannot update both languages, update this audit so the gap remains visible.
+- Root-level docs may remain temporarily for compatibility while the migration is in progress.
+- New user-facing docs should be created in both language directories when practical.
 
-## Priority order
-
-### P0: release-blocking for bilingual readiness
+## P0: release-blocking language entry points
 
 These should be understandable in both Japanese and English before tagging `v0.1.0`.
 
-| Document | Current status | Needed work |
-|---|---|---|
-| `README.md` | Bilingual | Keep Japanese and English entry content in sync. |
-| `docs/README.md` | Bilingual | Keep Japanese and English documentation index and reading order in sync. |
-| `docs/installation.md` | Bilingual | Keep installation requirements, CSS/importmap guidance, CI notes, and packaged file lists in sync. |
-| `docs/minimal-usage.md` | Bilingual | Keep the minimal controller/view/row partial example in sync. |
-| `docs/usage.md` | Bilingual summary | Expand detailed English coverage when usage sections change. |
-| `docs/api-overview.md` | Bilingual | Keep the high-level API overview in sync with `docs/api.md`. |
-| `docs/api.md` | Japanese-first | Detailed API reference remains Japanese-first; use `docs/api-overview.md` as the bilingual entry point. |
-| `docs/public-api.md` | Bilingual summary | Expand Japanese details when the public API surface changes. |
-| `docs/release.md` | Bilingual summary | Expand Japanese details when the release process changes. |
+| Topic | Japanese | English | Status | Needed work |
+|---|---|---|---|---|
+| Top-level README | `README.md` | `README.md` | Bilingual summary | Keep short entry content in sync. |
+| Docs selector | `docs/README.md` | `docs/README.md` | Split selector | Keep language selector current. |
+| Docs index | `docs/ja/README.md` | `docs/en/README.md` | Split | Keep reading order and links in sync. |
+| Installation | `docs/ja/installation.md` | `docs/en/installation.md` | Split | Keep requirements, CSS/importmap guidance, CI notes, and packaged file lists in sync. |
+| Minimal usage | `docs/ja/minimal-usage.md` | `docs/en/minimal-usage.md` | Split | Keep controller/view/row partial examples in sync. |
+| API overview | `docs/ja/api-overview.md` | `docs/en/api-overview.md` | Split | Keep high-level API overview in sync with `docs/api.md`. |
+| Usage guide | `docs/usage.md` | `docs/en/usage.md` | Pending split | Move Japanese detail to `docs/ja/usage.md` and English guide to `docs/en/usage.md`. |
+| API reference | `docs/api.md` | `docs/en/api.md` | Pending split | Move detailed API reference into language-specific files when practical. |
+| Public API policy | `docs/public-api.md` | `docs/en/public-api.md` | Bilingual summary | Split later if the policy grows. |
+| Release checklist | `docs/release.md` | `docs/en/release.md` | Bilingual summary | Split later if the release process grows. |
 
-### P1: important feature docs
+## P1: important feature docs
 
-These should be bilingual soon after P0.
+These should be split after the P0 entry points.
 
-| Document | Current status | Needed work |
-|---|---|---|
-| `docs/selection.md` | Needs audit | Ensure selection visibility, payload, disabled state, cascade, indeterminate, and max count are bilingual. |
-| `docs/lazy-loading.md` | Needs audit | Ensure lazy loading hooks, remote-state events, and children pagination guidance are bilingual. |
-| `docs/windowed-rendering.md` | Needs audit | Ensure VisibleRows/RenderWindow/windowed rendering guidance is bilingual. |
-| `docs/persisted-state.md` | Needs audit | Ensure generator output and owner-side usage are bilingual. |
-| `docs/breadcrumb.md` | Needs audit | Ensure helper usage and builder options are bilingual. |
-| `docs/drag-and-drop.md` | Needs audit | Ensure event payload and host app responsibilities are bilingual. |
-| `docs/children-pagination.md` | Needs audit | Ensure server-side pagination boundaries are bilingual. |
+| Topic | Current doc | Status | Needed work |
+|---|---|---|---|
+| Selection | `docs/selection.md` | Pending split | Create `docs/ja/selection.md` and `docs/en/selection.md`. |
+| Lazy loading | `docs/lazy-loading.md` | Pending split | Create `docs/ja/lazy-loading.md` and `docs/en/lazy-loading.md`. |
+| Windowed rendering | `docs/windowed-rendering.md` | Pending split | Create `docs/ja/windowed-rendering.md` and `docs/en/windowed-rendering.md`. |
+| Persisted state | `docs/persisted-state.md` | Pending split | Create language-specific files. |
+| Breadcrumb | `docs/breadcrumb.md` | Pending split | Create language-specific files. |
+| Drag and drop | `docs/drag-and-drop.md` | Pending split | Create language-specific files. |
+| Children pagination | `docs/children-pagination.md` | Pending split | Create language-specific files. |
 
-### P2: supporting and maintainer docs
+## P2: supporting and maintainer docs
 
 These can follow after user-facing coverage is in place.
 
-| Document | Current status | Needed work |
-|---|---|---|
-| `docs/cookbook.md` | Needs audit | Ensure examples and guidance are bilingual. |
-| `docs/glossary.md` | Needs audit | Ensure terms map clearly between Japanese and English. |
-| `docs/node-keys.md` | Needs audit | Ensure node key collision guidance is bilingual. |
-| `docs/tree-diagnostics.md` | Needs audit | Ensure diagnostics APIs and use cases are bilingual. |
-| `docs/depth-labels.md` | Needs audit | Ensure builder usage is bilingual. |
-| `docs/row-status.md` | Needs audit | Ensure disabled/readonly status guidance is bilingual. |
-| `docs/filtered-trees.md` | Needs audit | Ensure filter modes and use cases are bilingual. |
-| `docs/rendering-boundaries.md` | Needs audit | Ensure Rails helper/ERB/host app boundary guidance is bilingual. |
-| `docs/render-scale.md` | Needs audit | Ensure large tree performance guidance is bilingual. |
-| `docs/host-app-extension-points.md` | Needs audit | Ensure extension points are bilingual. |
-| `docs/design-policy.md` | Needs audit | Ensure responsibility boundaries are bilingual. |
-| `docs/development.md` | Needs audit | Ensure current CI/development workflow is bilingual. |
-| `docs/code-quality.md` | Needs audit | Ensure lint/test quality expectations are bilingual. |
+| Topic | Current doc | Status | Needed work |
+|---|---|---|---|
+| Cookbook | `docs/cookbook.md` | Pending split | Create language-specific files. |
+| Glossary | `docs/glossary.md` | Pending split | Create language-specific files. |
+| Node keys | `docs/node-keys.md` | Pending split | Create language-specific files. |
+| Tree diagnostics | `docs/tree-diagnostics.md` | Pending split | Create language-specific files. |
+| Depth labels | `docs/depth-labels.md` | Pending split | Create language-specific files. |
+| Row status | `docs/row-status.md` | Pending split | Create language-specific files. |
+| Filtered trees | `docs/filtered-trees.md` | Pending split | Create language-specific files. |
+| Rendering boundaries | `docs/rendering-boundaries.md` | Pending split | Create language-specific files. |
+| Render scale | `docs/render-scale.md` | Pending split | Create language-specific files. |
+| Host app extension points | `docs/host-app-extension-points.md` | Pending split | Create language-specific files. |
+| Design policy | `docs/design-policy.md` | Pending split | Create language-specific files. |
+| Development | `docs/development.md` | Pending split | Create language-specific files. |
+| Code quality | `docs/code-quality.md` | Pending split | Create language-specific files. |
 
-### Technical assets
+## Technical assets
 
 These do not need prose translation unless comments or visible labels become release-facing docs.
 
@@ -94,9 +105,10 @@ These do not need prose translation unless comments or visible labels become rel
 
 ## Recommended next PRs
 
-1. Work through P1 feature docs in small topic-based PRs.
-2. Expand full English details in `docs/api.md` if the detailed API reference needs to be fully bilingual before a later release.
+1. Split `usage.md` into `docs/ja/usage.md` and `docs/en/usage.md`.
+2. Split `api.md` into language-specific API reference files when practical.
+3. Work through P1 feature docs in topic-based PRs.
 
 ## Release decision
 
-Do not block all translation work on a single large PR. For `v0.1.0`, the release should at least have bilingual entry points and a visible i18n backlog so readers know which documents are canonical and which translations are pending.
+Do not block all translation work on a single large PR. For `v0.1.0`, the release should at least have language-specific entry points and a visible i18n backlog so readers know which documents are canonical and which translations are pending.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,0 +1,44 @@
+# tree_view ドキュメント
+
+`tree_view` の日本語ドキュメントです。
+
+README は利用者向けの短い入口に留め、設計思想・導入手順・API仕様・開発方針はこの `docs/` 配下に分けて管理します。
+
+## ドキュメントの言語対応
+
+`0.1.0` リリース前に、ドキュメントの日英対応状況を明示的に管理します。
+
+- [Documentation i18n audit](../i18n-audit.md): 各ドキュメントの言語状態、優先度、翻訳方針
+- [English documentation](../en/README.md)
+
+## 利用者向け
+
+TreeViewをhost Rails appに組み込む人は、まず以下を確認してください。
+
+| ドキュメント | 内容 |
+|---|---|
+| [導入手順](installation.md) | Gemfile、CSS、importmap、Propshaft / Sprockets、開発環境 |
+| [最小利用例](minimal-usage.md) | host app での controller、view、row partial の最小構成 |
+| [使い方](../usage.md) | 通常Tree、static表示、Turbo表示、RenderState、view実装例 |
+| [API概要](api-overview.md) | 主要公開APIの概要 |
+| [API仕様](../api.md) | 主要オブジェクト、引数、挙動、制約 |
+| [Selection](../selection.md) | checkbox selection、visibility、送信値parse |
+| [Lazy Loading](../lazy-loading.md) | 子ノードを必要なタイミングで読み込むためのhookとdata属性 |
+| [Windowed Rendering](../windowed-rendering.md) | 表示対象行をoffset / limitで一部だけ描画するopt-in API |
+
+## 保守者向け
+
+| ドキュメント | 内容 |
+|---|---|
+| [Public API](../public-api.md) | host app が直接使ってよいAPIと互換性方針 |
+| [Release checklist](../release.md) | release前に確認するテスト、docs、gem package作業 |
+| [設計思想と責務範囲](../design-policy.md) | gemが担う責務、含めるもの、含めないもの、設計判断 |
+| [開発・保守方針](../development.md) | テスト、CI、ドキュメント更新、今後の作業 |
+
+## 読む順番
+
+初めて使う場合は [導入手順](installation.md)、[最小利用例](minimal-usage.md)、[使い方](../usage.md) の順に確認してください。
+
+API全体の入口を確認したい場合は、まず [API概要](api-overview.md) を読み、細かい仕様は [API仕様](../api.md) を参照してください。
+
+翻訳・日英対応の優先度を確認する場合は [Documentation i18n audit](../i18n-audit.md) を参照してください。

--- a/docs/ja/api-overview.md
+++ b/docs/ja/api-overview.md
@@ -1,0 +1,172 @@
+# API概要
+
+このページでは、主要な公開APIの概要を説明します。詳細な仕様は [API仕様](../api.md) を参照してください。
+
+## 中心オブジェクト
+
+| API | 説明 |
+|---|---|
+| `TreeView::Tree` | records、resolver、adapterからツリー構造を作り、問い合わせる中心オブジェクトです。 |
+| `TreeView::RenderState` | root、row partial、UI設定、展開状態、selection、描画範囲など、画面単位の描画状態をまとめます。 |
+| `TreeView::UiConfig` | static / Turbo描画で使うDOM IDやpath builderの設定を保持します。 |
+| `TreeView::UiConfigBuilder` | Rails view contextから `UiConfig` を組み立てます。 |
+| `TreeView::VisibleRows` | 現在のrender stateで表示対象となる行を一次元化します。 |
+| `TreeView::RenderWindow` | visible rowsを `offset` / `limit` で切り出し、ページング用metadataを提供します。 |
+| `TreeView::PersistedState` | 保存された開閉状態を表します。 |
+| `TreeView::StateStore` | host app側のmodelを通じて開閉状態を読み書きします。 |
+
+## ツリー構築
+
+### records mode
+
+各itemがIDと親IDを持つ場合は records mode を使います。
+
+```ruby
+tree = TreeView::Tree.new(
+  records: documents,
+  parent_id_method: :parent_document_id
+)
+```
+
+主なoption:
+
+| Option | 説明 |
+|---|---|
+| `records:` | ツリー化するitem配列。 |
+| `parent_id_method:` | 親IDを返すmethod名。 |
+| `id_method:` | item IDを返すmethod名。既定値は `:id`。 |
+| `sorter:` | root / children の並び順を決めるcallable。 |
+| `orphan_strategy:` | records内に親が存在しないnodeの扱い。 |
+
+### resolver mode
+
+親IDではなくcallableでchildrenを返したい場合は resolver mode を使います。
+
+```ruby
+tree = TreeView::Tree.new(
+  roots: roots,
+  children_resolver: ->(node) { node.children }
+)
+```
+
+### adapter mode
+
+異種node混在やgraph-likeな構造では adapter mode を使います。
+
+```ruby
+adapter = TreeView::GraphAdapter.new(
+  roots: roots,
+  children_resolver: ->(node) { node.children },
+  node_key_resolver: ->(node) { [node.class.name, node.id] }
+)
+
+tree = TreeView::Tree.new(adapter: adapter)
+```
+
+## 描画
+
+推奨される描画入口は `tree_view_rows(render_state)` です。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui
+)
+```
+
+```erb
+<tbody>
+  <%= tree_view_rows(@render_state) %>
+</tbody>
+```
+
+windowed renderingでは、window hashを渡します。
+
+```erb
+<%= tree_view_rows(@render_state, window: { offset: 0, limit: 50 }) %>
+```
+
+ページングmetadataが必要な場合は `tree_view_window` を使います。
+
+```ruby
+window = tree_view_window(@render_state, offset: 0, limit: 50)
+window.has_next?
+```
+
+## RenderStateのgrouped option
+
+`RenderState` は、従来の個別keyword optionとgrouped optionの両方を受け付けます。
+
+| Group | 説明 |
+|---|---|
+| `initial_expansion:` | 初期展開状態、初期最大depth、展開key、折りたたみkey。 |
+| `render_scope:` | 描画対象にするdepth / leaf距離の制限。 |
+| `toggle_scope:` | 開閉path builderへ渡すdepth / leaf距離の制限。 |
+| `selection:` | checkbox selectionの挙動とpayload設定。 |
+| `lazy_loading:` | remote children読み込みの状態とscope設定。 |
+
+個別keyword optionとgrouped optionを同時に指定した場合は、後方互換性のため個別keyword optionが優先されます。
+
+## 選択
+
+TreeViewはcheckbox selectionを描画できますが、業務処理はhost app側の責務です。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  selection: {
+    enabled: true,
+    checkbox_name: "selected_nodes[]",
+    visibility: :leaves
+  }
+)
+```
+
+送信されたJSON値をparseする場合は、必要に応じて `TreeView.parse_selection_params` を使います。
+
+## 親方向path helper
+
+records modeでは、親方向のpathを確認するhelperを使えます。
+
+| API | 説明 |
+|---|---|
+| `parent_for(item)` | 親itemを返します。 |
+| `ancestors_for(item)` | rootから親までの祖先配列を返します。 |
+| `path_for(item)` | rootから対象itemまでのpathを返します。 |
+| `paths_for(items)` | 複数itemのpathを返します。 |
+| `path_tree_for(items)` | rootからmatched itemへ向かう `PathTree` を作ります。 |
+| `reverse_tree_for(items)` | matched itemからroot方向へ向かう `ReverseTree` を作ります。 |
+
+## 公開helper入口
+
+| Helper | 説明 |
+|---|---|
+| `tree_view_rows` | render stateからTreeView行を描画します。 |
+| `tree_view_window` | render windowを作りmetadataを取得します。 |
+| `tree_node_dom_id` | `UiConfig` 経由でnode DOM IDを作ります。 |
+| `tree_selection_value` | checkbox value用JSONを作ります。 |
+| `tree_view_breadcrumb` | 祖先pathをbreadcrumbとして描画します。 |
+
+## JavaScript入口
+
+公開JavaScript入口は `tree_view/index.js` です。
+
+```js
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+exportされるcontroller classは安定入口として扱います。個別controller fileの配置は内部実装です。
+
+## 詳細
+
+- 詳細API仕様: [api.md](../api.md)
+- Public API互換性方針: [public-api.md](../public-api.md)
+- 最小利用例: [minimal-usage.md](minimal-usage.md)
+- 使い方: [usage.md](../usage.md)

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -1,0 +1,159 @@
+# 導入手順
+
+このページは、Rails host app に `tree_view` を導入するための手順です。
+
+## 必要環境
+
+- Ruby 3.2 以上
+- Rails 7.0 以上
+
+この条件は `tree_view.gemspec` の `required_ruby_version` と `railties` dependency に合わせます。
+
+## CIで確認している範囲
+
+GitHub Actions では、Pull Requestでは軽量なRuby lintのみを実行します。
+
+`main` へのpushでは、以下のfull CIを実行します。
+
+- Ruby spec matrix
+- Rails version matrix
+- JavaScript tests through `npm ci`
+- gem package verification
+
+release tag は、`main` のfull CIが成功したcommitに付けます。
+
+## Gemfile
+
+host app の `Gemfile` に追加します。
+
+```ruby
+gem "tree_view", git: "https://github.com/matsuo-haruhito/tree_view-rails.git"
+```
+
+その後、通常どおり bundle install します。
+
+```bash
+bundle install
+```
+
+## CSSの読み込み
+
+host app 側の stylesheet で TreeView 用CSSを読み込みます。
+
+```scss
+@import "tree_view";
+```
+
+例:
+
+```scss
+/* app/assets/stylesheets/application.scss */
+@import "tree_view";
+```
+
+## JavaScript / importmap
+
+必要に応じて importmap に TreeView 用のpinを追加します。
+
+```ruby
+pin "tree_view", to: "tree_view/index.js"
+```
+
+例:
+
+```ruby
+# config/importmap.rb
+pin "tree_view", to: "tree_view/index.js"
+```
+
+現在のTreeViewは、static表示だけであれば専用JavaScriptなしでも利用できます。Turbo Streamで開閉を行う場合も、host app側のTurbo構成とpath builderが中心になります。
+
+JavaScript controllers は、state tracking、keyboard navigation、selection cascade、transfer events、remote loading stateなどのbrowser-side integration hookで使います。
+
+## Packaged files
+
+TreeView gem package には、Rails host app で必要になる以下を含めます。
+
+- `app/assets/stylesheets/tree_view.scss`
+- `app/helpers/tree_view_helper.rb`
+- `app/helpers/tree_view_helper/**/*`
+- `app/javascript/tree_view/**/*`
+- `app/views/tree_view/**/*`
+- `config/importmap.tree_view.rb`
+- `lib/**/*`
+- `README.md`
+- `CHANGELOG.md`
+- `docs/**/*`
+
+導入手順を変更した場合は、`tree_view.gemspec` の packaged file list とこの一覧が食い違わないようにします。
+
+## Propshaft
+
+Rails 8 + Propshaft でも利用できます。
+
+最低限、host app 側から CSS / importmap を明示的に読み込む構成を推奨します。
+
+```scss
+@import "tree_view";
+```
+
+```ruby
+pin "tree_view", to: "tree_view/index.js"
+```
+
+## Sprockets
+
+Engine側にはSprockets互換のasset hookを残しています。
+
+- `app/javascript` を asset paths に追加
+- `tree_view.css` / `tree_view/index.js` を precompile 対象に追加
+
+ただし、導入の中心はhost app側でCSS / importmapを明示的に読み込む運用です。
+
+## Asset / importmap audit checklist
+
+asset または JavaScript の配置を変更した場合は、release 前に以下を確認します。
+
+- `tree_view.gemspec` がCSS、JavaScript、importmapファイルを含んでいる
+- README の導入例がこのファイルと一致している
+- `docs/ja/release.md` または `docs/release.md` の package checklist が更新されている
+- static表示がJavaScriptなしでも利用できる、という前提を壊していない
+- JavaScriptが必要な機能は、必要なimportmap pinやdata属性をdocsに書いている
+
+## 開発環境
+
+ローカルRubyで実行する場合:
+
+```bash
+bundle install
+bundle exec standardrb
+bundle exec rspec
+bundle exec rake build
+npm install
+npm test
+```
+
+Rails互換性確認用のGemfileは `gemfiles/` 配下にあります。
+
+```bash
+BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
+```
+
+Dockerで実行する場合:
+
+```bash
+cp .env.example .env
+docker compose build
+docker compose run --rm app bundle install
+docker compose run --rm app bundle exec rspec
+docker compose run --rm app bundle exec rake build
+```
+
+VS Code Dev Containersを使う場合は `.devcontainer/devcontainer.json` を利用できます。
+
+## CI
+
+GitHub Actions では、Pull Requestでは `bundle exec standardrb` のみを実行します。
+
+`main` へのpushでは、Ruby spec、Rails version matrix、JavaScript tests、gem package verificationを実行します。

--- a/docs/ja/minimal-usage.md
+++ b/docs/ja/minimal-usage.md
@@ -1,0 +1,96 @@
+# host appでの最小利用例
+
+このページでは、Rails host app でrecordsからツリーを描画するための最小構成を示します。
+
+## 目的
+
+最小構成は以下の3つです。
+
+1. controllerで `TreeView::Tree` を作る。
+2. `TreeView::UiConfigBuilder` でstatic用の `TreeView::UiConfig` を作る。
+3. viewで `TreeView::RenderState` から行を描画する。
+
+## Controller
+
+```ruby
+class DocumentsController < ApplicationController
+  def index
+    documents = Document.order(:name).to_a
+
+    tree = TreeView::Tree.new(
+      records: documents,
+      parent_id_method: :parent_document_id
+    )
+
+    tree_ui = TreeView::UiConfigBuilder.new(
+      context: view_context,
+      node_prefix: "document"
+    ).build_static
+
+    @render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "documents/tree_columns",
+      ui_config: tree_ui
+    )
+  end
+end
+```
+
+`records` には表示対象のActive Record objectsを渡します。
+
+`parent_id_method` には親IDを返すmethod名を指定します。この例では `Document#parent_document_id` を使います。
+
+`node_prefix` はDOM IDなどに使うprefixです。同じ画面に複数TreeViewを置く場合は、衝突しない値にしてください。
+
+## View
+
+```erb
+<table class="tree-view-table">
+  <tbody>
+    <%= tree_view_rows(@render_state) %>
+  </tbody>
+</table>
+```
+
+`tree_view_rows(@render_state)` は、root rows からツリー行を描画します。
+
+## Row partial
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td><%= item.name %></td>
+```
+
+`row_partial` には、TreeView標準行の中に差し込む列部分を指定します。
+
+このpartialでは `item` を使えます。
+
+## selection付きの最小例
+
+```ruby
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  selection: {
+    enabled: true,
+    visibility: :leaves
+  }
+)
+```
+
+`selection.enabled` を `true` にするとcheckbox selectionを有効化できます。
+
+`visibility: :leaves` はleaf nodeだけにcheckboxを表示します。
+
+詳しくは [Selection](../selection.md) を参照してください。
+
+## 次に読むもの
+
+- [導入手順](installation.md)
+- [使い方](../usage.md)
+- [API概要](api-overview.md)
+- [API仕様](../api.md)
+- [Selection](../selection.md)


### PR DESCRIPTION
## Summary

- Add `docs/ja/` and `docs/en/` documentation entry points.
- Make `docs/README.md` a language selector.
- Add split Japanese and English versions for installation, minimal usage, and API overview.
- Update the i18n audit for the new language-specific documentation structure.
- Keep root-level docs temporarily for compatibility during migration.
- Update CHANGELOG.

## Testing

- PR CI: `bundle exec standardrb` succeeded.
- PR CI confirmed `spec`, `rails_matrix`, `javascript`, and `gem_package` are skipped on pull requests by design.
- Full CI will run after merge to `main` by design.