### PR TITLE
Add README adoption guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Documentation
 
+- Added README adoption guidance to help users decide whether TreeView fits their use case and to clarify the virtual scrolling boundary.
 - Added accessibility semantics docs for table-first TreeView rows and ARIA placement policy.
 - Added public name decision docs in Japanese and English.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,31 @@ It provides reusable tree objects, render state, helpers, partials, and browser 
 
 日本語の説明、導入手順、API仕様は [日本語ドキュメント](docs/ja/README.md) を参照してください。
 
+## Is this gem for you?
+
+Use TreeView when you want Rails-friendly primitives for rendering tree or tree-table interfaces, not a complete file-manager application. It is a good fit when the host app owns the records, queries, routes, authorization, and business behavior, while TreeView handles reusable rendering and interaction hooks.
+
+TreeView is useful for:
+
+- Rails-friendly tree and table rendering
+- Turbo and Stimulus integration points
+- expandable rows
+- checkbox selection hooks
+- lazy-loading hooks
+- drag/drop hooks
+- host-app-controlled queries and business behavior
+
+TreeView does not provide:
+
+- a complete file-manager application
+- CRUD screens
+- authorization policies
+- product-specific context menus or bulk actions
+- server-side pagination algorithms
+- a full virtual scrolling engine
+
+For very large trees, combine TreeView's render controls with host-app loading and paging strategies. Start with [Render Scale](docs/en/render-scale.md), then add [Lazy Loading](docs/en/lazy-loading.md), [Children Pagination](docs/en/children-pagination.md), or custom virtual scrolling owned by the host app when your UI needs it.
+
 ## Features
 
 - Build trees from parent-child records.

--- a/docs/en/accessibility-semantics.md
+++ b/docs/en/accessibility-semantics.md
@@ -8,7 +8,7 @@ TreeView is table-first with tree-like row controls.
 
 TreeView renders host-app business columns in table rows, so it does not claim full `tree` semantics and does not currently opt into full `treegrid` semantics. Host apps should treat the generated markup as a table that includes expansion controls, selection state, current-row state, and optional lazy-loading state.
 
-TreeView may move toward `treegrid` semantics later, but that should be a focused compatibility decision. It should not happen as an incidental attribute change.
+Any move toward `treegrid` semantics should be a focused compatibility decision. It should not happen as an incidental attribute change.
 
 ## Current ARIA placement
 

--- a/docs/en/public-name-decisions.md
+++ b/docs/en/public-name-decisions.md
@@ -8,7 +8,7 @@ Use `badge_builder` as the recommended hook for row badge or marker display.
 
 `icon_builder` remains as a compatibility alias for existing callers. Internally, `RenderContext#badge_builder` may still fall back to `icon_builder` when `badge_builder` is not configured, but new docs and examples should not recommend `icon_builder`.
 
-Future toggle visuals should use a separate, toggle-specific hook such as `toggle_icon_builder` so TreeView can continue to own the toggle link or button structure, ARIA attributes, Turbo attributes, and keyboard behavior.
+If TreeView adds toggle-specific visual customization, it should use a separate, toggle-specific hook such as `toggle_icon_builder` so TreeView can continue to own the toggle link or button structure, ARIA attributes, Turbo attributes, and keyboard behavior.
 
 ## `row_event_payload_builder`
 

--- a/docs/ja/accessibility-semantics.md
+++ b/docs/ja/accessibility-semantics.md
@@ -8,7 +8,7 @@ TreeView は table-first with tree-like row controls として扱います。
 
 TreeView は host app の業務columnsをtable row内に描画するため、現時点では完全な `tree` semantics を名乗らず、完全な `treegrid` semantics にもopt-inしません。host appは、生成markupを「展開control、selection状態、current row状態、任意のlazy-loading状態を持つtable」として扱ってください。
 
-将来的に `treegrid` semantics へ寄せる可能性はありますが、その場合は互換性を意識した明示的な判断として行います。個別属性のついでに導入しないでください。
+`treegrid` semantics へ寄せる場合は、互換性を意識した明示的な判断として行います。個別属性のついでに導入しないでください。
 
 ## 現在のARIA配置
 

--- a/docs/ja/public-name-decisions.md
+++ b/docs/ja/public-name-decisions.md
@@ -8,7 +8,7 @@ row badge / marker 表示には `badge_builder` を推奨します。
 
 `icon_builder` は既存caller向けのcompatibility aliasとして残します。内部的には、`badge_builder` が未指定の場合に `RenderContext#badge_builder` が `icon_builder` へfallbackすることがあります。ただし、新しいdocsやexamplesでは `icon_builder` を推奨しません。
 
-将来のtoggle visualには、`toggle_icon_builder` のようなtoggle専用hookを使う方針です。TreeViewは引き続きtoggle link / button構造、ARIA属性、Turbo属性、keyboard behaviorを所有します。
+TreeView に toggle visual の専用customizationを追加する場合は、`toggle_icon_builder` のようなtoggle専用hookとして扱います。TreeViewは引き続きtoggle link / button構造、ARIA属性、Turbo属性、keyboard behaviorを所有します。
 
 ## `row_event_payload_builder`
 


### PR DESCRIPTION
## Summary

- Add an "Is this gem for you?" README section for adoption guidance.
- Clarify that TreeView provides Rails-friendly tree/table rendering primitives and integration hooks, not a complete file-manager application.
- Explicitly document that a full virtual scrolling engine is outside built-in scope.
- Link large-tree guidance to Render Scale, Lazy Loading, and Children Pagination docs.

## Testing

- Not run; documentation-only change.

Closes #310