### PR TITLE
docs: add narrow viewport TreeView mockup reference

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -11,8 +11,15 @@ They are **not** a complete Rails application and should not grow into host-app 
 | File | Covers |
 |---|---|
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
+
+## Narrow-width guidance
+
+- Keep the toggle control, the primary node label, and the current or selected cue visible in the first scan line.
+- Move owner, status, badges, and less-frequent actions into stacked metadata or a compact action surface before hiding hierarchy cues.
+- Treat exact truncation, action menus, and responsive breakpoints as host-app responsibilities. These mockups are reference layouts, not a shipped responsive design system.
 
 ## Review policy
 

--- a/docs/mockups/default-tree.css
+++ b/docs/mockups/default-tree.css
@@ -274,3 +274,98 @@ h2 {
   color: #9aa5b1;
   background: #f1f5f9;
 }
+
+.mock-narrow-frame {
+  inline-size: min(100%, 23rem);
+  margin: 0 auto 1.5rem;
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-narrow-frame--tight {
+  inline-size: min(100%, 18rem);
+}
+
+.mock-narrow-caption {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e4e7eb;
+  background: #f8fafc;
+  color: #52606d;
+  font-size: 0.9rem;
+}
+
+.mock-narrow-note {
+  color: #52606d;
+  font-size: 0.95rem;
+}
+
+.tree-view-table--narrow .tree-toggle-cell {
+  min-width: 0;
+  width: 8.25rem;
+  white-space: normal;
+}
+
+.tree-view-table--narrow .tree-toggle {
+  align-items: flex-start;
+}
+
+.tree-view-table--narrow .tree-toggle__control {
+  flex-wrap: wrap;
+}
+
+.tree-view-table--narrow .tree-toggle__action,
+.tree-view-table--narrow .tree-toggle__level,
+.tree-view-table--narrow .tree-depth-label {
+  min-width: 0;
+}
+
+.tree-view-table--narrow .tree-row-actions {
+  width: 1%;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.tree-view-table--narrow .tree-row-actions button {
+  padding: 0.3rem 0.5rem;
+}
+
+.tree-view-table--narrow .tree-node-marker,
+.tree-view-table--narrow .tree-node-badge,
+.tree-view-table--narrow .mock-status {
+  margin-left: 0;
+}
+
+.mock-node-stack {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.mock-node-primary,
+.mock-node-meta,
+.mock-pill-list {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.mock-node-title {
+  color: #102a43;
+  font-weight: 700;
+}
+
+.mock-node-secondary {
+  color: #52606d;
+  font-size: 0.88rem;
+}
+
+.mock-action-icon {
+  min-width: 2rem;
+  padding: 0.3rem 0.45rem;
+  font-weight: 700;
+}

--- a/docs/mockups/narrow-sidebar-tree.html
+++ b/docs/mockups/narrow-sidebar-tree.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Narrow TreeView sidebar mock</title>
+<link rel="stylesheet" href="default-tree.css">
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Narrow TreeView sidebar mock</h1>
+      <p>
+        Static HTML for reviewing how a table-first tree can stay legible in a narrow sidebar or small viewport.
+        The goal is not to ship a responsive design system. The mock keeps hierarchy cues, the primary label, and current or selection state visible while less-critical metadata wraps below.
+      </p>
+    </header>
+
+    <section class="mock-section" aria-labelledby="sidebar-width-heading">
+      <h2 id="sidebar-width-heading">22rem sidebar frame</h2>
+      <p class="mock-narrow-note">
+        Keep the toggle control and the primary label on the first scan line. Secondary metadata can stack below without hiding the tree path.
+      </p>
+      <div class="mock-narrow-frame">
+        <p class="mock-narrow-caption">Representative frame width: 22rem</p>
+        <table class="tree-view-table tree-view-table--narrow" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+          <thead>
+            <tr>
+              <th scope="col">tree</th>
+              <th scope="col">node</th>
+              <th scope="col">act</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="project_21" class="tree-row is-expanded is-selected" data-tree-node-key="project:21" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true" aria-selected="true" aria-current="page">
+              <td class="btn-cell tree-toggle-cell" id="project_21_button">
+                <span class="tree-toggle" aria-label="Root row expanded">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                    <span class="tree-toggle__level">root</span>
+                  </span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary">
+                    <span class="mock-node-title">Platform</span>
+                    <span class="mock-status mock-status--active">active</span>
+                  </div>
+                  <div class="mock-node-secondary">Owner: Team A</div>
+                  <div class="mock-pill-list">
+                    <span class="tree-node-marker" title="Folder">folder</span>
+                    <span class="tree-node-badge tree-node-badge--info" title="Current row">current</span>
+                    <span class="tree-depth-label">L0</span>
+                  </div>
+                </div>
+              </td>
+              <td class="tree-row-actions"><button type="button" class="mock-action-icon">...</button></td>
+            </tr>
+            <tr id="project_22" class="tree-row is-leaf" data-tree-node-key="project:22" data-tree-parent-key="project:21" data-tree-depth="1" aria-level="2" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="project_22_button">
+                <span class="tree-toggle" aria-label="Leaf row">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot has-line"></span>
+                    <span class="tree-toggle__branch-slot is-current is-last"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <span class="tree-toggle__level">leaf</span>
+                  </span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary">
+                    <span class="mock-node-title">Admin UI</span>
+                  </div>
+                  <div class="mock-node-meta">
+                    <span class="mock-node-secondary">Team B</span>
+                    <span class="mock-status">ready</span>
+                  </div>
+                  <div class="mock-pill-list">
+                    <span class="tree-node-marker" title="File">file</span>
+                    <span class="tree-depth-label">L1</span>
+                  </div>
+                </div>
+              </td>
+              <td class="tree-row-actions"><button type="button" class="mock-action-icon">Open</button></td>
+            </tr>
+            <tr id="project_23" class="tree-row is-collapsed" data-tree-node-key="project:23" data-tree-parent-key="project:21" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="project_23_button">
+                <span class="tree-toggle" aria-label="Collapsed row with hidden descendants">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot has-line"></span>
+                    <span class="tree-toggle__branch-slot is-current is-last"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a>
+                    <span class="tree-toggle__level">child</span>
+                    <span class="tree-toggle__hidden-count" title="Hidden descendants">12</span>
+                  </span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary">
+                    <span class="mock-node-title">Legacy reports</span>
+                    <span class="mock-status mock-status--archived">archived</span>
+                  </div>
+                  <div class="mock-node-secondary">Owner: Team C</div>
+                  <div class="mock-pill-list">
+                    <span class="tree-node-marker" title="Archive">archive</span>
+                    <span class="tree-node-badge tree-node-badge--warning" title="Archived subtree">12 hidden</span>
+                  </div>
+                </div>
+              </td>
+              <td class="tree-row-actions"><button type="button" class="mock-action-icon">...</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="tight-width-heading">
+      <h2 id="tight-width-heading">18rem tight rail</h2>
+      <p class="mock-narrow-note">
+        When the frame gets tighter, the mock still keeps the hierarchy cue and primary label visible. Status, badges, and actions become compact rather than trying to stay on a single line.
+      </p>
+      <div class="mock-narrow-frame mock-narrow-frame--tight">
+        <p class="mock-narrow-caption">Representative frame width: 18rem</p>
+        <table class="tree-view-table tree-view-table--narrow">
+          <tbody>
+            <tr id="project_24" class="tree-row is-expanded" data-tree-node-key="project:24" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="project_24_button">
+                <span class="tree-toggle" aria-label="Expanded root row">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                    <span class="tree-toggle__level">root</span>
+                  </span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary">
+                    <span class="mock-node-title">Docs portal</span>
+                  </div>
+                  <div class="mock-pill-list">
+                    <span class="mock-status mock-status--pending">review</span>
+                    <span class="tree-node-badge">3 child</span>
+                  </div>
+                </div>
+              </td>
+              <td class="tree-row-actions"><button type="button" class="mock-action-icon">Go</button></td>
+            </tr>
+            <tr id="project_25" class="tree-row is-loading" data-tree-node-key="project:25" data-tree-parent-key="project:24" data-tree-depth="1" aria-level="2" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="project_25_button">
+                <span class="tree-toggle" aria-label="Loading child row">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot has-line"></span>
+                    <span class="tree-toggle__branch-slot is-current is-last"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <span class="tree-toggle__action tree-toggle__action--pending">wait</span>
+                    <span class="tree-toggle__level">child</span>
+                  </span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary">
+                    <span class="mock-node-title">Publishing queue</span>
+                  </div>
+                  <div class="mock-pill-list">
+                    <span class="mock-status mock-status--pending">loading</span>
+                  </div>
+                </div>
+              </td>
+              <td class="tree-row-actions"><button type="button" class="mock-action-icon" disabled>...</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="narrow-rules-heading">
+      <h2 id="narrow-rules-heading">Review cues</h2>
+      <ul>
+        <li>Do not hide the toggle path or the primary label before secondary metadata has somewhere else to go.</li>
+        <li>Current, selected, loading, and archived state should remain visible without forcing a wide multi-column row.</li>
+        <li>Exact truncation, compact menus, and breakpoints remain host-app responsibilities; this mock is a product-neutral reference.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応 Issue
- Closes #432

## 判定分類
- `docs-missing`

## 変更理由
- current mockups are centered on desktop-width table examples, so adopters cannot quickly see what to preserve first when a tree row has to fit in a narrow sidebar or a small viewport.
- runtime code and the shipped stylesheet should stay product-neutral, but the repository can still provide a static reference for how hierarchy cues, primary labels, and state indicators can remain readable at smaller widths.

## 変更内容
- `docs/mockups/narrow-sidebar-tree.html`
  - 22rem sidebar frame と 18rem tight rail の static mockup を追加
  - toggle path、primary label、current / selected / loading / archived cue を narrow width でも先に残す例を追加
- `docs/mockups/default-tree.css`
  - narrow mockup 用の shared utility style を追加
  - stacked metadata、compact action button、small-width frame を表現する最小 CSS を追加
- `docs/mockups/README.md`
  - new mockup の導線を追加
  - narrow width で優先して守る情報と host app responsibility を短く追記

## この PR でやっていないこと
- shipped runtime stylesheet (`app/assets/stylesheets/tree_view.scss`) の responsive design 追加
- host app 固有の breakpoint、truncation rule、action menu 実装
- accessibility semantics や public API の新規 guarantee 追加

## 根拠
- `docs/mockups/default-tree.html`
- `docs/mockups/interaction-states.html`
- `docs/mockups/default-tree.css`
- Issue `#432`

## 確認
- compare `main...docs/432-narrow-viewport-mockup` で変更が `docs/mockups/*` に閉じていることを確認
- open PR `#428`, `#430`, `#431` と changed files が重ならないことを確認
- static docs asset の追加のみのため test / lint は未実施

## リスク
- low
- static visual reference と README 補足のみで、runtime behavior や public API には影響しません

## 補足
- narrow-width の exact breakpoint と action compaction は host app responsibility のままにし、repository 側では product-neutral な reference に留めています