### PR TITLE
Make root README English-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,48 @@
 # tree_view
 
-`tree_view` は、Rails アプリで親子データをツリー表示するためのgemです。
-
-親子関係を持つレコードを、再利用可能なTreeオブジェクト、描画状態、helper、partialとして扱えるようにします。
-
 `tree_view` is a Rails gem for rendering parent-child records as tree-style UIs.
 
-It provides reusable tree objects, render state, helpers, partials, and browser integration hooks while leaving application-specific CRUD and business actions to the host Rails app.
+It provides reusable tree objects, render state, helpers, partials, and browser integration hooks while leaving application-specific CRUD, authorization, and business actions to the host Rails app.
 
-## 主な機能 / Features
+日本語の説明、導入手順、API仕様は [日本語ドキュメント](docs/ja/README.md) を参照してください。
 
-- 親子データのツリー化 / Build trees from parent-child records
-- 子孫数の集計 / Count descendants
-- root / children の並び替え / Sort root and child items
-- static表示 / Static rendering
-- Turbo Stream開閉用path builder / Path builders for Turbo Stream expand/collapse actions
-- 異種ノード混在ツリー用 `GraphAdapter` / `GraphAdapter` for heterogeneous or graph-like nodes
-- 検索結果などから親階層を補完する `PathTree` / `PathTree` for rendering matched nodes with ancestor paths
-- 子ノード起点で親方向へ辿る `ReverseTree` / `ReverseTree` for child-to-parent paths
-- viewから使うDOM ID / toggle path / 枝情報helper / DOM ID, toggle path, and branch-info helpers for views
-- `RenderState` からroot行を描画する `tree_view_rows` helper / `tree_view_rows` helper for rendering root rows from `RenderState`
-- 表示対象行の一次元化API `TreeView::VisibleRows` / `TreeView::VisibleRows` for flattening currently visible rows
-- 表示対象行を一部だけ描画する `TreeView::RenderWindow` と `tree_view_rows(render_state, window: { offset:, limit: })` / `TreeView::RenderWindow` and opt-in windowed rendering
-- host app側の `row_partial` 差し替え / Host-app `row_partial` customization
-- 初期展開制御 / Initial expansion controls
-  - `initial_state`
-  - `expanded_keys`
-  - `collapsed_keys`
-  - `max_initial_depth`
-- 描画範囲制御 / Render scope controls
-  - `max_render_depth`
-  - `max_leaf_distance`
-- 開閉操作範囲制御 / Toggle scope controls
-  - `max_toggle_depth_from_root`
-  - `max_toggle_leaf_distance`
-- 行属性カスタマイズ / Row attribute customization
-  - `row_class_builder`
-  - `row_data_builder`
-- lazy loading hook
-  - `load_children_path_builder`
-  - `RenderState#lazy_loading`
-- checkbox selection
-  - JSON payload送信 / JSON payload submission
-  - nodeごとのdisabled制御 / Per-node disabled state
-  - `selected_keys` による初期選択 / Initial selection through `selected_keys`
-  - rendered rows の親子連動チェック / Parent-child cascade for rendered rows
-  - indeterminate表示 / Indeterminate state
-  - max count制限 / Max-count limit
-- persisted state helper / generator
-  - `TreeView::PersistedState`
-  - `TreeView::StateStore`
-  - `rails g tree_view:state:install`
-- JavaScript controllers
-  - state tracking / keyboard navigation
-  - selection collection / cascade / indeterminate
-  - drag and drop transfer events
-  - remote loading state hooks
+## Features
 
