### PR TITLE
Prepare 0.1.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,50 +13,9 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ## Unreleased
 
-### Added
+No unreleased changes.
 
-- Added `TreeView::RenderWindow` and opt-in windowed rendering through `tree_view_rows(render_state, window: { offset:, limit: })`.
-- Added `tree_view_window(render_state, offset:, limit:)` for pagination metadata around visible rows.
-- Added Standard Ruby linting to the development dependencies and CI.
-- Added Rails version matrix Gemfiles and a main-push-only Rails compatibility CI job.
-
-### Documentation
-
-- Expanded the default TreeView static HTML mock to cover root, child, leaf, expanded, collapsed, hidden-count, selection, disabled selection, badge, marker, depth label, data attributes, and row actions examples.
-- Added concrete multi-key sorter cookbook examples, including nil handling and stable fallback keys.
-- Clarified beta documentation cleanup responsibilities and the split between static mockups in this repository and Rails playground behavior in the demo repository.
-- Clarified the persisted state generator output and owner-side usage.
-- Added children pagination guidance for lazy loading examples.
-- Clarified large-tree performance hardening boundaries between TreeView gem support and host app responsibilities.
-- Added windowed rendering documentation.
-- Clarified public API, semi-public API, internal helper module, and JavaScript entrypoint compatibility policy.
-- Clarified that releases are normally managed by tags on `main`, with release branches reserved for parallel maintenance.
-- Added a documentation i18n audit covering language status, translation priority, and release readiness.
-- Added English documentation index content to `docs/README.md`.
-- Added Japanese summaries to `docs/public-api.md` and `docs/release.md`.
-- Added bilingual coverage to `docs/installation.md` and `docs/minimal-usage.md`.
-- Added bilingual summaries to `docs/usage.md` and a bilingual `docs/api-overview.md` entry point.
-- Started migrating documentation to language-specific `docs/ja/` and `docs/en/` directories.
-- Split the usage guide into `docs/ja/usage.md` and `docs/en/usage.md` entry points.
-- Split the selection guide into `docs/ja/selection.md` and `docs/en/selection.md` entry points.
-- Split the lazy loading and windowed rendering guides into language-specific `docs/ja/` and `docs/en/` entry points.
-- Split the persisted state and breadcrumb guides into language-specific `docs/ja/` and `docs/en/` entry points.
-- Split the drag-and-drop and children pagination guides into language-specific `docs/ja/` and `docs/en/` entry points.
-- Split the glossary, node keys, and tree diagnostics guides into language-specific `docs/ja/` and `docs/en/` entry points.
-- Split the cookbook, depth labels, and row status guides into language-specific `docs/ja/` and `docs/en/` entry points.
-- Split the remaining support docs into language-specific `docs/ja/` and `docs/en/` entry points: filtered trees, rendering boundaries, render scale, host app extension points, design policy, development, and code quality.
-- Added language-specific API reference entries at `docs/ja/api.md` and `docs/en/api.md`.
-- Added language-specific public API and release checklist docs, and converted several root-level docs into compatibility language selectors.
-- Converted root `docs/usage.md` into a short compatibility language selector.
-- Pointed the English docs index maintainer links to language-specific maintainer docs and added release readiness checks to the documentation i18n audit.
-
-### Tests
-
-- Added coverage for the persisted state install generator outputs.
-- Added unit and integration coverage for windowed rendering.
-- Added JavaScript controller tests for state, selection, transfer, and remote-state behavior.
-
-## 0.1.0 - Initial release
+## 0.1.0 - 2026-05-07
 
 ### Added
 
@@ -67,7 +26,8 @@ Breaking changes and required migration notes should be called out explicitly in
 - `TreeView::ReverseTree` via `Tree#reverse_tree_for(items)` for rendering child-to-parent paths.
 - `TreeView::RenderState` for screen-level rendering options.
 - `tree_view_rows(render_state)` helper.
-- Host app row partial support via `row_partial`.
+- `TreeView::RenderWindow` and opt-in windowed rendering through `tree_view_rows(render_state, window: { offset:, limit: })`.
+- `tree_view_window(render_state, offset:, limit:)` for pagination metadata around visible rows.
 - Static tree rendering.
 - Turbo Stream path builder integration.
 - Initial expansion controls:
@@ -103,19 +63,38 @@ Breaking changes and required migration notes should be called out explicitly in
 - Optional DOM ID collision diagnostics via `RenderState#validate_unique_dom_ids!`.
 - `TreeView::VisibleRows` for flattening currently visible rows with depth and expansion state.
 - Lazy-loading row data hooks through `UiConfig#load_children_path_builder` and `RenderState#lazy_loading`.
-- Japanese documentation under `docs/`.
+- Persisted state support through `TreeView::PersistedState`, `TreeView::StateStore`, and the install generator.
+- Breadcrumb rendering helper for parent paths.
+- Standard Ruby linting in development dependencies and CI.
+- Rails version matrix Gemfiles and a main-push-only Rails compatibility CI job.
 
 ### Documentation
 
