### PR TITLE
Follow up localized names documentation links

### DIFF
--- a/docs/en/node-presenter.md
+++ b/docs/en/node-presenter.md
@@ -74,6 +74,15 @@ TreeView does not render links, tooltips, or actions automatically. Host app row
 <%= link_to presenter.label_for(item), presenter.href_for(item), title: presenter.tooltip_for(item) %>
 ```
 
+For localized labels or tooltips, use the localized display-name helpers from [Localized names](localized-names.md):
+
+```ruby
+presenter = TreeView::NodePresenter.define do
+  label { |item| item.respond_to?(:title) ? item.title : TreeView.model_name_for(item) }
+  tooltip { |item| TreeView.type_name_for(item) }
+end
+```
+
 ## Responsibility boundary
 
 `NodePresenter` is intentionally a thin adapter over existing extension points. It does not replace host app row partials and does not introduce a table/action DSL. Column and action rendering can build on top of it in a later PR.

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -63,6 +63,11 @@ For the initial release, the priority is:
 
 All P1 feature docs are split under `docs/ja/` and `docs/en/`.
 
+| Topic | Japanese | English | Status | Notes |
+|---|---|---|---|---|
+| Localized names | `docs/ja/localized-names.md` | `docs/en/localized-names.md` | Split | Keep ActiveModel / I18n helper behavior and NodePresenter examples in sync. |
+| Turbo Frame option | `docs/ja/turbo-frame.md` | `docs/en/turbo-frame.md` | Split | Keep `turbo_frame:` behavior and host-app responsibility boundaries in sync. |
+
 ## P2: supporting and maintainer docs
 
 All P2 supporting and maintainer docs are split under `docs/ja/` and `docs/en/`.

--- a/docs/ja/node-presenter.md
+++ b/docs/ja/node-presenter.md
@@ -53,6 +53,15 @@ render_state = TreeView::RenderState.new(
 <%= link_to presenter.label_for(item), presenter.href_for(item), title: presenter.tooltip_for(item) %>
 ```
 
+localeに沿ったlabelやtooltipには、[Localized names](localized-names.md) のlocalized display-name helperを使えます。
+
+```ruby
+presenter = TreeView::NodePresenter.define do
+  label { |item| item.respond_to?(:title) ? item.title : TreeView.model_name_for(item) }
+  tooltip { |item| TreeView.type_name_for(item) }
+end
+```
+
 ## 責務境界
 
 `NodePresenter` は既存 extension point の薄いadapterです。host app row partial を置き換えず、table/action DSL もまだ提供しません。Column / Action DSL は後続PRでこの上に積み上げられます。


### PR DESCRIPTION
## Summary

- Link localized display-name helpers from the Japanese and English NodePresenter docs.
- Track the localized names and Turbo Frame split feature docs in the documentation i18n audit.

## Notes

This is a docs-only follow-up after #380. The localized names docs were added and linked from the main indexes/API docs, but NodePresenter is the main usage point, so this adds a direct cross-link there too.

## Testing

- Docs-only change; CI will verify.