-## 含まないもの / Out of scope
+- Build trees from parent-child records.
+- Count descendants.
+- Sort root and child items.
+- Render static tree rows.
+- Integrate Turbo Stream expand/collapse actions through path builders.
+- Use `GraphAdapter` for heterogeneous or graph-like nodes.
+- Use `PathTree` for matched nodes with ancestor paths.
+- Use `ReverseTree` for child-to-parent paths.
+- Render rows from `TreeView::RenderState` with `tree_view_rows`.
+- Flatten currently visible rows with `TreeView::VisibleRows`.
+- Render visible rows by offset and limit with `TreeView::RenderWindow` and windowed rendering.
+- Customize host-app row content through `row_partial`.
+- Control initial expansion with `initial_state`, `expanded_keys`, `collapsed_keys`, and `max_initial_depth`.
+- Limit render scope with `max_render_depth` and `max_leaf_distance`.
+- Limit toggle scope with `max_toggle_depth_from_root` and `max_toggle_leaf_distance`.
+- Customize row attributes with `row_class_builder` and `row_data_builder`.
+- Add lazy loading hooks with `load_children_path_builder` and `RenderState#lazy_loading`.
+- Add checkbox selection with JSON payloads, disabled states, selected keys, cascade, indeterminate state, and max-count limits.
+- Persist expansion state through `TreeView::PersistedState`, `TreeView::StateStore`, and `rails g tree_view:state:install`.
+- Register JavaScript controllers for state tracking, selection, transfer payloads, and remote loading state.
 
-このgemはツリー表示基盤に責務を絞ります。
+## Out of scope
 
-This gem focuses on tree rendering primitives.
-
-以下はhost app側で実装します。
-
-Host applications are responsible for:
+This gem focuses on tree rendering primitives. Host applications are responsible for:
 
 - CRUD
-- controller / model / form
-- 認証・権限管理 / authentication and authorization
-- 業務固有の文言やroute / application-specific labels and routes
-- Turbo Frame modal
-- 右クリックメニュー / context menus
-- checkbox selection後の削除・移動・関連付けなどの業務処理 / business actions after checkbox selection, such as delete, move, or attach
-- server-side children pagination の query / cursor strategy
-- infinite scroll / virtual scroll のJavaScript制御 / JavaScript control for infinite scroll or virtual scroll
-- demo data / seed
+- controllers, models, and forms
+- authentication and authorization
+- application-specific labels, routes, and actions
+- Turbo Frame modals
+- context menus
+- business actions after checkbox selection, such as delete, move, or attach
+- server-side children pagination query and cursor strategy
+- JavaScript control for infinite scroll or virtual scroll
+- demo data and seeds
 
 ## Installation
 
@@ -88,15 +54,11 @@ gem "tree_view", git: "https://github.com/matsuo-haruhito/tree_view-rails.git"
 bundle install
 ```
 
-CSSを読み込みます。
-
 Import the CSS:
 
 ```scss
 @import "tree_view";
 ```
-
-必要に応じて importmap に追加します。
 
 Add the importmap pin when needed:
 
@@ -104,13 +66,13 @@ Add the importmap pin when needed:
 pin "tree_view", to: "tree_view/index.js"
 ```
 
-詳しくは [日本語の導入手順](docs/ja/installation.md) を参照してください。
-
 See [Installation](docs/en/installation.md) for details.
+
+日本語の導入手順は [docs/ja/installation.md](docs/ja/installation.md) を参照してください。
 
 ## Quick Start
 
-controller:
+Controller:
 
 ```ruby
 tree = TreeView::Tree.new(
@@ -131,7 +93,7 @@ tree = TreeView::Tree.new(
 )
 ```
 
-view:
+View:
 
 ```erb
 <table class="tree-view-table">
@@ -141,11 +103,7 @@ view:
 </table>
 ```
 
-既存どおり `tree_view/tree_row` partial を直接renderすることもできます。
-
-You can also render the `tree_view/tree_row` partial directly when needed.
-
-row partial:
+Row partial:
 
 ```erb
 <!-- app/views/projects/_tree_columns.html.erb -->
@@ -153,33 +111,33 @@ row partial:
 <td><%= item.owner_name %></td>
 ```
 
-詳しくは [日本語の使い方](docs/ja/usage.md) を参照してください。
+You can also render the `tree_view/tree_row` partial directly when needed.
 
 See [Usage](docs/en/usage.md) for details.
