### PR TITLE
feat: add selection hidden input sync bridge

### DIFF
--- a/app/javascript/tree_view/selection_controller.js
+++ b/app/javascript/tree_view/selection_controller.js
@@ -4,7 +4,8 @@ export class TreeViewSelectionController extends Controller {
   static values = {
     cascade: Boolean,
     indeterminate: Boolean,
-    maxCount: Number
+    maxCount: Number,
+    hiddenInputName: String
   }
 
   connect() {
@@ -36,26 +37,35 @@ export class TreeViewSelectionController extends Controller {
   submit(event) {
     if (event) event.preventDefault()
 
+    const payloads = this.selectedPayloads()
+    this.syncHiddenInputs(payloads)
+
     this.dispatch("selected", {
       detail: {
-        payloads: this.selectedPayloads()
+        payloads
       }
     })
   }
 
   refresh() {
     this.updateIndeterminateStates()
+
+    const detail = this.selectionDetail()
+    this.syncHiddenInputs(detail.selectedPayloads)
+
     this.dispatch("selected", {
       detail: {
-        payloads: this.selectedPayloads()
+        payloads: detail.selectedPayloads
       }
     })
-    this.dispatchSelectionChanged()
+    this.dispatchSelectionChanged(detail)
   }
 
-  dispatchSelectionChanged() {
+  dispatchSelectionChanged(detail = this.selectionDetail()) {
+    this.syncHiddenInputs(detail.selectedPayloads)
+
     this.dispatch("change", {
-      detail: this.selectionDetail()
+      detail
     })
   }
 
@@ -88,6 +98,49 @@ export class TreeViewSelectionController extends Controller {
       })
       return null
     }
+  }
+
+  syncHiddenInputs(payloads = this.selectedPayloads()) {
+    if (!this.hiddenInputSyncEnabled()) return
+
+    const form = this.hiddenInputForm()
+    if (!form) return
+
+    this.removeSyncedHiddenInputs(form)
+
+    payloads.forEach((payload) => {
+      const input = document.createElement("input")
+      input.type = "hidden"
+      input.name = this.hiddenInputNameValue
+      input.value = JSON.stringify(payload)
+      input.dataset.treeViewSelectionGeneratedHiddenInput = "true"
+      input.dataset.treeViewSelectionSourceId = this.hiddenInputSourceId()
+      form.appendChild(input)
+    })
+  }
+
+  hiddenInputSyncEnabled() {
+    return this.hasHiddenInputNameValue && this.hiddenInputNameValue.length > 0
+  }
+
+  hiddenInputForm() {
+    return this.element.closest("form")
+  }
+
+  hiddenInputSourceId() {
+    if (!this.element.dataset.treeViewSelectionSourceId) {
+      this.element.dataset.treeViewSelectionSourceId = `tree-view-selection-${Math.random().toString(36).slice(2, 10)}`
+    }
+
+    return this.element.dataset.treeViewSelectionSourceId
+  }
+
+  removeSyncedHiddenInputs(form) {
+    form
+      .querySelectorAll(
+        `[data-tree-view-selection-generated-hidden-input="true"][data-tree-view-selection-source-id="${this.hiddenInputSourceId()}"]`
+      )
+      .forEach((input) => input.remove())
   }
 
   enforceMaxCount(checkbox, attemptedChecked) {

--- a/app/javascript/tree_view/selection_controller.test.js
+++ b/app/javascript/tree_view/selection_controller.test.js
@@ -1,0 +1,122 @@
+import { Application } from "@hotwired/stimulus"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { TreeViewSelectionController } from "./selection_controller.js"
+
+const flush = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const hiddenInputValues = (form) =>
+  Array.from(form.querySelectorAll('input[type="hidden"][data-tree-view-selection-generated-hidden-input="true"]'))
+    .map((input) => input.value)
+
+describe("TreeViewSelectionController", () => {
+  let application
+
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    application = Application.start()
+    application.register("tree-view-selection", TreeViewSelectionController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  it("mirrors checked payloads into hidden inputs on the nearest form", async () => {
+    document.body.innerHTML = `
+      <form id="bulk-form">
+        <table>
+          <tbody
+            data-controller="tree-view-selection"
+            data-action="change->tree-view-selection#toggle"
+            data-tree-view-selection-hidden-input-name-value="selected_nodes[]">
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  id="node-1"
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  checked
+                  value='{"id":1,"kind":"document"}'>
+              </td>
+            </tr>
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  id="node-2"
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  value='{"id":2,"kind":"document"}'>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    `
+
+    await flush()
+
+    const form = document.getElementById("bulk-form")
+    expect(hiddenInputValues(form)).toEqual(['{"id":1,"kind":"document"}'])
+
+    const second = document.getElementById("node-2")
+    second.checked = true
+    second.dispatchEvent(new Event("change", { bubbles: true }))
+
+    await flush()
+
+    expect(hiddenInputValues(form)).toEqual([
+      '{"id":1,"kind":"document"}',
+      '{"id":2,"kind":"document"}'
+    ])
+  })
+
+  it("skips disabled and invalid payloads when syncing hidden inputs", async () => {
+    document.body.innerHTML = `
+      <form id="bulk-form">
+        <table>
+          <tbody
+            data-controller="tree-view-selection"
+            data-tree-view-selection-hidden-input-name-value="selected_nodes[]">
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  checked
+                  value='{"id":1}'>
+              </td>
+            </tr>
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  checked
+                  value='not-json'>
+              </td>
+            </tr>
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  checked
+                  disabled
+                  value='{"id":3}'>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    `
+
+    await flush()
+
+    const form = document.getElementById("bulk-form")
+    expect(hiddenInputValues(form)).toEqual(['{"id":1}'])
+  })
+})

--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -107,6 +107,30 @@ document.addEventListener("tree-view-selection:change", (event) => {
 
 Only checked and enabled `.tree-selection-checkbox` elements are included. Invalid JSON values are skipped and reported through `tree-view-selection:invalid-payload`.
 
+## Hidden input sync for regular form submit
+
+When the tree sits inside a normal HTML form, the same controller can mirror checked payloads into hidden inputs on the nearest form.
+
+```erb
+<form action="/documents/bulk_update" method="post">
+  <table>
+    <tbody
+      data-controller="tree-view-selection"
+      data-action="change->tree-view-selection#toggle"
+      data-tree-view-selection-hidden-input-name-value="selected_nodes[]">
+      <%= tree_view_rows(@render_state) %>
+    </tbody>
+  </table>
+</form>
+```
+
+With `data-tree-view-selection-hidden-input-name-value`, TreeView writes one hidden input per valid checked payload and keeps those inputs in sync on connect, change, submit, and manual refresh.
+
+- The hidden input `name` stays host-app controlled.
+- Values are written as JSON strings, so `TreeView.parse_selection_params(params[:selected_nodes])` keeps working.
+- Disabled checkboxes and invalid JSON payloads are skipped, matching the existing event payload behavior.
+- If the tree is not inside a form, TreeView keeps dispatching selection events and does not create hidden inputs.
+
 ## Selection max count
 
 Host apps can limit the number of checked boxes on the JavaScript controller.
@@ -152,7 +176,7 @@ This behavior is DOM-based. It affects rendered rows only and skips disabled che
 |---|---|---|
 | Rendering checkboxes | yes | no |
 | JSON payload generation | yes | optional customization |
-| Submitted value parsing | helper provided | owns controller behavior |
+| Submitted value parsing and hidden input sync | helper provided, optional form bridge | owns controller placement and business action |
 | Cascade / indeterminate | rendered DOM only | decides unloaded/server-side semantics |
 | Max count event | dispatches event | shows message or blocks business action |
 | Delete / move / relate / API calls | no | yes |

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -107,6 +107,30 @@ document.addEventListener("tree-view-selection:change", (event) => {
 
 対象になるのは、checked かつ enabled な `.tree-selection-checkbox` だけです。不正なJSON値はskipされ、`tree-view-selection:invalid-payload` で通知されます。
 
+## 通常form送信用の hidden input 同期
+
+tree が通常の HTML form の中にある場合、同じ controller で checked payload を最寄りの form に hidden input としてミラーできます。
+
+```erb
+<form action="/documents/bulk_update" method="post">
+  <table>
+    <tbody
+      data-controller="tree-view-selection"
+      data-action="change->tree-view-selection#toggle"
+      data-tree-view-selection-hidden-input-name-value="selected_nodes[]">
+      <%= tree_view_rows(@render_state) %>
+    </tbody>
+  </table>
+</form>
+```
+
+`data-tree-view-selection-hidden-input-name-value` を指定すると、TreeView は valid な checked payload ごとに hidden input を 1 つずつ生成し、connect / change / submit / manual refresh に追従して同期します。
+
+- hidden input の `name` は host app 側で決められます。
+- value は JSON 文字列で書き込まれるため、`TreeView.parse_selection_params(params[:selected_nodes])` をそのまま使えます。
+- disabled checkbox と不正な JSON payload は既存 event と同じく skip されます。
+- tree が form の外にある場合は、selection event だけを dispatch し、hidden input は生成しません。
+
 ## 最大選択数
 
 JavaScript controller側で、checked checkboxの最大数を制限できます。
@@ -152,7 +176,7 @@ Stimulus controllerは、描画済みchild rowsとparent mixed stateも更新で
 |---|---|---|
 | Rendering checkboxes | yes | no |
 | JSON payload generation | yes | optional customization |
-| Submitted value parsing | helper provided | owns controller behavior |
+| Submitted value parsing と hidden input sync | helper 提供、form bridge は optional | controller の配置と業務 action を決める |
 | Cascade / indeterminate | rendered DOM only | decides unloaded/server-side semantics |
 | Max count event | dispatches event | shows message or blocks business action |
 | Delete / move / relate / API calls | no | yes |


### PR DESCRIPTION
## 対応 Issue
- Closes #404

## 変更内容
- `app/javascript/tree_view/selection_controller.js`
  - `data-tree-view-selection-hidden-input-name-value` を指定したとき、checked payload を最寄りの form に hidden input として同期する最小 bridge を追加
  - connect / change / submit / refresh で hidden input を追従させ、disabled checkbox と invalid payload は既存 event contract と同じく除外
- `app/javascript/tree_view/selection_controller.test.js`
  - hidden input 同期と invalid / disabled skip の Vitest を追加
- `docs/en/selection.md`
- `docs/ja/selection.md`
  - 通常 form submit へ流す最小 integration 例と責務境界を追記

## 受け入れ条件との対応
- [x] checked payloads を hidden inputs として送れる最小 path を追加
- [x] hidden input 名は host app が `data-tree-view-selection-hidden-input-name-value` で指定可能
- [x] disabled / invalid payload の扱いは既存 selection contract と矛盾しない
- [x] 日英 docs に最小 integration 例を追加

## 変更範囲
- selection controller
- selection controller test
- selection docs 日英

## 実施した確認
- ローカル clone はこの実行環境から GitHub へ出られず未実施
- そのため `npm test` / `bundle exec rspec` は未実行
- 代わりに Vitest を追加し、PR CI での確認前提に整理

## リスク
- medium
- hidden input 同期は opt-in で、`hidden-input-name` を指定した controller だけに作用
- nearest form へ hidden input を追加する実装なので、form 外に置いた tree は従来どおり event 利用のまま

## 未対応・補足
- bulk action API や server-side authorization は引き続き host app 側の責務
- hidden input 用の別 controller は増やさず、既存 selection controller の最小拡張に留めた