### PR TITLE
Add browser smoke tests for JavaScript controllers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
       - run: bundle exec rake
 
   javascript:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -83,8 +82,9 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - run: npm ci
-      - run: npm test
+      - run: npm install
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:js
 
   gem_package:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/app/javascript/tree_view/browser_smoke.html
+++ b/app/javascript/tree_view/browser_smoke.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>TreeView browser smoke fixture</title>
+  </head>
+  <body>
+    <main id="fixture"></main>
+    <script type="module">
+      import { Application } from "@hotwired/stimulus"
+      import { registerTreeViewControllers } from "./index.js"
+
+      window.treeViewSmoke = {
+        application: null,
+        events: [],
+        async mount(markup) {
+          if (this.application) this.application.stop()
+          this.events = []
+          const fixture = document.querySelector("#fixture")
+          fixture.innerHTML = markup
+          this.application = Application.start()
+          registerTreeViewControllers(this.application)
+          fixture.addEventListener("tree-view-state:state-changed", (event) => this.events.push({ type: event.type, detail: event.detail }))
+          fixture.addEventListener("tree-view-selection:change", (event) => this.events.push({ type: event.type, detail: event.detail }))
+          fixture.addEventListener("tree-view-remote-state:change", (event) => this.events.push({ type: event.type, detail: event.detail }))
+          fixture.addEventListener("tree-view-remote-state:retry", (event) => this.events.push({ type: event.type, detail: event.detail }))
+          fixture.addEventListener("tree-view-transfer:drop", (event) => this.events.push({ type: event.type, detail: event.detail }))
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        },
+        reset() {
+          if (this.application) this.application.stop()
+          this.application = null
+          this.events = []
+          document.querySelector("#fixture").innerHTML = ""
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -25,6 +25,7 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm test
+npm run test:browser
 ```
 
 For the Rails version matrix:
@@ -34,21 +35,35 @@ BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
 ```
 
+## JavaScript browser smoke tests
+
+Unit-style JavaScript tests run through Vitest and jsdom with:
+
+```bash
+npm test
+```
+
+Browser-level smoke tests run through Playwright with:
+
+```bash
+npm run test:browser
+```
+
+Use the browser smoke suite for representative interaction flows that need a real browser event loop, focus handling, and drag/drop APIs. Keep these tests small and stable: cover keyboard navigation, expand/collapse, checkbox cascade behavior, lazy-loading state changes, transfer payloads, and row form controls coexisting with tree behavior.
+
 ## CI policy
 
-Pull requests run the fast Ruby checks that protect day-to-day changes:
+Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-day changes:
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
+- JavaScript unit and browser smoke tests through `npm run test:js`
 
-Pushes to `main` run the broader compatibility and release checks:
+Pushes to `main` also run the broader compatibility and release checks:
 
 - Ruby version matrix
 - Rails version matrix
-- JavaScript tests
 - gem package verification
-
-This keeps pull request feedback focused on Ruby behavior and public API regressions while reserving heavier compatibility and packaging verification for `main` and release decisions.
 
 ## Change checklist
 
@@ -62,6 +77,7 @@ This keeps pull request feedback focused on Ruby behavior and public API regress
 ### JavaScript changes
 
 - Run `npm test`.
+- Run `npm run test:browser` when browser interactions, focus, drag/drop, or real form controls are affected.
 - Check importmap and packaged files.
 - Confirm JavaScript entrypoint compatibility.
 
@@ -76,6 +92,7 @@ This keeps pull request feedback focused on Ruby behavior and public API regress
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - `npm test`
+- `npm run test:browser`
 - `bundle exec rake build`
 - gem package contents
 - CHANGELOG

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -25,6 +25,7 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm test
+npm run test:browser
 ```
 
 Rails version matrixを確認する場合:
@@ -34,21 +35,35 @@ BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
 ```
 
+## JavaScript browser smoke tests
+
+Unit-style JavaScript testsはVitestとjsdomで実行します。
+
+```bash
+npm test
+```
+
+Browser-level smoke testsはPlaywrightで実行します。
+
+```bash
+npm run test:browser
+```
+
+Browser smoke suiteは、実ブラウザのevent loop、focus handling、drag/drop APIで差が出やすい代表的なinteraction flowを確認するために使います。Keyboard navigation、expand/collapse、checkbox cascade、lazy-loading state changes、transfer payloads、row form controlsとtree behaviorの共存を、小さく安定したtestsで守ります。
+
 ## CI方針
 
-Pull Requestでは、日常的な変更を守る高速なRuby checksを実行します。
+Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScript testsを実行します。
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
+- JavaScript unit and browser smoke tests: `npm run test:js`
 
-`main` へのpushでは、より広い互換性確認とrelease向けのchecksを実行します。
+`main` へのpushでは、より広い互換性確認とrelease向けのchecksも実行します。
 
 - Ruby version matrix
 - Rails version matrix
-- JavaScript tests
 - gem package verification
-
-この方針により、PRではRuby behaviorとpublic API regressionsを早く検出し、重い互換性確認とpackage検証は `main` / release判定で確認します。
 
 ## 変更時の確認ポイント
 
@@ -62,6 +77,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksを実行し
 ### JavaScriptを変更した場合
 
 - `npm test` を確認する
+- Browser interaction、focus、drag/drop、実際のform controlsに影響する場合は `npm run test:browser` を確認する
 - importmap / packaged files に影響がないか確認する
 - JavaScript entrypointの互換性を確認する
 
@@ -76,6 +92,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksを実行し
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - `npm test`
+- `npm run test:browser`
 - `bundle exec rake build`
 - gem package contents
 - CHANGELOG

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:browser": "playwright test",
+    "test:js": "npm test && npm run test:browser"
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@vitest/ui": "^4.0.7",
     "jsdom": "^27.1.0",
     "vitest": "^4.0.7"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const chromiumLaunchOptions = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+  ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH, args: ["--no-sandbox"] }
+  : { args: ["--no-sandbox"] }
+
+export default defineConfig({
+  testDir: "./test/browser",
+  timeout: 10_000,
+  expect: {
+    timeout: 2_000
+  },
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry"
+  },
+  webServer: {
+    command: "npx vite app/javascript/tree_view --host localhost --port 4173 --strictPort",
+    url: "http://localhost:4173/browser_smoke.html",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: chromiumLaunchOptions
+      }
+    }
+  ]
+})

