### PR TITLE
Add turbo_frame option to Turbo UiConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Added
 
+- Added `UiConfig#turbo_frame` and `UiConfigBuilder#build_turbo(turbo_frame:)` so Turbo toggle links can target a host-app Turbo Frame without custom JavaScript.
 - Added `tree_view_toolbar(render_state)` for rendering tree-wide expand/collapse toolbar actions through `UiConfig#toggle_all_path`.
 - Added `TreeView::NodePresenter` as a thin adapter for node-level resolver hooks and `RenderState` row class/data/icon/badge builders.
 - Added owner model argument support to the persisted state install generator so `tree_view:state:install User` can include `TreeViewStateOwner` in an existing owner model.
@@ -35,6 +36,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Documentation
 
+- Added Turbo Frame option docs in Japanese and English.
 - Added NodePresenter row partial cookbook docs and clarified criteria for promoting app-specific UI patterns into TreeView.
 - Added toolbar helper docs in Japanese and English.
 - Added README adoption guidance to help users decide whether TreeView fits their use case and to clarify the virtual scrolling boundary.
@@ -51,6 +53,7 @@ Breaking changes and required migration notes should be called out explicitly in
 
 ### Tests
 
+- Added Turbo Frame option unit and integration specs.
 - Added toolbar helper specs.
 - Added `NodePresenter` specs and `RenderState` integration specs.
 - Added generator specs for persisted state owner concern injection.

--- a/app/helpers/tree_view_helper/dom.rb
+++ b/app/helpers/tree_view_helper/dom.rb
@@ -32,6 +32,10 @@ module TreeViewHelper
       resolved_ui(ui).toggle_all_path(state: state)
     end
 
+    def tree_turbo_frame(ui: @tree_ui)
+      resolved_ui(ui).turbo_frame
+    end
+
     def tree_expand_all_path(ui: @tree_ui)
       tree_toggle_all_path(state: :expanded, ui: ui)
     end

--- a/app/views/tree_view/_tree_toggle_content_turbo.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_turbo.html.erb
@@ -12,6 +12,8 @@
 <% toggle_scope = tree_toggle_scope(depth: depth, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance) %>
 <% show_path = tree_show_descendants_path(item, depth + 1, scope: toggle_scope) %>
 <% hide_path = tree_hide_descendants_path(item, depth, scope: toggle_scope) %>
+<% turbo_data = { turbo_stream: true } %>
+<% turbo_data[:turbo_frame] = render_state.ui_config.turbo_frame if render_state.ui_config.turbo_frame %>
 <% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :turbo, leaf_distance: leaf_distance) %>
 
 <div class="tree-toggle">
@@ -25,11 +27,11 @@
   </div>
   <div class="tree-toggle__control">
     <% if hidden_count && show_path %>
-      <%= link_to show_path, data: { turbo_stream: true }, class: 'btn btn-primary show-button tree-toggle__action', id: tree_show_button_dom_id(item), aria: { expanded: false } do %>
+      <%= link_to show_path, data: turbo_data, class: 'btn btn-primary show-button tree-toggle__action', id: tree_show_button_dom_id(item), aria: { expanded: false } do %>
         <%= toggle_icon || tree_toggle_label(depth) %>
       <% end %>
     <% elsif children.any? && hide_path %>
-      <%= link_to hide_path, data: { turbo_stream: true }, class: 'btn btn-danger remove-button tree-toggle__action', aria: { expanded: true } do %>
+      <%= link_to hide_path, data: turbo_data, class: 'btn btn-danger remove-button tree-toggle__action', aria: { expanded: true } do %>
         <%= toggle_icon || tree_toggle_label(depth) %>
       <% end %>
     <% else %>

--- a/app/views/tree_view/_tree_toggle_content_turbo.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_turbo.html.erb
@@ -13,7 +13,8 @@
 <% show_path = tree_show_descendants_path(item, depth + 1, scope: toggle_scope) %>
 <% hide_path = tree_hide_descendants_path(item, depth, scope: toggle_scope) %>
 <% turbo_data = { turbo_stream: true } %>
-<% turbo_data[:turbo_frame] = render_state.ui_config.turbo_frame if render_state.ui_config.turbo_frame %>
+<% turbo_frame = tree_turbo_frame %>
+<% turbo_data[:turbo_frame] = turbo_frame if turbo_frame %>
 <% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :turbo, leaf_distance: leaf_distance) %>
 
 <div class="tree-toggle">

