### PR TITLE
Persisted state generator can include owner concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Added
 
+- Added owner model argument support to the persisted state install generator so `tree_view:state:install User` can include `TreeViewStateOwner` in an existing owner model.
 - Added `RenderState` current node ancestor expansion via `current_item` / `current_key` and `auto_expand_ancestors`.
 - Added `TreeView::PathTreeBuilder` for building generated folder nodes and record nodes from path-like record values.
 - Added `TreeView.configuration.render_log_level`, defaulting to `:warn`, so TreeView helper-rendered partial logs can be silenced without changing the host app's global Rails logger level.
@@ -46,6 +47,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Tests
 
+- Added generator specs for persisted state owner concern injection.
 - Added RenderState specs for current node ancestor auto-expansion.
 - Added accessibility semantics integration specs for row ARIA state in static, collapsed, selection, and windowed rendering.
 - Added render traversal regression specs for deep trees, wide trees, collapsed render scope, filtered path trees, sorter call growth, children lookup scope, and max leaf distance behavior.

--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -35,6 +35,18 @@ Review the migration, then run:
 bin/rails db:migrate
 ```
 
+### Include the owner concern automatically
+
+Pass an owner model name when you want the generator to include `TreeViewStateOwner` in an existing owner model.
+
+```bash
+bin/rails generate tree_view:state:install User
+```
+
+This still creates the same migration, model, and concern files. If `app/models/user.rb` exists and does not already include `TreeViewStateOwner`, the generator adds the include line.
+
+If the owner model file does not exist, the generator skips model injection and you can include the concern manually.
+
 ## Owner model
 
 Include the concern in the host app owner model.
@@ -114,7 +126,7 @@ Use different keys for different screens or trees, even when the owner is the sa
 | persisted state value object | yes | no |
 | generated model/migration template | yes | reviews and migrates |
 | loading/saving through StateStore | yes | provides owner and key |
-| choosing owner model | no | yes |
+| choosing owner model | optional generator argument | yes |
 | deciding save timing | no | yes |
 | controller/API endpoint | no | yes |
 | authorization | no | yes |

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -35,6 +35,18 @@ migrationを確認してから実行してください。
 bin/rails db:migrate
 ```
 
+### owner concern を自動で include する
+
+既存の owner model に `TreeViewStateOwner` を include したい場合は、owner model 名を渡します。
+
+```bash
+bin/rails generate tree_view:state:install User
+```
+
+この場合も、migration、model、concern は通常どおり生成されます。`app/models/user.rb` が存在し、まだ `TreeViewStateOwner` を include していなければ、generator が include 行を追加します。
+
+owner model file が存在しない場合、model への注入は skip されます。その場合は concern を手動で include してください。
+
 ## owner model
 
 host app側のowner modelに concern をincludeします。
@@ -114,7 +126,7 @@ render_state = TreeView::RenderState.new(
 | persisted state value object | yes | no |
 | generated model/migration template | yes | reviews and migrates |
 | loading/saving through StateStore | yes | provides owner and key |
-| choosing owner model | no | yes |
+| choosing owner model | optional generator argument | yes |
 | deciding save timing | no | yes |
 | controller/API endpoint | no | yes |
 | authorization | no | yes |

--- a/lib/generators/tree_view/state/install_generator.rb
+++ b/lib/generators/tree_view/state/install_generator.rb
@@ -8,6 +8,8 @@ module TreeView
       class InstallGenerator < Rails::Generators::Base
         source_root File.expand_path("templates", __dir__)
 
+        argument :owner_model_name, type: :string, required: false, banner: "OWNER_MODEL"
+
         def copy_files
           template "create_tree_view_states.rb", migration_path
           template "tree_view_state.rb", "app/models/tree_view_state.rb"

--- a/lib/generators/tree_view/state/install_generator.rb
+++ b/lib/generators/tree_view/state/install_generator.rb
@@ -16,6 +16,23 @@ module TreeView
           template "tree_view_state_owner.rb", "app/models/concerns/tree_view_state_owner.rb"
         end
 
+        def add_owner_concern
+          return if owner_model_name.to_s.strip.empty?
+
+          owner_path = File.join("app/models", "#{owner_model_name.underscore}.rb")
+          owner_file = File.join(destination_root, owner_path)
+          unless File.exist?(owner_file)
+            say_status :skip, "#{owner_path} does not exist"
+            return
+          end
+
+          content = File.read(owner_file)
+          return if content.include?("include TreeViewStateOwner")
+
+          updated = content.sub(/^class #{Regexp.escape(owner_model_name)}\b.*$/, "\\0\n  include TreeViewStateOwner")
+          File.write(owner_file, updated)
+        end
+
         private
 
         def migration_path

--- a/spec/generators/tree_view/state/install_generator_spec.rb
+++ b/spec/generators/tree_view/state/install_generator_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe TreeView::Generators::State::InstallGenerator do
     FileUtils.rm_rf(destination_root) if File.directory?(destination_root)
   end
 
-  def run_generator
-    described_class.start([], destination_root: destination_root)
+  def run_generator(*args)
+    described_class.start(args, destination_root: destination_root)
   end
 
   it "creates persisted state migration, model, and owner concern" do
@@ -39,5 +39,38 @@ RSpec.describe TreeView::Generators::State::InstallGenerator do
     expect(File.read(concern)).to include("def tree_view_state_for(tree_instance_key)")
     expect(File.read(concern)).to include("def save_tree_view_state!(tree_instance_key, expanded_keys:)")
     expect(File.read(concern)).to include("TreeView::PersistedState.new")
+  end
+
+  it "includes the owner concern when an owner model is provided" do
+    FileUtils.mkdir_p(File.join(destination_root, "app/models"))
+    user_model = File.join(destination_root, "app/models/user.rb")
+    File.write(user_model, <<~RUBY)
+      class User < ApplicationRecord
+      end
+    RUBY
+
+    run_generator("User")
+
+    expect(File.read(user_model)).to include("class User < ApplicationRecord\n  include TreeViewStateOwner\nend")
+  end
+
+  it "does not duplicate the owner concern include" do
+    FileUtils.mkdir_p(File.join(destination_root, "app/models"))
+    user_model = File.join(destination_root, "app/models/user.rb")
+    File.write(user_model, <<~RUBY)
+      class User < ApplicationRecord
+        include TreeViewStateOwner
+      end
+    RUBY
+
+    run_generator("User")
+
+    expect(File.read(user_model).scan("include TreeViewStateOwner").size).to eq(1)
+  end
+
+  it "skips owner concern injection when the owner model file does not exist" do
+    expect { run_generator("User") }.not_to raise_error
+
+    expect(File).not_to exist(File.join(destination_root, "app/models/user.rb"))
   end
 end


### PR DESCRIPTION
## Summary

- Add an optional owner model argument to `tree_view:state:install`.
- Include `TreeViewStateOwner` in an existing owner model when provided.
- Add generator specs for injection, duplicate prevention, and missing model skip.
- Update English and Japanese persisted-state docs.
- Update CHANGELOG.

## Testing

- CI on the previous head passed: lint, pr_specs, javascript.
- Latest docs/changelog follow-up commit is awaiting CI.