### PR TITLE
Document row customization cookbook patterns

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -16,6 +16,152 @@ For API details, see:
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
 
+## Row customization quick guide
+
+Use the smallest TreeView extension point that matches the UI you are adding.
+
+| Need | Recommended hook | Host app owns |
+|---|---|---|
+| Business data columns | `row_partial` | Field choice, formatting, links, permissions |
+| Edit, Show, Delete, Archive, or custom action buttons | `row_actions_partial` | Routes, controller actions, authorization, confirmation text |
+| Inputs, selects, or inline editable labels | `row_partial` or `row_actions_partial` | Form object, validation, dirty state, persistence |
+| Level labels | `depth_label_builder` | Label wording and localization |
+| Badges, status pills, or marker-like labels | `badge_builder` | Status names, classes, and product semantics |
+| Legacy/direct toggle-cell marker text | `marker_builder` when rendering toggle cells directly | Marker naming and classes |
+| Folder/file icons or type labels | `badge_builder`, `icon_builder`, or a cell in `row_partial` | Icon set, labels, and accessibility copy |
+| Current row highlighting or archived/disabled styling | `row_class_builder`, `row_data_builder`, and row-status docs | State rules and behavior |
+
+TreeView owns reusable tree structure, row rendering slots, toggle/selection hooks, and browser integration markers. CRUD, persistence, validation, authorization, product-specific actions, and host-app business workflows stay in the host app.
+
+## Add data display columns with row_partial
+
+Put the main row content in the configured `row_partial`. This is the right place for business columns such as name, owner, updated time, size, or type.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui
+)
+```
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td><%= item.name %></td>
+<td><%= item.owner_name %></td>
+<td><%= l(item.updated_at, format: :short) %></td>
+```
+
+Keep route decisions, authorization checks, and product-specific formatting in the host app partial.
+
+## Add row action links with row_actions_partial
+
+Use `row_actions_partial` for per-row action links and buttons such as Edit, Show, Delete, Archive, Duplicate, or application-specific actions.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  row_actions_partial: "documents/tree_actions",
+  ui_config: tree_ui
+)
+```
+
+```erb
+<!-- app/views/documents/_tree_actions.html.erb -->
+<td class="document-actions">
+  <%= link_to "Show", document_path(item) %>
+  <%= link_to "Edit", edit_document_path(item) %>
+  <%= button_to "Delete", document_path(item), method: :delete, data: { turbo_confirm: "Delete this document?" } %>
+</td>
+```
+
+The partial receives `item`, `tree`, and `render_state`. TreeView only supplies the slot; the host app owns routes, authorization, confirmation text, controller behavior, and persistence.
+
+## Put text input and select controls inside a row
+
+Native controls can live in row content or row actions. TreeView treats inputs, selects, textareas, buttons, links, and `contenteditable` labels as host-app controls and avoids starting tree keyboard navigation or transfer drag behavior from them.
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td>
+  <%= text_field_tag "documents[#{item.id}][name]", item.name %>
+</td>
+<td>
+  <%= select_tag "documents[#{item.id}][status]",
+        options_for_select(Document.statuses.keys, item.status) %>
+</td>
+```
+
+For custom widgets that are not native controls, add `data-tree-view-interactive="true"` to the widget or an ancestor.
+
+Validation, dirty-state handling, form submission, conflict handling, and persistence remain host-app responsibilities.
+
+## Customize depth labels, badges, markers, and icons
+
+Use `depth_label_builder` when the toggle cell should show a level label.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  depth_label_builder: ->(_document, depth) { "Level #{depth + 1}" }
+)
+```
+
+Use `badge_builder` for compact labels in the toggle cell, such as file type, workflow state, or attention markers.
+
+```ruby
+badge_builder = ->(document) {
+  if document.archived?
+    { text: "Archived", class: "is-muted", title: "This document is archived" }
+  elsif document.requires_review?
+    { text: "Review", class: "is-warning" }
+  end
+}
+```
+
+`badge_builder` may return text or a hash-like object with `text` or `label`, optional `class`, `title`, and `data`. For legacy direct rendering of toggle cells, `marker_builder` follows the same marker-style idea; prefer `badge_builder` with `RenderState` in new code.
+
+Use a badge or icon builder for compact folder/file type labels, or put richer icon markup in `row_partial` so the host app controls the HTML and accessibility copy.
+
+```ruby
+icon_builder = ->(document) {
+  document.folder? ? { text: "Folder", class: "is-folder" } : { text: "File", class: "is-file" }
+}
+```
+
+## Highlight current, archived, disabled, or status rows
+
+Use `row_class_builder` when visual state belongs on the whole `<tr>` and `badge_builder` when compact status text should appear near the toggle.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  row_class_builder: ->(document) {
+    [
+      "document-row",
+      ("is-current" if document.id == params[:id].to_i),
+      ("is-archived" if document.archived?),
+      ("is-disabled" unless document.editable?)
+    ]
+  },
+  badge_builder: ->(document) {
+    next { text: "Archived", class: "is-muted" } if document.archived?
+    next { text: "Locked", class: "is-locked" } unless document.editable?
+  }
+)
+```
+
+Use `row_data_builder` when host-app JavaScript needs stable metadata. If a row should be readonly or disabled for TreeView-level interaction, also see [Row status](row-status.md). Authorization decisions and business rules still belong in the host app.
+
 ## Stable name sorting
 
 ```ruby

--- a/docs/en/decision-guide.md
+++ b/docs/en/decision-guide.md
@@ -24,7 +24,9 @@ Use render controls first when the data is already available. Use lazy loading o
 | Show search results with ancestors | `path_tree_for` | `tree.path_tree_for(matches)` | Use when matched records need enough ancestors to preserve context from root to match. |
 | Show child-to-parent paths | `reverse_tree_for` | `tree.reverse_tree_for(items)` | Use when the primary display starts from children and expands toward parents. |
 | Add checkbox selection | `selection:` options | `enabled`, `checkbox_name`, `selected_keys`, `disabled_keys`, `visibility`, `cascade`, `max_selected` | TreeView renders selection state and values. The host app owns the submitted business action. |
-| Add editable fields inside rows | [Forms and editing rows](form-editing.md) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Objects | TreeView supports inline-editing layouts. The host app owns edit mode, validation, persistence, authorization, dirty-state handling, and Turbo workflows. |
+| Add editable fields inside rows | [Forms and editing rows](form-editing.md) and [Cookbook](cookbook.md#row-customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Objects | TreeView supports inline-editing layouts. The host app owns edit mode, validation, persistence, authorization, dirty-state handling, and Turbo workflows. |
+| Add row action buttons | [Cookbook](cookbook.md#row-customization-quick-guide) | `row_actions_partial` | Recommended slot for Edit, Show, Delete, Archive, and custom host-app actions. |
+| Customize level labels, badges, icons, or status visuals | [Cookbook](cookbook.md#row-customization-quick-guide) | `depth_label_builder`, `badge_builder`, `icon_builder`, `row_class_builder`, `row_data_builder` | TreeView provides rendering hooks; product-specific labels, statuses, and permissions stay in the host app. |
 | Add drag-and-drop | Drag/drop row hooks | Drag attributes and row event payloads | TreeView exposes integration hooks. The host app validates and persists the move. |
 | Persist expansion state | `TreeView::PersistedState`, `TreeView::StateStore` | `rails g tree_view:state:install`, persisted state model | Use when users should return to the same expanded/collapsed tree state. |
 | Validate tree data and identifiers | Diagnostics APIs | node key, DOM ID, orphan, and cycle diagnostics | Use during integration, tests, or admin diagnostics before rendering invalid structures. |
@@ -53,9 +55,11 @@ flowchart TD
   M -->|Children should point back to parents| O[reverse_tree_for]
   A --> P{Need interaction state?}
   P -->|Checkboxes| Q[selection: options]
-  P -->|Editable fields in rows| X[Forms and editing rows: host-app form workflow with TreeView row layouts]
+  P -->|Editable fields or row actions| X[row_partial / row_actions_partial plus host-app workflows]
   P -->|Expansion state between visits| R[PersistedState and StateStore]
   P -->|Drag/drop| S[Drag/drop hooks plus host-app handlers]
+  A --> Y{Need row visuals?}
+  Y -->|Level labels, badges, icons, status| Z[Cookbook row customization hooks]
   A --> T{Need confidence in input data?}
   T -->|Yes| U[Diagnostics APIs]
 ```
