### PR TITLE
fix: empty row と hidden count の a11y hook を整える

### DIFF
--- a/app/views/tree_view/_tree_empty_row.html.erb
+++ b/app/views/tree_view/_tree_empty_row.html.erb
@@ -1,3 +1,7 @@
 <tr class="tree-view-empty-row">
-  <td class="tree-view-empty-row__cell" colspan="999"><%= empty_message %></td>
+  <td class="tree-view-empty-row__cell" colspan="999">
+    <div class="tree-view-empty-row__content" data-tree-view-empty-state="true">
+      <span class="tree-view-empty-row__message"><%= empty_message %></span>
+    </div>
+  </td>
 </tr>

--- a/app/views/tree_view/_tree_toggle_content_static.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_static.html.erb
@@ -6,6 +6,7 @@
 <% branch_info = tree_branch_info(item, tree) %>
 <% ancestor_last_states = branch_info[:ancestor_last_states] %>
 <% is_last = branch_info[:is_last] %>
+<% hidden_descendants_sr_text = t("tree_view.accessibility.hidden_descendants", default: " descendants") %>
 <% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :static, leaf_distance: local_assigns[:leaf_distance]) %>
 
 <div class="tree-toggle">
@@ -20,7 +21,7 @@
   <div class="tree-toggle__control">
     <span class="tree-toggle__level"><%= toggle_icon || tree_toggle_label(depth) %></span>
     <% if hidden_count %>
-      <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %><span class="visually-hidden"> descendants</span></span>
+      <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %><span class="visually-hidden"><%= hidden_descendants_sr_text %></span></span>
     <% end %>
   </div>
 </div>

--- a/docs/en/accessibility-semantics.md
+++ b/docs/en/accessibility-semantics.md
@@ -23,6 +23,11 @@ Any move toward `treegrid` semantics should be a focused compatibility decision.
 - `aria-controls` is intentionally not emitted by toggle links for now.
 - TreeView intentionally does not emit `role="tree"` or `role="treeitem"` for table rows today.
 
+## Empty-state and hidden-count hooks
+
+- Empty rows now wrap the message in `.tree-view-empty-row__content` and `.tree-view-empty-row__message`, with `data-tree-view-empty-state="true"` on the wrapper so host apps can style or target empty states without overriding the partial.
+- Static hidden-count text appends a screen-reader-only suffix from `tree_view.accessibility.hidden_descendants`, which defaults to ` descendants` and can be localized by the host app.
+
 ## Supported rendering examples
 
 ### Static table rows

--- a/docs/ja/accessibility-semantics.md
+++ b/docs/ja/accessibility-semantics.md
@@ -23,6 +23,11 @@ TreeView は host app の業務columnsをtable row内に描画するため、現
 - `aria-controls` は現時点ではtoggle linkへ出力しません。
 - 現時点では table row に `role="tree"` や `role="treeitem"` は出力しません。
 
+## 空状態と hidden count の hook
+
+- 空状態 row は、message を `.tree-view-empty-row__content` と `.tree-view-empty-row__message` で包み、wrapper に `data-tree-view-empty-state="true"` を付けます。host app は partial override なしで空状態を装飾・target できます。
+- static hidden count の screen reader 向け suffix は `tree_view.accessibility.hidden_descendants` から取得します。default は ` descendants` で、host app 側 locale で差し替えできます。
+
 ## 対応している描画例
 
 ### Static table rows


### PR DESCRIPTION
## 対応Issue

- Closes #387

## 採用した方針

- 既存 partial を大きく作り替えず、host app が override なしで使える a11y / styling hook を最小追加する案を採用しました。
- hidden count の screen reader 向け補助文言は host app locale で差し替えられる i18n key に寄せ、空状態は wrapper class と data hook を足して調整しやすくしています。

## 比較した案

- 案A: partial に wrapper class / data hook と i18n key を追加する
  - 採用。既存 host app への影響が小さく、今回の issue に対して十分な改善になるため。
- 案B: builder / config API を追加して hidden count 文言や empty state markup を外から差し替えやすくする
  - 今回は見送り。柔軟だが public surface が広がり、small design fix としては重いです。
- 案C: host app override 前提で docs だけ整える
  - 今回は見送り。baseline 自体は変わらず、gem 側の改善としては弱いため。

## 変更内容

- empty row の message を `.tree-view-empty-row__content` / `.tree-view-empty-row__message` で包み、`data-tree-view-empty-state` hook を追加
- static hidden count の screen reader suffix を `tree_view.accessibility.hidden_descendants` から解決するよう変更
- 英日 accessibility docs に新しい hook と locale override 方法を追記

## 変更した画面・コンポーネント

- `app/views/tree_view/_tree_empty_row.html.erb`
- `app/views/tree_view/_tree_toggle_content_static.html.erb`
- `docs/en/accessibility-semantics.md`
- `docs/ja/accessibility-semantics.md`

## 確認内容

- local lint: 未実施
- local spec: 未実施
- UI表示確認: 差分レビューで wrapper / i18n hook の追加を確認
- レスポンシブ確認: 未実施
- アクセシビリティ確認: label ではなく empty state / hidden count の semantic hook 追加を確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->

## リスク

- low

## 補足

- ローカル clone と手元 test 実行は今回の環境では行えていないため、CI で追加確認します。