-- Public API and compatibility policy are documented in `docs/public-api.md`.
-- Release, versioning, CHANGELOG, and gem packaging checks are documented in `docs/release.md`.
-- Asset and importmap packaging expectations are documented in `docs/installation.md`.
-- JavaScript controller responsibility boundaries are documented in `docs/design-policy.md`.
-- TreeView-specific concepts and API names are defined in `docs/glossary.md`.
-- Tree diagnostics docs describe node key uniqueness and DOM ID collision checks.
-- Lazy loading, visible rows, sorter examples, and the static HTML mock are documented from the docs index.
+- Added Japanese documentation under `docs/`.
+- Added language-specific documentation trees under `docs/ja/` and `docs/en/`.
+- Added documentation language selector and i18n audit.
+- Added installation, minimal usage, usage, API overview, and API reference documentation in Japanese and English.
+- Added language-specific public API and release checklist docs.
+- Added feature docs in Japanese and English for selection, lazy loading, windowed rendering, persisted state, breadcrumb, drag and drop, and children pagination.
+- Added supporting docs in Japanese and English for glossary, node keys, tree diagnostics, cookbook, depth labels, row status, filtered trees, rendering boundaries, render scale, host app extension points, design policy, development, and code quality.
+- Expanded the default TreeView static HTML mock to cover root, child, leaf, expanded, collapsed, hidden-count, selection, disabled selection, badge, marker, depth label, data attributes, and row actions examples.
+- Added concrete multi-key sorter cookbook examples, including nil handling and stable fallback keys.
+- Clarified beta documentation cleanup responsibilities and the split between static mockups in this repository and Rails playground behavior in the demo repository.
+- Clarified the persisted state generator output and owner-side usage.
+- Added children pagination guidance for lazy loading examples.
+- Clarified large-tree performance hardening boundaries between TreeView gem support and host app responsibilities.
+- Clarified public API, semi-public API, internal helper module, JavaScript entrypoint, and compatibility policy.
+- Clarified that releases are normally managed by tags on `main`, with release branches reserved for parallel maintenance.
+- Converted root compatibility docs into short language selectors where practical.
+
+### Tests
+
+- Added coverage for the persisted state install generator outputs.
+- Added unit and integration coverage for windowed rendering.
+- Added JavaScript controller tests for state, selection, transfer, and remote-state behavior.
 
 ### Notes
 
 - This gem intentionally focuses on TreeView rendering primitives.
 - CRUD, authorization, business-specific actions, and selection side effects remain the responsibility of the host Rails application.
+- `TreeView::VERSION` is already set to `0.1.0` for this release.

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -19,7 +19,7 @@ For normal releases, do not create long-lived `release/*` branches. Tag a green 
 Release flow:
 
 1. Open a release preparation PR against `main`.
-2. Update `lib/tree_view/version.rb`.
+2. Update `lib/tree_view/version.rb` when the target version is not already set.
 3. Move relevant `CHANGELOG.md` entries from `Unreleased` into a dated version section.
 4. Merge the PR into `main`.
 5. Confirm main-push full CI is green.
@@ -35,6 +35,8 @@ The initial `0.1.0` release should include a coherent documented baseline rather
 
 Minimum release conditions:
 
+- `TreeView::VERSION` is set to `0.1.0`
+- `CHANGELOG.md` has a dated `0.1.0` section
 - core tree construction and rendering helpers are covered by specs
 - static rendering works without dedicated JavaScript
 - Turbo path-builder integration is documented
@@ -97,7 +99,7 @@ Include migration notes for breaking changes or deprecations.
 
 Before release:
 
-- Bump `TreeView::VERSION`.
+- Confirm `TreeView::VERSION` matches the release version.
 - Run `gem build tree_view.gemspec`.
 - Install the generated gem locally and confirm `require "tree_view"` works.
 - Confirm packaged files include:

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -19,7 +19,7 @@
 release flow:
 
 1. `main` 向けにrelease preparation PRを作る。
-2. `lib/tree_view/version.rb` を更新する。
+2. target version がまだ設定されていない場合は `lib/tree_view/version.rb` を更新する。
 3. `CHANGELOG.md` の `Unreleased` を日付付きversion sectionへ移す。
 4. PRを `main` にmergeする。
 5. main-push full CIがgreenであることを確認する。
@@ -35,6 +35,8 @@ release flow:
 
 Minimum release conditions:
 
+- `TreeView::VERSION` が `0.1.0` になっている
+- `CHANGELOG.md` に日付付き `0.1.0` section がある
 - core tree construction and rendering helpers are covered by specs
 - static rendering works without dedicated JavaScript
 - Turbo path-builder integration is documented
@@ -97,7 +99,7 @@ breaking changeやdeprecationにはmigration noteを書きます。
 
 release前に確認すること:
 
-- `TreeView::VERSION` を更新する
+- `TreeView::VERSION` がrelease versionと一致することを確認する
 - `gem build tree_view.gemspec` を実行する
 - 生成gemをローカルinstallして `require "tree_view"` を確認する
 - packaged filesに以下が含まれることを確認する


### PR DESCRIPTION
## Summary

- Move accumulated `Unreleased` entries into a dated `0.1.0 - 2026-05-07` CHANGELOG section.
- Leave `Unreleased` as `No unreleased changes.` for post-release work.
- Clarify in the Japanese and English release checklists that `TreeView::VERSION` only needs updating when the target version is not already set.
- Document that `TreeView::VERSION` is already `0.1.0` for this release.

## Testing

- PR CI: `bundle exec standardrb` succeeded.
- PR CI confirmed `spec`, `rails_matrix`, `javascript`, and `gem_package` are skipped on pull requests by design.
- Full CI will run after merge to `main` by design.

## Release follow-up after merge

- Confirm main-push full CI is green.
- Tag the green main commit as `v0.1.0`.
- Create GitHub Release / publish gem when ready.