@@ -78,7 +82,7 @@ flowchart TD
 3. Use [Render Scale](render-scale.md) when HTML size or visible row count becomes the issue.
 4. Use [Lazy Loading](lazy-loading.md) and [Children Pagination](children-pagination.md) when query volume or child count is the issue.
 5. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
-6. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction requirements are clear.
+6. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
 7. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
 
 ## Common combinations
@@ -92,13 +96,16 @@ flowchart TD
 | Breadcrumb-like reverse view | `reverse_tree_for` + custom row partial |
 | Bulk action page | Static or Turbo rendering + `selection:` + host-app form action |
 | Bulk edit page | Static or Turbo rendering + row partial form controls + host-app Form Object |
-| Per-row inline edit page | Display row partials + host-app edit action/Turbo response + editing row partial |
+| Per-row inline edit page | Display row partials + `row_actions_partial` + host-app edit action / Turbo response + editing row partial |
+| Row action menu | `row_actions_partial` + host-app routes, authorization, and action handlers |
+| Status-heavy tree table | `row_class_builder` + `badge_builder` + host-app status rules |
 | Reorderable hierarchy | Static or Turbo rendering + drag/drop hooks + host-app move endpoint |
 
 ## Related docs
 
 - [API overview](api-overview.md)
 - [API reference](api.md)
