### PR TITLE
Finalize docs cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added language-specific API reference entries at `docs/ja/api.md` and `docs/en/api.md`.
 - Added language-specific public API and release checklist docs, and converted several root-level docs into compatibility language selectors.
 - Converted root `docs/usage.md` into a short compatibility language selector.
+- Pointed the English docs index maintainer links to language-specific maintainer docs and added release readiness checks to the documentation i18n audit.
 
 ### Tests
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -46,8 +46,8 @@ If you are integrating TreeView into a Rails host app, start with these document
 
 | Document | Description |
 |---|---|
-| [Public API](../public-api.md) | APIs host apps may use directly and compatibility policy |
-| [Release checklist](../release.md) | Release tests, documentation, and gem package checklist |
+| [Public API](public-api.md) | APIs host apps may use directly and compatibility policy |
+| [Release checklist](release.md) | Release tests, documentation, and gem package checklist |
 | [Design policy](design-policy.md) | Gem responsibilities, included scope, excluded scope, and design decisions |
 | [Development](development.md) | Tests, CI, documentation updates, and future work |
 | [Code quality](code-quality.md) | Lint, tests, error messages, and documentation quality policy |

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -4,7 +4,7 @@ This document tracks documentation language status before the `0.1.0` release.
 
 ## Current structure
 
-Documentation is moving to language-specific directories.
+Documentation is organized around language-specific directories.
 
 - `docs/ja/`: Japanese documentation tree
 - `docs/en/`: English documentation tree
@@ -39,7 +39,7 @@ For the initial release, the priority is:
 |---|---|---|---|---|
 | Top-level README | `README.md` | `README.md` | Bilingual summary | Keep short entry content in sync. |
 | Docs selector | `docs/README.md` | `docs/README.md` | Compatibility selector | Keep language selector current. |
-| Docs index | `docs/ja/README.md` | `docs/en/README.md` | Split | Keep reading order and links in sync. |
+| Docs index | `docs/ja/README.md` | `docs/en/README.md` | Split | Reading order and maintainer links now point to language-specific docs. |
 | Installation | `docs/ja/installation.md` | `docs/en/installation.md` | Split | Keep requirements and asset/importmap guidance in sync. |
 | Minimal usage | `docs/ja/minimal-usage.md` | `docs/en/minimal-usage.md` | Split | Keep examples in sync. |
 | Usage guide | `docs/ja/usage.md` | `docs/en/usage.md` | Split | Root `docs/usage.md` is a compatibility selector. |
@@ -63,7 +63,17 @@ All P2 supporting and maintainer docs are split under `docs/ja/` and `docs/en/`.
 | `docs/mockups/default-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |
 
+## Release readiness documentation checks
+
+Before tagging `v0.1.0`, confirm:
+
+- `docs/ja/README.md` and `docs/en/README.md` point to language-specific user and maintainer docs.
+- Root compatibility pages are short language selectors where practical.
+- `docs/api.md` is the only known longer root compatibility reference.
+- `CHANGELOG.md` includes documentation migration entries.
+- New public API changes update both `docs/ja/api.md` and `docs/en/api.md` when practical.
+
 ## Remaining cleanup
 
-- Replace root `docs/api.md` with a short language selector when practical.
+- Replace root `docs/api.md` with a short language selector when its blob SHA can be retrieved reliably through the GitHub connector or a local git workflow.
 - Keep `docs/ja/` and `docs/en/` in sync for future user-facing changes.


### PR DESCRIPTION
## Summary

- Point `docs/en/README.md` maintainer links to language-specific maintainer docs.
- Add release readiness checks to `docs/i18n-audit.md`.
- Update CHANGELOG.

## Notes

- I retried replacing root `docs/api.md` with a short language selector, but the GitHub connector still did not expose a stable SHA for that large file, and update calls require the current SHA. It remains the only known longer root compatibility reference.

## Testing

- PR CI: `bundle exec standardrb` succeeded.
- PR CI confirmed `spec`, `rails_matrix`, `javascript`, and `gem_package` are skipped on pull requests by design.
- Full CI will run after merge to `main` by design.