### PR TITLE
Add declarative toggle_icons configuration

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -220,6 +220,8 @@ render_state = TreeView::RenderState.new(
 | `badge_builder:` | no | Callable that returns a row badge or marker value. |
 | `icon_builder:` | no | Compatibility alias for row badge or marker display; prefer `badge_builder` in new code. |
 | `depth_label_builder:` | no | Callable that returns a depth label. |
+| `toggle_icons:` | no | Declarative map for toggle control icons. Supports `by_state`, `by_depth`, and `by_type`; see [Toggle icon customization](toggle-icons.md). |
+| `toggle_icon_builder:` | no | Callable that returns toggle control content. Takes precedence over `toggle_icons:` when both are supplied. |
 | `row_status_builder:` | no | Callable that returns row state. |
 | `row_event_payload_builder:` | no | Callable that returns drag/drop transfer payloads. This is transfer-specific, not a generic row event hook. |
 | `persisted_state:` | no | Saved expansion state. |

--- a/docs/en/toggle-icons.md
+++ b/docs/en/toggle-icons.md
@@ -1,10 +1,48 @@
 # Toggle icon customization
 
-Use `toggle_icon_builder:` when you want to replace the visual content of TreeView's expand/collapse control without taking over the control itself.
+Use `toggle_icons:` or `toggle_icon_builder:` when you want to replace the visual content of TreeView's expand/collapse control without taking over the control itself.
 
-TreeView still owns link generation, Turbo Stream data attributes, ARIA state, depth/branch layout, and lazy-loading semantics. The builder only supplies the content rendered inside the toggle control.
+TreeView still owns link generation, Turbo Stream data attributes, ARIA state, depth/branch layout, and lazy-loading semantics. Custom content only supplies the content rendered inside the toggle control.
+
+## Configure icons by state, depth, and node type with toggle_icons
+
+Use `toggle_icons:` when you want to configure multiple icons declaratively.
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icons: {
+    by_state: {
+      expanded: "▾",
+      collapsed: "▸",
+      leaf: "•"
+    },
+    by_depth: {
+      0 => { expanded: "▼", collapsed: "▶", leaf: "●" },
+      1 => { expanded: "▾", collapsed: "▸", leaf: "•" }
+    },
+    by_type: {
+      folder: { expanded: "📂", collapsed: "📁" },
+      file: { leaf: "📄" }
+    }
+  }
+)
+```
+
+Icons are selected in this order: `by_type`, then `by_depth`, then `by_state`. If a more specific entry is not found, TreeView falls back to the next one.
+
+`by_type` reads the item using `node_type`, `type`, then `kind`. For Hash-like items, `:node_type` and `"node_type"` are also supported.
+
+`by_depth` uses the existing root-based `depth`, where root rows are depth `0`. This API uses `depth`, not `level`, to match the existing render context naming.
+
+When both `toggle_icon_builder:` and `toggle_icons:` are supplied, the explicit `toggle_icon_builder:` takes precedence.
 
 ## Builder arguments
+
+Use `toggle_icon_builder:` when you need more control.
 
 ```ruby
 toggle_icon_builder: ->(item, state, context) { ... }
@@ -16,7 +54,7 @@ toggle_icon_builder: ->(item, state, context) { ... }
 | `state` | One of `:expanded`, `:collapsed`, `:leaf`, or `:loading`. |
 | `context` | Hash containing `:state`, `:depth`, `:tree`, `:children`, `:hidden_count`, `:mode`, and `:leaf_distance`. |
 
