### PR TITLE
Clarify RenderWindow data-loading boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 - Added accessibility semantics docs for table-first TreeView rows and ARIA placement policy.
 - Added public name decision docs in Japanese and English.
+- Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 
 ## 0.1.0 - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It provides reusable tree objects, render state, helpers, partials, and browser 
 - Use `ReverseTree` for child-to-parent paths.
 - Render rows from `TreeView::RenderState` with `tree_view_rows`.
 - Flatten currently visible rows with `TreeView::VisibleRows`.
-- Render visible rows by offset and limit with `TreeView::RenderWindow` and windowed rendering.
+- Render currently visible rows by offset and limit with `TreeView::RenderWindow` and windowed rendering. This limits HTML output only; it does not reduce host-app queries or fetched records.
 - Customize host-app row content through `row_partial`.
 - Control initial expansion with `initial_state`, `expanded_keys`, `collapsed_keys`, and `max_initial_depth`.
 - Limit render scope with `max_render_depth` and `max_leaf_distance`.
@@ -41,7 +41,8 @@ This gem focuses on tree rendering primitives. Host applications are responsible
 - context menus
 - business actions after checkbox selection, such as delete, move, or attach
 - server-side children pagination query and cursor strategy
-- JavaScript control for infinite scroll or virtual scroll
+- data-fetching reductions beyond TreeView's lazy-loading hooks
+- JavaScript control for infinite scroll or full virtual scroll
 - demo data and seeds
 
 ## Installation

--- a/docs/en/decision-guide.md
+++ b/docs/en/decision-guide.md
@@ -7,7 +7,7 @@ TreeView APIs fall into two broad groups:
 - **Render controls** change which already-known tree rows are expanded, visible, or rendered into HTML.
 - **Data-loading controls** change when the host app fetches children or pages of children from the server.
 
-Use render controls first when the data is already available. Use lazy loading or children pagination when fetching all children up front is the problem.
+Use render controls first when the data is already available. Use lazy loading or children pagination when fetching all children up front is the problem. Use host-app JavaScript when the problem is full scroll-position-driven DOM virtualization.
 
 ## Start from the use case
 
@@ -17,9 +17,10 @@ Use render controls first when the data is already available. Use lazy loading o
 | Add Turbo expand/collapse | `TreeView::UiConfigBuilder#build` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | Host app routes and Turbo Stream actions own the response. TreeView builds row IDs and URLs. |
 | Keep the first render small | `TreeView::RenderState` | `max_initial_depth`, `initial_expansion:`, `render_scope:` | These are render controls. They reduce initial HTML volume, not database query volume by themselves. |
 | Limit which descendants can be rendered | `render_scope:` | `max_depth`, `max_leaf_distance` | Use when a page should never render beyond a chosen depth or distance from matched leaves. |
-| Render only a visible slice | `tree_view_rows(..., window:)`, `tree_view_window`, `TreeView::RenderWindow` | `window: { offset:, limit: }` | Slices already-visible rows. It does not fetch less data by itself. |
+| Render only a visible slice | `tree_view_rows(..., window:)`, `tree_view_window`, `TreeView::RenderWindow` | `window: { offset:, limit: }` | Slices already-visible rows. It reduces HTML output only; it does not fetch less data by itself. |
 | Avoid fetching every child up front | Lazy Loading | `load_children_path_builder`, `lazy_loading: { enabled:, loaded_keys: }` | TreeView renders hooks and URLs. The host app implements controller actions, queries, authorization, and Turbo responses. |
 | Page very large child sets | Children Pagination | Lazy-loading URLs plus host-app cursor / limit / next-page strategy | TreeView has integration boundaries and hooks; the host app owns pagination state and fetch behavior. |
+| Add full virtual scrolling | Host-app JavaScript | Scroll observers, virtualization library, URL/window state | TreeView does not provide built-in DOM virtualization or infinite-scroll control. Combine it with render metadata only when useful. |
 | Show search results with ancestors | `path_tree_for` | `tree.path_tree_for(matches)` | Use when matched records need enough ancestors to preserve context from root to match. |
 | Show child-to-parent paths | `reverse_tree_for` | `tree.reverse_tree_for(items)` | Use when the primary display starts from children and expands toward parents. |
 | Add checkbox selection | `selection:` options | `enabled`, `checkbox_name`, `selected_keys`, `disabled_keys`, `visibility`, `cascade`, `max_selected` | TreeView renders selection state and values. The host app owns the submitted business action. |
