### PR TITLE
docs: clarify render log silencing and troubleshooting

### DIFF
--- a/docs/en/render-log-silencing.md
+++ b/docs/en/render-log-silencing.md
@@ -1,0 +1,72 @@
+# Render Log Silencing
+
+TreeView lowers the log level for its own helper-rendered partials by default so host app logs do not fill up with repeated `Rendered tree_view/...` entries.
+
+This setting only affects partial rendering that goes through TreeView helpers such as `tree_view_rows`. It does not replace the host app's logger policy, business logs, controller logs, SQL logs, or custom instrumentation.
+
+## Default behavior
+
+- Default: `:warn`
+- Effect: TreeView wraps helper-rendered partial output in `Rails.logger.silence(...)` when the logger supports it
+- Scope: only TreeView helper-rendered partials
+
+TreeView reads this value from `TreeView.configuration.render_log_level`.
+
+## Configuration
+
+Use `TreeView.configure` to change the level globally.
+
+```ruby
+TreeView.configure do |config|
+  config.render_log_level = :info
+end
+```
+
+Valid symbolic values are:
+
+- `:debug`
+- `:info`
+- `:warn`
+- `:error`
+- `:fatal`
+- `:unknown`
+
+You can also pass the matching `Logger` constant. TreeView normalizes it back to the symbolic setting.
+
+```ruby
+TreeView.configure do |config|
+  config.render_log_level = Logger::INFO
+end
+```
+
+## When to use `nil`
+
+Set `render_log_level` to `nil` when you want Rails render logs to stay unchanged.
+
+```ruby
+TreeView.configure do |config|
+  config.render_log_level = nil
+end
+```
+
+This disables TreeView's `logger.silence(...)` wrapper and lets partial render entries appear with the host app's normal logging behavior.
+
+## Picking a level
+
+- Use `:warn` when TreeView render noise is not useful during normal development or operations.
+- Use `:info` or `:debug` when you want more visibility while checking row partial wiring or render flow.
+- Use `nil` when the host app already has its own log filtering rules and you want TreeView to stay out of that decision.
+
+## Responsibility boundary
+
+TreeView only decides whether to silence logs around its own helper-rendered partials.
+
+The host app still owns:
+
+- Rails logger configuration
+- log formatters and tagged logging
+- SQL and controller log verbosity
+- business-event logging
+- request tracing and instrumentation
+
+If the symptom is "I cannot see TreeView partial render lines" or "TreeView render lines are too noisy", start with this setting before changing the host app's broader logging policy.

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -66,6 +66,24 @@ Read next:
 - [Usage](usage.md)
 - [JavaScript event contract](js-events.md)
 
+## TreeView partial render logs are missing or too noisy
+
+TreeView lowers the log level around helper-rendered partials by default. That is intentional and only affects partial rendering that goes through TreeView helpers.
+
+Check these points.
+
+- `TreeView.configuration.render_log_level` defaults to `:warn`.
+- Set `TreeView.configure { |config| config.render_log_level = :info }` or `:debug` when you want more render visibility while inspecting row partial wiring.
+- Set `TreeView.configure { |config| config.render_log_level = nil }` when you want Rails render logs to remain unchanged.
+- If changing `render_log_level` has no effect, confirm the host app logger responds to `silence`; otherwise TreeView falls back to normal rendering without wrapping the logger.
+- If the missing or noisy lines come from controller, SQL, or business logs, adjust the host app logging policy instead of expecting TreeView to change them.
+
+Read next:
+
+- [Render log silencing](render-log-silencing.md)
+- [Usage](usage.md)
+- [Rendering Boundaries](rendering-boundaries.md)
+
 ## Lazy loading does not replace children or remote state stays stuck
 
 Lazy loading is Turbo/server-driven.

