### PR TITLE
feat: add lazy-loading placeholder helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added explicit `UiConfig#mode` values for `:turbo`, `:static`, and `:client`, plus `UiConfigBuilder#build_turbo` and `UiConfigBuilder#build_client_side`.
 - Added client-side-only expand/collapse mode that renders collapsed descendants into initial HTML and toggles rows in the browser with the bundled `tree-view-client` controller.
 - Added `TreeView::Diagnostics.run` as a consolidated diagnostics entrypoint for node keys, DOM IDs, orphans, and cycles.
+- Added `tree_children_container_dom_id`, `tree_remote_state_placeholder_dom_id`, and `tree_remote_state_placeholder_attributes` so host apps can reuse stable lazy-loading placeholder IDs and data attributes.
 
 ### Changed
 
@@ -52,6 +53,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added JavaScript event contract docs in Japanese and English for public Stimulus events and payload details.
 - Clarified the CI policy split between pull request Ruby checks and broader `main` / release checks.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
+- Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
 
 ### Tests
 

--- a/app/helpers/tree_view_helper/lazy_loading.rb
+++ b/app/helpers/tree_view_helper/lazy_loading.rb
@@ -9,10 +9,10 @@ module TreeViewHelper
     end
 
     def tree_remote_state_placeholder_attributes(item, state: nil, ui: @tree_ui)
-      attributes = { id: tree_remote_state_placeholder_dom_id(item, ui: ui) }
+      attributes = {id: tree_remote_state_placeholder_dom_id(item, ui: ui)}
       return attributes if state.nil?
 
-      attributes.merge(data: { tree_remote_state: state.to_s })
+      attributes.merge(data: {tree_remote_state: state.to_s})
     end
 
     def tree_lazy_loading_data(item, tree, render_context, depth:)

--- a/app/helpers/tree_view_helper/lazy_loading.rb
+++ b/app/helpers/tree_view_helper/lazy_loading.rb
@@ -1,5 +1,20 @@
 module TreeViewHelper
   module LazyLoading
+    def tree_children_container_dom_id(item, ui: @tree_ui)
+      "#{tree_node_dom_id(item, ui: ui)}_children"
+    end
+
+    def tree_remote_state_placeholder_dom_id(item, ui: @tree_ui)
+      "#{tree_node_dom_id(item, ui: ui)}_remote_state"
+    end
+
+    def tree_remote_state_placeholder_attributes(item, state: nil, ui: @tree_ui)
+      attributes = { id: tree_remote_state_placeholder_dom_id(item, ui: ui) }
+      return attributes if state.nil?
+
+      attributes.merge(data: { tree_remote_state: state.to_s })
+    end
+
     def tree_lazy_loading_data(item, tree, render_context, depth:)
       path = tree_load_children_path(item, depth, scope: render_context.lazy_loading_scope, ui: render_context.render_state.ui_config)
       return {} if path.nil?

--- a/docs/en/lazy-loading.md
+++ b/docs/en/lazy-loading.md
@@ -134,27 +134,34 @@ end
 
 The exact query shape is application-specific. The important boundary is that TreeView renders the hooks, while the host app decides which records the current user may see.
 
+When you render the host-app placeholder regions, TreeView can also generate the stable IDs for the children container and remote-state element.
+
+```erb
+<tbody id="<%= tree_children_container_dom_id(@parent) %>"></tbody>
+<span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent)) %>></span>
+```
+
 ## Turbo Stream response pattern
 
 Return only the subtree or placeholder region the host app owns. For example:
 
 ```erb
-<%= turbo_stream.replace dom_id(@parent, :children) do %>
-  <tbody id="<%= dom_id(@parent, :children) %>">
+<%= turbo_stream.replace tree_children_container_dom_id(@parent) do %>
+  <tbody id="<%= tree_children_container_dom_id(@parent) %>">
     <%= tree_view_rows(@render_state) %>
   </tbody>
 <% end %>
 
-<%= turbo_stream.replace dom_id(@parent, :remote_state) do %>
-  <span id="<%= dom_id(@parent, :remote_state) %>" data-tree-remote-state="loaded">loaded</span>
+<%= turbo_stream.replace tree_remote_state_placeholder_dom_id(@parent) do %>
+  <span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent, state: "loaded")) %>>loaded</span>
 <% end %>
 ```
 
 If a request fails, return a host-app retry affordance instead of hiding the error in TreeView internals:
 
 ```erb
-<%= turbo_stream.replace dom_id(@parent, :remote_state) do %>
-  <span id="<%= dom_id(@parent, :remote_state) %>" data-tree-remote-state="error">
+<%= turbo_stream.replace tree_remote_state_placeholder_dom_id(@parent) do %>
+  <span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent, state: "error")) %>>
     Could not load children.
     <%= link_to "Retry", children_document_path(@parent, format: :turbo_stream), data: { turbo_stream: true } %>
   </span>

--- a/docs/ja/lazy-loading.md
+++ b/docs/ja/lazy-loading.md
@@ -134,27 +134,34 @@ end
 
 実際のquery shapeはアプリごとに異なります。重要なのは、TreeViewはhookを描画し、現在のuserが見てよいrecordの判断はhost app側で行う、という境界です。
 
+host app側のplaceholder領域を描画するときは、TreeView helper で children container と remote state 要素の安定したIDを作れます。
+
+```erb
+<tbody id="<%= tree_children_container_dom_id(@parent) %>"></tbody>
+<span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent)) %>></span>
+```
+
 ## Turbo Stream response pattern
 
 host appが所有するsubtreeやplaceholder領域だけを返します。
 
 ```erb
