### PR TITLE
docs: document current branch auto expansion in API reference

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -259,7 +259,10 @@ render_state = TreeView::RenderState.new(
 | `initial_state:` | no | `:expanded` or `:collapsed`. |
 | `expanded_keys:` | no | Tree-side node keys to expand. These must match `tree.node_key_for(item)`, not UI-only DOM IDs. |
 | `collapsed_keys:` | no | Tree-side node keys to collapse. These must match `tree.node_key_for(item)`, not UI-only DOM IDs. |
-| `initial_expansion:` | no | Grouped initial expansion settings. Expansion keys inside this group follow the same tree-side node key rule. |
+| `current_item:` | no | Current node object. Used for row-state decisions and as the source item when ancestor auto-expansion is enabled. |
+| `current_key:` | no | Current node key when the host app only has an identifier. TreeView resolves the matching node under `root_items` before ancestor auto-expansion. |
+| `auto_expand_ancestors:` | no | Boolean that merges the current node's ancestor keys into `expanded_keys`. Requires `current_item` or a `current_key` that resolves to a node under `root_items`. |
+| `initial_expansion:` | no | Grouped initial expansion settings. Supported keys are `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, and `auto_expand_ancestors`. |
 | `render_scope:` | no | Grouped render scope settings. |
 | `toggle_scope:` | no | Grouped toggle scope settings. |
 | `selection:` | no | Grouped checkbox selection settings. |
@@ -274,6 +277,8 @@ render_state = TreeView::RenderState.new(
 | `row_status_builder:` | no | Callable that returns row state. |
 | `row_event_payload_builder:` | no | Callable that returns drag/drop transfer payloads. This is transfer-specific, not a generic row event hook. |
 | `persisted_state:` | no | Saved expansion state. |
+
+When both flat keyword options and `initial_expansion:` are supplied, the flat keyword options win. `auto_expand_ancestors:` only opens the current node's path; keep using `expanded_keys:` when sibling branches or additional paths should also start open. For a practical example, see [Cookbook: Expand only the current branch initially](cookbook.md#expand-only-the-current-branch-initially).
 
 For focused naming decisions, see [Public Name Decisions](public-name-decisions.md). For ARIA placement, see [Accessibility Semantics](accessibility-semantics.md). For identifier design, see [Node keys](node-keys.md).
 

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -259,7 +259,10 @@ render_state = TreeView::RenderState.new(
 | `initial_state:` | no | `:expanded` または `:collapsed`。 |
 | `expanded_keys:` | no | 展開するtree側node key配列。`tree.node_key_for(item)` と一致する必要があり、UIだけのDOM IDではありません。 |
 | `collapsed_keys:` | no | 折りたたむtree側node key配列。`tree.node_key_for(item)` と一致する必要があり、UIだけのDOM IDではありません。 |
-| `initial_expansion:` | no | 初期展開設定group。このgroup内の展開keyにも同じtree側node keyの規則が適用されます。 |
+| `current_item:` | no | 現在nodeのobject。row状態判定に使えるほか、ancestor 自動展開時の起点にもなります。 |
+| `current_key:` | no | host app 側が key だけ持っている場合の現在node key。ancestor 自動展開の前に、TreeView が `root_items` 配下から対応nodeを解決します。 |
+| `auto_expand_ancestors:` | no | 現在nodeの ancestor key を `expanded_keys` に自動で足す boolean。`current_item`、または `root_items` 配下で解決できる `current_key` が必要です。 |
+| `initial_expansion:` | no | 初期展開設定group。`default`、`max_depth`、`expanded_keys`、`collapsed_keys`、`current_item`、`current_key`、`auto_expand_ancestors` を使えます。 |
 | `render_scope:` | no | 描画範囲設定group。 |
 | `toggle_scope:` | no | 開閉操作範囲設定group。 |
 | `selection:` | no | checkbox selection設定group。 |
@@ -274,6 +277,8 @@ render_state = TreeView::RenderState.new(
 | `row_status_builder:` | no | row状態を返すcallable。 |
 | `row_event_payload_builder:` | no | drag/drop transfer payloadを返すcallable。transfer専用であり、汎用row event hookではない。 |
 | `persisted_state:` | no | 保存済み展開状態。 |
+
+個別引数と `initial_expansion:` を同時に指定した場合は、個別引数を優先します。`auto_expand_ancestors:` が開くのは current node に至る path だけなので、兄弟branchや別pathも最初から開きたい場合は引き続き `expanded_keys:` を併用してください。実用例は [Cookbook の「現在のブランチだけ初期展開する」](cookbook.md#現在のブランチだけ初期展開する) を参照してください。
 
 公開名の判断は [Public Name Decisions](public-name-decisions.md)、ARIA配置は [Accessibility Semantics](accessibility-semantics.md) を参照してください。識別子設計は [Node keys](node-keys.md) を参照してください。
 


### PR DESCRIPTION
## 対応 Issue
- Part of #437

## 判定分類
- `code-ahead-of-docs`

## 変更理由
- `TreeView::RenderState` の実装には `current_item`、`current_key`、`auto_expand_ancestors` が既にありますが、`docs/en/api.md` / `docs/ja/api.md` の `RenderState` 引数表には載っていませんでした
- current branch を初期展開するときの practical example 自体は cookbook にありますが、API 仕様から grouped option の対応 key と前提条件を辿れない状態でした
- `docs/en|ja/usage.md` は open PR `#421` と write set が重なるため、今回は競合を避けつつ API reference の stale を先に解消する slice に絞りました

## 変更内容
- `docs/en/api.md`
- `docs/ja/api.md`
  - `current_item` / `current_key` / `auto_expand_ancestors` を `RenderState` 引数表に追加
  - `initial_expansion` group で使える関連 key を明記
  - `auto_expand_ancestors` が current node の path だけを開くこと、追加の branch は `expanded_keys` を併用することを追記
  - 既存 cookbook の current-branch 例への導線を追加

## この PR でやっていないこと
- runtime code の変更
- `usage.md` の例の追加や再構成
- cookbook 既存 example の大きな書き換え

## 根拠
- `lib/tree_view/render_state.rb`
- `docs/en/api.md`
- `docs/ja/api.md`
- Issue `#437`

## 確認
- docs 2 ファイルだけの変更に閉じています
- open PR `#421`, `#425`, `#436` と changed files が重ならないようにしました
- docs-only 変更のため test / lint は未実施です

## リスク
- low
- 既存実装の API reference 追記のみで、runtime behavior や public API 自体は変更していません

## 補足
- `#437` のうち usage / cookbook まで含めた広い整備は、open PR との重なりを見ながら別 slice で進める余地があります