+
+日本語の使い方は [docs/ja/usage.md](docs/ja/usage.md) を参照してください。
 
 ## Documentation
 
 Documentation is organized by language.
 
-ドキュメントは言語別に管理しています。
-
 | Language | Entry point |
 |---|---|
-| 日本語 | [docs/ja/README.md](docs/ja/README.md) |
 | English | [docs/en/README.md](docs/en/README.md) |
+| 日本語 | [docs/ja/README.md](docs/ja/README.md) |
 
 Key documents:
 
-| 日本語 | English |
-|---|---|
-| [導入手順](docs/ja/installation.md) | [Installation](docs/en/installation.md) |
-| [最小利用例](docs/ja/minimal-usage.md) | [Minimal usage](docs/en/minimal-usage.md) |
-| [使い方](docs/ja/usage.md) | [Usage](docs/en/usage.md) |
-| [Cookbook](docs/ja/cookbook.md) | [Cookbook](docs/en/cookbook.md) |
-| [API概要](docs/ja/api-overview.md) | [API overview](docs/en/api-overview.md) |
-| [API仕様](docs/ja/api.md) | [API reference](docs/en/api.md) |
-| [Public API](docs/ja/public-api.md) | [Public API](docs/en/public-api.md) |
-| [Release checklist](docs/ja/release.md) | [Release checklist](docs/en/release.md) |
+| Topic | English | 日本語 |
+|---|---|---|
+| Installation | [Installation](docs/en/installation.md) | [導入手順](docs/ja/installation.md) |
+| Minimal usage | [Minimal usage](docs/en/minimal-usage.md) | [最小利用例](docs/ja/minimal-usage.md) |
+| Usage | [Usage](docs/en/usage.md) | [使い方](docs/ja/usage.md) |
+| Cookbook | [Cookbook](docs/en/cookbook.md) | [Cookbook](docs/ja/cookbook.md) |
+| API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
+| API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |
+| Public API | [Public API](docs/en/public-api.md) | [Public API](docs/ja/public-api.md) |
+| Release checklist | [Release checklist](docs/en/release.md) | [Release checklist](docs/ja/release.md) |
 
 Additional docs:
 
@@ -198,8 +156,6 @@ npm install
 npm test
 ```
 
-Rails互換性確認用のGemfileは `gemfiles/` 配下にあります。必要に応じて `BUNDLE_GEMFILE` を指定して実行します。
-
 Rails compatibility Gemfiles are under `gemfiles/`. Set `BUNDLE_GEMFILE` when checking a specific Rails version.
 
 ```bash
@@ -207,17 +163,11 @@ BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
 ```
 
-GitHub Actionsでは、Pull RequestではRuby lintのみを実行し、`main` へのpushで Ruby spec、Rails version matrix、JavaScript tests、gem package確認を実行します。
-
 GitHub Actions runs lightweight Ruby lint on pull requests. The full Ruby spec matrix, Rails version matrix, JavaScript tests, and gem package verification run on pushes to `main`.
 
 ## Release
 
-現在の初期リリース想定versionは `0.1.0` です。
-
 The initial release target is `0.1.0`.
-
-リリース前には以下を確認します。
 
 Before release, check:
 
@@ -226,13 +176,13 @@ Before release, check:
 - `bundle exec rake build`
 - Rails version matrix CI
 - `npm test`
-- README / docs / CHANGELOG の整合 / README, docs, and CHANGELOG consistency
+- README, docs, and CHANGELOG consistency
 - gemspec metadata
 
 See also:
 
+- [Release checklist](docs/en/release.md)
 - [日本語: Release checklist](docs/ja/release.md)
-- [English: Release checklist](docs/en/release.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Make the root README English-first instead of line-by-line Japanese/English bilingual text.
- Keep a clear Japanese documentation link near the top.
- Keep the Documentation section bilingual through a compact table of English/Japanese doc entry points.
- Reduce repeated bilingual phrasing in Features, Out of scope, Installation, Development, and Release sections.

## Testing

- PR CI should run lightweight lint only.