### PR TITLE
test: row state hook inventory を source spec で固定する

### DIFF
--- a/spec/row_state_hook_inventory_spec.rb
+++ b/spec/row_state_hook_inventory_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "row state hook inventory" do
+  let(:stylesheet_source) { File.read(File.expand_path("../app/assets/stylesheets/tree_view.scss", __dir__)) }
+  let(:default_mock_source) { File.read(File.expand_path("../docs/mockups/default-tree.html", __dir__)) }
+  let(:interaction_mock_source) { File.read(File.expand_path("../docs/mockups/interaction-states.html", __dir__)) }
+  let(:english_doc_source) { File.read(File.expand_path("../docs/en/accessibility-semantics.md", __dir__)) }
+  let(:japanese_doc_source) { File.read(File.expand_path("../docs/ja/accessibility-semantics.md", __dir__)) }
+
+  let(:mock_sources) { [default_mock_source, interaction_mock_source].join("\n") }
+  let(:documented_row_state_hooks) do
+    [
+      ".is-selected",
+      ".is-collapsed",
+      ".is-loading",
+      ".is-error",
+      ".is-drop-target"
+    ]
+  end
+
+  it "keeps the documented representative row state hooks in the shipped stylesheet" do
+    documented_row_state_hooks.each do |hook|
+      expect(stylesheet_source).to include(hook)
+    end
+  end
+
+  it "keeps the same representative row state hooks visible in the static mockups" do
+    documented_row_state_hooks.each do |hook|
+      expect(mock_sources).to include(hook)
+    end
+  end
+
+  it "documents the same representative row state hooks in both accessibility guides" do
+    documented_row_state_hooks.each do |hook|
+      expect(english_doc_source).to include(hook)
+      expect(japanese_doc_source).to include(hook)
+    end
+  end
+
+  it "keeps current-row semantics separate from class-based row state hooks" do
+    expect(stylesheet_source).to include('[aria-current="page"]')
+    expect(english_doc_source).to include('`aria-current="page"`')
+    expect(japanese_doc_source).to include('`aria-current="page"`')
+  end
+end

--- a/spec/row_state_hook_inventory_spec.rb
+++ b/spec/row_state_hook_inventory_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "row state hook inventory" do
 
   it "keeps the same representative row state hooks visible in the static mockups" do
     documented_row_state_hooks.each do |hook|
-      expect(mock_sources).to include(hook)
+      expect(mock_sources).to include(hook.delete_prefix("."))
     end
   end
 


### PR DESCRIPTION
## 対応 Issue
- Closes #433

## Issue ごとの完了内容
- `#433`
  - static mockup / shipped stylesheet / accessibility docs のあいだで共有している representative row state hook を source-level spec で固定
  - current-row semantics は class-based hook と別扱いだと分かる guard を追加

## 変更内容
- `spec/row_state_hook_inventory_spec.rb`
  - `app/assets/stylesheets/tree_view.scss`
  - `docs/mockups/default-tree.html`
  - `docs/mockups/interaction-states.html`
  - `docs/en/accessibility-semantics.md`
  - `docs/ja/accessibility-semantics.md`
  を直接読み、以下の representative hook が揃っていることを確認
    - `.is-selected`
    - `.is-collapsed`
    - `.is-loading`
    - `.is-error`
    - `.is-drop-target`
  - 追加で `aria-current="page"` が class-based hook と別の current-row semantics として扱われていることを確認

## 改善カテゴリ
- テスト追加・改善
- 回帰防止
- docs / shipped baseline / mockup drift hardening

## 既存仕様への影響
- なし
- runtime behavior、public class 名、mockup HTML は変更していません
- current `main` の共有 hook inventory を spec で固定しただけです

## 実施した確認
- `#428` がすでに `main` へ merge 済みで、`#433` の前提だった row-state baseline styling が current `main` に入っていることを確認
- 変更が spec 1 ファイルに閉じていることを確認
- representative hook を小さく保ち、mockup-only detail まで固定しない方針にしたことを確認

## 検証未実施 / 制約
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル `bundle exec rspec` は未実施です
- 最終確認は PR CI でお願いします

## リスク評価
- low
- source-level inventory spec の追加のみで、挙動変更はありません

## 補足事項
- `.is-drop-disabled` や purely visual detail までは representative inventory に含めず、public hook として docs に現れている主要 state に絞っています