### PR TITLE
docs: expand baseline TreeView mockups

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -71,7 +71,9 @@ Root compatibility selectors for API, usage, public API, release, design policy,
 
 | Asset | Status | Notes |
 |---|---|---|
+| `docs/mockups/README.md` | Technical asset | Index for static mockup assets. Short bilingual-style prose is acceptable; no separate translation needed. |
 | `docs/mockups/default-tree.html` | Technical asset | No translation needed. |
+| `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |
 
 ## Release readiness documentation checks

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -1,0 +1,22 @@
+# TreeView mockups
+
+This directory contains static HTML/CSS mockups for reviewing TreeView's baseline output without running a Rails app.
+
+These files are intentionally small, reviewable assets in the gem repository. They show representative DOM structure, CSS hooks, ARIA attributes, and row states emitted by the reusable TreeView primitives.
+
+They are **not** a complete Rails application and should not grow into host-app CRUD, query, authorization, seed data, or controller examples. Full playground/application examples belong in `matsuo-haruhito/tree_view-rails-demo` once that demo repository is public.
+
+## Files
+
+| File | Covers |
+|---|---|
+| [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
+
+## Review policy
+
+- Prefer static HTML/CSS that can be inspected directly in pull-request diffs.
+- Keep mockups product-neutral and free of host-app business behavior.
+- Add screenshots only when visual regression review needs them; the source HTML/CSS should remain the canonical mockup.
+- If a mockup needs Rails routes, controllers, database records, authorization, or Turbo responses to make sense, it belongs in a playground app rather than this directory.

--- a/docs/mockups/default-tree.css
+++ b/docs/mockups/default-tree.css
@@ -71,6 +71,26 @@ h2 {
   background: #fffaf0;
 }
 
+.tree-row.is-loading,
+.tree-row.tree-row--pagination {
+  background: #f8fafc;
+}
+
+.tree-row.is-error,
+.tree-row.is-drop-disabled {
+  background: #fff1f2;
+}
+
+.tree-row.is-dragging {
+  opacity: 0.62;
+  outline: 2px dashed #94a3b8;
+}
+
+.tree-row.is-drop-target {
+  background: #ecfdf5;
+  outline: 2px solid #86efac;
+}
+
 .tree-selection-cell {
   width: 4rem;
   text-align: center;
@@ -175,6 +195,11 @@ h2 {
   background: #eff6ff;
 }
 
+.tree-toggle__action--pending {
+  color: #64748b;
+  background: #f8fafc;
+}
+
 .tree-toggle__level,
 .tree-depth-label {
   display: inline-flex;
@@ -226,6 +251,16 @@ h2 {
 .mock-status--archived {
   background: #fef3c7;
   color: #92400e;
+}
+
+.mock-status--pending {
+  background: #e2e8f0;
+  color: #334155;
+}
+
+.mock-status--error {
+  background: #ffe4e6;
+  color: #9f1239;
 }
 
 .tree-row-actions button {

--- a/docs/mockups/interaction-states.html
+++ b/docs/mockups/interaction-states.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView interaction states mock</title>
+<link rel="stylesheet" href="default-tree.css">
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView interaction states mock</h1>
+      <p>
+        Lazy loading、loading、error/retry、children pagination、drag/drop の代表的な見た目とDOM hookを確認するための静的HTMLです。
+        Rails controller、Turbo Stream response、query、authorizationはhost appの責務なので、このmockには含めません。
+      </p>
+    </header>
+
+    <section class="mock-section" aria-labelledby="lazy-heading">
+      <h2 id="lazy-heading">Lazy loading and retry states</h2>
+      <table class="tree-view-table" data-controller="tree-view-state tree-view-remote-state">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">remote state</th>
+            <th scope="col">actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="folder_1" class="tree-row is-expanded" data-tree-node-key="folder:1" data-tree-depth="0" data-tree-expanded="true" data-tree-remote-state="loaded" aria-level="1" aria-expanded="true">
+            <td class="btn-cell tree-toggle-cell" id="folder_1_button">
+              <span class="tree-toggle" aria-label="Loaded branch">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                  <span class="tree-toggle__level">loaded</span>
+                </span>
+              </span>
+            </td>
+            <td>Loaded folder</td>
+            <td><span class="mock-status mock-status--active">loaded</span></td>
+            <td class="tree-row-actions"><button type="button">Refresh</button></td>
+          </tr>
+
+          <tr id="folder_2" class="tree-row is-loading" data-tree-node-key="folder:2" data-tree-depth="0" data-tree-expanded="false" data-tree-remote-state="loading" aria-level="1" aria-expanded="false" aria-busy="true">
+            <td class="btn-cell tree-toggle-cell" id="folder_2_button">
+              <span class="tree-toggle" aria-label="Loading children">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__action tree-toggle__action--pending">load</span>
+                  <span class="tree-toggle__level">loading</span>
+                </span>
+              </span>
+            </td>
+            <td>Loading folder</td>
+            <td><span class="mock-status mock-status--pending">loading children…</span></td>
+            <td class="tree-row-actions"><button type="button" disabled>Loading</button></td>
+          </tr>
+
+          <tr id="folder_3" class="tree-row is-error" data-tree-node-key="folder:3" data-tree-depth="0" data-tree-expanded="false" data-tree-remote-state="error" aria-level="1" aria-expanded="false">
+            <td class="btn-cell tree-toggle-cell" id="folder_3_button">
+              <span class="tree-toggle" aria-label="Loading failed">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">retry</a>
+                  <span class="tree-toggle__level">error</span>
+                </span>
+              </span>
+            </td>
+            <td>Failed folder</td>
+            <td><span class="mock-status mock-status--error">load failed</span></td>
+            <td class="tree-row-actions"><button type="button">Retry</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="pagination-heading">
+      <h2 id="pagination-heading">Children pagination state</h2>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">page state</th>
+            <th scope="col">actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="page_parent_1" class="tree-row is-expanded" data-tree-node-key="folder:large" data-tree-depth="0" data-tree-expanded="true" data-tree-next-page-cursor="cursor-002" aria-level="1" aria-expanded="true">
+            <td class="btn-cell tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Large child set">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control"><span class="tree-toggle__level">page 1</span></span>
+              </span>
+            </td>
+            <td>Large folder</td>
+            <td><span class="mock-status mock-status--active">25 of many loaded</span></td>
+            <td class="tree-row-actions"><button type="button">Load next page</button></td>
+          </tr>
+          <tr id="page_more_1" class="tree-row tree-row--pagination" data-tree-parent-key="folder:large" data-tree-depth="1" aria-level="2">
+            <td class="btn-cell tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Next page control">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control"><span class="tree-toggle__level">more</span></span>
+              </span>
+            </td>
+            <td>More children are available</td>
+            <td><span class="mock-status mock-status--pending">cursor: cursor-002</span></td>
+            <td class="tree-row-actions"><button type="button">Load more</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="drag-heading">
+      <h2 id="drag-heading">Drag/drop visual states</h2>
+      <table class="tree-view-table" data-controller="tree-view-transfer">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">drop state</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="drag_1" class="tree-row is-dragging" draggable="true" data-tree-node-key="task:1" data-tree-transfer-payload='{"key":"task:1","type":"Task"}' aria-level="1">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">drag</span></span></span></td>
+            <td>Dragged task</td>
+            <td><span class="mock-status mock-status--pending">dragging</span></td>
+          </tr>
+          <tr id="drag_2" class="tree-row is-drop-target" data-tree-node-key="task:2" data-tree-drop-position="inside" aria-level="1">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">target</span></span></span></td>
+            <td>Valid folder target</td>
+            <td><span class="mock-status mock-status--active">drop inside</span></td>
+          </tr>
+          <tr id="drag_3" class="tree-row is-drop-disabled" data-tree-node-key="task:3" data-tree-drop-disabled-reason="Readonly node" aria-level="1" aria-disabled="true">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">blocked</span></span></span></td>
+            <td>Readonly target</td>
+            <td><span class="mock-status mock-status--error">drop disabled</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add `docs/mockups/README.md` to explain the purpose and scope of static mockups.
- Add `docs/mockups/interaction-states.html` covering lazy-loading, loading, error/retry, children pagination, and drag/drop visual states.
- Extend the shared mockup CSS for interaction, pending, error, drag, and drop states.
- Update the i18n audit technical-assets table for the new mockup files.

## Issue triage

This closes #311 because the repository now has reviewable static HTML/CSS mockups for baseline TreeView output, selection, lazy-loading/loading/error states, children pagination, and drag/drop states while explicitly keeping host-app CRUD/query/auth examples out of the gem repository.

Closes #311

## Tests

- Not run; documentation/static mockup changes only.