### PR TITLE
test: add entrypoint smoke check for documented tree_view exports

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -25,6 +25,7 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm test
+npm run test:entrypoints
 npm run test:browser
 ```
 
@@ -49,7 +50,13 @@ Unit-style JavaScript tests run through Vitest and jsdom with:
 npm test
 ```
 
-The Vitest suite also includes an entrypoint smoke test for `app/javascript/tree_view/index.js` so the documented controller exports and `registerTreeViewControllers` helper stay aligned with the importmap entrypoint.
+A separate entrypoint smoke check loads `app/javascript/tree_view/index.js` directly:
+
+```bash
+npm run test:entrypoints
+```
+
+That check keeps the documented controller exports and `registerTreeViewControllers` helper aligned with the importmap entrypoint.
 
 Browser-level smoke tests run through Playwright with:
 
@@ -66,7 +73,7 @@ Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
 - Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile` and `gemfiles/rails_8_0.gemfile`
-- JavaScript unit and browser smoke tests through `npm run test:js`
+- JavaScript entrypoint, unit, and browser smoke tests through `npm run test:js`
 
 Pushes to `main` also run the broader compatibility and release checks:
 
@@ -87,6 +94,7 @@ Pushes to `main` also run the broader compatibility and release checks:
 ### JavaScript changes
 
 - Run `npm test`.
+- Run `npm run test:entrypoints` when documented controller exports or entrypoint wiring changes.
 - Run `npm run test:browser` when browser interactions, focus, drag/drop, or real form controls are affected.
 - Check importmap and packaged files.
 - Confirm JavaScript entrypoint compatibility and update compatibility specs when documented exports intentionally change.
@@ -102,6 +110,7 @@ Pushes to `main` also run the broader compatibility and release checks:
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - `npm test`
+- `npm run test:entrypoints`
 - `npm run test:browser`
 - `bundle exec rake build`
 - gem package contents

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -49,6 +49,8 @@ Unit-style JavaScript tests run through Vitest and jsdom with:
 npm test
 ```
 
+The Vitest suite also includes an entrypoint smoke test for `app/javascript/tree_view/index.js` so the documented controller exports and `registerTreeViewControllers` helper stay aligned with the importmap entrypoint.
+
 Browser-level smoke tests run through Playwright with:
 
 ```bash

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -25,6 +25,7 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm test
+npm run test:entrypoints
 npm run test:browser
 ```
 
@@ -49,7 +50,13 @@ Unit-style JavaScript testsはVitestとjsdomで実行します。
 npm test
 ```
 
-Vitest suite には `app/javascript/tree_view/index.js` を直接読む entrypoint smoke test も含め、documented controller exports と `registerTreeViewControllers` helper が importmap entrypoint とずれないようにしています。
+`app/javascript/tree_view/index.js` を直接読む entrypoint smoke check は次で実行します。
+
+```bash
+npm run test:entrypoints
+```
+
+このcheckで、documented controller exports と `registerTreeViewControllers` helper が importmap entrypoint とずれないようにします。
 
 Browser-level smoke testsはPlaywrightで実行します。
 
@@ -66,7 +73,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile` と `gemfiles/rails_8_0.gemfile`
-- JavaScript unit and browser smoke tests: `npm run test:js`
+- JavaScript entrypoint、unit、browser smoke tests: `npm run test:js`
 
 `main` へのpushでは、より広い互換性確認とrelease向けのchecksも実行します。
 
@@ -87,6 +94,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 ### JavaScriptを変更した場合
 
 - `npm test` を確認する
+- documented controller exports や entrypoint wiring を変える場合は `npm run test:entrypoints` を確認する
 - Browser interaction、focus、drag/drop、実際のform controlsに影響する場合は `npm run test:browser` を確認する
 - importmap / packaged files に影響がないか確認する
 - JavaScript entrypointの互換性を確認し、documented exportsを意図的に変更する場合はcompatibility specsを更新する
@@ -102,6 +110,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - `npm test`
+- `npm run test:entrypoints`
 - `npm run test:browser`
 - `bundle exec rake build`
 - gem package contents

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -49,6 +49,8 @@ Unit-style JavaScript testsはVitestとjsdomで実行します。
 npm test
 ```
 
+Vitest suite には `app/javascript/tree_view/index.js` を直接読む entrypoint smoke test も含め、documented controller exports と `registerTreeViewControllers` helper が importmap entrypoint とずれないようにしています。
+
 Browser-level smoke testsはPlaywrightで実行します。
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:js": "npm test && npm run test:browser"
+    "test:entrypoints": "node --input-type=module -e \"import('./app/javascript/tree_view/index.js').then((module) => { if (typeof module.registerTreeViewControllers !== 'function') throw new Error('registerTreeViewControllers export is missing'); const expected = [['tree-view-state', module.TreeViewStateController], ['tree-view-client', module.TreeViewClientController], ['tree-view-selection', module.TreeViewSelectionController], ['tree-view-transfer', module.TreeViewTransferController], ['tree-view-remote-state', module.TreeViewRemoteStateController]]; const application = { calls: [], register(identifier, controller) { this.calls.push([identifier, controller]); } }; module.registerTreeViewControllers(application); if (application.calls.length !== expected.length || expected.some(([identifier, controller], index) => application.calls[index]?.[0] !== identifier || application.calls[index]?.[1] !== controller)) { throw new Error('documented tree_view entrypoint exports are out of sync'); } })\"",
+    "test:js": "npm run test:entrypoints && npm test && npm run test:browser"
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2"


### PR DESCRIPTION
## 対応 Issue
- Closes #419

## Issue ごとの完了内容
- `#419`
  - documented `tree_view/index.js` を直接 load する lightweight smoke check を JavaScript test flow に追加
  - `registerTreeViewControllers` と documented controller exports の対応を自動確認
  - development docs に新しい check の位置づけを追記

## 変更内容
- `package.json`
  - `npm run test:entrypoints` を追加
  - `npm run test:js` で entrypoint smoke -> Vitest -> Playwright の順に実行するよう更新
- `docs/en/development.md`
- `docs/ja/development.md`
  - entrypoint smoke check の実行方法と意図を追記

## 改善カテゴリ
- テスト追加・改善
- docs 追従

## 既存仕様への影響
- なし
- runtime code、public export、importmap entrypoint は変更していません
- documented export wiring の drift を CI で早めに検知するだけです

## 実施した確認
- entrypoint smoke 用の Node command を手元の最小 fixture で再現し、export / register wiring の確認ロジックが動くことを確認
- compare で変更が `package.json` と development docs 2 ファイルに閉じていることを確認
- この実行環境では repo clone が `CONNECT tunnel failed, response 403` のため、repository 上での `npm run test:js` は未実施です

## リスク評価
- low
- JS test flow と docs のみの変更で、runtime behavior は変えていません

## 補足事項
- 新しい check は heavy host-app integration には広げず、documented importmap entrypoint と controller registration の wiring だけに責務を絞っています