### PR TITLE
Add toggle icon customization API

### DIFF
--- a/app/helpers/tree_view_helper/visuals.rb
+++ b/app/helpers/tree_view_helper/visuals.rb
@@ -28,6 +28,40 @@ module TreeViewHelper
       (depth.to_i >= 10) ? depth.to_i.to_s : "Lv#{depth}"
     end
 
+    def tree_toggle_icon(item, state, builder = nil, depth:, tree:, children: nil, hidden_count: nil, mode: nil, leaf_distance: nil)
+      return nil unless builder
+
+      context = {
+        state: state.to_sym,
+        depth: depth,
+        tree: tree,
+        children: Array(children),
+        hidden_count: hidden_count,
+        mode: mode,
+        leaf_distance: leaf_distance
+      }
+      value = builder.call(item, context[:state], context)
+      return nil if value.nil?
+
+      if value.respond_to?(:to_h)
+        icon = value.to_h.symbolize_keys
+        content = icon[:html] || icon[:text] || icon[:label] || icon[:icon]
+        return nil if content.blank?
+
+        tag.span(
+          content,
+          class: ["tree-toggle__icon", icon[:class]].flatten.compact_blank,
+          title: icon[:title],
+          data: icon[:data].respond_to?(:to_h) ? icon[:data].to_h : {},
+          aria: {hidden: icon.fetch(:aria_hidden, true)}
+        )
+      else
+        value
+      end
+    rescue NoMethodError
+      raise ArgumentError, "toggle_icon_builder must return text or a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
+    end
+
     def tree_context_menu_label(item)
       item.respond_to?(:name) ? item.name : item.to_s
     end

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -22,13 +22,22 @@
 <% row_aria[:expanded] = !effectively_collapsed if children.any? %>
 <% row_aria[:current] = "page" if row_context.current? %>
 <% hidden_count = render_children && effectively_collapsed && row_context.descendant_count.positive? && render_self ? row_context.descendant_count : nil %>
+<% toggle_state = if render_context.loading_builder&.call(item)
+                    :loading
+                  elsif hidden_count
+                    :collapsed
+                  elsif children.any?
+                    :expanded
+                  else
+                    :leaf
+                  end %>
 <% if render_self %>
   <%= tag.tr(**row_attrs) do %>
     <% if render_context.selection_enabled? %>
       <% selection_visible = tree_selection_visible?(item, tree, depth, render_context.selection_visibility) %>
       <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_visible: selection_visible, selection_payload_builder: render_context.selection_payload_builder, selection_checkbox_name: render_context.selection_checkbox_name, selection_disabled_builder: render_context.selection_disabled_builder, selection_disabled_reason_builder: render_context.selection_disabled_reason_builder, selection_selected_keys: render_context.selection_selected_keys %>
     <% end %>
-    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: render_context.hidden_message_builder, depth_label_builder: render_context.depth_label_builder, badge_builder: render_context.badge_builder, mode: mode, max_toggle_depth_from_root: render_context.max_toggle_depth_from_root, max_toggle_leaf_distance: render_context.max_toggle_leaf_distance, leaf_distance: leaf_distance %>
+    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: render_context.hidden_message_builder, depth_label_builder: render_context.depth_label_builder, badge_builder: render_context.badge_builder, toggle_icon_builder: render_context.toggle_icon_builder, toggle_state: toggle_state, mode: mode, max_toggle_depth_from_root: render_context.max_toggle_depth_from_root, max_toggle_leaf_distance: render_context.max_toggle_leaf_distance, leaf_distance: leaf_distance %>
     <%= render row_partial, item: item %>
     <% if row_actions_partial %>
       <%= render row_actions_partial, item: item, tree: tree, render_state: render_context.render_state %>

--- a/app/views/tree_view/_tree_toggle_cell.html.erb
+++ b/app/views/tree_view/_tree_toggle_cell.html.erb
@@ -3,6 +3,8 @@
 <% depth_label_builder = local_assigns[:depth_label_builder] %>
 <% badge_builder = local_assigns[:badge_builder] %>
 <% marker_builder = local_assigns[:marker_builder] %>
+<% toggle_icon_builder = local_assigns[:toggle_icon_builder] %>
+<% toggle_state = local_assigns[:toggle_state] || :leaf %>
 <% children ||= tree.children_for(item) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
@@ -20,7 +22,7 @@
             end %>
 
 <td class="btn-cell tree-toggle-cell" id="<%= tree_button_dom_id(item) %>">