+- [Cookbook: Row customization quick guide](cookbook.md#row-customization-quick-guide)
 - [Render Scale](render-scale.md)
 - [Lazy Loading](lazy-loading.md)
 - [Children Pagination](children-pagination.md)

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -129,6 +129,8 @@ Host-app-specific columns live in the configured `row_partial`.
 
 The partial receives `item`.
 
+Use `row_actions_partial` for per-row action links/buttons such as Edit, Show, Delete, Archive, and other host-app actions. For display columns, action links, inline controls, depth labels, badges, icons, and status markers, see [Cookbook: Row customization quick guide](cookbook.md#row-customization-quick-guide).
+
 ## Interactive controls inside rows
 
 Host apps can place inputs, selects, textareas, buttons, links, and `contenteditable` labels inside `row_partial` or `row_actions_partial`. TreeView treats these native interactive elements as application-owned controls, so tree keyboard navigation and transfer drag start behavior ignore events that originate from them.
@@ -268,6 +270,7 @@ reverse_tree = base_tree.reverse_tree_for(matched_documents)
 
 - [API overview](api-overview.md)
 - [API reference](../api.md)
+- [Cookbook: Row customization quick guide](cookbook.md#row-customization-quick-guide)
 - [Selection](../selection.md)
 - [Lazy Loading](../lazy-loading.md)
 - [Windowed Rendering](../windowed-rendering.md)

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -16,6 +16,152 @@ cookbook は、個別APIの詳細仕様ではなく、host appでよく使う構
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
 
+## 行customization quick guide
+
+追加したいUIに合わせて、最小のTreeView extension pointを使います。
+
+| やりたいこと | 推奨hook | host appの責務 |
+|---|---|---|
+| 業務データ列 | `row_partial` | 表示field、format、link、permission |
+| Edit、Show、Delete、Archive、独自action button | `row_actions_partial` | route、controller action、authorization、confirm文言 |
+| input、select、inline編集label | `row_partial` または `row_actions_partial` | Form Object、validation、dirty state、保存 |
+| level label | `depth_label_builder` | label文言とlocalization |
+| badge、status pill、marker風label | `badge_builder` | status名、class、product semantics |
+| legacy / direct toggle-cell marker text | toggle cellを直接描画する場合の `marker_builder` | marker名とclass |
+| folder/file iconやtype label | `badge_builder`、`icon_builder`、または `row_partial` 内のcell | icon set、label、accessibility文言 |
+| current row highlight、archived / disabled styling | `row_class_builder`、`row_data_builder`、Row status docs | 状態判定ruleとbehavior |
+
+TreeViewは再利用可能なtree構造、row rendering slot、toggle / selection hook、browser integration markerを提供します。CRUD、保存、validation、authorization、product固有action、host app固有workflowはhost app側で実装します。
+
+## row_partialで表示列を追加する
+
+主要なrow contentは設定した `row_partial` に置きます。name、owner、updated time、size、typeなどの業務列に向いています。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui
+)
+```
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td><%= item.name %></td>
+<td><%= item.owner_name %></td>
+<td><%= l(item.updated_at, format: :short) %></td>
+```
+
+route判断、authorization check、product固有formatはhost app partialに置きます。
+
+## row_actions_partialで行action linkを追加する
+
+Edit、Show、Delete、Archive、Duplicate、application固有actionなどの行単位action link / buttonは `row_actions_partial` に置きます。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  row_actions_partial: "documents/tree_actions",
+  ui_config: tree_ui
+)
+```
+
+```erb
+<!-- app/views/documents/_tree_actions.html.erb -->
+<td class="document-actions">
+  <%= link_to "Show", document_path(item) %>
+  <%= link_to "Edit", edit_document_path(item) %>
+  <%= button_to "Delete", document_path(item), method: :delete, data: { turbo_confirm: "Delete this document?" } %>
+</td>
+```
+
+このpartialでは `item`、`tree`、`render_state` を使えます。TreeViewはslotだけを提供し、route、authorization、confirm文言、controller behavior、保存はhost appが担当します。
+
+## 行内にtext inputやselectを置く
+
+native controlはrow contentにもrow actionsにも置けます。TreeViewは input、select、textarea、button、link、`contenteditable` label をhost app側controlとして扱い、そこからTreeView keyboard navigationやtransfer drag behaviorを開始しません。
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<td>
+  <%= text_field_tag "documents[#{item.id}][name]", item.name %>
+</td>
+<td>
+  <%= select_tag "documents[#{item.id}][status]",
+        options_for_select(Document.statuses.keys, item.status) %>
+</td>
+```
+
+native controlではないcustom widgetでは、widgetまたは祖先要素に `data-tree-view-interactive="true"` を付けます。
+
+validation、dirty-state handling、form submission、conflict handling、保存はhost app側の責務です。
+
+## depth label、badge、marker、iconをcustomizeする
+
+toggle cellにlevel labelを表示したい場合は `depth_label_builder` を使います。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  depth_label_builder: ->(_document, depth) { "Level #{depth + 1}" }
+)
+```
+
+file type、workflow state、注意喚起markerなどの短いlabelは `badge_builder` に向いています。
+
+```ruby
+badge_builder = ->(document) {
+  if document.archived?
+    { text: "Archived", class: "is-muted", title: "This document is archived" }
+  elsif document.requires_review?
+    { text: "Review", class: "is-warning" }
+  end
+}
+```
+
+`badge_builder` はtext、または `text` / `label`、任意の `class`、`title`、`data` を持つHash-like objectを返せます。toggle cellをlegacy / direct renderingする場合は `marker_builder` も同じmarker風labelとして使えます。新しい `RenderState` codeでは `badge_builder` を優先します。
+
+folder/file type labelを小さく表示する場合は badge / icon builder を使えます。より複雑なicon markupが必要なら、HTMLとaccessibility文言をhost appが管理できるよう `row_partial` に置きます。
+
+```ruby
+icon_builder = ->(document) {
+  document.folder? ? { text: "Folder", class: "is-folder" } : { text: "File", class: "is-file" }
+}
+```
+
+## current / archived / disabled / status rowを強調する
+
+`<tr>` 全体の見た目に関わる状態は `row_class_builder` を使い、toggle付近に短いstatus textを出したい場合は `badge_builder` を組み合わせます。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  row_class_builder: ->(document) {
+    [
+      "document-row",
+      ("is-current" if document.id == params[:id].to_i),
+      ("is-archived" if document.archived?),
+      ("is-disabled" unless document.editable?)
+    ]
+  },
+  badge_builder: ->(document) {
+    next { text: "Archived", class: "is-muted" } if document.archived?
+    next { text: "Locked", class: "is-locked" } unless document.editable?
+  }
+)
+```
+
+host app JavaScriptが安定したmetadataを必要とする場合は `row_data_builder` を使います。TreeView levelのinteractionとしてreadonly / disabledを表したい場合は [Row status](row-status.md) も参照してください。authorization decisionや業務ruleは引き続きhost app側で扱います。
+
 ## 名前順で安定ソートする
 
 ```ruby

--- a/docs/ja/decision-guide.md
+++ b/docs/ja/decision-guide.md
@@ -24,7 +24,9 @@ TreeViewのAPIは大きく分けると次の2種類です。
 | 検索結果をancestor付きで表示したい | `path_tree_for` | `tree.path_tree_for(matches)` | matchしたrecordをrootからの文脈付きで表示したい場合に使います。 |
 | childからparentへ辿る表示をしたい | `reverse_tree_for` | `tree.reverse_tree_for(items)` | 子側を起点にして親方向へ展開する表示に使います。 |
 | checkbox selectionを追加したい | `selection:` options | `enabled`, `checkbox_name`, `selected_keys`, `disabled_keys`, `visibility`, `cascade`, `max_selected` | TreeViewはselection stateとvalueを描画します。送信後の業務処理はhost appが担当します。 |
-| 行内に編集fieldを置きたい | [Form と編集行](form-editing.md) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Object | TreeViewはinline-editing layoutを支援します。edit mode、validation、persistence、authorization、dirty-state handling、Turbo workflowはhost appが担当します。 |
+| 行内に編集fieldを置きたい | [Form と編集行](form-editing.md) と [Cookbook](cookbook.md#行customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Object | TreeViewはinline-editing layoutを支援します。edit mode、validation、persistence、authorization、dirty-state handling、Turbo workflowはhost appが担当します。 |
+| 行action buttonを追加したい | [Cookbook](cookbook.md#行customization-quick-guide) | `row_actions_partial` | Edit、Show、Delete、Archive、host app固有actionの推奨slotです。 |
+| level label、badge、icon、status visualをcustomizeしたい | [Cookbook](cookbook.md#行customization-quick-guide) | `depth_label_builder`, `badge_builder`, `icon_builder`, `row_class_builder`, `row_data_builder` | TreeViewは描画hookを提供します。product固有label、status、permissionはhost app側に残します。 |
 | drag-and-dropを追加したい | Drag/drop row hooks | drag属性とrow event payload | TreeViewは連携hookを出します。移動のvalidationと永続化はhost appが担当します。 |
 | 開閉状態を保存したい | `TreeView::PersistedState`, `TreeView::StateStore` | `rails g tree_view:state:install`, persisted state model | ユーザが再訪したときに同じ開閉状態へ戻したい場合に使います。 |
 | tree dataや識別子を検証したい | Diagnostics APIs | node key、DOM ID、orphan、cycle diagnostics | integration時、test時、invalidな構造の描画前確認に使います。 |
@@ -53,9 +55,11 @@ flowchart TD
   M -->|childからparentへ見せたい| O[reverse_tree_for]
   A --> P{interaction stateが必要?}
   P -->|checkbox| Q[selection: options]
-  P -->|行内編集field| X[Form と編集行: TreeView row layout と host-app form workflow]
+  P -->|編集fieldや行action| X[row_partial / row_actions_partial と host-app workflow]
   P -->|訪問間で開閉状態を保存| R[PersistedState と StateStore]
   P -->|drag/drop| S[Drag/drop hooks と host-app handlers]
+  A --> Y{row visualが必要?}
+  Y -->|level label, badge, icon, status| Z[Cookbook row customization hooks]
   A --> T{input dataを検証したい?}
   T -->|はい| U[Diagnostics APIs]
 ```