@@ -44,6 +45,8 @@ flowchart TD
   A --> J{Is the problem HTML volume?}
   J -->|Initial HTML too large| K[max_initial_depth and render_scope]
   J -->|Visible rows too many| L[RenderWindow or window: offset/limit]
+  A --> V{Need scroll-position virtualization?}
+  V -->|Yes| W[Host-app JavaScript or external virtualization library]
   A --> M{Is the tree derived from a subset?}
   M -->|Search matches need ancestors| N[path_tree_for]
   M -->|Children should point back to parents| O[reverse_tree_for]
@@ -61,9 +64,10 @@ flowchart TD
 |---|---|---|---|
 | Initial expansion | `max_initial_depth`, `initial_expansion:` | Rows opened on first paint | Records loaded from the database |
 | Render scope | `render_scope: { max_depth:, max_leaf_distance: }` | Descendants eligible for rendering | Host-app query cost unless the app also scopes queries |
-| Windowed rendering | `window:`, `TreeView::RenderWindow` | HTML emitted for currently visible rows | Data needed to compute visibility |
+| Windowed rendering | `window:`, `TreeView::RenderWindow` | HTML emitted for currently visible rows | Data needed to compute visibility, host-app queries, or fetched records |
 | Lazy loading | `load_children_path_builder`, `lazy_loading:` | Up-front child fetching and HTML for unloaded children | Host-app controller/query implementation |
 | Children pagination | Host-app pagination around lazy loading | Per-request child count | TreeView does not choose cursor or SQL strategy |
+| Virtual scrolling | Host-app JavaScript or external library | DOM work tied to scroll position | TreeView does not observe scroll or virtualize DOM by itself |
 
 ## Recommended path by project stage
 
@@ -71,8 +75,9 @@ flowchart TD
 2. Add [API overview](api-overview.md) concepts only when the use case needs them.
 3. Use [Render Scale](render-scale.md) when HTML size or visible row count becomes the issue.
 4. Use [Lazy Loading](lazy-loading.md) and [Children Pagination](children-pagination.md) when query volume or child count is the issue.
-5. Add [Selection](selection.md), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction requirements are clear.
-6. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
+5. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
+6. Add [Selection](selection.md), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction requirements are clear.
+7. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
 
 ## Common combinations
 
@@ -80,6 +85,7 @@ flowchart TD
 |---|---|
 | Small admin taxonomy | Static tree + `max_initial_depth` if needed |
 | Large folder browser | Lazy Loading + Children Pagination + Persisted State |
+| Large scrolling browser | Host-app virtual scrolling + render/window metadata as needed |
 | Search page | `path_tree_for` + render scope around matches |
 | Breadcrumb-like reverse view | `reverse_tree_for` + custom row partial |
 | Bulk action page | Static or Turbo rendering + `selection:` + host-app form action |

--- a/docs/en/render-scale.md
+++ b/docs/en/render-scale.md
@@ -15,13 +15,28 @@ TreeView provides several rendering controls for large trees.
 
 TreeView does not control host-app server-side queries or the amount of data fetched.
 
+`TreeView::RenderWindow` is an HTML-output control. Even though it accepts `offset` and `limit`, it slices rows that are already visible in the current render state. It is not a server-side pagination API, a database query optimizer, or a built-in virtual scrolling solution.
+
 ## First things to consider
 
 1. Decide whether the initial view really needs every node.
 2. Limit initial expansion with `max_initial_depth`.
 3. Limit render scope with `max_render_depth` or `max_leaf_distance`.
-4. Use windowed rendering when many visible rows remain.
-5. Use host-app lazy loading or server-side pagination when data-fetching volume needs to shrink.
+4. Use windowed rendering when many visible rows remain and you only need to reduce HTML output.
+5. Use lazy loading when children should not be fetched or rendered until the user asks for them.
+6. Use children pagination when one parent can have many children and each request should fetch only a page.
+7. Add host-app virtual scrolling when scroll-position-driven DOM virtualization is required.
+
+## Decision table
+
+| Goal | Start with | What it reduces | Boundary |
+|---|---|---|---|
+| Reduce initial expansion | `max_initial_depth` | Rows opened on first paint | Does not reduce database records by itself. |
+| Limit rendered depth | `max_render_depth` / `max_leaf_distance` | Descendants eligible for HTML rendering | Host app must also scope queries if query volume matters. |
+| Render a slice of visible rows | `TreeView::RenderWindow` / `tree_view_rows(..., window:)` | HTML output for currently visible rows | Does not reduce host-app queries or fetched records. |
+| Reduce child fetching | [Lazy Loading](lazy-loading.md) | Up-front child fetching and unloaded-child HTML | Host app implements fetch, queries, and responses. |
+| Page many children | [Children Pagination](children-pagination.md) | Children fetched per request | Host app owns cursor, offset, limit, next-page checks, and query strategy. |
+| Full virtual scroll | Host app JavaScript | DOM work based on scroll position | Outside TreeView's built-in scope. |
 
 ## Limit initial expansion
 
