### PR TITLE
Add client-side tree toggle mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Breaking changes and required migration notes should be called out explicitly in
 
 - Added `TreeView.configuration.render_log_level`, defaulting to `:warn`, so TreeView helper-rendered partial logs can be silenced without changing the host app's global Rails logger level.
 - Added a public TreeView-specific error hierarchy rooted at `TreeView::Error` for rescuing validation and configuration failures.
+- Added explicit `UiConfig#mode` values for `:turbo`, `:static`, and `:client`, plus `UiConfigBuilder#build_turbo` and `UiConfigBuilder#build_client_side`.
+- Added client-side-only expand/collapse mode that renders collapsed descendants into initial HTML and toggles rows in the browser with the bundled `tree-view-client` controller.
 
 ### Changed
 
@@ -28,6 +30,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 - Added README adoption guidance to help users decide whether TreeView fits their use case and to clarify the virtual scrolling boundary.
 - Added accessibility semantics docs for table-first TreeView rows and ARIA placement policy.
+- Added client-side toggle mode docs in Japanese and English, including static / Turbo / client-side mode comparison and CSS customization guidance using `aria-expanded`.
 - Added error hierarchy docs in Japanese and English, including public rescue guidance and `ArgumentError` compatibility notes.
 - Added form and editing row docs for bulk edit forms, inline-editing layouts, Form Objects, validation errors, row actions, and host-app responsibility boundaries.
 - Added public name decision docs in Japanese and English.
@@ -39,6 +42,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 - Added render traversal regression specs for deep trees, wide trees, collapsed render scope, filtered path trees, sorter call growth, children lookup scope, and max leaf distance behavior.
 - Added specs for TreeView-specific error rescue behavior.
+- Added Ruby and JavaScript specs for client-side toggle mode, mode builders, public API exports, and browser-local descendant visibility updates.
 
 ## 0.1.0 - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ For very large trees, combine TreeView's render controls with host-app loading a
 - Render static tree rows.
 - Suppress TreeView partial render noise by default with configurable render log silencing.
 - Integrate Turbo Stream expand/collapse actions through path builders.
+- Expand/collapse small to medium trees in the browser with client-side toggle mode.
 - Use `GraphAdapter` for heterogeneous or graph-like nodes.
 - Use `PathTree` for matched nodes with ancestor paths.
 - Use `ReverseTree` for child-to-parent paths.
@@ -53,7 +54,7 @@ For very large trees, combine TreeView's render controls with host-app loading a
 - Add lazy loading hooks with `load_children_path_builder` and `RenderState#lazy_loading`.
 - Add checkbox selection with JSON payloads, disabled states, selected keys, cascade, indeterminate state, and max-count limits.
 - Persist expansion state through `TreeView::PersistedState`, `TreeView::StateStore`, and `rails g tree_view:state:install`.
-- Register JavaScript controllers for state tracking, selection, transfer payloads, and remote loading state.
+- Register JavaScript controllers for state tracking, client-side toggling, selection, transfer payloads, and remote loading state.
 
 ## Out of scope
 

--- a/app/helpers/tree_view_helper/render_scope.rb
+++ b/app/helpers/tree_view_helper/render_scope.rb
@@ -45,10 +45,10 @@ module TreeViewHelper
     end
 
     def tree_toggle_mode(mode = nil)
-      resolved_mode = (mode || (@tree_ui&.static? ? :static : :turbo)).to_sym
-      return resolved_mode if %i[static turbo].include?(resolved_mode)
+      resolved_mode = (mode || @tree_ui&.mode || (@tree_ui&.static? ? :static : :turbo)).to_sym
+      return resolved_mode if TreeView::UiConfig::TOGGLE_MODES.include?(resolved_mode)
 
-      raise ArgumentError, "TreeView toggle mode must be :static or :turbo, got: #{mode.inspect}"
+      raise ArgumentError, "TreeView toggle mode must be one of: #{TreeView::UiConfig::TOGGLE_MODES.join(", ")}, got: #{mode.inspect}"
     end
   end
 end

--- a/app/helpers/tree_view_helper/row_attributes.rb
+++ b/app/helpers/tree_view_helper/row_attributes.rb
@@ -31,10 +31,20 @@ module TreeViewHelper
         data = data.merge(remote_state: "loaded")
       end
 
-      data
+      data = data
         .merge(tree_depth: depth)
         .merge(tree_state_row_data(item, tree, expanded: expanded))
         .merge(transfer_data || {})
+
+      if tree_toggle_mode(render_context.mode) == :client
+        data = data.merge(
+          tree_view_client_node_key: tree.node_key_for(item),
+          tree_view_client_depth: depth,
+          tree_view_client_expanded: expanded
+        )
+      end
+
+      data
     end
 
     def tree_node_badge(item, builder = nil, tree: nil)

--- a/app/helpers/tree_view_state_helper.rb
+++ b/app/helpers/tree_view_state_helper.rb
@@ -3,6 +3,7 @@
 module TreeViewStateHelper
   def tree_view_state_data(render_state)
     controllers = ["tree-view-state"]
+    controllers << "tree-view-client" if render_state.respond_to?(:ui_config) && render_state.ui_config.respond_to?(:client?) && render_state.ui_config.client?
     controllers << "tree-view-selection" if render_state.selection_enabled?
     controllers << "tree-view-transfer" if render_state.respond_to?(:row_event_payload_builder) && render_state.row_event_payload_builder
     controllers << "tree-view-remote-state" if render_state.respond_to?(:lazy_loading_enabled?) && render_state.lazy_loading_enabled?

--- a/app/javascript/tree_view/client_controller.js
+++ b/app/javascript/tree_view/client_controller.js
@@ -43,9 +43,11 @@ export class TreeViewClientController extends Controller {
     if (!nodeKey) return
 
     this.element
-      .querySelectorAll(`[data-tree-view-client-hidden-count-for="${CSS.escape(nodeKey)}"]`)
+      .querySelectorAll("[data-tree-view-client-hidden-count-for]")
       .forEach((element) => {
-        element.hidden = !visible
+        if (element.dataset.treeViewClientHiddenCountFor === String(nodeKey)) {
+          element.hidden = !visible
+        }
       })
   }
 

--- a/app/javascript/tree_view/client_controller.js
+++ b/app/javascript/tree_view/client_controller.js
@@ -1,0 +1,59 @@
+import { Controller } from "@hotwired/stimulus"
+
+export class TreeViewClientController extends Controller {
+  toggle(event) {
+    const button = event.currentTarget
+    const row = this.rowForButton(button)
+    if (!row) return
+
+    const nextExpanded = !this.expanded(row)
+    this.setExpanded(row, button, nextExpanded)
+    this.refreshRows()
+  }
+
+  connect() {
+    this.refreshRows()
+  }
+
+  rowForButton(button) {
+    const key = button.dataset.treeViewClientNodeKey
+    if (!key) return button.closest("[data-tree-view-client-node-key]")
+
+    return this.rows().find((row) => row.dataset.treeViewClientNodeKey === key)
+  }
+
+  rows() {
+    return Array.from(this.element.querySelectorAll("[data-tree-view-client-node-key]"))
+  }
+
+  expanded(row) {
+    return row.dataset.treeViewClientExpanded === "true"
+  }
+
+  setExpanded(row, button, expanded) {
+    const value = expanded ? "true" : "false"
+    row.dataset.treeViewClientExpanded = value
+    row.dataset.treeViewStateExpanded = value
+    row.setAttribute("aria-expanded", value)
+    if (button) button.setAttribute("aria-expanded", value)
+  }
+
+  refreshRows() {
+    const collapsedDepths = []
+
+    this.rows().forEach((row) => {
+      const depth = Number.parseInt(row.dataset.treeViewClientDepth || "0", 10)
+
+      while (collapsedDepths.length > 0 && collapsedDepths[collapsedDepths.length - 1] >= depth) {
+        collapsedDepths.pop()
+      }
+
+      const hiddenByAncestor = collapsedDepths.length > 0
+      row.hidden = hiddenByAncestor
+
+      if (!this.expanded(row)) {
+        collapsedDepths.push(depth)
+      }
+    })
+  }
+}

