### PR TITLE
docs: keep AGENTS guidance repository-local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
-see `/mnt/c/work/AGENTS.md`
+Repository-specific maintainer guidance for `tree_view`.
+Use this file together with `README.md`, `docs/README.md`, and `Product Profile.md`.
 
 ## Purpose
 
@@ -129,5 +130,6 @@ Do not implement large feature areas opportunistically while working on unrelate
 
 ## Codex Common Operation
 
-- Inherit the common skill definitions described in the root [AGENTS.md](/mnt/c/work/AGENTS.md), even when Codex is launched directly in this repository.
+- Use this local `AGENTS.md` as the repository-specific operating contract.
+- Prefer repository-local durable docs when you need broader context: `README.md`, `docs/README.md`, `Product Profile.md`, and the relevant language-specific docs under `docs/`.
 - Keep repository-specific context in this local `AGENTS.md` and durable docs in `docs/`.


### PR DESCRIPTION
## 対応 Issue
Closes #451

## 判定分類
- `docs-stale`

## 変更理由
- current `AGENTS.md` には `/mnt/c/work/AGENTS.md` への参照が残っており、GitHub 上で読む maintainer や review agent には参照不能な案内になっていました。
- 一方で、この repository にはすでに `README.md`、`docs/README.md`、`Product Profile.md`、`docs/en/*`、`docs/ja/*` という durable な導線が揃っています。

## 変更内容
- `AGENTS.md`
  - 冒頭の repo 外パス参照を、repo 内の entrypoint docs を案内する repository-local wording に置き換え
  - `Codex Common Operation` セクションの `/mnt/c/work/AGENTS.md` 参照を削除
  - broader context を読む先として `README.md`、`docs/README.md`、`Product Profile.md`、language-specific docs を明示

## 根拠
- `AGENTS.md`
- `README.md`
- `docs/README.md`
- `Product Profile.md`
- Issue #451

## 確認
- current `main` の `AGENTS.md` に残っていた `/mnt/c/work/AGENTS.md` 参照 2 箇所がなくなることを確認
- 変更が `AGENTS.md` 1 ファイルだけに閉じていることを確認
- repository 内 docs への導線だけで maintainer first-read をたどれる wording に留めた
- docs-only 変更のため local test / lint は未実施

## リスク
- low
- maintainer guidance の wording 更新のみで、runtime code、public API、CI 設定には触れていません