### PR TITLE
design: align mockup language baseline for side-by-side review

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -6,6 +6,8 @@ These files are intentionally small, reviewable assets in the gem repository. Th
 
 They are **not** a complete Rails application and should not grow into host-app CRUD, query, authorization, seed data, or controller examples. Full playground/application examples belong in `matsuo-haruhito/tree_view-rails-demo` once that demo repository is public.
 
+Representative mockups in this directory use short, product-neutral English copy by default so side-by-side review can focus on structure and state differences instead of language drift. Final product copy and localization strategy remain host-app responsibilities.
+
 ## Files
 
 | File | Covers |

--- a/docs/mockups/default-tree.html
+++ b/docs/mockups/default-tree.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,8 +12,8 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>Default TreeView rendering mock</h1>
       <p>
-        Rails を起動せずに、gem 標準 partial が出力する代表的な table / row / cell / data 属性の形を確認するための静的HTMLです。
-        実アプリ上の playground は demo repo、本体 repo のこの mock は DOM 構造と CSS 適用状態の確認に使います。
+        Static HTML for reviewing the representative table, row, cell, and data-attribute shape emitted by the gem's default partials without booting Rails.
+        Use the demo repository for an app-level playground; use this repository mock to inspect DOM structure and baseline CSS behavior.
       </p>
     </header>
 
@@ -136,11 +136,11 @@
     <section class="mock-section" aria-labelledby="notes-heading">
       <h2 id="notes-heading">What this mock covers</h2>
       <ul>
-        <li>root / child / leaf の代表行</li>
-        <li>expanded / collapsed / hidden count 表示</li>
-        <li>selected checkbox と disabled checkbox</li>
-        <li>badge / marker / depth label の配置</li>
-        <li>row data 属性、tree state data 属性、row actions partial の列位置</li>
+        <li>Representative root, child, and leaf rows</li>
+        <li>Expanded, collapsed, and hidden-count states</li>
+        <li>Selected and disabled checkbox states</li>
+        <li>Badge, marker, and depth-label placement</li>
+        <li>Row data attributes, tree-state attributes, and row-action column placement</li>
       </ul>
     </section>
   </main>

--- a/docs/mockups/interaction-states.html
+++ b/docs/mockups/interaction-states.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,8 +12,8 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>TreeView interaction states mock</h1>
       <p>
-        Lazy loading、loading、error/retry、children pagination、drag/drop の代表的な見た目とDOM hookを確認するための静的HTMLです。
-        Rails controller、Turbo Stream response、query、authorizationはhost appの責務なので、このmockには含めません。
+        Static HTML for reviewing representative lazy-loading, loading, error or retry, children pagination, and drag or drop states.
+        Rails controllers, Turbo Stream responses, queries, and authorization remain host-app responsibilities, so they are intentionally out of scope for this mock.
       </p>
     </header>
 


### PR DESCRIPTION
## 対応Issue

- Closes #442

## 採用した方針

- 自動実行のため、既存 mockup の役割差は残したまま、代表 mockup の言語方針だけを英語ベースへそろえる low-risk 案を採用しました。
- runtime code や ARIA / DOM hook には触れず、review 時に layout / state 差分へ集中しやすくすることに絞っています。

## 比較した案

- 案A: `default-tree.html` と `interaction-states.html` を `narrow-sidebar-tree.html` に合わせて英語の product-neutral copy へ寄せ、README に language policy を追記する。
- 案B: bilingual を維持しつつ、README に各 mockup の言語方針だけを書く。
- 案C: mockup 全体を大きく再編集し、caption や review cue も全面的に統一する。
- 今回は案Aを採用しました。比較ノイズを最も素直に減らせて、既存 surface や write set も小さく保てるためです。

## 変更内容

- `docs/mockups/default-tree.html`
  - `lang` を `en` に変更
  - header 説明文と coverage list を英語の product-neutral copy に更新
- `docs/mockups/interaction-states.html`
  - `lang` を `en` に変更
  - header 説明文を英語の product-neutral copy に更新
- `docs/mockups/README.md`
  - representative mockup は side-by-side review 用に短い英語 copy を baseline にする方針を追記
  - final copy / localization は host app responsibility だと明記

## 変更した画面・コンポーネント

- static mockups:
  - `docs/mockups/default-tree.html`
  - `docs/mockups/interaction-states.html`
  - `docs/mockups/README.md`
- `docs/mockups/narrow-sidebar-tree.html` は既に同方針の英語 baseline だったため、今回の参照基準として据え置きました

## 確認内容

- lint: 未実施（docs/mockup only）
- typecheck: 該当なし
- UI表示確認: compare `main...design/442-mockup-language-baseline` で changed files が `docs/mockups` 配下 3 ファイルに閉じていることを確認
- レスポンシブ確認: runtime UI 変更なし
- アクセシビリティ確認: `lang` 属性の混在を減らし、mockup 間の比較時に読み分けしやすい baseline へ整理

## スクリーンショット

<!-- static mockup source review で十分なため未添付 -->

## リスク

- low
- static mockup の copy / language policy 整理のみで、runtime behavior や public API は変更していません

## 補足

- `#441` の empty-state mockup はすでに `main` に merge 済みだったため、その後の `docs/mockups` baseline を前提に進めています
- test / lint は実行していません