### PR TITLE
fix: add baseline keyboard focus state to default stylesheet

### DIFF
--- a/app/assets/stylesheets/tree_view.scss
+++ b/app/assets/stylesheets/tree_view.scss
@@ -77,12 +77,30 @@
 .tree-toggle__action{
   min-width: 2.9rem;
   padding: 0.05rem 0.25rem;
+  border-radius: 0.35rem;
+  color: inherit;
   text-decoration: none;
 }
 
-.tree-toggle__action:hover,
+.tree-toggle__action:hover{
+  text-decoration: none;
+  background-color: rgba(108, 117, 125, 0.08);
+}
+
 .tree-toggle__action:focus{
   text-decoration: none;
+}
+
+.tree-toggle__action:focus:not(:focus-visible){
+  outline: none;
+}
+
+.tree-toggle__action:focus-visible{
+  text-decoration: none;
+  outline: 2px solid rgba(13, 110, 253, 0.75);
+  outline-offset: 2px;
+  background-color: rgba(13, 110, 253, 0.12);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.95);
 }
 
 .tree-toggle__level{

--- a/docs/en/accessibility-semantics.md
+++ b/docs/en/accessibility-semantics.md
@@ -58,6 +58,8 @@ TreeView registers Stimulus controllers for state tracking, selection, transfer 
 
 Host apps remain responsible for page-level keyboard flow, focus order, table captions, action buttons, and any shortcut keys they add around TreeView. If a host app needs full treegrid keyboard navigation, treat that as an explicit application feature rather than assuming TreeView provides it automatically.
 
+The shipped stylesheet adds a lightweight `.tree-toggle__action:focus-visible` ring and background so keyboard focus is easier to track in quick-start setups. Host apps can override or replace that baseline in copied CSS.
+
 ## `aria-controls`
 
 A toggle link may reveal or hide multiple descendant rows, and in lazy-loading cases the controlled descendants may not exist in the DOM yet. There is no single stable container that the toggle always controls.

--- a/docs/ja/accessibility-semantics.md
+++ b/docs/ja/accessibility-semantics.md
@@ -58,6 +58,8 @@ TreeView は state tracking、selection、transfer payload、remote loading stat
 
 host app は page-level keyboard flow、focus order、table caption、action button、TreeView 周辺に追加する shortcut key に責任を持ちます。host app が完全な treegrid keyboard navigation を必要とする場合は、TreeView が自動提供しているものと見なさず、明示的な application feature として扱ってください。
 
+default stylesheet では `.tree-toggle__action:focus-visible` に軽量な ring と背景色を付けています。quick start のままでも keyboard focus を追いやすくするための baseline で、host app は copied stylesheet や上書き CSS でこの baseline を置き換えられます。
+
 ## `aria-controls`
 
 toggle linkは複数のdescendant rowsを表示/非表示にすることがあり、lazy-loading時は制御対象のdescendantsがまだDOM上に存在しない場合があります。常に制御対象と言える単一で安定したcontainerはありません。

--- a/spec/assets/tree_view_stylesheet_source_spec.rb
+++ b/spec/assets/tree_view_stylesheet_source_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "tree_view stylesheet source" do
+  let(:stylesheet_source) { File.read(File.expand_path("../../app/assets/stylesheets/tree_view.scss", __dir__)) }
+
+  it "adds a distinct focus-visible state for tree toggle actions" do
+    aggregate_failures do
+      expect(stylesheet_source).to include(".tree-toggle__action:focus-visible")
+      expect(stylesheet_source).to include("outline: 2px solid rgba(13, 110, 253, 0.75);")
+      expect(stylesheet_source).to include("background-color: rgba(13, 110, 253, 0.12);")
+    end
+  end
+
+  it "keeps hover styling separate from keyboard focus styling" do
+    aggregate_failures do
+      expect(stylesheet_source).to include(".tree-toggle__action:hover")
+      expect(stylesheet_source).to include("background-color: rgba(108, 117, 125, 0.08);")
+      expect(stylesheet_source).to include(".tree-toggle__action:focus:not(:focus-visible)")
+    end
+  end
+end

--- a/spec/docs/accessibility_semantics_docs_source_spec.rb
+++ b/spec/docs/accessibility_semantics_docs_source_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "accessibility semantics docs sources" do
+  let(:english_source) { File.read(File.expand_path("../../docs/en/accessibility-semantics.md", __dir__)) }
+  let(:japanese_source) { File.read(File.expand_path("../../docs/ja/accessibility-semantics.md", __dir__)) }
+
+  it "documents the focus-visible baseline and host app override expectation" do
+    aggregate_failures do
+      expect(english_source).to include("The shipped stylesheet adds a lightweight `.tree-toggle__action:focus-visible` ring and background")
+      expect(english_source).to include("Host apps can override or replace that baseline in copied CSS.")
+      expect(japanese_source).to include("default stylesheet では `.tree-toggle__action:focus-visible` に軽量な ring と背景色を付けています。")
+      expect(japanese_source).to include("host app は copied stylesheet や上書き CSS でこの baseline を置き換えられます。")
+    end
+  end
+end


### PR DESCRIPTION
## 対応Issue

- Closes #403

## 採用した方針

- default stylesheet にだけ軽量な keyboard focus-visible state を追加し、hover と見分けやすい baseline を整える最小案を採用しました。
- toggle の挙動や host app の keyboard flow には触れず、配布 CSS と accessibility docs の責務整理に留めています。
- host app が copied stylesheet や上書き CSS で置き換えやすいよう、単純な `outline` と薄い背景色だけで構成しています。

## 比較した案

- 案A: default stylesheet に `:focus-visible` ring と hover との差分だけを足す
- 採用。Issue の完了条件を満たしつつ、host app への影響が最小です。
- 案B: hidden count や depth label を含めて周辺 UI 全体の配色を再整理する
- 不採用。focus baseline を超えて host app の見た目ポリシーに踏み込みやすいためです。
- 案C: docs の注意書きだけ追加して CSS は host app 任せにする
- 不採用。quick start 状態の baseline 体験が改善されず、Issue の狙いに対して弱いためです。

## 変更内容

- `app/assets/stylesheets/tree_view.scss`
  - `.tree-toggle__action` に軽い radius / inherit color を追加
  - hover は中立の薄い背景、keyboard focus は `:focus-visible` の ring と背景で見分けられるよう整理
  - mouse focus と keyboard focus を分けるため `:focus:not(:focus-visible)` を追加
- `docs/en/accessibility-semantics.md`
- `docs/ja/accessibility-semantics.md`
  - shipped stylesheet の baseline focus-visible state と host app override 前提を追記
- `spec/assets/tree_view_stylesheet_source_spec.rb`
  - `:focus-visible` baseline と hover との差分を守る source-level guard を追加
- `spec/docs/accessibility_semantics_docs_source_spec.rb`
  - 英日 docs の説明が落ちないよう source-level guard を追加

## 変更した画面・コンポーネント

- default stylesheet の tree toggle action
- accessibility semantics docs（日英）

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: 未実施
- レスポンシブ確認: 未実施
- アクセシビリティ確認: hover と keyboard focus の視覚差分、host app override 前提を差分上で確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->

## リスク

- low
- hover / focus-visible の見た目だけを追加しており、toggle action の挙動や DOM contract には触れていません

## 補足

- この実行環境では GitHub clone が `CONNECT tunnel failed, response 403` で使えず、ローカル `bundle exec rspec` は未実施です
- 最終確認は PR CI をお願いします