-The builder may return plain text or a Hash-like value. Hash values support:
+Both `toggle_icons:` icon values and builder return values may be plain text or a Hash-like value. Hash values support:
 
 | Key | Description |
 |---|---|

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -220,6 +220,8 @@ render_state = TreeView::RenderState.new(
 | `badge_builder:` | no | row badge / marker 表示値を返すcallable。 |
 | `icon_builder:` | no | row badge / marker 表示のcompatibility alias。新しいcodeでは `badge_builder` を推奨。 |
 | `depth_label_builder:` | no | depth labelを返すcallable。 |
+| `toggle_icons:` | no | toggle control icon の宣言的map。`by_state`、`by_depth`、`by_type` を指定できます。詳細は [toggle icon のカスタマイズ](toggle-icons.md) を参照してください。 |
+| `toggle_icon_builder:` | no | toggle control content を返すcallable。`toggle_icons:` と両方指定した場合はこちらを優先します。 |
 | `row_status_builder:` | no | row状態を返すcallable。 |
 | `row_event_payload_builder:` | no | drag/drop transfer payloadを返すcallable。transfer専用であり、汎用row event hookではない。 |
 | `persisted_state:` | no | 保存済み展開状態。 |

--- a/docs/ja/toggle-icons.md
+++ b/docs/ja/toggle-icons.md
@@ -1,10 +1,48 @@
 # toggle icon のカスタマイズ
 
-`toggle_icon_builder:` を使うと、TreeView の開閉コントロール自体は TreeView に任せたまま、見た目の中身だけを差し替えられます。
+`toggle_icons:` または `toggle_icon_builder:` を使うと、TreeView の開閉コントロール自体は TreeView に任せたまま、見た目の中身だけを差し替えられます。
 
-TreeView は引き続き link 生成、Turbo Stream の data 属性、ARIA 状態、depth / branch layout、lazy-loading semantics を管理します。builder は toggle control の内側に描画する内容だけを返します。
+TreeView は引き続き link 生成、Turbo Stream の data 属性、ARIA 状態、depth / branch layout、lazy-loading semantics を管理します。custom content は toggle control の内側に描画する内容だけを返します。
+
+## toggle_icons で状態・depth・node type ごとに指定する
+
+複数の icon を declarative に指定したい場合は `toggle_icons:` を使います。
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  toggle_icons: {
+    by_state: {
+      expanded: "▾",
+      collapsed: "▸",
+      leaf: "•"
+    },
+    by_depth: {
+      0 => { expanded: "▼", collapsed: "▶", leaf: "●" },
+      1 => { expanded: "▾", collapsed: "▸", leaf: "•" }
+    },
+    by_type: {
+      folder: { expanded: "📂", collapsed: "📁" },
+      file: { leaf: "📄" }
+    }
+  }
+)
+```
+
+選択順は `by_type` → `by_depth` → `by_state` です。より具体的な指定が見つからない場合に、次の fallback を使います。
+
+`by_type` は item の `node_type`, `type`, `kind` の順に参照します。Hash-like な item の場合は `:node_type` / `"node_type"` も参照します。
+
+`by_depth` は root を `0` とする既存の `depth` を使います。既存 API や context と用語を揃えるため、`level` ではなく `depth` を使います。
+
+`toggle_icon_builder:` と `toggle_icons:` を両方指定した場合は、明示的な `toggle_icon_builder:` が優先されます。
 
 ## builder の引数
+
+より細かく制御したい場合は `toggle_icon_builder:` を使います。
 
 ```ruby
 toggle_icon_builder: ->(item, state, context) { ... }
@@ -16,7 +54,7 @@ toggle_icon_builder: ->(item, state, context) { ... }
 | `state` | `:expanded`, `:collapsed`, `:leaf`, `:loading` のいずれか。 |
 | `context` | `:state`, `:depth`, `:tree`, `:children`, `:hidden_count`, `:mode`, `:leaf_distance` を含む Hash。 |
 
-builder は plain text または Hash-like な値を返せます。Hash では以下を指定できます。
+`toggle_icons:` の各 icon value と builder は、plain text または Hash-like な値を返せます。Hash では以下を指定できます。
 
 | key | 説明 |
 |---|---|

--- a/lib/tree_view/render_state.rb
+++ b/lib/tree_view/render_state.rb
@@ -13,6 +13,9 @@ module TreeView
     VALID_TOGGLE_SCOPE_KEYS = %i[max_depth_from_root max_leaf_distance].freeze
     VALID_SELECTION_KEYS = SelectionConfig::VALID_KEYS
     VALID_SELECTION_VISIBILITIES = SelectionConfig::VALID_VISIBILITIES
+    VALID_TOGGLE_ICONS_KEYS = %i[by_state by_depth by_type].freeze
+    VALID_TOGGLE_ICON_STATES = %i[expanded collapsed leaf loading].freeze
+    TOGGLE_ICON_RENDER_KEYS = %i[text label icon html class title data aria_hidden].freeze
     DEFAULT_SELECTION_CHECKBOX_NAME = "selected_nodes[]"
 
     attr_reader :tree,
@@ -48,6 +51,7 @@ module TreeView
       :depth_label_builder,
       :badge_builder,
       :icon_builder,
+      :toggle_icons,
       :toggle_icon_builder
 
     # RenderState は「この画面ではどう描くか」を束ねる。
@@ -86,6 +90,7 @@ module TreeView
       depth_label_builder: nil,
       badge_builder: nil,
       icon_builder: nil,
+      toggle_icons: nil,
       toggle_icon_builder: nil)
       initial_expansion_options = normalize_options(initial_expansion, :initial_expansion, VALID_INITIAL_EXPANSION_KEYS)
       render_scope_options = normalize_options(render_scope, :render_scope, VALID_RENDER_SCOPE_KEYS)
