### PR TITLE
docs: add empty state mockup reference

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -13,6 +13,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
 
 ## Narrow-width guidance
@@ -20,6 +21,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 - Keep the toggle control, the primary node label, and the current or selected cue visible in the first scan line.
 - Move owner, status, badges, and less-frequent actions into stacked metadata or a compact action surface before hiding hierarchy cues.
 - Treat exact truncation, action menus, and responsive breakpoints as host-app responsibilities. These mockups are reference layouts, not a shipped responsive design system.
+
+## Empty-state guidance
+
+- Use `data-tree-view-empty-state="true"` together with `.tree-view-empty-row__content` and `.tree-view-empty-row__message` as the reusable baseline hook.
+- Keep final empty copy, CTA, permission messaging, and filter-reset behavior in the host app.
 
 ## Review policy
 

--- a/docs/mockups/default-tree.css
+++ b/docs/mockups/default-tree.css
@@ -369,3 +369,48 @@ h2 {
   padding: 0.3rem 0.45rem;
   font-weight: 700;
 }
+
+.tree-view-empty-row__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem 1.1rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.tree-view-empty-row__content[data-tree-view-empty-state="true"] {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+}
+
+.tree-view-empty-row__message {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-empty-note {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.95rem;
+}
+
+.mock-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.8rem;
+}
+
+.mock-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0f4c81;
+  font-size: 0.82rem;
+  font-weight: 700;
+}

--- a/docs/mockups/empty-state.html
+++ b/docs/mockups/empty-state.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView empty state mock</title>
+<link rel="stylesheet" href="default-tree.css">
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView empty state mock</h1>
+      <p>
+        no root items と no results の代表的な empty row を、Rails を起動せずに確認するための静的HTMLです。
+        final copy、CTA、permission messaging、search condition summary は host app の責務のままにし、ここでは TreeView が提供する wrapper hook と row slot の見え方だけを固定します。
+      </p>
+    </header>
+
+    <section class="mock-section" aria-labelledby="no-root-items-heading">
+      <h2 id="no-root-items-heading">No root items</h2>
+      <p class="mock-empty-note">
+        初回セットアップ直後や、まだ root item が 0 件のときの代表例です。empty state は full-width cell の中に収まり、toggle / selection / row action は出しません。
+      </p>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">owner</th>
+            <th scope="col">status</th>
+            <th scope="col">actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colspan="5">
+              <div class="tree-view-empty-row__content" data-tree-view-empty-state="true">
+                <p class="tree-view-empty-row__message">No root items are available yet.</p>
+                <p class="mock-empty-note">Host apps can replace this with onboarding copy, a create button, or permission-specific guidance.</p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="no-results-heading">
+      <h2 id="no-results-heading">No results after filtering</h2>
+      <div class="mock-filter-bar" aria-label="Filter summary example">
+        <span class="mock-filter-chip">status: archived</span>
+        <span class="mock-filter-chip">owner: Team B</span>
+        <span class="mock-filter-chip">query: reports</span>
+      </div>
+      <p class="mock-empty-note">
+        検索や filter の結果が 0 件のときも、same hook を使って row 全体を empty state slot として扱えます。どの filter が効いているかの説明や reset action は host app が持ちます。
+      </p>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">owner</th>
+            <th scope="col">status</th>
+            <th scope="col">actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colspan="5">
+              <div class="tree-view-empty-row__content" data-tree-view-empty-state="true">
+                <p class="tree-view-empty-row__message">No rows match the current filters.</p>
+                <p class="mock-empty-note">Keep filter reset links, saved views, and search help in the host app. TreeView only guarantees the wrapper hook and message slot.</p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="comparison-heading">
+      <h2 id="comparison-heading">Difference from a populated row</h2>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">owner</th>
+            <th scope="col">status</th>
+            <th scope="col">actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="reference_row_1" class="tree-row is-expanded" data-tree-node-key="project:1" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+            <td class="btn-cell tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Loaded branch">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                  <span class="tree-toggle__level">root</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="Folder">folder</span>
+            </td>
+            <td>Product Platform</td>
+            <td>Team A</td>
+            <td><span class="mock-status mock-status--active">active</span></td>
+            <td class="tree-row-actions"><button type="button">Open</button></td>
+          </tr>
+          <tr>
+            <td colspan="5">
+              <div class="tree-view-empty-row__content" data-tree-view-empty-state="true">
+                <p class="tree-view-empty-row__message">Empty rows consume the full content width instead of rendering branch controls.</p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <ul>
+        <li>Populated rows keep branch controls, badges, selection, and row actions.</li>
+        <li>Empty rows collapse those row-level controls into one full-width message slot.</li>
+        <li><code>data-tree-view-empty-state="true"</code> and the empty-row wrapper classes are the reusable surface.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応 Issue
- Closes #440

## 判定分類
- `docs-missing`

## 変更理由
- `docs/en/accessibility-semantics.md` では empty-state hook (`.tree-view-empty-row__content`, `.tree-view-empty-row__message`, `data-tree-view-empty-state="true"`) がすでに documented surface でした
- 一方で `docs/mockups/README.md` から辿れる static mockup は populated tree / interaction states / narrow width が中心で、no root items や no results を視覚的に確認できる reference がありませんでした
- open PR `#421`, `#431`, `#439` と write set を重ねずに docs-only で完結できるため、`docs/mockups/*` に閉じた slice で補いました

## 変更内容
- `docs/mockups/empty-state.html`
  - no root items と no results の代表 empty row を追加
  - full-width message slot と `data-tree-view-empty-state="true"` の見え方を static HTML で確認できるようにした
  - populated row との比較セクションを置き、branch control を出さない差分を見えるようにした
- `docs/mockups/default-tree.css`
  - empty-row wrapper hook と filter summary chips の mock styling を追加
- `docs/mockups/README.md`
  - new empty-state mockup への導線を追加
  - host app が final copy / CTA / permission messaging を持つ責務を短く明記

## この PR でやっていないこと
- runtime code の変更
- `docs/en|ja/accessibility-semantics.md` の wording 更新
- host app 固有の onboarding copy や search reset UI の決め打ち

## 根拠
- `docs/en/accessibility-semantics.md`
- `docs/mockups/README.md`
- `docs/mockups/default-tree.html`
- `docs/mockups/interaction-states.html`
- Issue `#440`

## 確認
- compare `main...docs/440-empty-state-mockup` で変更が `docs/mockups/README.md`, `docs/mockups/default-tree.css`, `docs/mockups/empty-state.html` の 3 ファイルだけに閉じていることを確認
- `data-tree-view-empty-state="true"` と `.tree-view-empty-row__content` / `.tree-view-empty-row__message` の documented hook だけを使い、runtime contract を広げていないことを確認
- docs-only 変更のため test / lint は未実施

## リスク
- low
- static mockup と docs index の追加だけで、runtime behavior や public API は変更していません