### PR TITLE
fix: hidden count の読み上げ補助を toggle mode 間でそろえる

### DIFF
--- a/app/views/tree_view/_tree_toggle_content_client.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_client.html.erb
@@ -8,6 +8,7 @@
 <% ancestor_last_states = branch_info[:ancestor_last_states] %>
 <% is_last = branch_info[:is_last] %>
 <% leaf_distance = local_assigns[:leaf_distance] %>
+<% hidden_descendants_sr_text = t("tree_view.accessibility.hidden_descendants", default: " descendants") %>
 <% toggle_icon = tree_toggle_icon(item, toggle_state, toggle_icon_builder, depth: depth, tree: tree, children: children, hidden_count: hidden_count, mode: :client, leaf_distance: leaf_distance) %>
 <% node_key = tree.node_key_for(item) %>
 <% expanded = !hidden_count && client_children_rendered %>
@@ -30,7 +31,7 @@
       <span class="tree-toggle__level"><%= toggle_icon || tree_toggle_label(depth) %></span>
     <% end %>
     <% if hidden_count %>
-      <span class="tree-toggle__hidden-count" data-tree-view-client-hidden-count-for="<%= node_key %>"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %></span>
+      <span class="tree-toggle__hidden-count" data-tree-view-client-hidden-count-for="<%= node_key %>"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %><span class="visually-hidden"><%= hidden_descendants_sr_text %></span></span>
     <% end %>
   </div>
 </div>

--- a/app/views/tree_view/_tree_toggle_content_turbo.html.erb
+++ b/app/views/tree_view/_tree_toggle_content_turbo.html.erb
@@ -9,6 +9,7 @@
 <% max_toggle_depth_from_root = local_assigns[:max_toggle_depth_from_root] %>
 <% max_toggle_leaf_distance = local_assigns[:max_toggle_leaf_distance] %>
 <% leaf_distance = local_assigns[:leaf_distance] %>
+<% hidden_descendants_sr_text = t("tree_view.accessibility.hidden_descendants", default: " descendants") %>
 <% toggle_scope = tree_toggle_scope(depth: depth, max_toggle_depth_from_root: max_toggle_depth_from_root, max_toggle_leaf_distance: max_toggle_leaf_distance, leaf_distance: leaf_distance) %>
 <% show_path = tree_show_descendants_path(item, depth + 1, scope: toggle_scope) %>
 <% hide_path = tree_hide_descendants_path(item, depth, scope: toggle_scope) %>
@@ -39,7 +40,7 @@
       <span class="tree-toggle__level"><%= toggle_icon || tree_toggle_label(depth) %></span>
     <% end %>
     <% if hidden_count %>
-      <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %></span>
+      <span class="tree-toggle__hidden-count"><%= tree_hidden_count_message(hidden_count, hidden_message_builder) %><span class="visually-hidden"><%= hidden_descendants_sr_text %></span></span>
     <% end %>
   </div>
 </div>

--- a/spec/views/tree_toggle_content_source_spec.rb
+++ b/spec/views/tree_toggle_content_source_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "tree toggle content partial sources" do
+  let(:static_source) { File.read(File.expand_path("../../app/views/tree_view/_tree_toggle_content_static.html.erb", __dir__)) }
+  let(:client_source) { File.read(File.expand_path("../../app/views/tree_view/_tree_toggle_content_client.html.erb", __dir__)) }
+  let(:turbo_source) { File.read(File.expand_path("../../app/views/tree_view/_tree_toggle_content_turbo.html.erb", __dir__)) }
+
+  it "uses the localized hidden descendants suffix in every toggle mode" do
+    aggregate_failures do
+      expect(static_source).to include('hidden_descendants_sr_text = t("tree_view.accessibility.hidden_descendants", default: " descendants")')
+      expect(client_source).to include('hidden_descendants_sr_text = t("tree_view.accessibility.hidden_descendants", default: " descendants")')
+      expect(turbo_source).to include('hidden_descendants_sr_text = t("tree_view.accessibility.hidden_descendants", default: " descendants")')
+    end
+  end
+
+  it "keeps the visually hidden suffix next to hidden count output in every toggle mode" do
+    aggregate_failures do
+      expect(static_source).to include('<span class="visually-hidden"><%= hidden_descendants_sr_text %></span>')
+      expect(client_source).to include('<span class="visually-hidden"><%= hidden_descendants_sr_text %></span>')
+      expect(turbo_source).to include('<span class="visually-hidden"><%= hidden_descendants_sr_text %></span>')
+    end
+  end
+end


### PR DESCRIPTION
## 対応Issue
- Closes #396

## 採用した方針
- static mode で既に使っている `tree_view.accessibility.hidden_descendants` を基準にして、client / turbo の hidden count にも同じ screen reader 向け補助を足す最小変更案を採用しました。
- 数字の見た目や toggle の挙動は変えず、意味づけだけを mode 間でそろえています。

## 比較した案
- 案A: client / turbo partial に既存 i18n key と visually-hidden suffix をそろえる
- 採用。既存の static 実装に寄せるだけで済み、host app への影響が最小です。
- 案B: helper 化して全 mode の hidden count markup を共通化する
- 今回は不採用。抽象化は進みますが、small design fix としては変更量が増えます。
- 案C: hidden count 自体の見た目や badge 表現も見直す
- 不採用。Issue 範囲を超えて host app の表示ポリシーに踏み込みやすいためです。

## 変更内容
- `app/views/tree_view/_tree_toggle_content_client.html.erb`
  - hidden count に screen reader 向け suffix を追加
- `app/views/tree_view/_tree_toggle_content_turbo.html.erb`
  - hidden count に screen reader 向け suffix を追加
- `spec/views/tree_toggle_content_source_spec.rb`
  - static / client / turbo の 3 mode で同じ i18n key と visually-hidden suffix を使う source-level guard を追加

## 変更した画面・コンポーネント
- tree toggle partial（client mode）
- tree toggle partial（turbo mode）
- hidden descendants count の読み上げ補助

## 確認内容
- lint: 未実施
- typecheck: 該当なし
- UI表示確認: 数字表示自体は変えず、screen reader 向け suffix だけ追加していることを差分上で確認
- レスポンシブ確認: 視覚表示は変更なし
- アクセシビリティ確認: static / client / turbo の hidden count が同じ意味で読み上げへ乗るよう整流

## スクリーンショット
<!-- UI変更がある場合は添付 -->

## リスク
- low
- partial 内の補助文言追加だけで、toggle action や host app の row 文言ポリシーは変えていません

## 補足
- ローカル `bundle exec rspec` は未実施です。最終確認は PR CI をお願いします。