### PR TITLE
design: add baseline row state styling to the shipped stylesheet

### DIFF
--- a/app/assets/stylesheets/tree_view.scss
+++ b/app/assets/stylesheets/tree_view.scss
@@ -128,6 +128,38 @@
   font-weight: 600;
 }
 
+/* Lightweight state cues for quick-start imports. Host apps can override these. */
+.tree-row.is-selected,
+.tree-row[aria-selected="true"]{
+  background-color: rgba(13, 110, 253, 0.08);
+}
+
+.tree-row[aria-current="page"] > td:first-child{
+  box-shadow: inset 3px 0 0 rgba(13, 110, 253, 0.45);
+}
+
+.tree-row.is-collapsed,
+.tree-row[aria-expanded="false"]{
+  background-color: rgba(255, 193, 7, 0.08);
+}
+
+.tree-row.is-loading{
+  background-color: rgba(108, 117, 125, 0.08);
+}
+
+.tree-row.is-loading .tree-toggle__action{
+  color: #6c757d;
+}
+
+.tree-row.is-error,
+.tree-row.is-drop-disabled{
+  background-color: rgba(220, 53, 69, 0.08);
+}
+
+.tree-row.is-drop-target{
+  background-color: rgba(25, 135, 84, 0.1);
+}
+
 .tree-view-table{
   min-width: 100%;
 }

--- a/docs/en/accessibility-semantics.md
+++ b/docs/en/accessibility-semantics.md
@@ -60,6 +60,17 @@ Host apps remain responsible for page-level keyboard flow, focus order, table ca
 
 The shipped stylesheet adds a lightweight `.tree-toggle__action:focus-visible` ring and background so keyboard focus is easier to track in quick-start setups. Host apps can override or replace that baseline in copied CSS.
 
+## Baseline row-state styling
+
+The shipped stylesheet also adds lightweight row-state cues for quick-start setups:
+
+- selected rows via `aria-selected="true"` and `.is-selected`
+- current rows via `aria-current="page"`
+- collapsed rows via `aria-expanded="false"` and `.is-collapsed`
+- loading, error, and drop-target rows via row state classes such as `.is-loading`, `.is-error`, and `.is-drop-target`
+
+These defaults are intentionally thin. They are meant to make common states easier to distinguish before a host app adds its own theme, not to provide a finished product design system.
+
 ## `aria-controls`
 
 A toggle link may reveal or hide multiple descendant rows, and in lazy-loading cases the controlled descendants may not exist in the DOM yet. There is no single stable container that the toggle always controls.

--- a/docs/ja/accessibility-semantics.md
+++ b/docs/ja/accessibility-semantics.md
@@ -60,6 +60,17 @@ host app は page-level keyboard flow、focus order、table caption、action but
 
 default stylesheet では `.tree-toggle__action:focus-visible` に軽量な ring と背景色を付けています。quick start のままでも keyboard focus を追いやすくするための baseline で、host app は copied stylesheet や上書き CSS でこの baseline を置き換えられます。
 
+## baseline row state styling
+
+default stylesheet には、quick start 用の軽量な row state cue も含めています。
+
+- selected row は `aria-selected="true"` と `.is-selected` を使って見分けやすくしています
+- current row は `aria-current="page"` を使って先頭cellに細いaccentを出します
+- collapsed row は `aria-expanded="false"` と `.is-collapsed` を使って補助的に見分けやすくしています
+- loading / error / drop target は `.is-loading`、`.is-error`、`.is-drop-target` などの row state class を使う前提です
+
+これらの default はあくまで薄い baseline です。host app が独自themeを載せる前でも主要状態を見分けやすくするためのもので、完成済みの product design system を提供する意図ではありません。
+
 ## `aria-controls`
 
 toggle linkは複数のdescendant rowsを表示/非表示にすることがあり、lazy-loading時は制御対象のdescendantsがまだDOM上に存在しない場合があります。常に制御対象と言える単一で安定したcontainerはありません。


### PR DESCRIPTION
## 対応Issue

- Closes #424

## 採用した方針

- 自動実行のため、quick start の `@import "tree_view"` だけでも主要 row state を見分けやすくする low-risk 案を採用しました。
- mockup の濃い visual treatment をそのまま移植するのではなく、background と current-row accent を最小限だけ足し、host app が上書きしやすい薄い baseline に留めています。

## 比較した案

- 案A: docs だけで shipped stylesheet と mockup の責務差を説明する。
- 案B: shipped stylesheet に selected / current / collapsed / loading / error / drop target の軽量 cue を追加し、docs に責務境界を短く追記する。
- 案C: mockup に近い強い row theme や badge styling まで shipped stylesheet に持ち込む。
- 今回は案Bを採用しました。Issue #424 の狙いである quick-start 時の状態視認性を改善しつつ、host app theme の自由度を崩しにくいためです。

## 変更内容

- `app/assets/stylesheets/tree_view.scss`
  - selected row を `aria-selected="true"` / `.is-selected` で薄くハイライト
  - current row を `aria-current="page"` で先頭 cell の細い accent として補助表示
  - collapsed row を `aria-expanded="false"` / `.is-collapsed` で軽く区別
  - loading / error / drop-disabled / drop-target の baseline background cue を追加
- `docs/en/accessibility-semantics.md`
- `docs/ja/accessibility-semantics.md`
  - shipped stylesheet が持つ row-state baseline と host app theme の責務境界を追記

## 変更した画面・コンポーネント

- shipped stylesheet (`tree_view.scss`)
- accessibility semantics docs（英語 / 日本語）

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: branch 上の changed file 内容を確認
- レスポンシブ確認: row 背景色と先頭 cell accent のみで layout 変更なし
- アクセシビリティ確認: existing row-level ARIA state を styling hook として使う方針を docs に追記

## スクリーンショット

<!-- CSS baseline の小変更のため未取得 -->

## リスク

- low
- runtime behavior や public class 名は変えておらず、default stylesheet の見え方補助だけに閉じています

## 補足

- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカルでの browser 確認や test 実行は未実施です
- `tree_view-rails#360` は `area:docs` 付きのため、今回の Design Fixer Agent の通常対象からは除外しました