-<%= turbo_stream.replace dom_id(@parent, :children) do %>
-  <tbody id="<%= dom_id(@parent, :children) %>">
+<%= turbo_stream.replace tree_children_container_dom_id(@parent) do %>
+  <tbody id="<%= tree_children_container_dom_id(@parent) %>">
     <%= tree_view_rows(@render_state) %>
   </tbody>
 <% end %>
 
-<%= turbo_stream.replace dom_id(@parent, :remote_state) do %>
-  <span id="<%= dom_id(@parent, :remote_state) %>" data-tree-remote-state="loaded">loaded</span>
+<%= turbo_stream.replace tree_remote_state_placeholder_dom_id(@parent) do %>
+  <span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent, state: "loaded")) %>>loaded</span>
 <% end %>
 ```
 
 requestが失敗した場合は、TreeView内部にerrorを隠さず、host app側のretry UIを返します。
 
 ```erb
-<%= turbo_stream.replace dom_id(@parent, :remote_state) do %>
-  <span id="<%= dom_id(@parent, :remote_state) %>" data-tree-remote-state="error">
+<%= turbo_stream.replace tree_remote_state_placeholder_dom_id(@parent) do %>
+  <span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent, state: "error")) %>>
     childrenを読み込めませんでした。
     <%= link_to "再試行", children_document_path(@parent, format: :turbo_stream), data: { turbo_stream: true } %>
   </span>

--- a/spec/helpers/tree_view_lazy_loading_helper_spec.rb
+++ b/spec/helpers/tree_view_lazy_loading_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "tree_view lazy loading helper" do
+  let(:helper_class) do
+    Class.new do
+      include TreeViewHelper
+    end
+  end
+
+  let(:helper) { helper_class.new }
+  let(:item) { Struct.new(:id).new(42) }
+  let(:ui_config) do
+    TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
+    )
+  end
+
+  it "builds a stable children container dom id from the tree node dom id" do
+    expect(helper.tree_children_container_dom_id(item, ui: ui_config)).to eq("node_42_children")
+  end
+
+  it "builds a stable remote state placeholder dom id from the tree node dom id" do
+    expect(helper.tree_remote_state_placeholder_dom_id(item, ui: ui_config)).to eq("node_42_remote_state")
+  end
+
+  it "returns placeholder attributes with optional remote state data" do
+    expect(helper.tree_remote_state_placeholder_attributes(item, ui: ui_config)).to eq(
+      { id: "node_42_remote_state" }
+    )
+
+    expect(helper.tree_remote_state_placeholder_attributes(item, state: :loaded, ui: ui_config)).to eq(
+      { id: "node_42_remote_state", data: { tree_remote_state: "loaded" } }
+    )
+  end
+end

--- a/spec/helpers/tree_view_lazy_loading_helper_spec.rb
+++ b/spec/helpers/tree_view_lazy_loading_helper_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe "tree_view lazy loading helper" do
 
   it "returns placeholder attributes with optional remote state data" do
     expect(helper.tree_remote_state_placeholder_attributes(item, ui: ui_config)).to eq(
-      { id: "node_42_remote_state" }
+      {id: "node_42_remote_state"}
     )
 
     expect(helper.tree_remote_state_placeholder_attributes(item, state: :loaded, ui: ui_config)).to eq(
-      { id: "node_42_remote_state", data: { tree_remote_state: "loaded" } }
+      {id: "node_42_remote_state", data: {tree_remote_state: "loaded"}}
     )
   end
 end


### PR DESCRIPTION
lazy loading の placeholder 足場を host app から再利用しやすい helper に寄せました。

## 対応 Issue
- Closes #393

## 採用した方針
- fetch / authorization / query / Turbo Stream action 自体は引き続き host app 側の責務に残し、DOM 命名と placeholder 属性だけを gem helper として補う最小変更案を採用しました。
- docs で毎回 `dom_id(..., :children)` / `dom_id(..., :remote_state)` を手書きしていた部分を、TreeView helper に揃えることで最小導入のずれを減らしています。
- 既存の row data hook や remote-state controller contract には触れず、host app が返す response shape も変えていません。

## 変更内容
- `app/helpers/tree_view_helper/lazy_loading.rb`
  - `tree_children_container_dom_id`
  - `tree_remote_state_placeholder_dom_id`
  - `tree_remote_state_placeholder_attributes`
  を追加
- `spec/helpers/tree_view_lazy_loading_helper_spec.rb`
  - children container id、remote state placeholder id、state data 付き attributes を守る helper spec を追加
- `docs/en/lazy-loading.md`
- `docs/ja/lazy-loading.md`
  - lazy loading の最小 placeholder と Turbo Stream response 例を helper ベースへ更新
- `CHANGELOG.md`
  - helper API 追加と docs 追従を追記

## 受け入れ条件との対応
- [x] lazy loading 用の最小 helper API を追加した
- [x] host app が helper を使って children / remote state の足場を組める
- [x] fetch / authorization / query は引き続き host app 側に残している
- [x] docs の lazy loading 例を helper ベースへ更新した

## 変更範囲
- lazy loading helper
- helper spec
- lazy loading docs（日英）
- changelog

## 実施した確認
- コード確認: current lazy loading helper / docs の責務境界を読み合わせ
- spec 追加: helper spec を追加
- lint: 未実施
- typecheck: 該当なし
- `bundle exec rspec`: 未実施
- 手動確認: docs と helper の対応関係を差分上で確認

## リスク
- medium
- 追加した helper は placeholder の DOM 命名と data 属性だけを扱い、既存の request lifecycle や remote-state controller の contract には触れていません
- この実行環境では GitHub clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル `bundle exec rspec` は未実施です

## 未対応・補足
- lazy loading の fetch 実装や Turbo Stream controller action を gem 側で自動化する変更は含めていません
- host app 固有の retry UI や error copy も引き続き host app 側の責務です