-  <%= render 'tree_view/tree_toggle_content', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
+  <%= render 'tree_view/tree_toggle_content', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, toggle_icon_builder: toggle_icon_builder, toggle_state: toggle_state, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
   <% if marker %>
     <%= tag.span marker[:text], class: ['tree-node-marker', marker[:class]].flatten.compact_blank, title: marker[:title], data: marker[:data] %>
   <% end %>

--- a/app/views/tree_view/_tree_toggle_content_static.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_static.html.erb
@@ -1,9 +1,12 @@
 <% hidden_count = local_assigns[:hidden_count] %>
 <% hidden_message_builder = local_assigns[:hidden_message_builder] %>
+<% toggle_icon_builder = local_assigns[:toggle_icon_builder] %>
+<% toggle_state = local_assigns[:toggle_state] || :leaf %>
 <% children ||= tree.children_for(item) %>
 <% branch_info = tree_branch_info(item, tree) %>
 <% ancestor_last_states = branch_info[:ancestor_last_states] %>
 <% is_last = branch_info[:is_last] %>
+<% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :static, leaf_distance: local_assigns[:leaf_distance]) %>
 
 <div class="tree-toggle">
   <div class="tree-toggle__branches" aria-hidden="true">
@@ -15,7 +18,7 @@
     <% end %>
   </div>
   <div class="tree-toggle__control">
-    <span class="tree-toggle__level"><%= tree_toggle_label(depth) %></span>
+    <span class="tree-toggle__level"><%= toggle_icon || tree_toggle_label(depth) %></span>
     <% if hidden_count %>
       <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %><span class="visually-hidden"> descendants</span></span>
     <% end %>

--- a/app/views/tree_view/_tree_toggle_content_turbo.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_turbo.html.erb
@@ -1,5 +1,7 @@
 <% hidden_count = local_assigns[:hidden_count] %>
 <% hidden_message_builder = local_assigns[:hidden_message_builder] %>
+<% toggle_icon_builder = local_assigns[:toggle_icon_builder] %>
+<% toggle_state = local_assigns[:toggle_state] || :leaf %>
 <% children ||= tree.children_for(item) %>
 <% branch_info = tree_branch_info(item, tree) %>
 <% ancestor_last_states = branch_info[:ancestor_last_states] %>
@@ -10,6 +12,7 @@
 <% toggle_scope = tree_toggle_scope(depth: depth, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance) %>
 <% show_path = tree_show_descendants_path(item, depth + 1, scope: toggle_scope) %>
 <% hide_path = tree_hide_descendants_path(item, depth, scope: toggle_scope) %>
+<% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :turbo, leaf_distance: leaf_distance) %>
 
 <div class="tree-toggle">
   <div class="tree-toggle__branches" aria-hidden="true">
@@ -23,14 +26,14 @@
   <div class="tree-toggle__control">
     <% if hidden_count && show_path %>
       <%= link_to show_path, data: { turbo_stream: true }, class: 'btn btn-primary show-button tree-toggle__action', id: tree_show_button_dom_id(item), aria: { expanded: false } do %>
-        <%= tree_toggle_label(depth) %>
+        <%= toggle_icon || tree_toggle_label(depth) %>
       <% end %>
     <% elsif children.any? && hide_path %>
       <%= link_to hide_path, data: { turbo_stream: true }, class: 'btn btn-danger remove-button tree-toggle__action', aria: { expanded: true } do %>
-        <%= tree_toggle_label(depth) %>
+        <%= toggle_icon || tree_toggle_label(depth) %>
       <% end %>
     <% else %>
-      <span class="tree-toggle__level"><%= tree_toggle_label(depth) %></span>
+      <span class="tree-toggle__level"><%= toggle_icon || tree_toggle_label(depth) %></span>
     <% end %>
     <% if hidden_count %>
       <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %></span>

--- a/app/views/tree_view/_tree_window_row.html.erb
+++ b/app/views/tree_view/_tree_window_row.html.erb
@@ -20,13 +20,22 @@
 <% row_aria[:expanded] = visible_row.expanded? if visible_row.has_children? %>
 <% row_aria[:current] = "page" if row_context.current? %>
 <% hidden_count = render_children && effectively_collapsed && row_context.descendant_count.positive? && render_self ? row_context.descendant_count : nil %>
