### PR TITLE
Add tree_view_toolbar helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Added
 
+- Added `tree_view_toolbar(render_state)` for rendering tree-wide expand/collapse toolbar actions through `UiConfig#toggle_all_path`.
 - Added `TreeView::NodePresenter` as a thin adapter for node-level resolver hooks and `RenderState` row class/data/icon/badge builders.
 - Added owner model argument support to the persisted state install generator so `tree_view:state:install User` can include `TreeViewStateOwner` in an existing owner model.
 - Added `RenderState` current node ancestor expansion via `current_item` / `current_key` and `auto_expand_ancestors`.
@@ -34,6 +35,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Documentation
 
+- Added toolbar helper docs in Japanese and English.
 - Added README adoption guidance to help users decide whether TreeView fits their use case and to clarify the virtual scrolling boundary.
 - Promoted accessibility semantics as a first-class capability in the README and docs indexes, including ARIA placement, keyboard boundaries, and host-app responsibilities.
 - Added accessibility semantics docs for table-first TreeView rows and ARIA placement policy.
@@ -48,6 +50,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Tests
 
+- Added toolbar helper specs.
 - Added `NodePresenter` specs and `RenderState` integration specs.
 - Added generator specs for persisted state owner concern injection.
 - Added RenderState specs for current node ancestor auto-expansion.

--- a/app/helpers/tree_view_helper.rb
+++ b/app/helpers/tree_view_helper.rb
@@ -7,6 +7,7 @@ require_relative "tree_view_helper/transfer"
 require_relative "tree_view_helper/visuals"
 require_relative "tree_view_helper/render_scope"
 require_relative "tree_view_helper/lazy_loading"
+require_relative "tree_view_helper/toolbar"
 require_relative "tree_view_breadcrumb_helper"
 
 module TreeViewHelper
@@ -19,4 +20,5 @@ module TreeViewHelper
   include Visuals
   include RenderScope
   include LazyLoading
+  include Toolbar
 end

--- a/app/helpers/tree_view_helper/toolbar.rb
+++ b/app/helpers/tree_view_helper/toolbar.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module TreeViewHelper
+  module Toolbar
+    DEFAULT_TREE_VIEW_TOOLBAR_ACTIONS = %i[expand_all collapse_all].freeze
+    TREE_VIEW_TOOLBAR_ACTIONS = %i[expand_all collapse_all collapse_all_except_current_path].freeze
+    TREE_VIEW_TOOLBAR_LABELS = {
+      expand_all: "Expand all",
+      collapse_all: "Collapse all",
+      collapse_all_except_current_path: "Collapse all except current path"
+    }.freeze
+    TREE_VIEW_TOOLBAR_STATES = {
+      expand_all: :expanded,
+      collapse_all: :collapsed,
+      collapse_all_except_current_path: :current_path
+    }.freeze
+
+    def tree_view_toolbar(render_state, actions: DEFAULT_TREE_VIEW_TOOLBAR_ACTIONS, labels: {}, class_name: "tree-view-toolbar", button_class_name: "tree-view-toolbar__button")
+      normalized_actions = normalize_tree_view_toolbar_actions(actions)
+      normalized_labels = labels.to_h.transform_keys(&:to_sym)
+
+      content_tag(:div, class: class_name, data: {tree_view_toolbar: true}) do
+        safe_join(
+          normalized_actions.filter_map do |action|
+            tree_view_toolbar_action(render_state, action, normalized_labels, button_class_name)
+          end
+        )
+      end
+    end
+
+    private
+
+    def normalize_tree_view_toolbar_actions(actions)
+      Array(actions).map do |action|
+        normalized_action = action.to_sym
+        next normalized_action if TREE_VIEW_TOOLBAR_ACTIONS.include?(normalized_action)
+
+        raise TreeView::ConfigurationError, "unknown tree_view_toolbar action: #{action}; supported actions are: #{TREE_VIEW_TOOLBAR_ACTIONS.join(", ")}"
+      end
+    end
+
+    def tree_view_toolbar_action(render_state, action, labels, button_class_name)
+      path = tree_view_toolbar_path(render_state, action)
+      label = labels.fetch(action, TREE_VIEW_TOOLBAR_LABELS.fetch(action))
+      data = {tree_view_toolbar_action: action}
+
+      if path
+        link_to(label, path, class: button_class_name, data: data)
+      else
+        button_tag(label, type: "button", class: button_class_name, disabled: true, data: data.merge(tree_view_toolbar_disabled: true))
+      end
+    end
+
+    def tree_view_toolbar_path(render_state, action)
+      return nil unless render_state.ui_config.respond_to?(:toggle_all_path)
+
+      render_state.ui_config.toggle_all_path(state: TREE_VIEW_TOOLBAR_STATES.fetch(action))
+    end
+  end
+end