@@ -78,7 +82,7 @@ flowchart TD
 3. HTML量やvisible row数が問題になったら [Render Scale](render-scale.md) を使います。
 4. query量や子要素数が問題になったら [Lazy Loading](lazy-loading.md) と [Children Pagination](children-pagination.md) を使います。
 5. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
-6. interaction要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
+6. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
 7. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
 
 ## よくある組み合わせ
@@ -92,13 +96,16 @@ flowchart TD
 | breadcrumb風のreverse view | `reverse_tree_for` + custom row partial |
 | bulk action page | StaticまたはTurbo rendering + `selection:` + host-app form action |
 | bulk edit page | StaticまたはTurbo rendering + row partial form controls + host-app Form Object |
-| per-row inline edit page | 表示用row partial + host-app edit action / Turbo response + 編集用row partial |
+| per-row inline edit page | 表示用row partial + `row_actions_partial` + host-app edit action / Turbo response + 編集用row partial |
+| row action menu | `row_actions_partial` + host-app route、authorization、action handler |
+| statusが多いtree table | `row_class_builder` + `badge_builder` + host-app status rules |
 | 並び替え可能な階層 | StaticまたはTurbo rendering + drag/drop hooks + host-app move endpoint |
 
 ## 関連docs
 
 - [API概要](api-overview.md)
 - [API仕様](api.md)