+<% toggle_state = if render_context.loading_builder&.call(item)
+                    :loading
+                  elsif hidden_count
+                    :collapsed
+                  elsif children.any?
+                    :expanded
+                  else
+                    :leaf
+                  end %>
 <% if render_self %>
   <%= tag.tr(**row_attrs) do %>
     <% if render_context.selection_enabled? %>
       <% selection_visible = tree_selection_visible?(item, tree, depth, render_context.selection_visibility) %>
       <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_visible: selection_visible, selection_payload_builder: render_context.selection_payload_builder, selection_checkbox_name: render_context.selection_checkbox_name, selection_disabled_builder: render_context.selection_disabled_builder, selection_disabled_reason_builder: render_context.selection_disabled_reason_builder, selection_selected_keys: render_context.selection_selected_keys %>
     <% end %>
-    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: render_context.hidden_message_builder, depth_label_builder: render_context.depth_label_builder, badge_builder: render_context.badge_builder, mode: mode, max_toggle_depth_from_root: render_context.max_toggle_depth_from_root, max_toggle_leaf_distance: render_context.max_toggle_leaf_distance, leaf_distance: leaf_distance %>
+    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: render_context.hidden_message_builder, depth_label_builder: render_context.depth_label_builder, badge_builder: render_context.badge_builder, toggle_icon_builder: render_context.toggle_icon_builder, toggle_state: toggle_state, mode: mode, max_toggle_depth_from_root: render_context.max_toggle_depth_from_root, max_toggle_leaf_distance: render_context.max_toggle_leaf_distance, leaf_distance: leaf_distance %>
     <%= render row_partial, item: item %>
     <% if row_actions_partial %>
       <%= render row_actions_partial, item: item, tree: tree, render_state: render_context.render_state %>

--- a/docs/en/toggle-icons.md
+++ b/docs/en/toggle-icons.md
@@ -1,0 +1,83 @@
+# Toggle icon customization
+
+Use `toggle_icon_builder:` when you want to replace the visual content of TreeView's expand/collapse control without taking over the control itself.
+
+TreeView still owns link generation, Turbo Stream data attributes, ARIA state, depth/branch layout, and lazy-loading semantics. The builder only supplies the content rendered inside the toggle control.
+
+## Builder arguments
+
+```ruby
+toggle_icon_builder: ->(item, state, context) { ... }
+```
+
+| Argument | Description |
+|---|---|
+| `item` | The row item. |
+| `state` | One of `:expanded`, `:collapsed`, `:leaf`, or `:loading`. |
+| `context` | Hash containing `:state`, `:depth`, `:tree`, `:children`, `:hidden_count`, `:mode`, and `:leaf_distance`. |
+
+The builder may return plain text or a Hash-like value. Hash values support:
+
+| Key | Description |
+|---|---|
+| `:text`, `:label`, `:icon`, `:html` | Content to render. |
+| `:class` | Extra CSS class or classes for the wrapper. |
+| `:title` | Optional title attribute. |
+| `:data` | Optional data attributes. |
+| `:aria_hidden` | Whether to mark the icon wrapper as `aria-hidden`; defaults to `true`. |
+
+## Simple text symbols
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icon_builder: ->(_item, state, _context) {
+    case state
+    when :expanded then "▾"
+    when :collapsed then "▸"
+    else "•"
+    end
+  }
+)
+```
+
+## CSS icon classes
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icon_builder: ->(_item, state, _context) {
+    icon_class = case state
+    when :expanded then "fa fa-chevron-down"
+    when :collapsed then "fa fa-chevron-right"
+    when :loading then "fa fa-spinner fa-spin"
+    else "fa fa-file"
+    end
+
+    { text: "", class: ["document-toggle-icon", icon_class], title: state.to_s }
+  }
+)
+```
+
+## Inline SVG or helper-rendered content
+
+Because the builder output is rendered inside TreeView's existing toggle action, keep custom content decorative and avoid placing buttons or links inside it.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icon_builder: ->(_item, state, _context) {
+    icon_name = (state == :expanded) ? "chevron-down" : "chevron-right"
+    { html: helpers.inline_svg_tag("icons/#{icon_name}.svg"), class: "document-toggle-svg" }
+  }
+)
+```

--- a/docs/ja/toggle-icons.md
+++ b/docs/ja/toggle-icons.md
@@ -1,0 +1,83 @@
+# toggle icon のカスタマイズ
+
+`toggle_icon_builder:` を使うと、TreeView の開閉コントロール自体は TreeView に任せたまま、見た目の中身だけを差し替えられます。
+
+TreeView は引き続き link 生成、Turbo Stream の data 属性、ARIA 状態、depth / branch layout、lazy-loading semantics を管理します。builder は toggle control の内側に描画する内容だけを返します。
+
+## builder の引数
+
+```ruby
+toggle_icon_builder: ->(item, state, context) { ... }
+```
+
+| 引数 | 説明 |
+|---|---|
+| `item` | row item。 |
+| `state` | `:expanded`, `:collapsed`, `:leaf`, `:loading` のいずれか。 |
+| `context` | `:state`, `:depth`, `:tree`, `:children`, `:hidden_count`, `:mode`, `:leaf_distance` を含む Hash。 |
+
+builder は plain text または Hash-like な値を返せます。Hash では以下を指定できます。
+
+| key | 説明 |
+|---|---|
+| `:text`, `:label`, `:icon`, `:html` | 描画する内容。 |
+| `:class` | wrapper に追加する CSS class。 |
+| `:title` | 任意の title 属性。 |
+| `:data` | 任意の data 属性。 |
+| `:aria_hidden` | icon wrapper に `aria-hidden` を付けるか。既定値は `true`。 |
+
+## simple な文字記号
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icon_builder: ->(_item, state, _context) {
+    case state
+    when :expanded then "▾"
+    when :collapsed then "▸"
+    else "•"
+    end
+  }
+)
+```
+
+## CSS icon class
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icon_builder: ->(_item, state, _context) {
+    icon_class = case state
+    when :expanded then "fa fa-chevron-down"
+    when :collapsed then "fa fa-chevron-right"
+    when :loading then "fa fa-spinner fa-spin"
+    else "fa fa-file"
+    end
+
+    { text: "", class: ["document-toggle-icon", icon_class], title: state.to_s }
+  }
+)
+```
+
+## inline SVG や helper-rendered content
+
+builder の出力は TreeView 既存の toggle action の内側に描画されます。custom content は装飾用途にとどめ、button や link を入れ子にしないでください。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icon_builder: ->(_item, state, _context) {
+    icon_name = (state == :expanded) ? "chevron-down" : "chevron-right"
+    { html: helpers.inline_svg_tag("icons/#{icon_name}.svg"), class: "document-toggle-svg" }
+  }
+)
+```

