### PR TITLE
docs: persisted state の複数 tree instance 例を追加

### DIFF
--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -119,6 +119,54 @@ Examples:
 
 Use different keys for different screens or trees, even when the owner is the same.
 
+## Multiple tree instances in one host app
+
+A host app can render more than one persisted tree for the same owner. A common pattern is a sidebar tree plus a detail tree on the main content area.
+
+```ruby
+sidebar_store = TreeView::StateStore.new(
+  owner: current_user,
+  tree_instance_key: "projects:sidebar"
+)
+
+detail_store = TreeView::StateStore.new(
+  owner: current_user,
+  tree_instance_key: "projects:#{project.id}:detail"
+)
+
+sidebar_state = sidebar_store.load
+
+detail_state = detail_store.load
+```
+
+Pass each loaded state to the matching render state.
+
+```ruby
+@sidebar_render_state = TreeView::RenderState.new(
+  tree: sidebar_tree,
+  root_items: sidebar_tree.root_items,
+  row_partial: "projects/sidebar_tree_columns",
+  ui_config: sidebar_tree_ui,
+  persisted_state: sidebar_state
+)
+
+@detail_render_state = TreeView::RenderState.new(
+  tree: detail_tree,
+  root_items: detail_tree.root_items,
+  row_partial: "projects/detail_tree_columns",
+  ui_config: detail_tree_ui,
+  persisted_state: detail_state
+)
+```
+
+Use these rules when choosing keys:
+
+- split keys by placement or responsibility, such as `sidebar`, `index`, or `detail`
+- include a record or workspace identifier when the detail tree changes by page
+- reuse the same key only when two renders are intentionally sharing the same expansion state
+
+TreeView stores expanded keys only. The host app still decides where save requests enter, when to persist updates, and how to combine persisted state with the current render scope.
+
 ## Responsibility boundary
 
 | Area | TreeView | Host app |

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -119,6 +119,54 @@ render_state = TreeView::RenderState.new(
 
 同じownerでも画面やtreeが異なる場合は、別のkeyを使ってください。
 
+## 1 つの host app で複数 tree instance を使う
+
+同じ owner に対して、sidebar tree と詳細 tree のように複数の persisted tree を並行運用できます。
+
+```ruby
+sidebar_store = TreeView::StateStore.new(
+  owner: current_user,
+  tree_instance_key: "projects:sidebar"
+)
+
+detail_store = TreeView::StateStore.new(
+  owner: current_user,
+  tree_instance_key: "projects:#{project.id}:detail"
+)
+
+sidebar_state = sidebar_store.load
+
+detail_state = detail_store.load
+```
+
+読み込んだ state は、それぞれ対応する render state に渡します。
+
+```ruby
+@sidebar_render_state = TreeView::RenderState.new(
+  tree: sidebar_tree,
+  root_items: sidebar_tree.root_items,
+  row_partial: "projects/sidebar_tree_columns",
+  ui_config: sidebar_tree_ui,
+  persisted_state: sidebar_state
+)
+
+@detail_render_state = TreeView::RenderState.new(
+  tree: detail_tree,
+  root_items: detail_tree.root_items,
+  row_partial: "projects/detail_tree_columns",
+  ui_config: detail_tree_ui,
+  persisted_state: detail_state
+)
+```
+
+key を決めるときは、次の考え方を使うと整理しやすくなります。
+
+- `sidebar`、`index`、`detail` のように、配置場所や責務ごとに key を分ける
+- 詳細 tree がページごとに変わる場合は、record ID や workspace ID を key に含める
+- 2 つの描画で本当に同じ展開状態を共有したい場合だけ、同じ key を再利用する
+
+TreeView が保存するのは expanded keys です。保存 request の入口、更新をいつ永続化するか、現在の render scope とどう組み合わせるかは引き続き host app 側で決めます。
+
 ## 責務範囲
 
 | Area | TreeView | Host app |


### PR DESCRIPTION
## 対応 Issue
- Closes #389

## 変更理由
- 既存の persisted state docs には `tree_instance_key` の基本説明はありましたが、同じ owner に対して sidebar tree と detail tree を並行運用する実運用例までは載っていませんでした。
- host app 側が、どの粒度で key を分けるか、いつ同じ key を再利用してよいかを短く判断できるようにしています。

## 変更内容
- `docs/ja/persisted-state.md`
  - sidebar tree と detail tree を例にした複数 tree instance の保存・復元例を追加
  - key を分ける考え方を箇条書きで追加
- `docs/en/persisted-state.md`
  - 同内容の英語版を追加

## 既存仕様との整合
- 既存の `TreeView::StateStore` / `persisted_state` / `RenderState` API の組み合わせだけで説明しています
- 新しい API や host app responsibility の拡張は行っていません

## 確認内容
- 既存の `tree_instance_key` / `StateStore` / `RenderState` 節に追記する形で整理
- docs 変更のみで、Ruby / JavaScript / generator 実装には触れていません

## リスク
- low
- 既存 API の使い方を具体化する docs 追記のみです