--- a/docs/en/toolbar.md
+++ b/docs/en/toolbar.md
@@ -1,0 +1,71 @@
+# Toolbar helper
+
+`tree_view_toolbar(render_state)` renders a small toolbar for tree-wide actions.
+
+The helper is intentionally thin. It uses `render_state.ui_config.toggle_all_path(state:)` when available and otherwise renders disabled buttons. Host apps still own routes, authorization, Turbo responses, and the exact state transition behavior.
+
+## Basic usage
+
+```erb
+<%= tree_view_toolbar(@render_state) %>
+```
+
+By default, the toolbar renders:
+
+- `expand_all`
+- `collapse_all`
+
+If `UiConfig#toggle_all_path` is configured, each action renders as a link.
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_turbo(
+  toggle_all_path_builder: ->(state) { documents_tree_path(state: state) }
+)
+```
+
+## Actions
+
+```erb
+<%= tree_view_toolbar(
+  @render_state,
+  actions: [:expand_all, :collapse_all, :collapse_all_except_current_path]
+) %>
+```
+
+Supported actions:
+
+| Action | `toggle_all_path` state | Description |
+|---|---|---|
+| `:expand_all` | `:expanded` | Ask the host app to expand the tree. |
+| `:collapse_all` | `:collapsed` | Ask the host app to collapse the tree. |
+| `:collapse_all_except_current_path` | `:current_path` | Ask the host app to keep only the current path open. |
+
+`collapse_all_except_current_path` is a host-app contract. TreeView only emits the toolbar action and state value.
+
+## Custom labels and classes
+
+```erb
+<%= tree_view_toolbar(
+  @render_state,
+  actions: [:expand_all],
+  labels: { expand_all: "Open all" },
+  class_name: "documents-toolbar",
+  button_class_name: "documents-toolbar__button"
+) %>
+```
+
+## Responsibility boundary
+
+TreeView renders the toolbar shell, validates action names, and builds links with `toggle_all_path`.
+
+Host apps own:
+
+- routes and controllers
+- Turbo Stream responses
+- authorization
+- persistence of expanded keys
+- semantics of `:current_path`
+- visual styling beyond default class names

--- a/docs/ja/toolbar.md
+++ b/docs/ja/toolbar.md
@@ -1,0 +1,71 @@
+# Toolbar helper
+
+`tree_view_toolbar(render_state)` は、tree全体に対する操作用の小さなtoolbarを描画します。
+
+このhelperは薄いadapterです。`render_state.ui_config.toggle_all_path(state:)` が使える場合はlinkを描画し、使えない場合はdisabled buttonを描画します。route、authorization、Turbo response、実際の状態遷移はhost app側の責務です。
+
+## 基本例
+
+```erb
+<%= tree_view_toolbar(@render_state) %>
+```
+
+既定では以下を描画します。
+
+- `expand_all`
+- `collapse_all`
+
+`UiConfig#toggle_all_path` が設定されている場合、各actionはlinkとして描画されます。
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_turbo(
+  toggle_all_path_builder: ->(state) { documents_tree_path(state: state) }
+)
+```
+
+## actions
+
+```erb
+<%= tree_view_toolbar(
+  @render_state,
+  actions: [:expand_all, :collapse_all, :collapse_all_except_current_path]
+) %>
+```
+
+対応action:
+
+| Action | `toggle_all_path` state | 説明 |
+|---|---|---|
+| `:expand_all` | `:expanded` | host appにtree全体の展開を依頼します。 |
+| `:collapse_all` | `:collapsed` | host appにtree全体の折りたたみを依頼します。 |
+| `:collapse_all_except_current_path` | `:current_path` | current path だけを開いた状態にするようhost appへ依頼します。 |
+
+`collapse_all_except_current_path` はhost appとのcontractです。TreeViewはtoolbar actionとstate値を出すだけです。
+
+## label と class の変更
+
+```erb
+<%= tree_view_toolbar(
+  @render_state,
+  actions: [:expand_all],
+  labels: { expand_all: "Open all" },
+  class_name: "documents-toolbar",
+  button_class_name: "documents-toolbar__button"
+) %>
+```
+
+## 責務境界
+
+TreeViewはtoolbar shell、action名validation、`toggle_all_path` によるlink生成だけを担います。
+
+host appは以下を担当します。
+
+- routes and controllers
+- Turbo Stream responses
+- authorization
+- expanded keys の保存
+- `:current_path` の意味づけ
+- default class names 以上の見た目調整

--- a/spec/helpers/tree_view_toolbar_helper_spec.rb
+++ b/spec/helpers/tree_view_toolbar_helper_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_view"
+require "action_view/helpers"
+
+RSpec.describe "tree_view_toolbar helper" do
+  let(:helper_class) do
+    Class.new do
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::UrlHelper
+      include ActionView::Helpers::OutputSafetyHelper
+      include ActionView::Helpers::FormTagHelper
+      include TreeViewHelper
+    end
+  end
+  let(:helper) { helper_class.new }
+  let(:ui_config) do
+    TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" },
+      toggle_all_path_builder: ->(state) { "/tree?state=#{state}" }
+    )
+  end
+  let(:render_state) do
+    instance_double(TreeView::RenderState, ui_config: ui_config)
+  end
+
+  it "renders expand and collapse links by default" do
+    html = helper.tree_view_toolbar(render_state)
+
+    expect(html).to include("tree-view-toolbar")
+    expect(html).to include("href=\"/tree?state=expanded\"")
+    expect(html).to include("Expand all")
+    expect(html).to include("href=\"/tree?state=collapsed\"")
+    expect(html).to include("Collapse all")
+  end
+
+  it "renders collapse current path action" do
+    html = helper.tree_view_toolbar(render_state, actions: [:collapse_all_except_current_path])
+
+    expect(html).to include("href=\"/tree?state=current_path\"")
+    expect(html).to include("Collapse all except current path")
+  end
+
+  it "supports custom labels and class names" do
+    html = helper.tree_view_toolbar(
+      render_state,
+      actions: [:expand_all],
+      labels: {expand_all: "Open all"},
+      class_name: "custom-toolbar",
+      button_class_name: "custom-button"
+    )
+
+    expect(html).to include("custom-toolbar")
+    expect(html).to include("custom-button")
+    expect(html).to include("Open all")
+  end
+
+  it "renders disabled buttons when no toggle_all_path is configured" do
+    static_ui_config = TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" }
+    )
+    static_render_state = instance_double(TreeView::RenderState, ui_config: static_ui_config)
+
+    html = helper.tree_view_toolbar(static_render_state, actions: [:expand_all])
+
+    expect(html).to include("disabled=\"disabled\"")
+    expect(html).to include("data-tree-view-toolbar-disabled=\"true\"")
+  end
+
+  it "rejects unknown actions" do
+    expect do
+      helper.tree_view_toolbar(render_state, actions: [:unknown])
+    end.to raise_error(TreeView::ConfigurationError, /unknown tree_view_toolbar action/)
+  end
+end

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe "Public API compatibility" do
       tree_node_dom_id
       tree_selection_value
       tree_view_breadcrumb
+      tree_view_toolbar
     ].each do |method_name|
       expect(TreeViewHelper.public_instance_methods).to include(method_name)
     end


### PR DESCRIPTION
## Summary

- tree_view_toolbar helper を追加
- expand_all / collapse_all / collapse_all_except_current_path action を追加
- helper spec、public API spec、日英docs、CHANGELOGを追加

## Notes

#371 の Toolbar helper 対応です。routes、Turbo response、authorization、state persistence は host app 側の責務として残しています。

## Testing

- CIで確認します。