### PR TITLE
docs: release install と git install の使い分けを明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,19 @@ This gem focuses on tree rendering primitives. Host applications are responsible
 
 ## Installation
 
+When you are installing a published release, add the gem normally:
+
+```ruby
+gem "tree_view"
+```
+
+If you need unreleased `main` changes, use the GitHub source explicitly:
+
 ```ruby
 gem "tree_view", git: "https://github.com/matsuo-haruhito/tree_view-rails.git"
 ```
+
+Then run `bundle install` as usual.
 
 ```bash
 bundle install

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -29,6 +29,14 @@ Release tags should be placed only on `main` commits whose full CI has passed.
 
 Add the gem to the host app's `Gemfile`.
 
+For a published release, use the ordinary RubyGems install path:
+
+```ruby
+gem "tree_view"
+```
+
+When you need unreleased `main` changes, use the GitHub source explicitly:
+
 ```ruby
 gem "tree_view", git: "https://github.com/matsuo-haruhito/tree_view-rails.git"
 ```

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -29,6 +29,14 @@ release tag は、`main` のfull CIが成功したcommitに付けます。
 
 host app の `Gemfile` に追加します。
 
+公開済み release を使うときは、通常の RubyGems 経路を使います。
+
+```ruby
+gem "tree_view"
+```
+
+まだ release に入っていない `main` の変更が必要なときだけ、GitHub source を明示します。
+
 ```ruby
 gem "tree_view", git: "https://github.com/matsuo-haruhito/tree_view-rails.git"
 ```


### PR DESCRIPTION
## 対応 Issue

- Closes #384

## 分類

- `docs-stale`

## 変更内容

- `README.md` の Installation で、公開済み release を使う場合の `gem "tree_view"` と、未 release の `main` を使う場合の `git:` 指定を分けて記載
- `docs/en/installation.md` と `docs/ja/installation.md` も同じルールにそろえ、README と導入手順の説明差分を解消
- `git:` 指定が必要なのは unreleased change を取りたい場合だけだと分かる書き方に整理

## 確認観点

- `tree_view.gemspec` と release / package 文脈を壊さず、README 冒頭だけ読んでも導入経路を誤解しにくいこと
- まだ release に入っていない変更が必要な利用者向けの `git:` 導線は残っていること
- 英日 docs の説明がそろっていること

## リスク

- low
- docs only

## 未実施

- ローカル検証は未実行
- CI の最終確認は GitHub Actions を参照してください