+- [Cookbook: 行customization quick guide](cookbook.md#行customization-quick-guide)
 - [Render Scale](render-scale.md)
 - [Lazy Loading](lazy-loading.md)
 - [Children Pagination](children-pagination.md)

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -127,6 +127,8 @@ host app固有の列は `row_partial` に実装します。
 
 このpartialでは `item` を使えます。
 
+Edit、Show、Delete、Archiveなどの行単位action link / buttonには `row_actions_partial` を使います。表示列、action link、inline control、depth label、badge、icon、status markerの例は [Cookbook: 行customization quick guide](cookbook.md#行customization-quick-guide) を参照してください。
+
 ## 行内のinteractive control
 
 host appは `row_partial` や `row_actions_partial` の中に、input、select、textarea、button、link、`contenteditable` label を配置できます。TreeViewはこれらのnative interactive elementをhost app側のcontrolとして扱い、それらから発生したeventではTreeViewのkeyboard navigationやtransfer drag startを実行しません。
@@ -266,6 +268,7 @@ reverse_tree = base_tree.reverse_tree_for(matched_documents)
 
 - [API概要](api-overview.md)
 - [API仕様](../api.md)
+- [Cookbook: 行customization quick guide](cookbook.md#行customization-quick-guide)
 - [Selection](../selection.md)
 - [Lazy Loading](../lazy-loading.md)
 - [Windowed Rendering](../windowed-rendering.md)


### PR DESCRIPTION
## Summary

- Add English and Japanese cookbook examples for row customization patterns.
- Document `row_actions_partial` as the recommended slot for row action links and buttons.
- Cover data display columns, inline controls, depth labels, badges, marker-style labels, folder/file labels, current row highlighting, and archived/disabled/status row visuals.
- Link the row customization cookbook from usage docs and the API decision guides.
- Reaffirm that CRUD, persistence, validation, authorization, and product-specific actions remain host-app responsibilities.

## Testing

- Not run; documentation-only change.

Closes #314