@@ -56,7 +71,17 @@ render_state = TreeView::RenderState.new(
 <%= tree_view_rows(@render_state, window: { offset: 0, limit: 50 }) %>
 ```
 
-Windowed rendering slices currently visible rows by offset and limit. It does not change server-side queries.
+Windowed rendering slices currently visible rows by offset and limit. It limits how many rows are emitted as HTML from the visible-row list that TreeView has already computed.
+
+Windowed rendering does not:
+
+- change host-app server-side queries
+- reduce records fetched from the database
+- page children for a parent
+- observe scroll position
+- implement DOM virtualization or infinite scroll
+
+Use it when the tree data is already available but emitting every currently visible row would create too much HTML. If data-fetching volume needs to shrink, use [Lazy Loading](lazy-loading.md) or [Children Pagination](children-pagination.md) in the host app. If the product needs scroll-position-driven virtualization, implement that in the host app.
 
 ## Lazy loading
 
@@ -69,7 +94,13 @@ lazy_loading: {
 }
 ```
 
-Fetch behavior, queries, pagination, and Turbo Stream responses are host app responsibilities.
+TreeView renders child URL and row-state hooks. Fetch behavior, queries, pagination, and Turbo Stream responses are host app responsibilities. See [Lazy Loading](lazy-loading.md) for details.
+
+## Children pagination
+
+Use children pagination when a parent can have many children and the host app should fetch them in smaller pages.
+
+TreeView does not choose cursor, offset, limit, ordering, next-page detection, or response shape. It provides integration boundaries through lazy-loading URLs and row data hooks. See [Children Pagination](children-pagination.md) for details.
 
 ## Responsibility boundary
 
@@ -79,6 +110,8 @@ Fetch behavior, queries, pagination, and Turbo Stream responses are host app res
 | visible rows calculation | yes | no |
 | window slicing | yes | renders controls |
 | lazy loading hooks | yes | implements fetch/query |
+| children pagination algorithm | no | yes |
 | server-side pagination | no | yes |
 | data loading strategy | no | yes |
+| infinite scroll / virtual scroll | no | yes |
 | performance budget | signals only | yes |

--- a/docs/en/windowed-rendering.md
+++ b/docs/en/windowed-rendering.md
@@ -17,6 +17,8 @@ TreeView is responsible for:
 
 The host app remains responsible for scroll observers, infinite scroll, URL query state, server-side pagination, and data fetching.
 
+Windowed rendering controls HTML output only. It does not reduce host-app queries or fetched records. If the problem is data-loading volume, start with [Lazy Loading](lazy-loading.md) or [Children Pagination](children-pagination.md). If the problem is scroll-position-driven DOM virtualization, implement virtual scrolling in the host app.
+
 ## Passing a window to tree_view_rows
 
 ```erb
@@ -79,7 +81,7 @@ Windowed rendering is not DOM virtualization.
 - It does not change server-side queries.
 - It does not reduce the amount of tree data fetched by the host app.
 
-If data-fetching volume needs to be reduced, combine this with host-app server-side pagination or lazy loading.
+If data-fetching volume needs to be reduced, use [Lazy Loading](lazy-loading.md), [Children Pagination](children-pagination.md), or another host-app data-loading strategy.
 
 ## Responsibility boundary
 
@@ -91,5 +93,6 @@ If data-fetching volume needs to be reduced, combine this with host-app server-s
 | pagination controls | metadata only | renders UI |
 | URL/query state | no | yes |
 | infinite scroll | no | yes |
+| virtual scroll | no | yes |
 | server-side pagination | no | yes |
 | data fetching | no | yes |

--- a/docs/ja/decision-guide.md
+++ b/docs/ja/decision-guide.md
@@ -7,7 +7,7 @@ TreeViewのAPIは大きく分けると次の2種類です。
 - **描画制御**: すでに手元にあるtree rowsのうち、何を開くか、何をvisibleにするか、どこまでHTMLとして描画するかを制御します。
 - **データ読み込み制御**: host appが子要素や子要素のpageをいつserverから取得するかを制御します。
 
-データがすでに取得済みなら、まず描画制御を使います。全ての子要素を先に取得すること自体が問題なら、Lazy LoadingやChildren Paginationを使います。
+データがすでに取得済みなら、まず描画制御を使います。全ての子要素を先に取得すること自体が問題なら、Lazy LoadingやChildren Paginationを使います。scroll位置に応じたDOM仮想化が問題なら、host app側のJavaScriptで実装します。
 
 ## やりたいことから選ぶ
 
@@ -17,9 +17,10 @@ TreeViewのAPIは大きく分けると次の2種類です。
 | Turboでexpand/collapseしたい | `TreeView::UiConfigBuilder#build` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | host appのroutesとTurbo Stream actionがresponseを担当します。TreeViewはrow IDとURLを組み立てます。 |
 | 初期描画を小さくしたい | `TreeView::RenderState` | `max_initial_depth`, `initial_expansion:`, `render_scope:` | これは描画制御です。初期HTML量は減りますが、それだけでdatabase query量が減るわけではありません。 |
 | 描画対象の子孫範囲を制限したい | `render_scope:` | `max_depth`, `max_leaf_distance` | ページ上で一定のdepthやmatched leavesからの距離を超えて描画したくない場合に使います。 |
-| visible rowsの一部だけ描画したい | `tree_view_rows(..., window:)`, `tree_view_window`, `TreeView::RenderWindow` | `window: { offset:, limit: }` | すでにvisibleなrowsをsliceします。これだけで取得データ量が減るわけではありません。 |
+| visible rowsの一部だけ描画したい | `tree_view_rows(..., window:)`, `tree_view_window`, `TreeView::RenderWindow` | `window: { offset:, limit: }` | すでにvisibleなrowsをsliceします。HTML出力量だけを減らし、それだけで取得データ量が減るわけではありません。 |
 | 全ての子要素を先に取得したくない | Lazy Loading | `load_children_path_builder`, `lazy_loading: { enabled:, loaded_keys: }` | TreeViewはhookとURLを描画します。controller action、query、authorization、Turbo responseはhost appが実装します。 |
 | 非常に大きい子要素集合をpage分割したい | Children Pagination | Lazy-loading URLとhost app側のcursor / limit / next-page strategy | TreeViewは連携境界とhookを提供します。pagination stateとfetch behaviorはhost appが担当します。 |
+| full virtual scrollingを追加したい | host app JavaScript | scroll observer、virtualization library、URL/window state | TreeViewは組み込みのDOM仮想化やinfinite-scroll制御を提供しません。必要に応じてrender metadataと組み合わせます。 |
 | 検索結果をancestor付きで表示したい | `path_tree_for` | `tree.path_tree_for(matches)` | matchしたrecordをrootからの文脈付きで表示したい場合に使います。 |
 | childからparentへ辿る表示をしたい | `reverse_tree_for` | `tree.reverse_tree_for(items)` | 子側を起点にして親方向へ展開する表示に使います。 |
 | checkbox selectionを追加したい | `selection:` options | `enabled`, `checkbox_name`, `selected_keys`, `disabled_keys`, `visibility`, `cascade`, `max_selected` | TreeViewはselection stateとvalueを描画します。送信後の業務処理はhost appが担当します。 |
@@ -44,6 +45,8 @@ flowchart TD
   A --> J{問題はHTML量ですか?}
   J -->|初期HTMLが大きい| K[max_initial_depth と render_scope]
   J -->|visible rowsが多い| L[RenderWindow または window: offset/limit]
+  A --> V{scroll位置に応じた仮想化が必要?}
+  V -->|はい| W[host app JavaScript または外部virtualization library]
   A --> M{subsetからtreeを作りたい?}
   M -->|検索matchにancestorが必要| N[path_tree_for]
   M -->|childからparentへ見せたい| O[reverse_tree_for]
@@ -61,9 +64,10 @@ flowchart TD
 |---|---|---|---|
 | 初期展開 | `max_initial_depth`, `initial_expansion:` | 初回表示で開くrow | databaseから読み込むrecord数 |
 | 描画範囲 | `render_scope: { max_depth:, max_leaf_distance: }` | 描画対象になる子孫 | host appがqueryも絞らない限りquery costは減りません |
-| windowed rendering | `window:`, `TreeView::RenderWindow` | 現在visibleなrowsから出力するHTML | visibility計算に必要なデータ |
+| windowed rendering | `window:`, `TreeView::RenderWindow` | 現在visibleなrowsから出力するHTML | visibility計算に必要なデータ、host app query、取得済みrecord数 |
 | Lazy Loading | `load_children_path_builder`, `lazy_loading:` | 初期の子要素取得と未読み込み子要素のHTML | host appのcontroller / query実装 |
 | Children Pagination | lazy loading周辺のhost app pagination | 1requestあたりの子要素数 | TreeViewはcursorやSQL strategyを選びません |
+| Virtual scrolling | host app JavaScript または外部library | scroll位置に応じたDOM作業 | TreeViewはscroll監視やDOM仮想化を単体では行いません |
 
 ## project stageごとのおすすめ順
 
@@ -71,8 +75,9 @@ flowchart TD
 2. 必要になったuse caseに応じて [API概要](api-overview.md) の概念を足します。
 3. HTML量やvisible row数が問題になったら [Render Scale](render-scale.md) を使います。
 4. query量や子要素数が問題になったら [Lazy Loading](lazy-loading.md) と [Children Pagination](children-pagination.md) を使います。
-5. interaction要件が固まったら [Selection](selection.md)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
-6. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
+5. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
+6. interaction要件が固まったら [Selection](selection.md)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
+7. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
 
 ## よくある組み合わせ
 
@@ -80,6 +85,7 @@ flowchart TD
 |---|---|
 | 小さな管理用taxonomy | Static tree + 必要に応じて `max_initial_depth` |
 | 大きなfolder browser | Lazy Loading + Children Pagination + Persisted State |
+| 大きなscrolling browser | host app virtual scrolling + 必要に応じてrender/window metadata |
 | 検索ページ | `path_tree_for` + match周辺のrender scope |
 | breadcrumb風のreverse view | `reverse_tree_for` + custom row partial |
 | bulk action page | StaticまたはTurbo rendering + `selection:` + host-app form action |

--- a/docs/ja/render-scale.md
+++ b/docs/ja/render-scale.md
@@ -15,13 +15,28 @@ TreeViewは、大きなtreeでも扱いやすいように複数の描画制御AP
 
 ただし、TreeView gemはserver-side queryやdata fetching量そのものは制御しません。
 
+`TreeView::RenderWindow` はHTML出力を制御するためのAPIです。`offset` と `limit` を受け取りますが、現在のrender stateでvisibleになっているrowをsliceするだけです。server-side pagination API、database query optimizer、組み込みのvirtual scrolling機能ではありません。
+
 ## 最初に検討すること
 
 1. 初期表示で本当に全nodeが必要か確認する。
 2. `max_initial_depth` で初期展開を制限する。
 3. `max_render_depth` や `max_leaf_distance` で描画範囲を制限する。
-4. visible rowsが多い場合は windowed rendering を使う。
-5. データ取得量を減らしたい場合は lazy loading / server-side pagination をhost app側で実装する。
+4. visible rowsが多く、HTML出力量だけを減らしたい場合は windowed rendering を使う。
+5. 子nodeを必要になるまで取得・描画したくない場合は lazy loading を使う。
+6. 1つの親に大量のchildrenがあり、requestごとの取得件数を減らしたい場合は children pagination を使う。
+7. scroll位置に応じたDOM仮想化が必要な場合は、host app側でvirtual scrollingを実装する。
+
+## 判断表
+
+| 目的 | まず使うもの | 減らせるもの | 境界 |
+|---|---|---|---|
+| 初期展開を減らす | `max_initial_depth` | 初回表示で開くrow | database record数はそれだけでは減りません。 |
+| 描画depthを制限する | `max_render_depth` / `max_leaf_distance` | HTML描画対象になる子孫 | query量も減らしたい場合はhost app側でqueryを絞ります。 |
+| visible rowsの一部だけを描画する | `TreeView::RenderWindow` / `tree_view_rows(..., window:)` | 現在visibleなrowsから出力されるHTML | host app queryや取得済みrecord数は減りません。 |
+| 子node取得を減らす | [Lazy Loading](lazy-loading.md) | 初期の子node取得と未読み込みchildrenのHTML | fetch、query、responseはhost appが実装します。 |
+| 大量childrenをpage分割する | [Children Pagination](children-pagination.md) | 1requestあたりに取得するchildren | cursor、offset、limit、次page判定、query strategyはhost appが担当します。 |
+| full virtual scrollを行う | host app JavaScript | scroll位置に応じたDOM作業 | TreeViewの組み込みscope外です。 |
 
 ## 初期展開を制限する
 
@@ -56,7 +71,17 @@ render_state = TreeView::RenderState.new(
 <%= tree_view_rows(@render_state, window: { offset: 0, limit: 50 }) %>
 ```
 
-windowed renderingは、現在のvisible rowsをoffset/limitで切るだけです。server-side queryは変えません。
+windowed renderingは、現在のvisible rowsをoffset/limitで切ります。TreeViewがすでに計算したvisible rowsのうち、HTMLとして出力する行数を制限するための機能です。
+
+windowed rendering は以下を行いません。
+
+- host appのserver-side queryを変える
+- databaseから取得するrecord数を減らす
+- 親ごとのchildrenをpage分割する
+- scroll位置を監視する
+- DOM virtualizationやinfinite scrollを実装する
+
+tree dataがすでに手元にあり、現在visibleなrowをすべてHTMLとして出力すると大きすぎる場合に使います。data fetching量を減らしたい場合は、host app側で [Lazy Loading](lazy-loading.md) または [Children Pagination](children-pagination.md) を使ってください。scroll位置に応じた仮想化が必要な場合は、host app側で実装してください。
 
 ## lazy loading
 
@@ -69,7 +94,13 @@ lazy_loading: {
 }
 ```
 
-実際のfetch、query、pagination、Turbo Stream responseはhost app側で実装します。
+TreeViewはchildren URLとrow state hookを描画します。実際のfetch、query、pagination、Turbo Stream responseはhost app側で実装します。詳細は [Lazy Loading](lazy-loading.md) を参照してください。
+
+## children pagination
+
+1つの親が大量のchildrenを持つ場合、host app側でchildrenを小さなpageに分けて取得します。
+
+TreeViewはcursor、offset、limit、ordering、次page判定、response shapeを選びません。lazy-loading URLとrow data hookによる連携境界を提供します。詳細は [Children Pagination](children-pagination.md) を参照してください。
 
 ## 責務範囲
 
@@ -79,6 +110,8 @@ lazy_loading: {
 | visible rows calculation | yes | no |
 | window slicing | yes | renders controls |
 | lazy loading hooks | yes | implements fetch/query |
+| children pagination algorithm | no | yes |
 | server-side pagination | no | yes |
 | data loading strategy | no | yes |
+| infinite scroll / virtual scroll | no | yes |
 | performance budget | signals only | yes |

--- a/docs/ja/windowed-rendering.md
+++ b/docs/ja/windowed-rendering.md
@@ -17,6 +17,8 @@ TreeView gem が担当するのは以下です。
 
 scroll監視、infinite scroll、URL query、server-side pagination、データ取得はhost app側で実装します。
 
+windowed rendering が制御するのはHTML出力だけです。host app queryや取得済みrecord数は減りません。問題がdata loading量なら [Lazy Loading](lazy-loading.md) または [Children Pagination](children-pagination.md) から検討してください。scroll位置に応じたDOM仮想化が必要な場合は、host app側でvirtual scrollingを実装してください。
+
 ## tree_view_rows でwindowを指定する
 
 ```erb
@@ -79,7 +81,7 @@ windowed rendering はDOM仮想化ではありません。
 - server-side queryを変えません
 - 全treeのデータ取得量を減らすものではありません
 
-全データ取得量を減らしたい場合は、host app側でserver-side paginationやlazy loadingを組み合わせてください。
+全データ取得量を減らしたい場合は、[Lazy Loading](lazy-loading.md)、[Children Pagination](children-pagination.md)、またはhost app側のdata-loading strategyを使ってください。
 
 ## 責務範囲
 
@@ -91,5 +93,6 @@ windowed rendering はDOM仮想化ではありません。
 | pagination controls | metadata only | renders UI |
 | URL/query state | no | yes |
 | infinite scroll | no | yes |
+| virtual scroll | no | yes |
 | server-side pagination | no | yes |
 | data fetching | no | yes |


### PR DESCRIPTION
## Summary

- Clarify that `TreeView::RenderWindow` / windowed rendering limits HTML output for currently visible rows only.
- Add decision guidance for `max_initial_depth`, render scope, RenderWindow, Lazy Loading, Children Pagination, and host-app virtual scrolling.
- Link Windowed Rendering docs to Lazy Loading and Children Pagination for data-loading cases.
- Update README scope notes and CHANGELOG so users do not expect RenderWindow to reduce host-app queries or fetched records.

## Testing

- Not run; documentation-only changes.

Closes #301