### PR TITLE
Support interactive controls inside tree rows

### DIFF
--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -1,5 +1,6 @@
 import { Application } from "@hotwired/stimulus"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { isTreeViewInteractiveTarget } from "./interactive.js"
 import {
   TreeViewRemoteStateController,
   TreeViewSelectionController,
@@ -10,6 +11,38 @@ import {
 function nextFrame() {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
+
+describe("tree view interactive target helpers", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("detects native controls and tree view markers", () => {
+    document.body.innerHTML = `
+      <table id="tree">
+        <tbody>
+          <tr>
+            <td>
+              <input id="native-input">
+              <span id="editable" contenteditable="true">Rename me</span>
+              <span id="custom" data-tree-view-interactive="true">Custom widget</span>
+              <span id="keyboard-only" data-tree-view-ignore-keyboard="true">Keyboard widget</span>
+              <span id="row-click-only" data-tree-view-ignore-row-click="true">Row click widget</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `
+    const root = document.querySelector("#tree")
+
+    expect(isTreeViewInteractiveTarget(document.querySelector("#native-input"), "keyboard", root)).toBe(true)
+    expect(isTreeViewInteractiveTarget(document.querySelector("#editable"), "keyboard", root)).toBe(true)
+    expect(isTreeViewInteractiveTarget(document.querySelector("#custom"), "drag", root)).toBe(true)
+    expect(isTreeViewInteractiveTarget(document.querySelector("#keyboard-only"), "keyboard", root)).toBe(true)
+    expect(isTreeViewInteractiveTarget(document.querySelector("#row-click-only"), "rowClick", root)).toBe(true)
+    expect(isTreeViewInteractiveTarget(document.querySelector("#keyboard-only"), "rowClick", root)).toBe(false)
+  })
+})
 
 describe("TreeViewStateController", () => {
   let application
@@ -26,7 +59,14 @@ describe("TreeViewStateController", () => {
             <td><button class="remove-button" type="button"></button></td>
           </tr>
           <tr id="row-2" data-tree-view-state-target="node" data-tree-view-state-node-key="project:2" data-tree-view-state-expanded="false">
-            <td><button class="show-button" type="button"></button></td>
+            <td>
+              <button class="show-button" type="button"></button>
+              <input class="title-input" type="text" value="Project 2">
+              <a class="edit-link" href="/projects/2/edit">Edit</a>
+              <span class="editable-label" contenteditable="true">Editable label</span>
+              <span class="custom-widget" data-tree-view-interactive="true">Custom widget</span>
+              <span class="keyboard-widget" data-tree-view-ignore-keyboard="true">Keyboard widget</span>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -75,6 +115,46 @@ describe("TreeViewStateController", () => {
     })
 
     expect(click).toHaveBeenCalledOnce()
+  })
+
+  it("ignores keyboard navigation from interactive row controls", () => {
+    const element = document.querySelector("[data-controller='tree-view-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-state")
+    const button = document.querySelector("#row-2 .show-button")
+    const click = vi.spyOn(button, "click")
+    const preventDefault = vi.fn()
+
+    controller.keydown({
+      key: "ArrowRight",
+      preventDefault,
+      target: document.querySelector("#row-2 .title-input")
+    })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(click).not.toHaveBeenCalled()
+  })
+
+  it("ignores keyboard navigation from explicit tree view interactive markers", () => {
+    const element = document.querySelector("[data-controller='tree-view-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-state")
+    const button = document.querySelector("#row-2 .show-button")
+    const click = vi.spyOn(button, "click")
+    const preventDefault = vi.fn()
+
+    controller.keydown({
+      key: "Enter",
+      preventDefault,
+      target: document.querySelector("#row-2 .custom-widget")
+    })
+
+    controller.keydown({
+      key: " ",
+      preventDefault,
+      target: document.querySelector("#row-2 .keyboard-widget")
+    })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(click).not.toHaveBeenCalled()
   })
 })
 
@@ -235,7 +315,12 @@ describe("TreeViewTransferController", () => {
     document.body.innerHTML = `
       <table data-controller="tree-view-transfer">
         <tbody>
-          <tr id="source-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:1"}'></tr>
+          <tr id="source-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:1"}'>
+            <td>
+              <button class="action-button" type="button">Edit</button>
+              <span class="drag-widget" data-tree-view-ignore-drag="true">Drag widget</span>
+            </td>
+          </tr>
           <tr id="target-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:2"}'></tr>
         </tbody>
       </table>
@@ -263,6 +348,24 @@ describe("TreeViewTransferController", () => {
 
     expect(dataTransfer.effectAllowed).toBe("move")
     expect(dataTransfer.setData).toHaveBeenCalledWith("application/json", JSON.stringify({ key: "project:1" }))
+  })
+
+  it("ignores drag start from interactive row controls", () => {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-transfer")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-transfer:drag-start", eventSpy)
+    const dataTransfer = {
+      effectAllowed: null,
+      setData: vi.fn()
+    }
+
+    controller.start({ target: document.querySelector("#source-row .action-button"), dataTransfer })
+    controller.start({ target: document.querySelector("#source-row .drag-widget"), dataTransfer })
+
+    expect(dataTransfer.effectAllowed).toBeNull()
+    expect(dataTransfer.setData).not.toHaveBeenCalled()
+    expect(eventSpy).not.toHaveBeenCalled()
   })
 
   it("dispatches drop payloads with calculated position", () => {

--- a/app/javascript/tree_view/interactive.js
+++ b/app/javascript/tree_view/interactive.js
@@ -1,0 +1,34 @@
+const TREE_VIEW_NATIVE_INTERACTIVE_SELECTOR = [
+  "input",
+  "textarea",
+  "select",
+  "button",
+  "a",
+  "[contenteditable]:not([contenteditable='false'])"
+].join(", ")
+
+const TREE_VIEW_INTERACTIVE_MARKER_SELECTOR = "[data-tree-view-interactive]"
+
+const TREE_VIEW_BEHAVIOR_MARKER_SELECTORS = {
+  keyboard: "[data-tree-view-ignore-keyboard]",
+  rowClick: "[data-tree-view-ignore-row-click]",
+  drag: "[data-tree-view-ignore-drag]"
+}
+
+export function isTreeViewInteractiveTarget(target, behavior = null, root = null) {
+  if (!target || typeof target.closest !== "function") return false
+
+  const selectors = [TREE_VIEW_NATIVE_INTERACTIVE_SELECTOR, TREE_VIEW_INTERACTIVE_MARKER_SELECTOR]
+  if (behavior && TREE_VIEW_BEHAVIOR_MARKER_SELECTORS[behavior]) {
+    selectors.push(TREE_VIEW_BEHAVIOR_MARKER_SELECTORS[behavior])
+  }
+
+  const interactiveElement = target.closest(selectors.join(", "))
+  if (!interactiveElement) return false
+
+  if (root && typeof root.contains === "function") {
+    return root.contains(interactiveElement)
+  }
+
+  return true
+}

--- a/app/javascript/tree_view/state_controller.js
+++ b/app/javascript/tree_view/state_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { isTreeViewInteractiveTarget } from "./interactive.js"
 
 export class TreeViewStateController extends Controller {
   static targets = ["node"]
@@ -34,6 +35,7 @@ export class TreeViewStateController extends Controller {
 
   keydown(event) {
     if (!this.keyboardValue) return
+    if (isTreeViewInteractiveTarget(event.target, "keyboard", this.element)) return
 
     const row = this.currentNode(event)
     if (!row) return

--- a/app/javascript/tree_view/transfer_controller.js
+++ b/app/javascript/tree_view/transfer_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
+import { isTreeViewInteractiveTarget } from "./interactive.js"
 
 export class TreeViewTransferController extends Controller {
   start(event) {
+    if (isTreeViewInteractiveTarget(event.target, "drag", this.element)) return
+
     const row = this.rowFromEvent(event)
     if (!row || row.dataset.treeTransferDisabled === "true") return
 

--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -58,6 +58,28 @@ row_data_builder: ->(document) {
 }
 ```
 
+## Interactive controls inside draggable rows
+
+Rows that are draggable can still contain host-app controls such as links, buttons, inputs, selects, textareas, and `contenteditable` labels. TreeView ignores drag start events that originate from those native interactive controls so that using the control does not accidentally start a row transfer.
+
+For custom widgets that are not native controls, add a TreeView marker to the widget or an ancestor inside the row.
+
+```erb
+<td>
+  <span data-tree-view-interactive="true">Custom picker</span>
+</td>
+```
+
+Use `data-tree-view-ignore-drag="true"` when only drag start should be ignored and other TreeView behaviors may still apply.
+
+```erb
+<td>
+  <span data-tree-view-ignore-drag="true">Drag-safe widget</span>
+</td>
+```
+
+See [Usage](usage.md#interactive-controls-inside-rows) for keyboard and row interaction markers.
+
 ## Drop behavior
 
 Drop targets are implemented by the host app.
@@ -76,6 +98,7 @@ function onDrop(event) {
 | row transfer payload builder validation | yes | provides builder |
 | transfer data attributes | yes | consumes them |
 | dragstart helper | yes | wires action |
+| interactive-control drag-start guard | yes | marks custom widgets when needed |
 | drop target | no | yes |
 | reorder / move persistence | no | yes |
 | authorization | no | yes |

--- a/docs/en/host-app-extension-points.md
+++ b/docs/en/host-app-extension-points.md
@@ -34,6 +34,18 @@ row_partial: "documents/tree_columns"
 <td><%= item.owner_name %></td>
 ```
 
+The partial can include application-owned controls such as inputs, selects, buttons, links, and inline editable labels. TreeView ignores keyboard navigation and transfer drag start when events originate from native interactive controls. For custom controls, add `data-tree-view-interactive="true"` or a narrower marker such as `data-tree-view-ignore-keyboard="true"`, `data-tree-view-ignore-row-click="true"`, or `data-tree-view-ignore-drag="true"`.
+
+```erb
+<td>
+  <%= text_field_tag "documents[#{item.id}][name]", item.name %>
+  <%= link_to "Edit", edit_document_path(item) %>
+  <span data-tree-view-interactive="true">Custom picker</span>
+</td>
+```
+
+See [Usage](usage.md#interactive-controls-inside-rows) for complete row-control examples.
+
 ## Row class / data builders
 
 ```ruby
@@ -93,6 +105,7 @@ load_children_path_builder: ->(item, depth, scope) {
 | extension hook definitions | yes | no |
 | builder invocation | yes | provides builders |
 | business UI | no | yes |
+| interactive-control guards | yes | marks custom widgets when needed |
 | routes and controllers | no | yes |
 | authorization | no | yes |
 | CSS/design system | hooks only | yes |

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -129,6 +129,41 @@ Host-app-specific columns live in the configured `row_partial`.
 
 The partial receives `item`.
 
+## Interactive controls inside rows
+
+Host apps can place inputs, selects, textareas, buttons, links, and `contenteditable` labels inside `row_partial` or `row_actions_partial`. TreeView treats these native interactive elements as application-owned controls, so tree keyboard navigation and transfer drag start behavior ignore events that originate from them.
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td>
+  <%= text_field_tag "documents[#{item.id}][name]", item.name %>
+</td>
+```
+
+```erb
+<!-- app/views/documents/_tree_actions.html.erb -->
+<td>
+  <%= link_to "Edit", edit_document_path(item) %>
+  <%= button_to "Archive", archive_document_path(item), method: :post %>
+</td>
+```
+
+For custom widgets that are not native controls, add `data-tree-view-interactive="true"` to the widget or an ancestor inside the row.
+
+```erb
+<td>
+  <span data-tree-view-interactive="true" contenteditable="true"><%= item.name %></span>
+</td>
+```
+
+Use narrower markers when only one tree behavior should ignore the control:
+
+- `data-tree-view-ignore-keyboard="true"` prevents arrow, space, and enter keys from triggering TreeView keyboard navigation.
+- `data-tree-view-ignore-row-click="true"` is reserved for row-click integrations in host apps.
+- `data-tree-view-ignore-drag="true"` prevents TreeView transfer drag start from that control.
+
+These markers only opt a control out of TreeView behavior. Validation, persistence, authorization, CRUD routes, and inline editing flows still belong to the host app.
+
 ## Grouped options
 
 Initial expansion, render scope, and toggle scope can be configured with grouped options.

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -58,6 +58,28 @@ row_data_builder: ->(document) {
 }
 ```
 
+## draggable row内のinteractive control
+
+`draggable` なrowにも、link、button、input、select、textarea、`contenteditable` label などのhost app controlを配置できます。TreeViewはこれらのnative interactive controlから発生したdrag start eventを無視するため、control操作が誤ってrow transferを開始することはありません。
+
+native controlではないcustom widgetでは、row内のwidgetまたはその祖先にTreeView markerを付けます。
+
+```erb
+<td>
+  <span data-tree-view-interactive="true">Custom picker</span>
+</td>
+```
+
+Drag startだけを無視し、他のTreeView動作は残したい場合は `data-tree-view-ignore-drag="true"` を使います。
+
+```erb
+<td>
+  <span data-tree-view-ignore-drag="true">Drag-safe widget</span>
+</td>
+```
+
+keyboardやrow interaction向けのmarkerは [使い方](usage.md#行内のinteractive-control) を参照してください。
+
 ## drop処理
 
 drop先はhost app側で実装します。
@@ -76,6 +98,7 @@ function onDrop(event) {
 | row transfer payload builder validation | yes | provides builder |
 | transfer data attributes | yes | consumes them |
 | dragstart helper | yes | wires action |
+| interactive-control drag-start guard | yes | marks custom widgets when needed |
 | drop target | no | yes |
 | reorder / move persistence | no | yes |
 | authorization | no | yes |

--- a/docs/ja/host-app-extension-points.md
+++ b/docs/ja/host-app-extension-points.md
@@ -34,6 +34,18 @@ row_partial: "documents/tree_columns"
 <td><%= item.owner_name %></td>
 ```
 
+このpartialには、input、select、button、link、inline editable labelなど、host app側のcontrolも配置できます。TreeViewはnative interactive controlから発生したeventでは、keyboard navigationやtransfer drag startを実行しません。Custom controlでは、`data-tree-view-interactive="true"` または `data-tree-view-ignore-keyboard="true"`、`data-tree-view-ignore-row-click="true"`、`data-tree-view-ignore-drag="true"` のようなより狭いmarkerを付けます。
+
+```erb
+<td>
+  <%= text_field_tag "documents[#{item.id}][name]", item.name %>
+  <%= link_to "Edit", edit_document_path(item) %>
+  <span data-tree-view-interactive="true">Custom picker</span>
+</td>
+```
+
+詳しいrow control例は [使い方](usage.md#行内のinteractive-control) を参照してください。
+
 ## row class / data builders
 
 ```ruby
@@ -93,6 +105,7 @@ load_children_path_builder: ->(item, depth, scope) {
 | extension hook definitions | yes | no |
 | builder invocation | yes | provides builders |
 | business UI | no | yes |
+| interactive-control guards | yes | marks custom widgets when needed |
 | routes and controllers | no | yes |
 | authorization | no | yes |
 | CSS/design system | hooks only | yes |

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -72,7 +72,7 @@ tree_ui = TreeView::UiConfigBuilder.new(
   hide_descendants_path_builder: ->(item, depth, scope) {
     hide_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
   },
-  show_descendants_path_builder: ->(item, depth, scope) {
+  show_descendants_path_builder: ->(item, depth: depth, scope: scope) {
     show_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
   },
   toggle_all_path_builder: ->(state) {
@@ -126,6 +126,41 @@ host app固有の列は `row_partial` に実装します。
 ```
 
 このpartialでは `item` を使えます。
+
+## 行内のinteractive control
+
+host appは `row_partial` や `row_actions_partial` の中に、input、select、textarea、button、link、`contenteditable` label を配置できます。TreeViewはこれらのnative interactive elementをhost app側のcontrolとして扱い、それらから発生したeventではTreeViewのkeyboard navigationやtransfer drag startを実行しません。
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td>
+  <%= text_field_tag "documents[#{item.id}][name]", item.name %>
+</td>
+```
+
+```erb
+<!-- app/views/documents/_tree_actions.html.erb -->
+<td>
+  <%= link_to "Edit", edit_document_path(item) %>
+  <%= button_to "Archive", archive_document_path(item), method: :post %>
+</td>
+```
+
+native controlではないcustom widgetでは、row内のwidgetまたはその祖先に `data-tree-view-interactive="true"` を付けます。
+
+```erb
+<td>
+  <span data-tree-view-interactive="true" contenteditable="true"><%= item.name %></span>
+</td>
+```
+
+特定のTreeView動作だけを無視したい場合は、より狭いmarkerを使えます。
+
+- `data-tree-view-ignore-keyboard="true"` は、arrow key、space、enter によるTreeView keyboard navigationを抑止します。
+- `data-tree-view-ignore-row-click="true"` は、host app側のrow click連携向けに予約されています。
+- `data-tree-view-ignore-drag="true"` は、そのcontrolからTreeView transfer drag startが始まることを抑止します。
+
+これらのmarkerはTreeView側の動作を無視するためのものです。validation、保存、認可、CRUD route、inline editing flowは引き続きhost app側で実装します。
 
 ## grouped option
 

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -72,7 +72,7 @@ tree_ui = TreeView::UiConfigBuilder.new(
   hide_descendants_path_builder: ->(item, depth, scope) {
     hide_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
   },
-  show_descendants_path_builder: ->(item, depth: depth, scope: scope) {
+  show_descendants_path_builder: ->(item, depth, scope) {
     show_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
   },
   toggle_all_path_builder: ->(state) {


### PR DESCRIPTION
## Summary

- add a shared TreeView interactive target helper for native controls, contenteditable elements, and TreeView ignore markers
- skip TreeView keyboard navigation and transfer drag start when events originate from interactive row controls
- document inline form/action patterns and opt-out markers in English and Japanese usage guides
- add Vitest coverage for native controls, custom interactive markers, keyboard behavior, and drag start behavior

## Testing

- Not run locally: the execution environment cannot resolve github.com to clone/install the repository. Please rely on GitHub Actions for `npm test` and existing checks.

Closes #313