@@ -136,7 +141,8 @@ module TreeView
       @depth_label_builder = depth_label_builder
       @badge_builder = badge_builder
       @icon_builder = icon_builder
-      @toggle_icon_builder = toggle_icon_builder
+      @toggle_icons = normalize_toggle_icons(toggle_icons)
+      @toggle_icon_builder = toggle_icon_builder || build_toggle_icon_builder(@toggle_icons)
 
       validate_builders!(
         row_class_builder: row_class_builder,
@@ -147,7 +153,7 @@ module TreeView
         depth_label_builder: depth_label_builder,
         badge_builder: badge_builder,
         icon_builder: icon_builder,
-        toggle_icon_builder: toggle_icon_builder,
+        toggle_icon_builder: @toggle_icon_builder,
         selection_payload_builder: @selection_payload_builder,
         selection_disabled_builder: @selection_disabled_builder,
         selection_disabled_reason_builder: @selection_disabled_reason_builder
@@ -189,6 +195,85 @@ module TreeView
       end
 
       options
+    end
+
+    def normalize_toggle_icons(value)
+      return {} if value.nil?
+      normalize_options(value, :toggle_icons, VALID_TOGGLE_ICONS_KEYS)
+    end
+
+    def build_toggle_icon_builder(icons)
+      return nil if icons.empty?
+
+      lambda do |item, state, context|
+        normalized_state = state.to_sym
+        icon_for_type(icons[:by_type], item, normalized_state) ||
+          icon_for_key(icons[:by_depth], context[:depth], normalized_state) ||
+          icon_for_state(icons[:by_state], normalized_state)
+      end
+    end
+
+    def icon_for_type(icons, item, state)
+      type = toggle_icon_node_type(item)
+      return nil if type.nil?
+
+      icon_for_key(icons, type, state)
+    end
+
+    def icon_for_key(icons, key, state)
+      return nil if icons.nil? || key.nil? || !icons.respond_to?(:to_h)
+
+      entry = lookup_icon_value(icons.to_h, key)
+      return nil if entry.nil?
+
+      icon_for_state_entry(entry, state)
+    end
+
+    def icon_for_state(icons, state)
+      return nil if icons.nil? || !icons.respond_to?(:to_h)
+
+      lookup_icon_value(icons.to_h, state)
+    end
+
+    def icon_for_state_entry(entry, state)
+      return entry unless entry.respond_to?(:to_h)
+
+      entry_hash = entry.to_h
+      return entry unless state_icon_map?(entry_hash)
+
+      lookup_icon_value(entry_hash, state)
+    end
+
+    def state_icon_map?(entry_hash)
+      normalized_keys = entry_hash.keys.filter_map { |key| key.to_sym if key.respond_to?(:to_sym) }
+      (normalized_keys & VALID_TOGGLE_ICON_STATES).any? && (normalized_keys & TOGGLE_ICON_RENDER_KEYS).empty?
+    end
+
+    def lookup_icon_value(hash, key)
+      return nil unless hash.respond_to?(:key?)
+
+      return hash[key] if hash.key?(key)
+
+      symbol_key = key.to_sym if key.respond_to?(:to_sym)
+      return hash[symbol_key] if !symbol_key.nil? && hash.key?(symbol_key)
+
+      string_key = key.to_s
+      return hash[string_key] if hash.key?(string_key)
+
+      nil
+    end
+
+    def toggle_icon_node_type(item)
+      if item.respond_to?(:[])
+        hash_type = lookup_icon_value(item, :node_type)
+        return hash_type unless hash_type.nil?
+      end
+
+      return item.node_type if item.respond_to?(:node_type)
+      return item.type if item.respond_to?(:type)
+      return item.kind if item.respond_to?(:kind)
+
+      nil
     end
 
     def normalize_initial_state(value)

--- a/spec/integration/tree_view_toggle_icon_builder_integration_spec.rb
+++ b/spec/integration/tree_view_toggle_icon_builder_integration_spec.rb
@@ -3,12 +3,12 @@ require "action_view"
 require "fileutils"
 require "tmpdir"
 
-ToggleIconBuilderNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+ToggleIconBuilderNode = Struct.new(:id, :parent_item_id, :name, :node_type, keyword_init: true)
 
 RSpec.describe "TreeView toggle_icon_builder integration" do
-  let(:root) { ToggleIconBuilderNode.new(id: 1, parent_item_id: nil, name: "root") }
-  let(:child) { ToggleIconBuilderNode.new(id: 2, parent_item_id: 1, name: "child") }
-  let(:leaf) { ToggleIconBuilderNode.new(id: 3, parent_item_id: 2, name: "leaf") }
+  let(:root) { ToggleIconBuilderNode.new(id: 1, parent_item_id: nil, name: "root", node_type: :folder) }
+  let(:child) { ToggleIconBuilderNode.new(id: 2, parent_item_id: 1, name: "child", node_type: :folder) }
+  let(:leaf) { ToggleIconBuilderNode.new(id: 3, parent_item_id: 2, name: "leaf", node_type: :file) }
   let(:nodes) { [root, child, leaf] }
   let(:tree) { TreeView::Tree.new(records: nodes, parent_id_method: :parent_item_id) }
   let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
@@ -81,5 +81,62 @@ RSpec.describe "TreeView toggle_icon_builder integration" do
     expect(rendered).to include("expanded:root")
     expect(rendered).to include('class="tree-toggle__icon chevron chevron-leaf"')
     expect(rendered).to include("leaf:leaf")
+  end
+
+  it "selects toggle icons by type, depth, then state" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build(
+      hide_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/hide?depth=#{depth}&scope=#{scope}" },
+      show_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/show?depth=#{depth}&scope=#{scope}" },
+      toggle_all_path_builder: ->(state) { "/projects/toggle_all?state=#{state}" }
+    )
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      toggle_icons: {
+        by_state: {
+          expanded: "state-expanded",
+          collapsed: "state-collapsed",
+          leaf: "state-leaf"
+        },
+        by_depth: {
+          1 => {expanded: "depth-1-expanded", collapsed: "depth-1-collapsed", leaf: "depth-1-leaf"}
+        },
+        by_type: {
+          folder: {expanded: "folder-expanded", collapsed: "folder-collapsed"},
+          file: {leaf: "file-leaf"}
+        }
+      }
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state, mode: :turbo)
+
+    expect(rendered).to include("folder-expanded")
+    expect(rendered).not_to include("state-expanded")
+    expect(rendered).to include("depth-1-expanded")
+    expect(rendered).to include("file-leaf")
+  end
+
+  it "uses toggle_icon_builder before toggle_icons when both are supplied" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_static
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui,
+      initial_state: :collapsed,
+      toggle_icons: {
+        by_state: {collapsed: "mapped-collapsed"}
+      },
+      toggle_icon_builder: ->(_item, state, _context) { "builder-#{state}" }
+    )
+    view = build_view(tree_ui: nil)
+
+    rendered = view.tree_view_rows(render_state)
+
+    expect(rendered).to include("builder-collapsed")
+    expect(rendered).not_to include("mapped-collapsed")
   end
 end