--- a/lib/tree_view/render_context.rb
+++ b/lib/tree_view/render_context.rb
@@ -31,6 +31,7 @@ module TreeView
       :depth_label_builder,
       :badge_builder,
       :icon_builder,
+      :toggle_icon_builder,
       keyword_init: true
     ) do
       def effective_initial_state
@@ -78,7 +79,8 @@ module TreeView
           error_builder: local_assigns[:error_builder],
           depth_label_builder: local_assigns[:depth_label_builder],
           badge_builder: local_assigns[:badge_builder],
-          icon_builder: local_assigns[:icon_builder]
+          icon_builder: local_assigns[:icon_builder],
+          toggle_icon_builder: local_assigns[:toggle_icon_builder]
         ),
         mode: local_assigns[:mode],
         collapsed: local_assigns.fetch(:collapsed, false)
@@ -227,6 +229,12 @@ module TreeView
 
     def icon_builder
       render_state.icon_builder
+    end
+
+    def toggle_icon_builder
+      return nil unless render_state.respond_to?(:toggle_icon_builder)
+
+      render_state.toggle_icon_builder
     end
   end
 end

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -45,7 +45,8 @@ module TreeView
       :error_builder,
       :depth_label_builder,
       :badge_builder,
-      :icon_builder
+      :icon_builder,
+      :toggle_icon_builder
 
     # RenderState は「この画面ではどう描くか」を束ねる。
     def initialize(tree:,
@@ -82,7 +83,8 @@ module TreeView
       error_builder: nil,
       depth_label_builder: nil,
       badge_builder: nil,
-      icon_builder: nil)
+      icon_builder: nil,
+      toggle_icon_builder: nil)
       initial_expansion_options = normalize_options(initial_expansion, :initial_expansion, VALID_INITIAL_EXPANSION_KEYS)
       render_scope_options = normalize_options(render_scope, :render_scope, VALID_RENDER_SCOPE_KEYS)
       toggle_scope_options = normalize_options(toggle_scope, :toggle_scope, VALID_TOGGLE_SCOPE_KEYS)
@@ -120,6 +122,7 @@ module TreeView
       @depth_label_builder = depth_label_builder
       @badge_builder = badge_builder
       @icon_builder = icon_builder