--- a/app/javascript/tree_view/client_controller.js
+++ b/app/javascript/tree_view/client_controller.js
@@ -36,6 +36,17 @@ export class TreeViewClientController extends Controller {
     row.dataset.treeViewStateExpanded = value
     row.setAttribute("aria-expanded", value)
     if (button) button.setAttribute("aria-expanded", value)
+    this.setHiddenCountVisible(row.dataset.treeViewClientNodeKey, !expanded)
+  }
+
+  setHiddenCountVisible(nodeKey, visible) {
+    if (!nodeKey) return
+
+    this.element
+      .querySelectorAll(`[data-tree-view-client-hidden-count-for="${CSS.escape(nodeKey)}"]`)
+      .forEach((element) => {
+        element.hidden = !visible
+      })
   }
 
   refreshRows() {
@@ -50,6 +61,7 @@ export class TreeViewClientController extends Controller {
 
       const hiddenByAncestor = collapsedDepths.length > 0
       row.hidden = hiddenByAncestor
+      this.setHiddenCountVisible(row.dataset.treeViewClientNodeKey, !this.expanded(row))
 
       if (!this.expanded(row)) {
         collapsedDepths.push(depth)

--- a/app/javascript/tree_view/client_controller.js
+++ b/app/javascript/tree_view/client_controller.js
@@ -17,13 +17,13 @@ export class TreeViewClientController extends Controller {
 
   rowForButton(button) {
     const key = button.dataset.treeViewClientNodeKey
-    if (!key) return button.closest("[data-tree-view-client-node-key]")
+    if (!key) return button.closest("[data-tree-view-client-depth][data-tree-view-client-node-key]")
 
     return this.rows().find((row) => row.dataset.treeViewClientNodeKey === key)
   }
 
   rows() {
-    return Array.from(this.element.querySelectorAll("[data-tree-view-client-node-key]"))
+    return Array.from(this.element.querySelectorAll("[data-tree-view-client-depth][data-tree-view-client-node-key]"))
   }
 
   expanded(row) {

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -1,8 +1,10 @@
+import { TreeViewClientController } from "./client_controller.js"
 import { TreeViewRemoteStateController } from "./remote_state_controller.js"
 import { TreeViewSelectionController } from "./selection_controller.js"
 import { TreeViewStateController } from "./state_controller.js"
 import { TreeViewTransferController } from "./transfer_controller.js"
 
+export { TreeViewClientController } from "./client_controller.js"
 export { TreeViewRemoteStateController } from "./remote_state_controller.js"
 export { TreeViewSelectionController } from "./selection_controller.js"
 export { TreeViewStateController } from "./state_controller.js"
@@ -10,6 +12,7 @@ export { TreeViewTransferController } from "./transfer_controller.js"
 
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
+  application.register("tree-view-client", TreeViewClientController)
   application.register("tree-view-selection", TreeViewSelectionController)
   application.register("tree-view-transfer", TreeViewTransferController)
   application.register("tree-view-remote-state", TreeViewRemoteStateController)

--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -52,13 +52,16 @@ describe("TreeViewClientController", () => {
     document.body.innerHTML = `
       <table data-controller="tree-view-client">
         <tbody>
-          <tr id="row-1" data-tree-view-client-node-key="1" data-tree-view-client-depth="0" data-tree-view-client-expanded="false" data-tree-view-state-expanded="false" aria-expanded="false"></tr>
-          <tr id="row-2" data-tree-view-client-node-key="2" data-tree-view-client-depth="1" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden></tr>
-          <tr id="row-3" data-tree-view-client-node-key="3" data-tree-view-client-depth="2" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden></tr>
-          <tr id="row-4" data-tree-view-client-node-key="4" data-tree-view-client-depth="1" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden></tr>
+          <tr id="row-1" data-tree-view-client-node-key="1" data-tree-view-client-depth="0" data-tree-view-client-expanded="false" data-tree-view-state-expanded="false" aria-expanded="false">
+            <td>
+              <button id="toggle-1" data-action="tree-view-client#toggle" data-tree-view-client-node-key="1" aria-expanded="false"></button>
+              <span id="hidden-count-1" data-tree-view-client-hidden-count-for="1">3</span>
+            </td>
+          </tr>
+          <tr id="row-2" data-tree-view-client-node-key="2" data-tree-view-client-depth="1" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden><td></td></tr>
+          <tr id="row-3" data-tree-view-client-node-key="3" data-tree-view-client-depth="2" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden><td></td></tr>
+          <tr id="row-4" data-tree-view-client-node-key="4" data-tree-view-client-depth="1" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden><td></td></tr>
         </tbody>
-        <button id="toggle-1" data-action="tree-view-client#toggle" data-tree-view-client-node-key="1" aria-expanded="false"></button>
-        <span id="hidden-count-1" data-tree-view-client-hidden-count-for="1">3</span>
       </table>
     `
 

--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -72,7 +72,12 @@ describe("TreeViewClientController", () => {
     document.body.innerHTML = ""
   })
 
-  it("keeps descendants hidden while an ancestor is collapsed"), () => {}
+  it("keeps descendants hidden while an ancestor is collapsed", () => {
+    expect(document.querySelector("#row-2").hidden).toBe(true)
+    expect(document.querySelector("#row-3").hidden).toBe(true)
+    expect(document.querySelector("#row-4").hidden).toBe(true)
+    expect(document.querySelector("#hidden-count-1").hidden).toBe(false)
+  })
 
   it("opens descendants in the browser and preserves nested expansion state", () => {
     const button = document.querySelector("#toggle-1")

--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -2,6 +2,7 @@ import { Application } from "@hotwired/stimulus"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { isTreeViewInteractiveTarget } from "./interactive.js"
 import {
+  TreeViewClientController,
   TreeViewRemoteStateController,
   TreeViewSelectionController,
   TreeViewStateController,
@@ -41,6 +42,63 @@ describe("tree view interactive target helpers", () => {
     expect(isTreeViewInteractiveTarget(document.querySelector("#keyboard-only"), "keyboard", root)).toBe(true)
     expect(isTreeViewInteractiveTarget(document.querySelector("#row-click-only"), "rowClick", root)).toBe(true)
     expect(isTreeViewInteractiveTarget(document.querySelector("#keyboard-only"), "rowClick", root)).toBe(false)
+  })
+})
+
+describe("TreeViewClientController", () => {
+  let application
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <table data-controller="tree-view-client">
+        <tbody>
+          <tr id="row-1" data-tree-view-client-node-key="1" data-tree-view-client-depth="0" data-tree-view-client-expanded="false" data-tree-view-state-expanded="false" aria-expanded="false"></tr>
+          <tr id="row-2" data-tree-view-client-node-key="2" data-tree-view-client-depth="1" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden></tr>
+          <tr id="row-3" data-tree-view-client-node-key="3" data-tree-view-client-depth="2" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden></tr>
+          <tr id="row-4" data-tree-view-client-node-key="4" data-tree-view-client-depth="1" data-tree-view-client-expanded="true" data-tree-view-state-expanded="true" aria-expanded="true" hidden></tr>
+        </tbody>
+        <button id="toggle-1" data-action="tree-view-client#toggle" data-tree-view-client-node-key="1" aria-expanded="false"></button>
+        <span id="hidden-count-1" data-tree-view-client-hidden-count-for="1">3</span>
+      </table>
+    `
+
+    application = Application.start()
+    application.register("tree-view-client", TreeViewClientController)
+    await nextFrame()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  it("keeps descendants hidden while an ancestor is collapsed"), () => {}
+
+  it("opens descendants in the browser and preserves nested expansion state", () => {
+    const button = document.querySelector("#toggle-1")
+    button.click()
+
+    expect(document.querySelector("#row-1").dataset.treeViewClientExpanded).toBe("true")
+    expect(document.querySelector("#row-1").dataset.treeViewStateExpanded).toBe("true")
+    expect(document.querySelector("#row-1").getAttribute("aria-expanded")).toBe("true")
+    expect(button.getAttribute("aria-expanded")).toBe("true")
+    expect(document.querySelector("#row-2").hidden).toBe(false)
+    expect(document.querySelector("#row-3").hidden).toBe(false)
+    expect(document.querySelector("#row-4").hidden).toBe(false)
+    expect(document.querySelector("#hidden-count-1").hidden).toBe(true)
+
+    button.click()
+
+    expect(document.querySelector("#row-1").dataset.treeViewClientExpanded).toBe("false")
+    expect(document.querySelector("#row-2").hidden).toBe(true)
+    expect(document.querySelector("#row-3").hidden).toBe(true)
+    expect(document.querySelector("#row-4").hidden).toBe(true)
+    expect(document.querySelector("#hidden-count-1").hidden).toBe(false)
+
+    button.click()
+
+    expect(document.querySelector("#row-2").hidden).toBe(false)
+    expect(document.querySelector("#row-3").hidden).toBe(false)
   })
 })
 

--- a/app/javascript/tree_view/public_api_compatibility.test.js
+++ b/app/javascript/tree_view/public_api_compatibility.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import {
+  TreeViewClientController,
   TreeViewRemoteStateController,
   TreeViewSelectionController,
   TreeViewStateController,
@@ -10,6 +11,7 @@ import {
 describe("TreeView JavaScript public API compatibility", () => {
   it("keeps documented controller exports available", () => {
     expect(TreeViewStateController).toBeTypeOf("function")
+    expect(TreeViewClientController).toBeTypeOf("function")
     expect(TreeViewSelectionController).toBeTypeOf("function")
     expect(TreeViewTransferController).toBeTypeOf("function")
     expect(TreeViewRemoteStateController).toBeTypeOf("function")
@@ -21,6 +23,7 @@ describe("TreeView JavaScript public API compatibility", () => {
     registerTreeViewControllers(application)
 
     expect(application.register).toHaveBeenCalledWith("tree-view-state", TreeViewStateController)
+    expect(application.register).toHaveBeenCalledWith("tree-view-client", TreeViewClientController)
     expect(application.register).toHaveBeenCalledWith("tree-view-selection", TreeViewSelectionController)
     expect(application.register).toHaveBeenCalledWith("tree-view-transfer", TreeViewTransferController)
     expect(application.register).toHaveBeenCalledWith("tree-view-remote-state", TreeViewRemoteStateController)

--- a/app/javascript/tree_view/state_controller.js
+++ b/app/javascript/tree_view/state_controller.js
@@ -113,6 +113,16 @@ export class TreeViewStateController extends Controller {
   }
 
   activateToggle(row, preferredAction = null) {
+    const clientButton = row.querySelector(".tree-toggle__client-action")
+    if (clientButton) {
+      const expanded = row.dataset.treeViewStateExpanded === "true"
+      if (preferredAction === "show" && expanded) return
+      if (preferredAction === "hide" && !expanded) return
+
+      clientButton.click()
+      return
+    }
+
     const showButton = row.querySelector(".show-button")
     const hideButton = row.querySelector(".remove-button")
     const button = preferredAction === "show" ? showButton : preferredAction === "hide" ? hideButton : showButton || hideButton

--- a/app/views/tree_view/_tree_children.html.erb
+++ b/app/views/tree_view/_tree_children.html.erb
@@ -1,8 +1,9 @@
 <% render_context = local_assigns.fetch(:render_context) %>
 <% tree = render_context.tree %>
 <% sorted_items = tree.sort_items(items) %>
+<% hidden_by_client_parent = local_assigns.fetch(:hidden_by_client_parent, false) %>
 
 <% sorted_items.each do |child_item| %>
   <% current_depth = depth + 1 %>
-  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, render_context: render_context %>
+  <%= render 'tree_view/tree_row', item: child_item, depth: current_depth, render_context: render_context, hidden_by_client_parent: hidden_by_client_parent %>
 <% end %>

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -2,6 +2,7 @@
 <% tree = render_context.tree %>
 <% branch_info = tree_branch_info(item, tree) %>
 <% depth = local_assigns.fetch(:depth, branch_info[:depth]) %>
+<% hidden_by_client_parent = local_assigns.fetch(:hidden_by_client_parent, false) %>
 <% row_context = TreeView::RowContext.new(render_context: render_context, item: item, depth: depth) %>
 <% row_partial = render_context.row_partial %>
 <% row_actions_partial = render_context.row_actions_partial %>
@@ -13,10 +14,12 @@
 <% leaf_distance = tree_leaf_distance(item, tree) %>
 <% effectively_collapsed = explicitly_collapsed || (!explicitly_expanded && (render_context.collapsed? || depth_boundary)) %>
 <% mode = tree_toggle_mode(render_context.mode) %>
+<% client_mode = mode == :client %>
 <% row_classes = tree_row_classes(item, render_context.row_class_builder) %>
 <% transfer_data = tree_row_transfer_data(item, tree, render_context.row_event_payload_builder) %>
 <% row_data = tree_render_row_data(item, tree, render_context, expanded: !effectively_collapsed, depth: depth, transfer_data: transfer_data) %>
 <% row_attrs = { id: tree_node_dom_id(item), class: row_classes.presence, data: row_data, aria: row_aria = { level: depth + 1, selected: tree_selection_checked?(item, tree, render_context.selection_selected_keys) } } %>
+<% row_attrs[:hidden] = true if hidden_by_client_parent %>
 <% row_attrs[:draggable] = true if transfer_data.present? %>
 <% children = row_context.children %>
 <% row_aria[:expanded] = !effectively_collapsed if children.any? %>
@@ -44,6 +47,6 @@
     <% end %>
   <% end %>
 <% end %>
-<% if render_children && !effectively_collapsed %>
-  <%= render 'tree_view/tree_children', items: children, depth: depth, render_context: render_context %>
+<% if render_children && (!effectively_collapsed || client_mode) %>
+  <%= render 'tree_view/tree_children', items: children, depth: depth, render_context: render_context, hidden_by_client_parent: hidden_by_client_parent || (client_mode && effectively_collapsed) %>
 <% end %>

--- a/app/views/tree_view/_tree_toggle_content.html.erb
+++ b/app/views/tree_view/_tree_toggle_content.html.erb
@@ -1,3 +1,10 @@
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
-<% partial_name = mode == :static ? 'tree_view/tree_toggle_content_static' : 'tree_view/tree_toggle_content_turbo' %>
+<% partial_name = case mode
+                  when :static
+                    'tree_view/tree_toggle_content_static'
+                  when :client
+                    'tree_view/tree_toggle_content_client'
+                  else
+                    'tree_view/tree_toggle_content_turbo'
+                  end %>
 <%= render partial_name, local_assigns %>

--- a/app/views/tree_view/_tree_toggle_content_client.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_client.html.erb
@@ -1,0 +1,35 @@
+<% hidden_count = local_assigns[:hidden_count] %>
+<% hidden_message_builder = local_assigns[:hidden_message_builder] %>
+<% toggle_icon_builder = local_assigns[:toggle_icon_builder] %>
+<% toggle_state = local_assigns[:toggle_state] || :leaf %>
+<% children ||= tree.children_for(item) %>
+<% branch_info = tree_branch_info(item, tree) %>
+<% ancestor_last_states = branch_info[:ancestor_last_states] %>
+<% is_last = branch_info[:is_last] %>
+<% leaf_distance = local_assigns[:leaf_distance] %>
+<% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :client, leaf_distance: leaf_distance) %>
+<% node_key = tree.node_key_for(item) %>
+<% expanded = !hidden_count && children.any? %>
+
+<div class="tree-toggle">
+  <div class="tree-toggle__branches" aria-hidden="true">
+    <% ancestor_last_states.each do |ancestor_is_last| %>
+      <span class="<%= ['tree-toggle__branch-slot', ('is-empty' if ancestor_is_last), ('has-line' unless ancestor_is_last)].compact.join(' ') %>"></span>
+    <% end %>
+    <% if depth.positive? %>
+      <span class="<%= ['tree-toggle__branch-slot', 'is-current', ('is-last' if is_last), ('is-middle' unless is_last)].compact.join(' ') %>"></span>
+    <% end %>
+  </div>
+  <div class="tree-toggle__control">
+    <% if children.any? %>
+      <%= button_tag type: 'button', class: 'btn btn-primary tree-toggle__action tree-toggle__client-action', id: tree_show_button_dom_id(item), data: { action: 'tree-view-client#toggle', tree_view_client_node_key: node_key }, aria: { expanded: expanded } do %>
+        <%= toggle_icon || tree_toggle_label(depth) %>
+      <% end %>
+    <% else %>
+      <span class="tree-toggle__level"><%= toggle_icon || tree_toggle_label(depth) %></span>
+    <% end %>
+    <% if hidden_count %>
+      <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %></span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tree_view/_tree_toggle_content_client.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_client.html.erb
@@ -29,7 +29,7 @@
       <span class="tree-toggle__level"><%= toggle_icon || tree_toggle_label(depth) %></span>
     <% end %>
     <% if hidden_count %>
-      <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %></span>
+      <span class="tree-toggle__hidden-count" data-tree-view-client-hidden-count-for="<%= node_key %>"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %></span>
     <% end %>
   </div>
 </div>

--- a/docs/en/api-overview.md
+++ b/docs/en/api-overview.md
@@ -8,8 +8,8 @@ This page gives an overview of the main public APIs. See [API reference](api.md)
 |---|---|
 | `TreeView::Tree` | Builds and queries tree structures from records, resolvers, or adapters. |
 | `TreeView::RenderState` | Holds screen-level rendering state such as roots, row partial, UI config, expansion, selection, and render scope. |
-| `TreeView::UiConfig` | Stores DOM ID and path-building behavior for static or Turbo rendering. |
-| `TreeView::UiConfigBuilder` | Builds `UiConfig` objects from a Rails view context. |
+| `TreeView::UiConfig` | Stores DOM ID, toggle mode, and path-building behavior for static, Turbo, or client-side rendering. |
+| `TreeView::UiConfigBuilder` | Builds `UiConfig` objects from a Rails view context, including `build_turbo`, `build_static`, and `build_client_side`. |
 | `TreeView::VisibleRows` | Flattens currently visible rows from a render state. |
 | `TreeView::RenderWindow` | Slices visible rows by `offset` and `limit` and exposes pagination metadata. |
 | `TreeView::PersistedState` | Represents persisted expansion state. |
@@ -107,6 +107,16 @@ render_state = TreeView::RenderState.new(
 ```
 
 This keeps tree-side expansion state, diagnostics, and UI-side DOM targets aligned. If expansion does not affect the expected rows, first confirm which keys the tree returns before changing UI-only DOM ID settings.
+
+## Toggle modes
+
+Choose the toggle mode when building `TreeView::UiConfig`.
+
+| Builder | Mode | Use when |
+|---|---|---|
+| `build_turbo` / `build` | `:turbo` | Expand/collapse should round-trip through host-app Turbo Stream endpoints. |
+| `build_static` | `:static` | The page should render a static snapshot with no browser-side opening. |
+| `build_client_side` | `:client` | All rows in the render scope can be included in initial HTML and toggled locally in the browser. |
 
 ## Rendering
 

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -228,7 +228,16 @@ For focused naming decisions, see [Public Name Decisions](public-name-decisions.
 
 ## TreeView::UiConfig / UiConfigBuilder
 
-Configuration for DOM IDs and path builders.
+Configuration for DOM IDs, toggle mode, and path builders.
+
+| Builder | Mode | Description |
+|---|---|---|
+| `build_turbo(...)` | `:turbo` | Builds Turbo Stream expand/collapse URLs with host-app path builders. |
+| `build(...)` | `:turbo` | Backward-compatible alias for `build_turbo`. |
+| `build_static` | `:static` | Builds a static snapshot config with no expand/collapse URLs. |
+| `build_client_side` | `:client` | Builds a browser-local expand/collapse config with no Turbo endpoints. |
+
+`UiConfig#mode` returns `:turbo`, `:static`, or `:client`. Convenience predicates `turbo?`, `static?`, and `client?` are available.
 
 ### Static
 
@@ -245,13 +254,24 @@ tree_ui = TreeView::UiConfigBuilder.new(
 tree_ui = TreeView::UiConfigBuilder.new(
   context: view_context,
   node_prefix: "document"
-).build(
+).build_turbo(
   hide_descendants_path_builder: ->(item, depth, scope) { hide_document_path(item, depth: depth, scope: scope) },
   show_descendants_path_builder: ->(item, depth, scope) { show_document_path(item, depth: depth, scope: scope) },
   load_children_path_builder: ->(item, depth, scope) { children_document_path(item, depth: depth, scope: scope) },
   toggle_all_path_builder: ->(state) { documents_path(state: state) }
 )
 ```
+
+### Client-side
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_client_side
+```
+
+Client-side mode renders collapsed descendants inside the render scope into the initial HTML with `hidden`, then uses the bundled `tree-view-client` controller to toggle row visibility in the browser. It is intended for small to medium trees where initial HTML volume is acceptable.
 
 ## TreeView::PersistedState / StateStore
 
@@ -288,6 +308,8 @@ registerTreeViewControllers(application)
 
 Main controllers:
 
+- `tree-view-state`
+- `tree-view-client`
 - `tree-view-selection`
 - `tree-view-transfer`
 - `tree-view-remote-state`

--- a/docs/en/decision-guide.md
+++ b/docs/en/decision-guide.md
@@ -14,7 +14,8 @@ Use render controls first when the data is already available. Use lazy loading o
 | I want to... | Start with | Key options or APIs | Notes |
 |---|---|---|---|
 | Render a simple static tree | `TreeView::Tree`, `TreeView::RenderState`, `tree_view_rows` | `records:`, `parent_id_method:`, `row_partial:`, `UiConfigBuilder#build_static` | Best first implementation when all nodes are already available and no remote expand/collapse is needed. |
-| Add Turbo expand/collapse | `TreeView::UiConfigBuilder#build` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | Host app routes and Turbo Stream actions own the response. TreeView builds row IDs and URLs. |
+| Add Turbo expand/collapse | `TreeView::UiConfigBuilder#build_turbo` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | `build` remains a backward-compatible alias. Host app routes and Turbo Stream actions own the response. |
+| Add browser-local expand/collapse without Turbo endpoints | `TreeView::UiConfigBuilder#build_client_side` | `initial_state`, `initial_expansion:`, `render_scope:` | Good for small to medium trees where all rows in the render scope can be included in the initial HTML. |
 | Keep the first render small | `TreeView::RenderState` | `max_initial_depth`, `initial_expansion:`, `render_scope:` | These are render controls. They reduce initial HTML volume, not database query volume by themselves. |
 | Limit which descendants can be rendered | `render_scope:` | `max_depth`, `max_leaf_distance` | Use when a page should never render beyond a chosen depth or distance from matched leaves. |
 | Render only a visible slice | `tree_view_rows(..., window:)`, `tree_view_window`, `TreeView::RenderWindow` | `window: { offset:, limit: }` | Slices already-visible rows. It reduces HTML output only; it does not fetch less data by itself. |
@@ -39,8 +40,9 @@ flowchart TD
   A[What are you trying to do?]
   A --> B{Do you already have the tree data?}
   B -->|Yes| C{Need remote expand/collapse?}
-  C -->|No| D[Static rendering: Tree + RenderState + tree_view_rows]
-  C -->|Yes| E[Turbo rendering: UiConfigBuilder#build with show/hide path builders]
+  C -->|No, no browser opening| D[Static rendering: Tree + RenderState + tree_view_rows]
+  C -->|No, browser-local opening is enough| CL[Client-side rendering: UiConfigBuilder#build_client_side]
+  C -->|Yes| E[Turbo rendering: UiConfigBuilder#build_turbo with show/hide path builders]
   B -->|No, fetching everything is too expensive| F[Lazy Loading or Children Pagination]
   F --> G{Are child sets huge per parent?}
   G -->|Yes| H[Children Pagination in the host app, exposed through lazy-loading URLs]
@@ -69,6 +71,7 @@ flowchart TD
 | Category | APIs | What they reduce | What they do not reduce |
 |---|---|---|---|
 | Initial expansion | `max_initial_depth`, `initial_expansion:` | Rows opened on first paint | Records loaded from the database |
+| Client-side toggling | `build_client_side`, `tree-view-client` | Server round-trips for expand/collapse | Initial HTML volume; rows in render scope are still emitted |
 | Render scope | `render_scope: { max_depth:, max_leaf_distance: }` | Descendants eligible for rendering | Host-app query cost unless the app also scopes queries |
 | Windowed rendering | `window:`, `TreeView::RenderWindow` | HTML emitted for currently visible rows | Data needed to compute visibility, host-app queries, or fetched records |
 | Lazy loading | `load_children_path_builder`, `lazy_loading:` | Up-front child fetching and HTML for unloaded children | Host-app controller/query implementation |
@@ -81,15 +84,17 @@ flowchart TD
 2. Add [API overview](api-overview.md) concepts only when the use case needs them.
 3. Use [Render Scale](render-scale.md) when HTML size or visible row count becomes the issue.
 4. Use [Lazy Loading](lazy-loading.md) and [Children Pagination](children-pagination.md) when query volume or child count is the issue; those pages include copyable host-app controller, Turbo Stream, cursor, and retry patterns.
-5. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
-6. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
-7. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
+5. Use `build_client_side` when the data is already available, initial HTML volume is acceptable, and Turbo endpoints would be unnecessary overhead.
+6. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
+7. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
+8. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
 
 ## Common combinations
 
 | Scenario | Combination |
 |---|---|
 | Small admin taxonomy | Static tree + `max_initial_depth` if needed |
+| Small docs sidebar with local opening | Client-side mode + `initial_state: :collapsed` + render scope as needed |
 | Large folder browser | Lazy Loading + Children Pagination + Persisted State |
 | Large scrolling browser | Host-app virtual scrolling + render/window metadata as needed |
 | Search page | `path_tree_for` + render scope around matches |

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -16,6 +16,102 @@ The usual flow is:
 
 TreeView renders the tree UI primitives. Host apps remain responsible for application-specific CRUD, authorization, persistence, server-side queries, Turbo Stream responses, and business actions.
 
+## Toggle modes
+
+Choose the toggle mode per tree instance. One host app can use different modes on different screens, or even render multiple trees with different modes on the same page.
+
+| Builder | Mode | Behavior |
+|---|---|---|
+| `build_turbo` / `build` | `:turbo` | Expand/collapse through host-app Turbo Stream endpoints. |
+| `build_static` | `:static` | Render a static snapshot. Collapsed descendants are not rendered and cannot be opened in the browser. |
+| `build_client_side` | `:client` | Render descendants into the initial HTML and use TreeView JavaScript to show/hide rows in the browser. |
+
+## Static rendering
+
+Use `build_static` when you want static tree rows without expand/collapse URLs.
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_static
+```
+
+## Turbo Stream expand/collapse
+
+Use `build_turbo` with path builders when the host app handles expand/collapse through Turbo Stream endpoints. `build` is kept as a backward-compatible alias for `build_turbo`.
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_turbo(
+  hide_descendants_path_builder: ->(item, depth, scope) {
+    hide_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
+  },
+  show_descendants_path_builder: ->(item, depth, scope) {
+    show_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
+  },
+  toggle_all_path_builder: ->(state) {
+    documents_path(state: state)
+  }
+)
+```
+
+Path builders only build URLs. The host app owns controller actions, Turbo Stream responses, authorization, and server-side queries.
+
+## Client-side expand/collapse
+
+Use `build_client_side` when all nodes in the render scope can be included in the initial HTML and you only need browser-local expand/collapse.
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_client_side
+
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  initial_state: :collapsed
+)
+```
+
+In client-side mode, collapsed descendants inside `max_render_depth` / `max_leaf_distance` are still rendered into the initial HTML with the `hidden` attribute. The bundled `tree-view-client` controller toggles `hidden`, `aria-expanded`, and TreeView row state data inside the current tree element. It does not replace lazy loading, children pagination, authorization, or server-side query strategies for large trees.
+
+Register TreeView JavaScript controllers as usual:
+
+```js
+import { application } from "controllers/application"
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+Render the controller data on the tree root element:
+
+```erb
+<table class="tree-view-table" data: tree_view_state_data(@render_state)>
+  <tbody>
+    <%= tree_view_rows(@render_state) %>
+  </tbody>
+</table>
+```
+
+Client-side mode uses one toggle button icon for both open and closed states. If you want a visual state change, style the button from `aria-expanded` in the host app CSS:
+
+```css
+.tree-toggle__client-action[aria-expanded="false"] .tree-toggle__client-icon::before {
+  content: "▶";
+}
+
+.tree-toggle__client-action[aria-expanded="true"] .tree-toggle__client-icon::before {
+  content: "▼";
+}
+```
+
 ## Regular tree
 
 Use records mode when your items have parent-child relationships.
@@ -50,40 +146,6 @@ sorter = ->(nodes, _tree) {
   end
 }
 ```
-
-## Static rendering
-
-Use `build_static` when you want static tree rows without expand/collapse URLs.
-
-```ruby
-tree_ui = TreeView::UiConfigBuilder.new(
-  context: view_context,
-  node_prefix: "document"
-).build_static
-```
-
-## Turbo Stream expand/collapse
-
-Use `build` with path builders when the host app handles expand/collapse through Turbo Stream endpoints.
-
-```ruby
-tree_ui = TreeView::UiConfigBuilder.new(
-  context: view_context,
-  node_prefix: "document"
-).build(
-  hide_descendants_path_builder: ->(item, depth, scope) {
-    hide_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
-  },
-  show_descendants_path_builder: ->(item, depth, scope) {
-    show_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
-  },
-  toggle_all_path_builder: ->(state) {
-    documents_path(state: state)
-  }
-)
-```
-
-Path builders only build URLs. The host app owns controller actions, Turbo Stream responses, authorization, and server-side queries.
 
 ## RenderState
 
@@ -224,7 +286,7 @@ Use `load_children_path_builder` and `RenderState#lazy_loading` when children ar
 tree_ui = TreeView::UiConfigBuilder.new(
   context: view_context,
   node_prefix: "document"
-).build(
+).build_turbo(
   hide_descendants_path_builder: ->(item, depth, scope) { hide_document_path(item, depth:, scope:) },
   show_descendants_path_builder: ->(item, depth, scope) { show_document_path(item, depth:, scope:) },
   load_children_path_builder: ->(item, depth, scope) {

--- a/docs/ja/api-overview.md
+++ b/docs/ja/api-overview.md
@@ -8,8 +8,8 @@
 |---|---|
 | `TreeView::Tree` | records、resolver、adapterからツリー構造を作り、問い合わせる中心オブジェクトです。 |
 | `TreeView::RenderState` | root、row partial、UI設定、展開状態、selection、描画範囲など、画面単位の描画状態をまとめます。 |
-| `TreeView::UiConfig` | static / Turbo描画で使うDOM IDやpath builderの設定を保持します。 |
-| `TreeView::UiConfigBuilder` | Rails view contextから `UiConfig` を組み立てます。 |
+| `TreeView::UiConfig` | static / Turbo / client-side描画で使うDOM ID、toggle mode、path builderの設定を保持します。 |
+| `TreeView::UiConfigBuilder` | Rails view contextから `build_turbo`、`build_static`、`build_client_side` で `UiConfig` を組み立てます。 |
 | `TreeView::VisibleRows` | 現在のrender stateで表示対象となる行を一次元化します。 |
 | `TreeView::RenderWindow` | visible rowsを `offset` / `limit` で切り出し、ページング用metadataを提供します。 |
 | `TreeView::PersistedState` | 保存された開閉状態を表します。 |
@@ -107,6 +107,16 @@ render_state = TreeView::RenderState.new(
 ```
 
 この形にすると、tree側の開閉状態、diagnostics、UI側のDOM targetを揃えやすくなります。期待した行が初期展開されない場合は、UIだけのDOM ID設定を変える前に、treeが返しているnode keyを確認してください。
+
+## toggle mode
+
+`TreeView::UiConfig` を作る時に、tree instanceごとのtoggle modeを選びます。
+
+| Builder | Mode | 使う場面 |
+|---|---|---|
+| `build_turbo` / `build` | `:turbo` | host appのTurbo Stream endpointで開閉したい場合。 |
+| `build_static` | `:static` | 開閉できない静的snapshotとして描画したい場合。 |
+| `build_client_side` | `:client` | render scope内の全行を初期HTMLに含め、browser内だけで開閉したい場合。 |
 
 ## 描画
 

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -228,7 +228,16 @@ render_state = TreeView::RenderState.new(
 
 ## TreeView::UiConfig / UiConfigBuilder
 
-DOM IDやpath builderをまとめる設定objectです。
+DOM ID、toggle mode、path builderをまとめる設定objectです。
+
+| Builder | Mode | 説明 |
+|---|---|---|
+| `build_turbo(...)` | `:turbo` | host appのpath builderでTurbo Stream開閉URLを作る。 |
+| `build(...)` | `:turbo` | 後方互換のための `build_turbo` alias。 |
+| `build_static` | `:static` | 開閉URLを持たない静的snapshot設定を作る。 |
+| `build_client_side` | `:client` | Turbo endpointを使わないbrowser-local開閉設定を作る。 |
+
+`UiConfig#mode` は `:turbo`、`:static`、`:client` を返します。`turbo?`、`static?`、`client?` predicateも使えます。
 
 ### static
 
@@ -245,13 +254,24 @@ tree_ui = TreeView::UiConfigBuilder.new(
 tree_ui = TreeView::UiConfigBuilder.new(
   context: view_context,
   node_prefix: "document"
-).build(
+).build_turbo(
   hide_descendants_path_builder: ->(item, depth, scope) { hide_document_path(item, depth: depth, scope: scope) },
   show_descendants_path_builder: ->(item, depth, scope) { show_document_path(item, depth: depth, scope: scope) },
   load_children_path_builder: ->(item, depth, scope) { children_document_path(item, depth: depth, scope: scope) },
   toggle_all_path_builder: ->(state) { documents_path(state: state) }
 )
 ```
+
+### client-side
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_client_side
+```
+
+client-side modeでは、render scope内のcollapsed descendantsを初期HTMLに `hidden` 付きで描画し、bundled `tree-view-client` controllerでbrowser内の行表示を切り替えます。初期HTML量を許容できる小〜中規模tree向けです。
 
 ## TreeView::PersistedState / StateStore
 
@@ -288,6 +308,8 @@ registerTreeViewControllers(application)
 
 主なcontroller:
 
+- `tree-view-state`
+- `tree-view-client`
 - `tree-view-selection`
 - `tree-view-transfer`
 - `tree-view-remote-state`

--- a/docs/ja/decision-guide.md
+++ b/docs/ja/decision-guide.md
@@ -14,7 +14,8 @@ TreeViewのAPIは大きく分けると次の2種類です。
 | やりたいこと | まず使うAPI | 主なoption / API | 補足 |
 |---|---|---|---|
 | 単純なstatic treeを描画したい | `TreeView::Tree`, `TreeView::RenderState`, `tree_view_rows` | `records:`, `parent_id_method:`, `row_partial:`, `UiConfigBuilder#build_static` | 全nodeが取得済みでremote expand/collapseが不要な場合の最初の実装です。 |
-| Turboでexpand/collapseしたい | `TreeView::UiConfigBuilder#build` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | host appのroutesとTurbo Stream actionがresponseを担当します。TreeViewはrow IDとURLを組み立てます。 |
+| Turboでexpand/collapseしたい | `TreeView::UiConfigBuilder#build_turbo` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | `build` は後方互換aliasです。host appのroutesとTurbo Stream actionがresponseを担当します。 |
+| Turbo endpointなしでbrowser内だけで開閉したい | `TreeView::UiConfigBuilder#build_client_side` | `initial_state`, `initial_expansion:`, `render_scope:` | render scope内の全行を初期HTMLに含められる小〜中規模treeに向いています。 |
 | 初期描画を小さくしたい | `TreeView::RenderState` | `max_initial_depth`, `initial_expansion:`, `render_scope:` | これは描画制御です。初期HTML量は減りますが、それだけでdatabase query量が減るわけではありません。 |
 | 描画対象の子孫範囲を制限したい | `render_scope:` | `max_depth`, `max_leaf_distance` | ページ上で一定のdepthやmatched leavesからの距離を超えて描画したくない場合に使います。 |
 | visible rowsの一部だけ描画したい | `tree_view_rows(..., window:)`, `tree_view_window`, `TreeView::RenderWindow` | `window: { offset:, limit: }` | すでにvisibleなrowsをsliceします。HTML出力量だけを減らし、それだけで取得データ量が減るわけではありません。 |
@@ -39,8 +40,9 @@ flowchart TD
   A[何をしたいですか?]
   A --> B{tree dataはすでにありますか?}
   B -->|はい| C{remote expand/collapseが必要?}
-  C -->|いいえ| D[Static rendering: Tree + RenderState + tree_view_rows]
-  C -->|はい| E[Turbo rendering: UiConfigBuilder#build と show/hide path builders]
+  C -->|いいえ、browser上で開かない| D[Static rendering: Tree + RenderState + tree_view_rows]
+  C -->|いいえ、browser内開閉で十分| CL[Client-side rendering: UiConfigBuilder#build_client_side]
+  C -->|はい| E[Turbo rendering: UiConfigBuilder#build_turbo と show/hide path builders]
   B -->|いいえ、全取得が重い| F[Lazy Loading または Children Pagination]
   F --> G{親ごとの子要素数が非常に多い?}
   G -->|はい| H[host app側のChildren Paginationをlazy-loading URL経由で連携]
@@ -69,6 +71,7 @@ flowchart TD
 | 種類 | API | 減らせるもの | それだけでは減らないもの |
 |---|---|---|---|
 | 初期展開 | `max_initial_depth`, `initial_expansion:` | 初回表示で開くrow | databaseから読み込むrecord数 |
+| client-side開閉 | `build_client_side`, `tree-view-client` | 開閉時のserver round-trip | 初期HTML量。render scope内の行は初期HTMLに出力されます。 |
 | 描画範囲 | `render_scope: { max_depth:, max_leaf_distance: }` | 描画対象になる子孫 | host appがqueryも絞らない限りquery costは減りません |
 | windowed rendering | `window:`, `TreeView::RenderWindow` | 現在visibleなrowsから出力するHTML | visibility計算に必要なデータ、host app query、取得済みrecord数 |
 | Lazy Loading | `load_children_path_builder`, `lazy_loading:` | 初期の子要素取得と未読み込み子要素のHTML | host appのcontroller / query実装 |
@@ -81,15 +84,17 @@ flowchart TD
 2. 必要になったuse caseに応じて [API概要](api-overview.md) の概念を足します。
 3. HTML量やvisible row数が問題になったら [Render Scale](render-scale.md) を使います。
 4. query量や子要素数が問題になったら [Lazy Loading](lazy-loading.md) と [Children Pagination](children-pagination.md) を使います。これらのページには、host app controller、Turbo Stream、cursor、retry patternのコピー可能な例があります。
-5. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
-6. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
-7. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
+5. dataは取得済みで、初期HTML量を許容でき、Turbo endpointが過剰な場合は `build_client_side` を使います。
+6. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
+7. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
+8. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
 
 ## よくある組み合わせ
 
 | Scenario | 組み合わせ |
 |---|---|
 | 小さな管理用taxonomy | Static tree + 必要に応じて `max_initial_depth` |
+| 小さなdocs sidebarのlocal開閉 | Client-side mode + `initial_state: :collapsed` + 必要に応じてrender scope |
 | 大きなfolder browser | Lazy Loading + Children Pagination + Persisted State |
 | 大きなscrolling browser | host app virtual scrolling + 必要に応じてrender/window metadata |
 | 検索ページ | `path_tree_for` + match周辺のrender scope |

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -14,6 +14,102 @@
 
 TreeView gem はツリーUIの基盤を提供します。CRUD、認可、保存、server-side query、Turbo Stream response、業務固有actionはhost app側で実装します。
 
+## toggle mode
+
+開閉方式はtree instanceごとに選びます。1つのhost app内で画面ごとに使い分けたり、同じpage内に異なるmodeのtreeを並べたりできます。
+
+| Builder | Mode | 挙動 |
+|---|---|---|
+| `build_turbo` / `build` | `:turbo` | host appのTurbo Stream endpointで開閉する。 |
+| `build_static` | `:static` | 静的snapshotとして描画する。collapsed descendantsは描画されず、browser上では開けない。 |
+| `build_client_side` | `:client` | 初期HTMLにdescendantsを残し、TreeView JavaScriptでbrowser内だけで表示/非表示を切り替える。 |
+
+## static表示
+
+開閉URLを使わない静的なツリーとして表示する場合は `build_static` を使います。
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_static
+```
+
+## Turbo Stream開閉
+
+Turbo Streamで開閉したい場合は、`build_turbo` にpath builderを渡します。`build` は後方互換のため `build_turbo` と同じ意味で残しています。
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_turbo(
+  hide_descendants_path_builder: ->(item, depth, scope) {
+    hide_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
+  },
+  show_descendants_path_builder: ->(item, depth, scope) {
+    show_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
+  },
+  toggle_all_path_builder: ->(state) {
+    documents_path(state: state)
+  }
+)
+```
+
+path builderはURLを作るだけです。実際のcontroller action、Turbo Stream response、認可、server-side queryはhost app側の責務です。
+
+## client-side開閉
+
+`max_render_depth` / `max_leaf_distance` の範囲内のnodeを初期HTMLに含めても問題ない小〜中規模treeでは、`build_client_side` を使えます。Turbo routeやTurbo Stream responseを用意せず、browser内だけで開閉します。
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_client_side
+
+@render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  initial_state: :collapsed
+)
+```
+
+client-side modeでは、collapsed descendantsも初期HTMLに描画し、初期状態では `hidden` 属性で隠します。bundled `tree-view-client` controller が、現在のtree element内だけで `hidden`、`aria-expanded`、TreeView row state dataを同期します。lazy loading、children pagination、認可、server-side query削減の代替ではありません。
+
+TreeView JavaScript controllerを通常どおり登録します。
+
+```js
+import { application } from "controllers/application"
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+Tree root elementには `tree_view_state_data` を付けます。
+
+```erb
+<%= tag.table class: "tree-view-table", data: tree_view_state_data(@render_state) do %>
+  <tbody>
+    <%= tree_view_rows(@render_state) %>
+  </tbody>
+<% end %>
+```
+
+client-side modeでは、開閉両方に使うtoggle button iconは1種類だけを標準サポートします。見た目を開閉状態で変えたい場合は、host app側のCSSで `aria-expanded` を使って調整できます。
+
+```css
+.tree-toggle__client-action[aria-expanded="false"] .tree-toggle__client-icon::before {
+  content: "▶";
+}
+
+.tree-toggle__client-action[aria-expanded="true"] .tree-toggle__client-icon::before {
+  content: "▼";
+}
+```
+
 ## 通常Tree
 
 親子関係を持つrecordsからtreeを作る場合は、`records:` と `parent_id_method:` を指定します。
@@ -48,40 +144,6 @@ sorter = ->(nodes, _tree) {
   end
 }
 ```
-
-## static表示
-
-開閉URLを使わない静的なツリーとして表示する場合は `build_static` を使います。
-
-```ruby
-tree_ui = TreeView::UiConfigBuilder.new(
-  context: view_context,
-  node_prefix: "document"
-).build_static
-```
-
-## Turbo Stream開閉
-
-Turbo Streamで開閉したい場合は、`build` にpath builderを渡します。
-
-```ruby
-tree_ui = TreeView::UiConfigBuilder.new(
-  context: view_context,
-  node_prefix: "document"
-).build(
-  hide_descendants_path_builder: ->(item, depth, scope) {
-    hide_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
-  },
-  show_descendants_path_builder: ->(item, depth, scope) {
-    show_document_path(item, depth: depth, scope: scope, format: :turbo_stream)
-  },
-  toggle_all_path_builder: ->(state) {
-    documents_path(state: state)
-  }
-)
-```
-
-path builderはURLを作るだけです。実際のcontroller action、Turbo Stream response、認可、server-side queryはhost app側の責務です。
 
 ## RenderState
 
@@ -222,7 +284,7 @@ checkboxの描画、payload生成、JavaScript controllerによる収集はTreeV
 tree_ui = TreeView::UiConfigBuilder.new(
   context: view_context,
   node_prefix: "document"
-).build(
+).build_turbo(
   hide_descendants_path_builder: ->(item, depth, scope) { hide_document_path(item, depth:, scope:) },
   show_descendants_path_builder: ->(item, depth, scope) { show_document_path(item, depth:, scope:) },
   load_children_path_builder: ->(item, depth, scope) {

--- a/lib/tree_view/render_context.rb
+++ b/lib/tree_view/render_context.rb
@@ -45,6 +45,10 @@ module TreeView
       def tree_instance_key
         nil
       end
+
+      def ui_config
+        nil
+      end
     end
 
     attr_reader :render_state, :mode
@@ -89,7 +93,7 @@ module TreeView
 
     def initialize(render_state:, mode: nil, collapsed: nil)
       @render_state = render_state
-      @mode = mode
+      @mode = mode || render_state_ui_mode
       @collapsed_override = collapsed
     end
 
@@ -235,6 +239,17 @@ module TreeView
       return nil unless render_state.respond_to?(:toggle_icon_builder)
 
       render_state.toggle_icon_builder
+    end
+
+    private
+
+    def render_state_ui_mode
+      return nil unless render_state.respond_to?(:ui_config)
+
+      ui_config = render_state.ui_config
+      return nil unless ui_config.respond_to?(:mode)
+
+      ui_config.mode
     end
   end
 end

--- a/lib/tree_view/ui_config.rb
+++ b/lib/tree_view/ui_config.rb
@@ -3,6 +3,7 @@
 module TreeView
   class UiConfig
     SCOPE_FORMATS = %i[string object].freeze
+    TOGGLE_MODES = %i[turbo static client].freeze
 
     # DOM ID と path helper 周辺の UI 依存だけを受け持つ。
     attr_reader :node_dom_id_builder,
@@ -13,7 +14,8 @@ module TreeView
       :load_children_path_builder,
       :toggle_all_path_builder,
       :indent_unit,
-      :scope_format
+      :scope_format,
+      :mode
 
     def initialize(node_dom_id_builder:,
       button_dom_id_builder:,
@@ -23,7 +25,8 @@ module TreeView
       load_children_path_builder: nil,
       toggle_all_path_builder: nil,
       indent_unit: "&ensp; &ensp; &ensp;",
-      scope_format: :string)
+      scope_format: :string,
+      mode: nil)
       validate_builder!(node_dom_id_builder, :node_dom_id_builder)
       validate_builder!(button_dom_id_builder, :button_dom_id_builder)
       validate_builder!(show_button_dom_id_builder, :show_button_dom_id_builder)
@@ -41,6 +44,7 @@ module TreeView
       @toggle_all_path_builder = toggle_all_path_builder
       @indent_unit = indent_unit
       @scope_format = normalize_scope_format(scope_format)
+      @mode = normalize_mode(mode || inferred_mode)
     end
 
     def node_dom_id(item_or_id)
@@ -83,14 +87,30 @@ module TreeView
       toggle_all_path_builder.call(state.to_sym)
     end
 
+    def turbo?
+      mode == :turbo
+    end
+
     def static?
-      hide_descendants_path_builder.nil? &&
-        show_descendants_path_builder.nil? &&
-        load_children_path_builder.nil? &&
-        toggle_all_path_builder.nil?
+      mode == :static
+    end
+
+    def client?
+      mode == :client
     end
 
     private
+
+    def inferred_mode
+      if hide_descendants_path_builder.nil? &&
+          show_descendants_path_builder.nil? &&
+          load_children_path_builder.nil? &&
+          toggle_all_path_builder.nil?
+        :static
+      else
+        :turbo
+      end
+    end
 
     def validate_builder!(builder, name)
       return if builder.respond_to?(:call)
@@ -113,8 +133,21 @@ module TreeView
       raise_invalid_scope_format!
     end
 
+    def normalize_mode(value)
+      raise_invalid_mode! unless value.respond_to?(:to_sym)
+
+      normalized_value = value.to_sym
+      return normalized_value if TOGGLE_MODES.include?(normalized_value)
+
+      raise_invalid_mode!
+    end
+
     def raise_invalid_scope_format!
       raise ArgumentError, "scope_format must be one of: #{SCOPE_FORMATS.join(", ")}"
+    end
+
+    def raise_invalid_mode!
+      raise ArgumentError, "mode must be one of: #{TOGGLE_MODES.join(", ")}"
     end
   end
 end

--- a/lib/tree_view/ui_config_builder.rb
+++ b/lib/tree_view/ui_config_builder.rb
@@ -14,26 +14,58 @@ module TreeView
       load_children_path_builder: nil,
       indent_unit: "&ensp; &ensp; &ensp;",
       scope_format: :string)
-      UiConfig.new(
-        node_dom_id_builder: ->(item_or_id) { "#{@node_prefix}_#{@key_resolver.call(item_or_id)}" },
-        button_dom_id_builder: ->(item_or_id) { "#{@node_prefix}_button_box_#{@key_resolver.call(item_or_id)}" },
-        show_button_dom_id_builder: ->(item_or_id) { "#{@node_prefix}_show_button_#{@key_resolver.call(item_or_id)}" },
-        hide_descendants_path_builder: hide_descendants_path_builder,
+      build_turbo(
         show_descendants_path_builder: show_descendants_path_builder,
-        load_children_path_builder: load_children_path_builder,
+        hide_descendants_path_builder: hide_descendants_path_builder,
         toggle_all_path_builder: toggle_all_path_builder,
+        load_children_path_builder: load_children_path_builder,
         indent_unit: indent_unit,
         scope_format: scope_format
       )
     end
 
+    def build_turbo(show_descendants_path_builder:,
+      hide_descendants_path_builder:,
+      toggle_all_path_builder:,
+      load_children_path_builder: nil,
+      indent_unit: "&ensp; &ensp; &ensp;",
+      scope_format: :string)
+      UiConfig.new(
+        **dom_builders,
+        hide_descendants_path_builder: hide_descendants_path_builder,
+        show_descendants_path_builder: show_descendants_path_builder,
+        load_children_path_builder: load_children_path_builder,
+        toggle_all_path_builder: toggle_all_path_builder,
+        indent_unit: indent_unit,
+        scope_format: scope_format,
+        mode: :turbo
+      )
+    end
+
     def build_static(indent_unit: "&ensp; &ensp; &ensp;")
       UiConfig.new(
+        **dom_builders,
+        indent_unit: indent_unit,
+        mode: :static
+      )
+    end
+
+    def build_client_side(indent_unit: "&ensp; &ensp; &ensp;")
+      UiConfig.new(
+        **dom_builders,
+        indent_unit: indent_unit,
+        mode: :client
+      )
+    end
+
+    private
+
+    def dom_builders
+      {
         node_dom_id_builder: ->(item_or_id) { "#{@node_prefix}_#{@key_resolver.call(item_or_id)}" },
         button_dom_id_builder: ->(item_or_id) { "#{@node_prefix}_button_box_#{@key_resolver.call(item_or_id)}" },
-        show_button_dom_id_builder: ->(item_or_id) { "#{@node_prefix}_show_button_#{@key_resolver.call(item_or_id)}" },
-        indent_unit: indent_unit
-      )
+        show_button_dom_id_builder: ->(item_or_id) { "#{@node_prefix}_show_button_#{@key_resolver.call(item_or_id)}" }
+      }
     end
   end
 end

--- a/spec/helpers/tree_view_helper_spec.rb
+++ b/spec/helpers/tree_view_helper_spec.rb
@@ -73,11 +73,19 @@ RSpec.describe TreeViewHelper do
   end
 
   describe "tree_toggle_mode" do
-    it "returns static and turbo as-is" do
+    it "returns static, turbo, and client as-is" do
       helper = helper_host_class.new(tree_ui: ui_config)
 
       expect(helper.tree_toggle_mode(:static)).to eq(:static)
       expect(helper.tree_toggle_mode(:turbo)).to eq(:turbo)
+      expect(helper.tree_toggle_mode(:client)).to eq(:client)
+    end
+
+    it "uses the UiConfig mode when no explicit mode is given" do
+      client_ui = TreeView::UiConfigBuilder.new(context: Object.new).build_client_side
+      helper = helper_host_class.new(tree_ui: client_ui)
+
+      expect(helper.tree_toggle_mode).to eq(:client)
     end
 
     it "raises a clear error for invalid modes" do
@@ -85,7 +93,7 @@ RSpec.describe TreeViewHelper do
 
       expect do
         helper.tree_toggle_mode(:statc)
-      end.to raise_error(ArgumentError, /must be :static or :turbo/)
+      end.to raise_error(ArgumentError, /must be one of: turbo, static, client/)
     end
   end
 

--- a/spec/integration/tree_view_client_mode_integration_spec.rb
+++ b/spec/integration/tree_view_client_mode_integration_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+require "action_view"
+require "fileutils"
+require "tmpdir"
+
+ClientModeNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+RSpec.describe "TreeView client-side toggle mode" do
+  let(:root) { ClientModeNode.new(id: 1, parent_item_id: nil, name: "root") }
+  let(:child) { ClientModeNode.new(id: 2, parent_item_id: 1, name: "child") }
+  let(:grandchild) { ClientModeNode.new(id: 3, parent_item_id: 2, name: "grandchild") }
+  let(:sibling) { ClientModeNode.new(id: 4, parent_item_id: 1, name: "sibling") }
+  let(:tree) { TreeView::Tree.new(records: [root, child, grandchild, sibling], parent_id_method: :parent_item_id) }
+  let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
+  let(:host_view_dir) { Dir.mktmpdir("tree_view_client_mode_views") }
+
+  before do
+    FileUtils.mkdir_p(File.join(host_view_dir, "projects"))
+    File.write(
+      File.join(host_view_dir, "projects", "_tree_columns.html.erb"),
+      '<td class="project-cell"><%= item.name %></td>'
+    )
+  end
+
+  after do
+    FileUtils.remove_entry(host_view_dir) if Dir.exist?(host_view_dir)
+  end
+
+  def build_view(tree_ui:)
+    view = ActionView::Base.with_empty_template_cache.with_view_paths([host_view_dir, gem_view_path], {}, nil)
+    view.extend(TreeViewHelper)
+    view.instance_variable_set(:@tree_ui, tree_ui)
+    view
+  end
+
+  it "renders collapsed descendants into the initial HTML as hidden rows" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_client_side
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      initial_state: :collapsed
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state)
+
+    expect(rendered).to include('id="project_1"')
+    expect(rendered).to include('id="project_2"')
+    expect(rendered).to include('id="project_3"')
+    expect(rendered).to include('id="project_4"')
+    expect(rendered).to include('data-tree-view-client-node-key="1"')
+    expect(rendered).to include('data-tree-view-client-node-key="2"')
+    expect(rendered).to include('data-tree-view-client-depth="0"')
+    expect(rendered).to include('data-tree-view-client-depth="1"')
+    expect(rendered).to include('data-tree-view-client-expanded="false"')
+    expect(rendered).to include('hidden="hidden"')
+    expect(rendered).to include('data-action="tree-view-client#toggle"')
+    expect(rendered).to include('data-tree-view-client-hidden-count-for="1"')
+  end
+
+  it "respects max_render_depth while keeping collapsed descendants inside the render scope" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_client_side
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      initial_state: :collapsed,
+      max_render_depth: 1
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state)
+
+    expect(rendered).to include('id="project_1"')
+    expect(rendered).to include('id="project_2"')
+    expect(rendered).to include('id="project_4"')
+    expect(rendered).not_to include('id="project_3"')
+  end
+
+  it "adds the client controller to tree_view_state_data for client-side UiConfig" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_client_side
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui
+    )
+    view = build_view(tree_ui: nil)
+
+    expect(view.tree_view_state_data(render_state)).to eq(controller: "tree-view-state tree-view-client")
+  end
+end

--- a/spec/integration/tree_view_integration_spec.rb
+++ b/spec/integration/tree_view_integration_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe "TreeView integration" do
         )
       end.to raise_error(ActionView::Template::Error) { |error|
         expect(error.cause).to be_a(ArgumentError)
-        expect(error.cause.message).to match(/must be :static or :turbo/)
+        expect(error.cause.message).to match(/must be one of: turbo, static, client/)
       }
     end
   end

--- a/spec/lib/tree_view/ui_config_builder_spec.rb
+++ b/spec/lib/tree_view/ui_config_builder_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe TreeView::UiConfigBuilder do
     expect(config.toggle_all_path(state: :collapsed)).to eq("/entries?state=collapsed")
     expect(config.scope_format).to eq(:string)
     expect(config.object_scope?).to eq(false)
+    expect(config.mode).to eq(:turbo)
+    expect(config.turbo?).to eq(true)
+  end
+
+  it "builds turbo config with the explicit method" do
+    context = double(:context)
+
+    config = described_class.new(context: context, node_prefix: "entry").build_turbo(
+      hide_descendants_path_builder: ->(_candidate, _depth, _scope) {},
+      show_descendants_path_builder: ->(_candidate, _depth, _scope) {},
+      toggle_all_path_builder: ->(_state) {}
+    )
+
+    expect(config.mode).to eq(:turbo)
+    expect(config.turbo?).to eq(true)
   end
 
   it "builds config with object scope format" do
@@ -50,6 +65,17 @@ RSpec.describe TreeView::UiConfigBuilder do
     end.to raise_error(ArgumentError, /scope_format/)
   end
 
+  it "rejects invalid explicit modes" do
+    expect do
+      TreeView::UiConfig.new(
+        node_dom_id_builder: ->(item_or_id) { "item_#{item_or_id}" },
+        button_dom_id_builder: ->(item_or_id) { "item_button_box_#{item_or_id}" },
+        show_button_dom_id_builder: ->(item_or_id) { "item_show_button_#{item_or_id}" },
+        mode: :invalid
+      )
+    end.to raise_error(ArgumentError, /mode/)
+  end
+
   it "builds static config without toggle paths" do
     context = double(:context)
     item = Struct.new(:id).new(8)
@@ -60,6 +86,22 @@ RSpec.describe TreeView::UiConfigBuilder do
     expect(config.button_dom_id(item)).to eq("entry_button_box_8")
     expect(config.show_button_dom_id(item)).to eq("entry_show_button_8")
     expect(config.static?).to eq(true)
+    expect(config.mode).to eq(:static)
+    expect(config.toggle_all_path(state: :collapsed)).to be_nil
+  end
+
+  it "builds client-side config without toggle paths" do
+    context = double(:context)
+    item = Struct.new(:id).new(8)
+
+    config = described_class.new(context: context, node_prefix: "entry").build_client_side
+
+    expect(config.node_dom_id(item)).to eq("entry_8")
+    expect(config.button_dom_id(item)).to eq("entry_button_box_8")
+    expect(config.show_button_dom_id(item)).to eq("entry_show_button_8")
+    expect(config.client?).to eq(true)
+    expect(config.static?).to eq(false)
+    expect(config.mode).to eq(:client)
     expect(config.toggle_all_path(state: :collapsed)).to be_nil
   end
 end

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe "Public API compatibility" do
     end
   end
 
+  it "keeps documented UiConfigBuilder mode methods available" do
+    builder = TreeView::UiConfigBuilder.new(context: Object.new)
+
+    expect(builder).to respond_to(:build)
+    expect(builder).to respond_to(:build_turbo)
+    expect(builder).to respond_to(:build_static)
+    expect(builder).to respond_to(:build_client_side)
+  end
+
   it "keeps documented RenderState grouped options available" do
     tree = instance_double(TreeView::Tree)
     ui_config = instance_double(TreeView::UiConfig)


### PR DESCRIPTION
## Summary

Closes #340.

- Add explicit `UiConfig#mode` with `:turbo`, `:static`, and `:client`
- Add `UiConfigBuilder#build_turbo` and keep `#build` as a backward-compatible alias
- Add `UiConfigBuilder#build_client_side`
- Render collapsed descendants into the initial HTML for client mode and hide them with `hidden`
- Add `tree-view-client` Stimulus controller for browser-local expand/collapse
- Keep nested descendant expansion state when an ancestor is collapsed and reopened
- Add client-mode Ruby integration specs and JavaScript controller/public API specs
- Document static / Turbo / client-side mode selection and CSS customization using `aria-expanded`

## Testing

Not run locally: this environment could not clone the repository from GitHub (`Could not resolve host: github.com`). CI should run the project test suite on the PR.

## Notes

The branch was created from `9127d3c353865f6fa613552ebb7e2cffaf99398b`. `main` advanced afterward; the newer main changes appear to be docs/accessibility and related specs, while this PR changes the client-toggle implementation and usage docs.