--- a/test/browser/tree_view_smoke.spec.js
+++ b/test/browser/tree_view_smoke.spec.js
@@ -1,0 +1,167 @@
+import { expect, test } from "@playwright/test"
+
+async function openFixture(page, markup) {
+  await page.goto("/browser_smoke.html")
+  await page.evaluate((html) => window.treeViewSmoke.mount(html), markup)
+}
+
+test.afterEach(async ({ page }) => {
+  await page.evaluate(() => window.treeViewSmoke.reset())
+})
+
+test("keyboard navigation moves focus and expands or collapses rows", async ({ page }) => {
+  await openFixture(page, `
+    <table
+      data-controller="tree-view-state"
+      data-tree-view-state-keyboard-value="true"
+      data-action="keydown->tree-view-state#keydown"
+    >
+      <tbody>
+        <tr id="row-1" data-tree-view-state-target="node" data-tree-view-state-node-key="project:1" data-tree-view-state-expanded="true">
+          <td><button class="remove-button" type="button" data-action="click->tree-view-state#markCollapsed">Collapse</button></td>
+        </tr>
+        <tr id="row-2" data-tree-view-state-target="node" data-tree-view-state-node-key="project:2" data-tree-view-state-expanded="false">
+          <td><button class="show-button" type="button" data-action="click->tree-view-state#markExpanded">Expand</button></td>
+        </tr>
+      </tbody>
+    </table>
+  `)
+
+  await page.locator("#row-1").focus()
+  await page.keyboard.press("ArrowDown")
+  await expect(page.locator("#row-2")).toBeFocused()
+
+  await page.keyboard.press("ArrowRight")
+  await expect(page.locator("#row-2")).toHaveAttribute("data-tree-view-state-expanded", "true")
+
+  await page.locator("#row-1").focus()
+  await page.keyboard.press("ArrowLeft")
+  await expect(page.locator("#row-1")).toHaveAttribute("data-tree-view-state-expanded", "false")
+})
+
+test("row form controls do not trigger tree keyboard behavior", async ({ page }) => {
+  await openFixture(page, `
+    <table
+      data-controller="tree-view-state"
+      data-tree-view-state-keyboard-value="true"
+      data-action="keydown->tree-view-state#keydown"
+    >
+      <tbody>
+        <tr id="row-1" data-tree-view-state-target="node" data-tree-view-state-node-key="project:1" data-tree-view-state-expanded="false">
+          <td>
+            <button class="show-button" type="button" data-action="click->tree-view-state#markExpanded">Expand</button>
+            <input id="row-input" value="Editable row text">
+            <a id="row-link" href="#inside-row">Inline link</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `)
+
+  await page.locator("#row-input").focus()
+  await page.keyboard.press("ArrowRight")
+  await expect(page.locator("#row-1")).toHaveAttribute("data-tree-view-state-expanded", "false")
+
+  await page.locator("#row-link").focus()
+  await page.keyboard.press("Enter")
+  await expect(page.locator("#row-1")).toHaveAttribute("data-tree-view-state-expanded", "false")
+})
+
+test("checkbox selection cascades to enabled descendants only", async ({ page }) => {
+  await openFixture(page, `
+    <table data-controller="tree-view-selection" data-tree-view-selection-cascade-value="true" data-tree-view-selection-indeterminate-value="true">
+      <tbody>
+        <tr data-tree-depth="0">
+          <td><input id="parent" class="tree-selection-checkbox" type="checkbox" value='{"key":"project:1"}' data-action="change->tree-view-selection#toggle"></td>
+        </tr>
+        <tr data-tree-depth="1">
+          <td><input id="enabled-child" class="tree-selection-checkbox" type="checkbox" value='{"key":"project:2"}' data-action="change->tree-view-selection#toggle"></td>
+        </tr>
+        <tr data-tree-depth="1">
+          <td><input id="disabled-child" class="tree-selection-checkbox" type="checkbox" value='{"key":"project:3"}' disabled data-action="change->tree-view-selection#toggle"></td>
+        </tr>
+      </tbody>
+    </table>
+  `)
+
+  await page.locator("#parent").check()
+  await expect(page.locator("#enabled-child")).toBeChecked()
+  await expect(page.locator("#disabled-child")).not.toBeChecked()
+
+  const latestSelection = await page.evaluate(() => window.treeViewSmoke.events.findLast((event) => event.type === "tree-view-selection:change")?.detail)
+  expect(latestSelection.selectedPayloads).toEqual([{ key: "project:1" }, { key: "project:2" }])
+})
+
+test("lazy-loading state actions mark rows as loading, loaded, error, and retry", async ({ page }) => {
+  await openFixture(page, `
+    <table data-controller="tree-view-remote-state">
+      <tbody>
+        <tr id="remote-row" data-tree-view-state-target="node" data-tree-view-state-node-key="project:1" data-tree-children-url="/projects/1/children">
+          <td>
+            <button id="loading" data-action="click->tree-view-remote-state#loading">Loading</button>
+            <button id="loaded" data-action="click->tree-view-remote-state#loaded">Loaded</button>
+            <button id="error" data-action="click->tree-view-remote-state#error">Error</button>
+            <button id="retry" data-action="click->tree-view-remote-state#retry">Retry</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `)
+
+  await page.locator("#loading").click()
+  await expect(page.locator("#remote-row")).toHaveAttribute("data-remote-state", "loading")
+
+  await page.locator("#loaded").click()
+  await expect(page.locator("#remote-row")).toHaveAttribute("data-remote-state", "loaded")
+  await expect(page.locator("#remote-row")).toHaveAttribute("data-tree-loaded", "true")
+
+  await page.locator("#error").click()
+  await expect(page.locator("#remote-row")).toHaveAttribute("data-remote-state", "error")
+
+  await page.locator("#retry").click()
+  await expect(page.locator("#remote-row")).toHaveAttribute("data-remote-state", "loading")
+
+  const eventTypes = await page.evaluate(() => window.treeViewSmoke.events.map((event) => event.type))
+  expect(eventTypes).toContain("tree-view-remote-state:change")
+  expect(eventTypes).toContain("tree-view-remote-state:retry")
+})
+
+test("drag and drop emits source payload, target payload, and target position", async ({ page }) => {
+  await openFixture(page, `
+    <table data-controller="tree-view-transfer">
+      <tbody>
+        <tr id="source-row" draggable="true" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:1"}' data-action="dragstart->tree-view-transfer#start">
+          <td>Source</td>
+        </tr>
+        <tr id="target-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:2"}' data-action="dragover->tree-view-transfer#over drop->tree-view-transfer#drop">
+          <td>Target</td>
+        </tr>
+      </tbody>
+    </table>
+  `)
+
+  const detail = await page.evaluate(() => {
+    const dataTransfer = new DataTransfer()
+    const source = document.querySelector("#source-row")
+    const target = document.querySelector("#target-row")
+    target.getBoundingClientRect = () => ({ top: 0, height: 90, left: 0, right: 100, bottom: 90, width: 100 })
+
+    source.dispatchEvent(new DragEvent("dragstart", { bubbles: true, dataTransfer }))
+    target.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, clientY: 80, dataTransfer }))
+
+    const drop = window.treeViewSmoke.events.findLast((event) => event.type === "tree-view-transfer:drop")
+    return {
+      sourcePayload: drop.detail.sourcePayload,
+      targetPayload: drop.detail.targetPayload,
+      position: drop.detail.position,
+      targetRowId: drop.detail.targetRow.id
+    }
+  })
+
+  expect(detail).toEqual({
+    sourcePayload: { key: "project:1" },
+    targetPayload: { key: "project:2" },
+    position: "after",
+    targetRowId: "target-row"
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     environment: "jsdom",
-    globals: true
+    globals: true,
+    include: ["app/javascript/**/*.test.js"]
   }
 })


### PR DESCRIPTION
## Summary
- Add a Playwright browser smoke fixture for the TreeView JavaScript controllers.
- Cover keyboard navigation, expand/collapse behavior, row form controls, checkbox cascade behavior, lazy-loading states, and drag/drop payload/position behavior.
- Add `test:browser` / `test:js` scripts, keep Vitest scoped to unit-style specs, run JavaScript checks in CI, and document the workflow in English and Japanese.

## Testing
- `npm install --ignore-scripts` in a partial local fixture.
- Not fully run locally: `npm run test:browser` because this sandbox could not download Playwright Chromium and its system Chromium blocked localhost navigation with `ERR_BLOCKED_BY_ADMINISTRATOR`. CI installs Playwright Chromium before running the suite.

Closes #302