+      @toggle_icon_builder = toggle_icon_builder
 
       validate_builders!(
         row_class_builder: row_class_builder,
@@ -130,6 +133,7 @@ module TreeView
         depth_label_builder: depth_label_builder,
         badge_builder: badge_builder,
         icon_builder: icon_builder,
+        toggle_icon_builder: toggle_icon_builder,
         selection_payload_builder: @selection_payload_builder,
         selection_disabled_builder: @selection_disabled_builder,
         selection_disabled_reason_builder: @selection_disabled_reason_builder

--- a/spec/integration/tree_view_toggle_icon_builder_integration_spec.rb
+++ b/spec/integration/tree_view_toggle_icon_builder_integration_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+require "action_view"
+require "fileutils"
+require "tmpdir"
+
+ToggleIconBuilderNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+RSpec.describe "TreeView toggle_icon_builder integration" do
+  let(:root) { ToggleIconBuilderNode.new(id: 1, parent_item_id: nil, name: "root") }
+  let(:child) { ToggleIconBuilderNode.new(id: 2, parent_item_id: 1, name: "child") }
+  let(:leaf) { ToggleIconBuilderNode.new(id: 3, parent_item_id: 2, name: "leaf") }
+  let(:nodes) { [root, child, leaf] }
+  let(:tree) { TreeView::Tree.new(records: nodes, parent_id_method: :parent_item_id) }
+  let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
+  let(:host_view_dir) { Dir.mktmpdir("tree_view_host_views") }
+
+  before do
+    FileUtils.mkdir_p(File.join(host_view_dir, "projects"))
+    File.write(
+      File.join(host_view_dir, "projects", "_tree_columns.html.erb"),
+      '<td class="project-cell"><%= item.name %></td>'
+    )
+  end
+
+  after do
+    FileUtils.remove_entry(host_view_dir) if Dir.exist?(host_view_dir)
+  end
+
+  def build_view(tree_ui:)
+    view = ActionView::Base.with_empty_template_cache.with_view_paths([host_view_dir, gem_view_path], {}, nil)
+    view.extend(TreeViewHelper)
+    view.instance_variable_set(:@tree_ui, tree_ui)
+    view
+  end
+
+  it "customizes static toggle content with state context" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      initial_state: :collapsed,
+      toggle_icon_builder: ->(item, state, context) {
+        {text: "#{state}:#{context[:depth]}:#{item.name}", class: "icon-#{state}"}
+      }
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state)
+
+    expect(rendered).to include('class="tree-toggle__icon icon-collapsed"')
+    expect(rendered).to include("collapsed:0:root")
+    expect(rendered).to include('aria-expanded="false"')
+    expect(rendered).to include("tree-toggle__hidden-count")
+  end
+
+  it "customizes turbo toggle link labels while preserving link behavior and ARIA" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build(
+      hide_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/hide?depth=#{depth}&scope=#{scope}" },
+      show_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/show?depth=#{depth}&scope=#{scope}" },
+      toggle_all_path_builder: ->(state) { "/projects/toggle_all?state=#{state}" }
+    )
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      toggle_icon_builder: ->(item, state, _context) {
+        {text: "#{state}:#{item.name}", class: ["chevron", "chevron-#{state}"]}
+      }
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state, mode: :turbo)
+
+    expect(rendered).to include("/projects/1/hide?depth=0&amp;scope=all")
+    expect(rendered).to include('data-turbo-stream="true"')
+    expect(rendered).to include('aria-expanded="true"')
+    expect(rendered).to include('class="tree-toggle__icon chevron chevron-expanded"')
+    expect(rendered).to include("expanded:root")
+    expect(rendered).to include('class="tree-toggle__icon chevron chevron-leaf"')
+    expect(rendered).to include("leaf:leaf")
+  end
+end


### PR DESCRIPTION
## Summary

- Add `toggle_icon_builder` to `TreeView::RenderState` and legacy render locals.
- Render custom toggle content for `:expanded`, `:collapsed`, `:leaf`, and `:loading` states while keeping TreeView-owned link behavior, Turbo attributes, ARIA attributes, and hidden-count rendering intact.
- Add integration coverage for static and Turbo toggle rendering.
- Add English and Japanese docs with simple text-symbol, CSS-class, and inline SVG examples.

## Notes

- Local `git clone` was not available in the execution environment because `github.com` DNS resolution failed, so I validated generated Ruby files with `ruby -c` before committing and used the connected GitHub API for repository changes.
- The branch is currently behind the latest `main`; GitHub should indicate if an update or conflict resolution is required.

Closes #312