--- a/docs/ja/render-log-silencing.md
+++ b/docs/ja/render-log-silencing.md
@@ -1,0 +1,72 @@
+# Render log silencing
+
+TreeView は、host app の log が `Rendered tree_view/...` で埋まりすぎないよう、helper 経由で描画する partial の log level を既定で下げます。
+
+この設定が効くのは `tree_view_rows` など TreeView helper を通る partial render だけです。host app 全体の logger policy、business log、controller log、SQL log、custom instrumentation を肩代わりするものではありません。
+
+## 既定挙動
+
+- 既定値: `:warn`
+- 効果: logger が対応していれば、TreeView は helper-rendered partial を `Rails.logger.silence(...)` で囲って描画する
+- 適用範囲: TreeView helper 経由で描画される partial だけ
+
+TreeView はこの値を `TreeView.configuration.render_log_level` から読みます。
+
+## 設定方法
+
+global 設定は `TreeView.configure` で変更します。
+
+```ruby
+TreeView.configure do |config|
+  config.render_log_level = :info
+end
+```
+
+使える symbol は次のとおりです。
+
+- `:debug`
+- `:info`
+- `:warn`
+- `:error`
+- `:fatal`
+- `:unknown`
+
+対応する `Logger` 定数を渡しても構いません。TreeView 側で symbol に正規化します。
+
+```ruby
+TreeView.configure do |config|
+  config.render_log_level = Logger::INFO
+end
+```
+
+## `nil` を使う場面
+
+Rails の render log をそのまま残したい場合は `render_log_level` に `nil` を指定します。
+
+```ruby
+TreeView.configure do |config|
+  config.render_log_level = nil
+end
+```
+
+この設定では TreeView の `logger.silence(...)` wrapper を使わず、partial render の log も host app の通常設定どおりに出ます。
+
+## 設定値の選び方
+
+- 通常の開発や運用で TreeView partial の render log が多すぎるなら `:warn`
+- row partial の wiring や render flow を追いたいなら `:info` または `:debug`
+- host app 側で独自の log 制御をしており、TreeView に介入させたくないなら `nil`
+
+## 責務境界
+
+TreeView が決めるのは、自分の helper-rendered partial の周辺で log を silence するかどうかだけです。
+
+次は引き続き host app 側の責務です。
+
+- Rails logger 設定
+- formatter や tagged logging
+- SQL / controller log の粒度
+- business event の log
+- request tracing や instrumentation
+
+「TreeView partial の render log が見えない」「TreeView の render log だけ多い」と感じたら、host app 全体の logger policy を変える前に、まずこの設定を見直してください。

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -66,6 +66,24 @@ TreeView は row wrapper と共通 tree UI cell を担当し、`row_partial` の
 - [使い方](usage.md)
 - [JavaScript event contract](js-events.md)
 
+## TreeView partial の render log が見えない / 多すぎる
+
+TreeView は helper-rendered partial の周辺だけ、既定で log level を下げて描画します。これは意図した挙動で、TreeView helper を通る partial render だけに効きます。
+
+次を確認してください。
+
+- `TreeView.configuration.render_log_level` の既定値は `:warn`
+- row partial の wiring や render flow を追いたいときは `TreeView.configure { |config| config.render_log_level = :info }` または `:debug` を試す
+- Rails の render log をそのまま見たいときは `TreeView.configure { |config| config.render_log_level = nil }` を使う
+- `render_log_level` を変えても効かない場合は、host app の logger が `silence` に対応しているか確認する。対応していなければ TreeView は logger wrapper を使わず通常描画に戻る
+- 足りない / 多すぎる log が controller、SQL、business log 側の話なら、TreeView ではなく host app の logger policy を調整する
+
+次に読む文書:
+
+- [Render log silencing](render-log-silencing.md)
+- [使い方](usage.md)
+- [Rendering Boundaries](rendering-boundaries.md)
+
 ## lazy loading で children が置き換わらない / remote state が戻らない
 
 lazy loading は Turbo / server-driven 前提です。


### PR DESCRIPTION
## 対応 Issue
- Closes #435

## 判定分類
- `code-ahead-of-docs`

## 変更理由
- `render_log_level` は `Configuration` と helper 実装では public configuration として存在していましたが、README の短い注記以外に後から見返せる正本がありませんでした
- `docs/en|ja/troubleshooting.md` にも「TreeView partial の render log が見えない / 多すぎる」という症状入口がなく、host app の logger policy と TreeView の責務境界が辿りにくい状態でした
- `README.md` と `docs/en|ja/usage.md` は別 open PR と write set が重なっているため、今回は競合を避けつつ docs-only で完結する slice に絞りました

## 変更内容
- `docs/en/render-log-silencing.md`
- `docs/ja/render-log-silencing.md`
  - `render_log_level` の既定値 `:warn`
  - `:info` / `:debug` / `nil` を選ぶ意図
  - `Logger` 定数を受け取れること
  - helper-rendered partial log だけに効くことと host app 側責務
- `docs/en/troubleshooting.md`
- `docs/ja/troubleshooting.md`
  - render log が見えない / 多すぎるときの確認項目を追加
  - 新しい guide への導線を追加
  - host app の broader logging policy と切り分ける観点を追記

## この PR でやっていないこと
- runtime code の変更
- logging backend や instrumentation surface の追加
- `README.md` や `docs/en|ja/usage.md` の更新

## 根拠
- `lib/tree_view/configuration.rb`
- `app/helpers/tree_view_helper/rendering.rb`
- Issue `#435`

## 確認
- compare `main...docs/435-render-log-silencing-main` で変更が docs 4 ファイルに閉じていることを確認
- current `main` head `51fda6f8aef8a58aa2749c2652b6a53d326c11b7` から branch を切り直し、open PR と不要な drift を持たない状態にした
- docs-only 変更のため test / lint は未実施

## リスク
- low
- 既存 configuration の説明追加だけで、runtime behavior や public API は変更していません