--- a/docs/en/turbo-frame.md
+++ b/docs/en/turbo-frame.md
@@ -1,0 +1,39 @@
+# Turbo frame option
+
+`UiConfigBuilder#build_turbo` accepts `turbo_frame:` for host apps that want TreeView toggle links to target a specific Turbo Frame without adding custom JavaScript.
+
+## Basic usage
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_turbo(
+  hide_descendants_path_builder: ->(item, depth, scope) { hide_document_path(item, depth: depth, scope: scope) },
+  show_descendants_path_builder: ->(item, depth, scope) { show_document_path(item, depth: depth, scope: scope) },
+  toggle_all_path_builder: ->(state) { documents_path(state: state) },
+  turbo_frame: "documents_tree"
+)
+```
+
+TreeView adds the frame target to Turbo toggle links:
+
+```html
+<a data-turbo-stream="true" data-turbo-frame="documents_tree" ...>
+```
+
+## Scope
+
+This option only adds `data-turbo-frame` to TreeView Turbo toggle links. It does not create frames, controller actions, authorization, or Turbo Stream responses.
+
+Host apps remain responsible for:
+
+- rendering the target `<turbo-frame>`
+- implementing expand/collapse endpoints
+- returning Turbo Stream or frame-compatible responses
+- authorization and business rules
+- persistence of expanded keys
+
+## Why this belongs in TreeView
+
+Targeting a Turbo Frame is a common Hotwire integration point for tree UIs, and it can be represented as a thin configuration value. It helps Rails apps avoid custom JavaScript while keeping response behavior in the host app.

--- a/docs/ja/turbo-frame.md
+++ b/docs/ja/turbo-frame.md
@@ -1,0 +1,39 @@
+# Turbo frame option
+
+`UiConfigBuilder#build_turbo` は `turbo_frame:` を受け取れます。host app が TreeView のtoggle linkを特定のTurbo Frameへ向けたい場合に、追加JavaScriptなしで使えます。
+
+## 基本例
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document"
+).build_turbo(
+  hide_descendants_path_builder: ->(item, depth, scope) { hide_document_path(item, depth: depth, scope: scope) },
+  show_descendants_path_builder: ->(item, depth, scope) { show_document_path(item, depth: depth, scope: scope) },
+  toggle_all_path_builder: ->(state) { documents_path(state: state) },
+  turbo_frame: "documents_tree"
+)
+```
+
+TreeView は Turbo toggle link に frame target を追加します。
+
+```html
+<a data-turbo-stream="true" data-turbo-frame="documents_tree" ...>
+```
+
+## Scope
+
+このoptionは、TreeView の Turbo toggle link に `data-turbo-frame` を追加するだけです。frame、controller action、authorization、Turbo Stream response は生成しません。
+
+host app は以下を担当します。
+
+- target `<turbo-frame>` の描画
+- expand / collapse endpoint の実装
+- Turbo Stream または frame-compatible response の返却
+- authorization と business rule
+- expanded keys の保存
+
+## なぜ TreeView に含めるか
+
+Turbo Frame のtarget指定は tree UI でよく使う Hotwire integration point です。薄い設定値として表現でき、custom JavaScript を増やさず Rails / Turbo 標準に乗せられるため、TreeView 側で支援します。

--- a/lib/tree_view/ui_config.rb
+++ b/lib/tree_view/ui_config.rb
@@ -13,6 +13,7 @@ module TreeView
       :show_descendants_path_builder,
       :load_children_path_builder,
       :toggle_all_path_builder,
+      :turbo_frame,
       :indent_unit,
       :scope_format,
       :mode
@@ -24,6 +25,7 @@ module TreeView
       show_descendants_path_builder: nil,
       load_children_path_builder: nil,
       toggle_all_path_builder: nil,
+      turbo_frame: nil,
       indent_unit: "&ensp; &ensp; &ensp;",
       scope_format: :string,
       mode: nil)
@@ -42,6 +44,7 @@ module TreeView
       @show_descendants_path_builder = show_descendants_path_builder
       @load_children_path_builder = load_children_path_builder
       @toggle_all_path_builder = toggle_all_path_builder
+      @turbo_frame = normalize_turbo_frame(turbo_frame)
       @indent_unit = indent_unit
       @scope_format = normalize_scope_format(scope_format)
       @mode = normalize_mode(mode || inferred_mode)
@@ -122,6 +125,15 @@ module TreeView
       return if builder.nil?
 
       validate_builder!(builder, name)
+    end
+
+    def normalize_turbo_frame(value)
+      return nil if value.nil?
+
+      normalized_value = value.to_s.strip
+      return nil if normalized_value.empty?
+
+      normalized_value
     end
 
     def normalize_scope_format(value)

--- a/lib/tree_view/ui_config_builder.rb
+++ b/lib/tree_view/ui_config_builder.rb
@@ -12,6 +12,7 @@ module TreeView
       hide_descendants_path_builder:,
       toggle_all_path_builder:,
       load_children_path_builder: nil,
+      turbo_frame: nil,
       indent_unit: "&ensp; &ensp; &ensp;",
       scope_format: :string)
       build_turbo(
@@ -19,6 +20,7 @@ module TreeView
         hide_descendants_path_builder: hide_descendants_path_builder,
         toggle_all_path_builder: toggle_all_path_builder,
         load_children_path_builder: load_children_path_builder,
+        turbo_frame: turbo_frame,
         indent_unit: indent_unit,
         scope_format: scope_format
       )
@@ -28,6 +30,7 @@ module TreeView
       hide_descendants_path_builder:,
       toggle_all_path_builder:,
       load_children_path_builder: nil,
+      turbo_frame: nil,
       indent_unit: "&ensp; &ensp; &ensp;",
       scope_format: :string)
       UiConfig.new(
@@ -36,6 +39,7 @@ module TreeView
         show_descendants_path_builder: show_descendants_path_builder,
         load_children_path_builder: load_children_path_builder,
         toggle_all_path_builder: toggle_all_path_builder,
+        turbo_frame: turbo_frame,
         indent_unit: indent_unit,
         scope_format: scope_format,
         mode: :turbo

--- a/spec/integration/tree_view_turbo_frame_integration_spec.rb
+++ b/spec/integration/tree_view_turbo_frame_integration_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_view"
+require "fileutils"
+require "tmpdir"
+
+TurboFrameIntegrationNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+RSpec.describe "TreeView turbo frame integration" do
+  let(:root) { TurboFrameIntegrationNode.new(id: 1, parent_item_id: nil, name: "root") }
+  let(:child) { TurboFrameIntegrationNode.new(id: 2, parent_item_id: 1, name: "child") }
+  let(:tree) { TreeView::Tree.new(records: [root, child], parent_id_method: :parent_item_id) }
+  let(:gem_view_path) { File.expand_path("../../app/views", __dir__) }
+  let(:host_view_dir) { Dir.mktmpdir("tree_view_host_views") }
+
+  before do
+    FileUtils.mkdir_p(File.join(host_view_dir, "projects"))
+    File.write(
+      File.join(host_view_dir, "projects", "_tree_columns.html.erb"),
+      '<td class="project-cell"><%= item.name %></td>'
+    )
+  end
+
+  after do
+    FileUtils.remove_entry(host_view_dir) if Dir.exist?(host_view_dir)
+  end
+
+  def build_view
+    view = ActionView::Base.with_empty_template_cache.with_view_paths([host_view_dir, gem_view_path], {}, nil)
+    view.extend(TreeViewHelper)
+    view
+  end
+
+  it "adds data-turbo-frame to turbo toggle links when configured" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_turbo(
+      hide_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/hide?depth=#{depth}&scope=#{scope}" },
+      show_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/show?depth=#{depth}&scope=#{scope}" },
+      toggle_all_path_builder: ->(state) { "/projects/toggle_all?state=#{state}" },
+      turbo_frame: "projects_tree"
+    )
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui
+    )
+
+    rendered = build_view.tree_view_rows(render_state)
+
+    expect(rendered).to include('data-turbo-stream="true"')
+    expect(rendered).to include('data-turbo-frame="projects_tree"')
+    expect(rendered).to include("/projects/1/hide?depth=0&amp;scope=all")
+  end
+
+  it "does not add data-turbo-frame when it is not configured" do
+    tree_ui = TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "project").build_turbo(
+      hide_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/hide?depth=#{depth}&scope=#{scope}" },
+      show_descendants_path_builder: ->(item, depth, scope) { "/projects/#{item.id}/show?depth=#{depth}&scope=#{scope}" },
+      toggle_all_path_builder: ->(state) { "/projects/toggle_all?state=#{state}" }
+    )
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "projects/tree_columns",
+      ui_config: tree_ui
+    )
+
+    rendered = build_view.tree_view_rows(render_state)
+
+    expect(rendered).to include('data-turbo-stream="true"')
+    expect(rendered).not_to include("data-turbo-frame")
+  end
+end

--- a/spec/lib/tree_view/ui_config_builder_spec.rb
+++ b/spec/lib/tree_view/ui_config_builder_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe TreeView::UiConfigBuilder do
     config = described_class.new(context: context, node_prefix: "entry").build(
       hide_descendants_path_builder: ->(candidate, depth, scope) { "/entries/#{candidate.id}/hide?depth=#{depth}&scope=#{scope}" },
       show_descendants_path_builder: ->(candidate, depth, scope) { "/entries/#{candidate.id}/show?depth=#{depth}&scope=#{scope}" },
-      toggle_all_path_builder: ->(state) { "/entries?state=#{state}" }
+      toggle_all_path_builder: ->(state) { "/entries?state=#{state}" },
+      turbo_frame: "entries_tree"
     )
 
     expect(config.node_dom_id(item)).to eq("entry_8")
@@ -19,6 +20,7 @@ RSpec.describe TreeView::UiConfigBuilder do
     expect(config.show_descendants_path(item, 2)).to eq("/entries/8/show?depth=2&scope=all")
     expect(config.show_descendants_path(item, 2, scope: "children")).to eq("/entries/8/show?depth=2&scope=children")
     expect(config.toggle_all_path(state: :collapsed)).to eq("/entries?state=collapsed")
+    expect(config.turbo_frame).to eq("entries_tree")
     expect(config.scope_format).to eq(:string)
     expect(config.object_scope?).to eq(false)
     expect(config.mode).to eq(:turbo)
@@ -31,11 +33,13 @@ RSpec.describe TreeView::UiConfigBuilder do
     config = described_class.new(context: context, node_prefix: "entry").build_turbo(
       hide_descendants_path_builder: ->(_candidate, _depth, _scope) {},
       show_descendants_path_builder: ->(_candidate, _depth, _scope) {},
-      toggle_all_path_builder: ->(_state) {}
+      toggle_all_path_builder: ->(_state) {},
+      turbo_frame: "entries_tree"
     )
 
     expect(config.mode).to eq(:turbo)
     expect(config.turbo?).to eq(true)
+    expect(config.turbo_frame).to eq("entries_tree")
   end
 
   it "builds config with object scope format" do
@@ -87,6 +91,7 @@ RSpec.describe TreeView::UiConfigBuilder do
     expect(config.show_button_dom_id(item)).to eq("entry_show_button_8")
     expect(config.static?).to eq(true)
     expect(config.mode).to eq(:static)
+    expect(config.turbo_frame).to be_nil
     expect(config.toggle_all_path(state: :collapsed)).to be_nil
   end
 
@@ -102,6 +107,7 @@ RSpec.describe TreeView::UiConfigBuilder do
     expect(config.client?).to eq(true)
     expect(config.static?).to eq(false)
     expect(config.mode).to eq(:client)
+    expect(config.turbo_frame).to be_nil
     expect(config.toggle_all_path(state: :collapsed)).to be_nil
   end
 end

--- a/spec/lib/tree_view/ui_config_spec.rb
+++ b/spec/lib/tree_view/ui_config_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe TreeView::UiConfig do
     expect(config.toggle_all_path(state: :collapsed)).to eq("/toggle?state=collapsed")
   end
 
+  it "stores normalized turbo frame names" do
+    config = build_config(turbo_frame: " documents_tree ")
+
+    expect(config.turbo_frame).to eq("documents_tree")
+  end
+
+  it "normalizes blank turbo frame names to nil" do
+    config = build_config(turbo_frame: " ")
+
+    expect(config.turbo_frame).to be_nil
+  end
+
   it "permits static configs without path builders" do
     config = build_config
 


### PR DESCRIPTION
## Summary

- Add `UiConfig#turbo_frame` and `UiConfigBuilder#build_turbo(turbo_frame:)`.
- Emit `data-turbo-frame` on TreeView Turbo toggle links when configured.
- Add unit and integration specs.
- Add Japanese and English docs and CHANGELOG entries.

## Notes

This is the final #371 Turbo / Hotwire focused slice. It keeps the scope to a thin Rails/Turbo contract and does not add custom JavaScript or host-app response helpers.

## Testing

- Not run locally; CI will verify this PR.