--- a/spec/integration/tree_view_toggle_icon_builder_integration_spec.rb
+++ b/spec/integration/tree_view_toggle_icon_builder_integration_spec.rb
@@ -84,6 +84,9 @@ RSpec.describe "TreeView toggle_icon_builder integration" do
   end
 
   it "selects toggle icons by type, depth, then state" do
+    untyped_child = ToggleIconBuilderNode.new(id: 2, parent_item_id: 1, name: "child", node_type: nil)
+    untyped_leaf = ToggleIconBuilderNode.new(id: 3, parent_item_id: 2, name: "leaf", node_type: nil)
+    tree = TreeView::Tree.new(records: [root, untyped_child, untyped_leaf], parent_id_method: :parent_item_id)
     tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build(
       hide_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/hide?depth=#{depth}&scope=#{scope}" },
       show_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/show?depth=#{depth}&scope=#{scope}" },
@@ -114,9 +117,8 @@ RSpec.describe "TreeView toggle_icon_builder integration" do
     rendered = view.tree_view_rows(render_state, mode: :turbo)
 
     expect(rendered).to include("folder-expanded")
-    expect(rendered).not_to include("state-expanded")
     expect(rendered).to include("depth-1-expanded")
-    expect(rendered).to include("file-leaf")
+    expect(rendered).to include("state-leaf")
   end
 
   it "uses toggle_icon_builder before toggle_icons when both are supplied" do


### PR DESCRIPTION
## Summary
- Add `toggle_icons:` to `TreeView::RenderState` for declarative toggle icon selection.
- Support `by_state`, `by_depth`, and `by_type` icon maps.
- Prefer `by_type` over `by_depth` over `by_state`; keep explicit `toggle_icon_builder:` as the highest-priority override.
- Document the new API in Japanese and English.
- Add integration specs for map selection and builder precedence.

## Notes
- The depth-based key is named `by_depth` rather than `by_level` to match the existing render context terminology.
- `by_type` resolves node type from `node_type`, `type`, or `kind`; Hash-like items can use `:node_type` or `"node_type"`.

## Testing
- Not run locally in this environment.