### PR TITLE
docs: normalize mockup copy language policy

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -16,6 +16,12 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
 
+## Copy and language policy
+
+- Mockups use short, product-neutral English copy so reviewers can compare layout and state cues without language changes becoming visual noise.
+- Final labels, localization, permission messaging, and business wording remain host-app responsibilities.
+- If a future mockup intentionally uses another language, document that exception here so reviewers know it is deliberate.
+
 ## Narrow-width guidance
 
 - Keep the toggle control, the primary node label, and the current or selected cue visible in the first scan line.

--- a/docs/mockups/default-tree.html
+++ b/docs/mockups/default-tree.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,8 +12,8 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>Default TreeView rendering mock</h1>
       <p>
-        Rails を起動せずに、gem 標準 partial が出力する代表的な table / row / cell / data 属性の形を確認するための静的HTMLです。
-        実アプリ上の playground は demo repo、本体 repo のこの mock は DOM 構造と CSS 適用状態の確認に使います。
+        Static HTML for reviewing representative table, row, cell, and data-attribute output from the bundled TreeView partials without running Rails.
+        Full playground scenarios belong in the demo repository; this mock stays focused on DOM structure and baseline CSS coverage.
       </p>
     </header>
 
@@ -136,11 +136,11 @@
     <section class="mock-section" aria-labelledby="notes-heading">
       <h2 id="notes-heading">What this mock covers</h2>
       <ul>
-        <li>root / child / leaf の代表行</li>
-        <li>expanded / collapsed / hidden count 表示</li>
-        <li>selected checkbox と disabled checkbox</li>
-        <li>badge / marker / depth label の配置</li>
-        <li>row data 属性、tree state data 属性、row actions partial の列位置</li>
+        <li>Representative root, child, and leaf rows</li>
+        <li>Expanded and collapsed rows with hidden-count cues</li>
+        <li>Selected and disabled checkbox states</li>
+        <li>Badge, marker, and depth-label placement</li>
+        <li>Row data attributes, tree state attributes, and row-actions column placement</li>
       </ul>
     </section>
   </main>

--- a/docs/mockups/interaction-states.html
+++ b/docs/mockups/interaction-states.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,8 +12,8 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>TreeView interaction states mock</h1>
       <p>
-        Lazy loading、loading、error/retry、children pagination、drag/drop の代表的な見た目とDOM hookを確認するための静的HTMLです。
-        Rails controller、Turbo Stream response、query、authorizationはhost appの責務なので、このmockには含めません。
+        Static HTML for reviewing representative lazy-loading, loading, error or retry, children-pagination, and drag or drop states.
+        Rails controllers, Turbo Stream responses, queries, and authorization remain host-app responsibilities and are intentionally not modeled here.
       </p>
     </header>
 


### PR DESCRIPTION
## 対応 Issue
Closes #442

## 判定分類
- `docs-stale`

## 変更理由
- `docs/mockups/narrow-sidebar-tree.html` は英語の product-neutral copy で揃っていた一方、`default-tree.html` と `interaction-states.html` は日本語の説明文や review cue が残っていて、mockup 横断で比較すると layout 差分と文言差分が混ざりやすい状態でした。
- `docs/mockups/README.md` に mockup copy の language policy が無く、今後の追加 mockup で意図的な例外か単なる追従漏れかを判別しづらかったため、方針を source に残しました。

## 変更内容
- `docs/mockups/README.md`
  - mockup は short, product-neutral English copy を使うという方針を追加
  - final labels / localization / business wording は host app 側責務だと明記
- `docs/mockups/default-tree.html`
  - `lang` を `en` に変更
  - header explanation と review cue list を英語へ統一
- `docs/mockups/interaction-states.html`
  - `lang` を `en` に変更
  - header explanation を英語へ統一

## この PR でやっていないこと
- runtime code、shipped stylesheet、ARIA hook の変更
- narrow / empty-state mockup の layout や DOM structure の作り直し
- host app 向けの localization strategy の決め打ち

## 根拠
- `docs/mockups/README.md`
- `docs/mockups/default-tree.html`
- `docs/mockups/interaction-states.html`
- `docs/mockups/narrow-sidebar-tree.html`
- Issue #442

## 確認
- compare `main...docs/442-mockup-language-policy-main` で変更が `docs/mockups/README.md`, `docs/mockups/default-tree.html`, `docs/mockups/interaction-states.html` の 3 ファイルだけに閉じていることを確認
- representative row labels, state hooks, DOM structure, and CSS references は変えず、copy / `lang` / README policy だけを調整
- docs-only 変更のため local test / lint は未実施

## リスク
- low
- static mockup copy と README guidance の更新のみで、public API や runtime behavior には触れていません