### PR TITLE
Handle client-side mode follow-ups

### DIFF
--- a/app/javascript/tree_view/client_controller.js
+++ b/app/javascript/tree_view/client_controller.js
@@ -16,6 +16,8 @@ export class TreeViewClientController extends Controller {
   }
 
   rowForButton(button) {
+    if (!this.ownsElement(button)) return null
+
     const key = button.dataset.treeViewClientNodeKey
     if (!key) return button.closest("[data-tree-view-client-depth][data-tree-view-client-node-key]")
 
@@ -23,7 +25,11 @@ export class TreeViewClientController extends Controller {
   }
 
   rows() {
-    return Array.from(this.element.querySelectorAll("[data-tree-view-client-depth][data-tree-view-client-node-key]"))
+    return Array.from(this.element.querySelectorAll("[data-tree-view-client-depth][data-tree-view-client-node-key]")).filter((row) => this.ownsElement(row))
+  }
+
+  ownsElement(element) {
+    return element?.closest("[data-controller~='tree-view-client']") === this.element
   }
 
   expanded(row) {
@@ -45,7 +51,7 @@ export class TreeViewClientController extends Controller {
     this.element
       .querySelectorAll("[data-tree-view-client-hidden-count-for]")
       .forEach((element) => {
-        if (element.dataset.treeViewClientHiddenCountFor === String(nodeKey)) {
+        if (this.ownsElement(element) && element.dataset.treeViewClientHiddenCountFor === String(nodeKey)) {
           element.hidden = !visible
         }
       })

--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -148,7 +148,7 @@ describe("TreeViewClientController", () => {
     expect(document.querySelector("#outer-child").hidden).toBe(true)
     expect(document.querySelector("#inner-row").hidden).toBe(false)
     expect(document.querySelector("#inner-child").hidden).toBe(false)
-    expect(document.querySelector("#inner-hidden-count").hidden).toBe(false)
+    expect(document.querySelector("#inner-hidden-count").hidden).toBe(true)
   })
 })
 

--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -109,7 +109,7 @@ describe("TreeViewClientController", () => {
     expect(document.querySelector("#row-3").hidden).toBe(false)
   })
 
-  it("ignores rows and hidden counts that belong to a nested client tree", () => {
+  it("ignores rows and hidden counts that belong to a nested client tree", async () => {
     application.stop()
     document.body.innerHTML = `
       <table id="outer" data-controller="tree-view-client">
@@ -138,6 +138,7 @@ describe("TreeViewClientController", () => {
 
     application = Application.start()
     application.register("tree-view-client", TreeViewClientController)
+    await nextFrame()
 
     const outer = document.querySelector("#outer")
     const outerController = application.getControllerForElementAndIdentifier(outer, "tree-view-client")

--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -108,6 +108,47 @@ describe("TreeViewClientController", () => {
     expect(document.querySelector("#row-2").hidden).toBe(false)
     expect(document.querySelector("#row-3").hidden).toBe(false)
   })
+
+  it("ignores rows and hidden counts that belong to a nested client tree", () => {
+    application.stop()
+    document.body.innerHTML = `
+      <table id="outer" data-controller="tree-view-client">
+        <tbody>
+          <tr id="outer-row" data-tree-view-client-node-key="outer" data-tree-view-client-depth="0" data-tree-view-client-expanded="false">
+            <td>
+              <button id="outer-toggle" data-action="tree-view-client#toggle" data-tree-view-client-node-key="outer" aria-expanded="false"></button>
+              <span id="outer-hidden-count" data-tree-view-client-hidden-count-for="outer">1</span>
+              <table id="inner" data-controller="tree-view-client">
+                <tbody>
+                  <tr id="inner-row" data-tree-view-client-node-key="inner" data-tree-view-client-depth="0" data-tree-view-client-expanded="true">
+                    <td>
+                      <button id="inner-toggle" data-action="tree-view-client#toggle" data-tree-view-client-node-key="inner" aria-expanded="true"></button>
+                      <span id="inner-hidden-count" data-tree-view-client-hidden-count-for="inner">1</span>
+                    </td>
+                  </tr>
+                  <tr id="inner-child" data-tree-view-client-node-key="inner-child" data-tree-view-client-depth="1" data-tree-view-client-expanded="true"><td></td></tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          <tr id="outer-child" data-tree-view-client-node-key="outer-child" data-tree-view-client-depth="1" data-tree-view-client-expanded="true" hidden><td></td></tr>
+        </tbody>
+      </table>
+    `
+
+    application = Application.start()
+    application.register("tree-view-client", TreeViewClientController)
+
+    const outer = document.querySelector("#outer")
+    const outerController = application.getControllerForElementAndIdentifier(outer, "tree-view-client")
+
+    outerController.refreshRows()
+
+    expect(document.querySelector("#outer-child").hidden).toBe(true)
+    expect(document.querySelector("#inner-row").hidden).toBe(false)
+    expect(document.querySelector("#inner-child").hidden).toBe(false)
+    expect(document.querySelector("#inner-hidden-count").hidden).toBe(false)
+  })
 })
 
 describe("TreeViewStateController", () => {

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -22,6 +22,7 @@
 <% row_attrs[:hidden] = true if hidden_by_client_parent %>
 <% row_attrs[:draggable] = true if transfer_data.present? %>
 <% children = row_context.children %>
+<% client_children_rendered = client_mode && render_children && children.any? %>
 <% row_aria[:expanded] = !effectively_collapsed if children.any? %>
 <% row_aria[:current] = "page" if row_context.current? %>
 <% hidden_count = render_children && effectively_collapsed && row_context.descendant_count.positive? && render_self ? row_context.descendant_count : nil %>
@@ -40,7 +41,7 @@
       <% selection_visible = tree_selection_visible?(item, tree, depth, render_context.selection_visibility) %>
       <%= render 'tree_view/tree_selection_cell', item: item, tree: tree, selection_visible: selection_visible, selection_payload_builder: render_context.selection_payload_builder, selection_checkbox_name: render_context.selection_checkbox_name, selection_disabled_builder: render_context.selection_disabled_builder, selection_disabled_reason_builder: render_context.selection_disabled_reason_builder, selection_selected_keys: render_context.selection_selected_keys %>
     <% end %>
-    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: render_context.hidden_message_builder, depth_label_builder: render_context.depth_label_builder, badge_builder: render_context.badge_builder, toggle_icon_builder: render_context.toggle_icon_builder, toggle_state: toggle_state, mode: mode, max_toggle_depth_from_root: render_context.max_toggle_depth_from_root, max_toggle_leaf_distance: render_context.max_toggle_leaf_distance, leaf_distance: leaf_distance %>
+    <%= render 'tree_view/tree_toggle_cell', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: render_context.hidden_message_builder, depth_label_builder: render_context.depth_label_builder, badge_builder: render_context.badge_builder, toggle_icon_builder: render_context.toggle_icon_builder, toggle_state: toggle_state, mode: mode, max_toggle_depth_from_root: render_context.max_toggle_depth_from_root, max_toggle_leaf_distance: render_context.max_toggle_leaf_distance, leaf_distance: leaf_distance, client_children_rendered: client_children_rendered %>
     <%= render row_partial, item: item %>
     <% if row_actions_partial %>
       <%= render row_actions_partial, item: item, tree: tree, render_state: render_context.render_state %>

--- a/app/views/tree_view/_tree_toggle_cell.html.erb
+++ b/app/views/tree_view/_tree_toggle_cell.html.erb
@@ -5,6 +5,7 @@
 <% marker_builder = local_assigns[:marker_builder] %>
 <% toggle_icon_builder = local_assigns[:toggle_icon_builder] %>
 <% toggle_state = local_assigns[:toggle_state] || :leaf %>
+<% client_children_rendered = local_assigns[:client_children_rendered] == true %>
 <% children ||= tree.children_for(item) %>
 <% mode = tree_toggle_mode(local_assigns[:mode]) %>
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
@@ -22,7 +23,7 @@
             end %>
 
 <td class="btn-cell tree-toggle-cell" id="<%= tree_button_dom_id(item) %>">
-  <%= render 'tree_view/tree_toggle_content', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, toggle_icon_builder: toggle_icon_builder, toggle_state: toggle_state, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance %>
+  <%= render 'tree_view/tree_toggle_content', item: item, depth: depth, tree: tree, children: children, hidden_count: hidden_count, hidden_message_builder: hidden_message_builder, toggle_icon_builder: toggle_icon_builder, toggle_state: toggle_state, mode: mode, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance, client_children_rendered: client_children_rendered %>
   <% if marker %>
     <%= tag.span marker[:text], class: ['tree-node-marker', marker[:class]].flatten.compact_blank, title: marker[:title], data: marker[:data] %>
   <% end %>

--- a/app/views/tree_view/_tree_toggle_content_client.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_client.html.erb
@@ -2,6 +2,7 @@
 <% hidden_message_builder = local_assigns[:hidden_message_builder] %>
 <% toggle_icon_builder = local_assigns[:toggle_icon_builder] %>
 <% toggle_state = local_assigns[:toggle_state] || :leaf %>
+<% client_children_rendered = local_assigns[:client_children_rendered] == true %>
 <% children ||= tree.children_for(item) %>
 <% branch_info = tree_branch_info(item, tree) %>
 <% ancestor_last_states = branch_info[:ancestor_last_states] %>
@@ -9,7 +10,7 @@
 <% leaf_distance = local_assigns[:leaf_distance] %>
 <% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :client, leaf_distance: leaf_distance) %>
 <% node_key = tree.node_key_for(item) %>
-<% expanded = !hidden_count && children.any? %>
+<% expanded = !hidden_count && client_children_rendered %>
 
 <div class="tree-toggle">
   <div class="tree-toggle__branches" aria-hidden="true">
@@ -21,7 +22,7 @@
     <% end %>
   </div>
   <div class="tree-toggle__control">
-    <% if children.any? %>
+    <% if client_children_rendered %>
       <%= button_tag type: 'button', class: 'btn btn-primary tree-toggle__action tree-toggle__client-action', id: tree_show_button_dom_id(item), data: { action: 'tree-view-client#toggle', tree_view_client_node_key: node_key }, aria: { expanded: expanded } do %>
         <%= toggle_icon || tree_toggle_label(depth) %>
       <% end %>

--- a/docs/en/lazy-loading.md
+++ b/docs/en/lazy-loading.md
@@ -15,6 +15,8 @@ TreeView is responsible for:
 
 The host app remains responsible for fetch behavior, Turbo requests, controller actions, authorization, queries, retry UI, and children pagination.
 
+Lazy loading is intended for Turbo/server-driven rendering. It cannot be enabled with client-side toggle mode because client-side mode can only reveal descendants that are already present in the initial HTML.
+
 ## UiConfig setup
 
 Pass `load_children_path_builder` to `UiConfigBuilder#build`.
@@ -64,6 +66,8 @@ render_state = TreeView::RenderState.new(
 | `enabled:` | Whether lazy-loading data attributes should be rendered. |
 | `loaded_keys:` | Node keys whose children are already loaded. |
 | `scope:` | Optional scope value passed to path builders. |
+
+Do not combine `lazy_loading: { enabled: true }` with `UiConfigBuilder#build_client_side`. Client-side toggle mode assumes revealable descendants are already rendered in the initial DOM, while lazy loading assumes descendants may be fetched later. TreeView raises a configuration error for this combination.
 
 ## Minimal host-app pattern
 

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -81,6 +81,8 @@ tree_ui = TreeView::UiConfigBuilder.new(
 
 In client-side mode, collapsed descendants inside `max_render_depth` / `max_leaf_distance` are still rendered into the initial HTML with the `hidden` attribute. The bundled `tree-view-client` controller toggles `hidden`, `aria-expanded`, and TreeView row state data inside the current tree element. It does not replace lazy loading, children pagination, authorization, or server-side query strategies for large trees.
 
+Do not combine client-side mode with `lazy_loading: { enabled: true }`. Client-side mode can only reveal rows already present in the initial DOM; use Turbo mode for children that must be fetched later.
+
 Register TreeView JavaScript controllers as usual:
 
 ```js
@@ -307,7 +309,7 @@ tree_ui = TreeView::UiConfigBuilder.new(
 )
 ```
 
-The host app owns fetch behavior, Turbo requests, retry behavior, loading messages, and authorization.
+The host app owns fetch behavior, Turbo requests, retry behavior, loading messages, and authorization. Lazy loading requires Turbo/server-driven rendering and cannot be enabled with `build_client_side`.
 
 ## PathTree / ReverseTree
 

--- a/docs/ja/lazy-loading.md
+++ b/docs/ja/lazy-loading.md
@@ -15,6 +15,8 @@ TreeView gem が担当するのは以下です。
 
 実際のfetch、Turbo request、controller action、認可、query、retry UI、children paginationはhost app側で実装します。
 
+lazy loading は Turbo / server-driven rendering 向けです。client-side toggle mode は初期HTML内にすでに存在する子孫だけを表示できる前提なので、lazy loading と同時には有効にできません。
+
 ## UiConfigの設定
 
 lazy loadingを使う場合は、`UiConfigBuilder#build` に `load_children_path_builder` を渡します。
@@ -64,6 +66,8 @@ render_state = TreeView::RenderState.new(
 | `enabled:` | lazy loading用data属性を出すかどうか。 |
 | `loaded_keys:` | すでにchildrenを読み込み済みのnode_key配列。 |
 | `scope:` | path builderへ渡すscope。省略可能。 |
+
+`lazy_loading: { enabled: true }` と `UiConfigBuilder#build_client_side` は併用しないでください。client-side toggle mode は、表示可能な子孫が初期DOMに描画済みであることを前提にします。一方、lazy loading は子孫を後から取得する前提です。この組み合わせでは TreeView は configuration error を発生させます。
 
 ## 最小host-app pattern
 

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -79,6 +79,8 @@ tree_ui = TreeView::UiConfigBuilder.new(
 
 client-side modeでは、collapsed descendantsも初期HTMLに描画し、初期状態では `hidden` 属性で隠します。bundled `tree-view-client` controller が、現在のtree element内だけで `hidden`、`aria-expanded`、TreeView row state dataを同期します。lazy loading、children pagination、認可、server-side query削減の代替ではありません。
 
+client-side mode と `lazy_loading: { enabled: true }` は併用しないでください。client-side mode は初期DOMに存在するrowだけを表示できるため、後からchildrenを取得する必要がある場合は Turbo mode を使います。
+
 TreeView JavaScript controllerを通常どおり登録します。
 
 ```js
@@ -305,7 +307,7 @@ tree_ui = TreeView::UiConfigBuilder.new(
 )
 ```
 
-fetch、Turbo request、retry、loading message、認可はhost app側で実装します。
+fetch、Turbo request、retry、loading message、認可はhost app側で実装します。Lazy loading は Turbo / server-driven rendering を前提とし、`build_client_side` とは併用できません。
 
 ## PathTree / ReverseTree
 

--- a/lib/tree_view/render_state_lazy_loading.rb
+++ b/lib/tree_view/render_state_lazy_loading.rb
@@ -21,6 +21,7 @@ module TreeView
       @lazy_loading_scope = resolve_lazy_loading_option(options.delete(:lazy_loading_scope), lazy_loading_options[:scope]) || "all"
 
       super
+      validate_lazy_loading_mode_contract!
     end
 
     def lazy_loading_enabled?
@@ -51,6 +52,13 @@ module TreeView
       return value if value == true || value == false
 
       raise ArgumentError, "#{name} must be true or false"
+    end
+
+    def validate_lazy_loading_mode_contract!
+      return unless lazy_loading_enabled?
+      return unless ui_config.respond_to?(:client?) && ui_config.client?
+
+      raise TreeView::ConfigurationError, "lazy_loading cannot be enabled with client-side toggle mode; use turbo mode for remote child loading or disable lazy_loading"
     end
   end
 end

--- a/spec/integration/tree_view_client_mode_integration_spec.rb
+++ b/spec/integration/tree_view_client_mode_integration_spec.rb
@@ -56,11 +56,10 @@ RSpec.describe "TreeView client-side toggle mode" do
     expect(rendered).to include('data-tree-view-client-depth="1"')
     expect(rendered).to include('data-tree-view-client-expanded="false"')
     expect(rendered).to include('hidden="hidden"')
-    expect(rendered).to include('data-action="tree-view-client#toggle"')
     expect(rendered).to include('data-tree-view-client-hidden-count-for="1"')
   end
 
-  it "respects max_render_depth while keeping collapsed descendants inside the render scope" do
+  it "does not render client toggle buttons when children are outside the render scope" do
     tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_client_side
     render_state = TreeView::RenderState.new(
       tree: tree,
@@ -78,6 +77,25 @@ RSpec.describe "TreeView client-side toggle mode" do
     expect(rendered).to include('id="project_2"')
     expect(rendered).to include('id="project_4"')
     expect(rendered).not_to include('id="project_3"')
+    expect(rendered).not_to include('data-action="tree-view-client#toggle"')
+    expect(rendered).to include('data-tree-view-client-hidden-count-for="1"')
+  end
+
+  it "renders client toggle buttons when children are present in the render scope" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_client_side
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      initial_state: :collapsed,
+      max_render_depth: 2
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state)
+
+    expect(rendered).to include('data-action="tree-view-client#toggle"')
   end
 
   it "adds the client controller to tree_view_state_data for client-side UiConfig" do

--- a/spec/integration/tree_view_client_mode_integration_spec.rb
+++ b/spec/integration/tree_view_client_mode_integration_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe "TreeView client-side toggle mode" do
     expect(rendered).to include('id="project_2"')
     expect(rendered).to include('id="project_4"')
     expect(rendered).not_to include('id="project_3"')
-    expect(rendered).not_to include('data-action="tree-view-client#toggle"')
+    expect(rendered).to include('data-action="tree-view-client#toggle" data-tree-view-client-node-key="1"')
+    expect(rendered).not_to include('data-action="tree-view-client#toggle" data-tree-view-client-node-key="2"')
     expect(rendered).to include('data-tree-view-client-hidden-count-for="1"')
   end
 

--- a/spec/lib/tree_view/render_state_spec.rb
+++ b/spec/lib/tree_view/render_state_spec.rb
@@ -243,6 +243,20 @@ RSpec.describe TreeView::RenderState do
     expect(state.lazy_loading_scope).to eq("children")
   end
 
+  it "rejects lazy loading with client-side toggle mode" do
+    client_ui = instance_double(TreeView::UiConfig, client?: true)
+
+    expect do
+      described_class.new(
+        tree: tree,
+        root_items: [],
+        row_partial: "items/tree_columns",
+        ui_config: client_ui,
+        lazy_loading: {enabled: true}
+      )
+    end.to raise_error(TreeView::ConfigurationError, /lazy_loading cannot be enabled with client-side toggle mode/)
+  end
+
   it "rejects unknown lazy_loading keys" do
     expect do
       described_class.new(


### PR DESCRIPTION
## Summary

- avoid rendering client-side toggle buttons when child rows are outside the rendered client scope
- reject `lazy_loading` with client-side toggle mode and document the contract in EN/JA docs
- scope `tree-view-client` row and hidden-count lookup to the current Stimulus controller so nested TreeViews/tables are ignored

## Tests

- Not run locally; repository clone/network access is unavailable in this environment.
- Added regression coverage in `app/javascript/tree_view/index.test.js` and `spec/lib/tree_view/render_state_spec.rb`.

Follow-up for #340 after #350.