### PR TITLE
docs: add a static mockup review gallery

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -10,11 +10,18 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 | File | Covers |
 |---|---|
+| [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the default, narrow, interaction, and empty-state mockups, with embedded previews and links to each full reference page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
+
+## Recommended review flow
+
+1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the main mockup surfaces.
+2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
+3. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView mockup review gallery</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-gallery-page {
+  max-width: 1320px;
+}
+
+.mock-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.mock-gallery-card {
+  display: grid;
+  gap: 16px;
+  background: #fff;
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+  padding: 20px;
+}
+
+.mock-gallery-card h2,
+.mock-gallery-card p,
+.mock-gallery-card ul {
+  margin: 0;
+}
+
+.mock-gallery-eyebrow {
+  color: #52606d;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-gallery-copy {
+  display: grid;
+  gap: 10px;
+}
+
+.mock-gallery-points {
+  padding-left: 1.2rem;
+  color: #334e68;
+}
+
+.mock-gallery-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.mock-gallery-links a {
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-gallery-links a:hover,
+.mock-gallery-links a:focus {
+  text-decoration: underline;
+}
+
+.mock-gallery-preview {
+  min-height: 340px;
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f8fafc;
+}
+
+.mock-gallery-preview iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 340px;
+  border: 0;
+  background: #fff;
+}
+
+.mock-comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-comparison-table th,
+.mock-comparison-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-comparison-table th {
+  background: #f1f5f9;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .mock-gallery-preview,
+  .mock-gallery-preview iframe {
+    min-height: 280px;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-gallery-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView mockup review gallery</h1>
+      <p>
+        Static review hub for comparing the main TreeView mockups without running a Rails app.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, and empty-state spacing in one session.
+      </p>
+    </header>
+
+    <section class="mock-section" aria-labelledby="gallery-usage-heading">
+      <h2 id="gallery-usage-heading">How to use this gallery</h2>
+      <ul>
+        <li>Start here when a review needs quick side-by-side comparison across the main mockup surfaces.</li>
+        <li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li>
+        <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li>
+      </ul>
+    </section>
+
+    <section class="mock-gallery-grid" aria-label="Mockup comparison gallery">
+      <article class="mock-gallery-card" aria-labelledby="gallery-default-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Baseline structure</p>
+          <h2 id="gallery-default-heading">Default tree</h2>
+          <p>
+            Use this surface to inspect representative root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Expanded and collapsed hierarchy cues</li>
+            <li>Selection, badges, and status placement</li>
+            <li>Baseline row-actions column layout</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="default-tree.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Responsive reference</p>
+          <h2 id="gallery-narrow-heading">Narrow sidebar</h2>
+          <p>
+            Use this surface to compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>22rem and 18rem representative frames</li>
+            <li>Current, archived, and loading cues in compressed rows</li>
+            <li>Compact action treatment without hiding the tree path</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="narrow-sidebar-tree.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">State transitions</p>
+          <h2 id="gallery-interaction-heading">Interaction states</h2>
+          <p>
+            Use this surface to review lazy loading, retry, pagination, and drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Loaded, loading, and error or retry rows</li>
+            <li>Children pagination placeholder rows</li>
+            <li>Dragging, valid drop, and blocked drop states</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="interaction-states.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Spacing and fallback</p>
+          <h2 id="gallery-empty-heading">Empty state</h2>
+          <p>
+            Use this surface to compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Reusable empty-row wrapper hook</li>
+            <li>Full-width message slot behavior</li>
+            <li>Difference from a populated row with controls</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="empty-state.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+    </section>
+
+    <section class="mock-section" aria-labelledby="comparison-cues-heading">
+      <h2 id="comparison-cues-heading">Comparison cues</h2>
+      <table class="mock-comparison-table">
+        <thead>
+          <tr>
+            <th scope="col">Surface</th>
+            <th scope="col">Best for</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Default tree</td>
+            <td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td>
+            <td>Host-app CRUD, queries, business labels, or authorization behavior.</td>
+          </tr>
+          <tr>
+            <td>Narrow sidebar</td>
+            <td>Hierarchy readability when width shrinks and metadata needs to wrap.</td>
+            <td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td>
+          </tr>
+          <tr>
+            <td>Interaction states</td>
+            <td>Loading, retry, pagination, and drag or drop status cues.</td>
+            <td>Real Turbo responses, route wiring, or persistence behavior.</td>
+          </tr>
+          <tr>
+            <td>Empty state</td>
+            <td>Spacing, wrapper hooks, and the full-width empty-row slot.</td>
+            <td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #444

## 採用した方針

- 自動実行のため、既存 mockup の DOM や ARIA、state class は変えずに、比較導線だけを足す low-risk 案を採用しました。
- 1 枚の static gallery から `default` / `narrow` / `interaction` / `empty-state` を見比べられるようにしつつ、各 mockup 本体は source of truth のまま維持しています。

## 比較した案

- 案A: `docs/mockups/README.md` のリンク順だけを整理する。
- 案B: 新しい `review-gallery.html` を追加し、既存 mockup を埋め込み preview とリンクで横断比較できるようにする。
- 案C: mockup 一式を 1 つの巨大な HTML に統合し、既存 reference を再編する。
- 今回は案Bを採用しました。reviewer が 1 画面から比較しやすくなりつつ、既存 mockup の責務や diff の読みやすさを崩さないためです。

## 変更内容

- `docs/mockups/review-gallery.html`
  - 既存 4 mockup を横断比較する static review gallery を追加
  - embedded preview、比較観点、full mockup への導線を整理
  - product-neutral な説明と scope guard を明示
- `docs/mockups/README.md`
  - gallery を file index に追加
  - 推奨 review flow を追記

## 変更した画面・コンポーネント

- `docs/mockups/review-gallery.html`
- `docs/mockups/README.md`

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: compare diff で gallery と README の導線が `docs/mockups/*` に閉じていることを確認
- レスポンシブ確認: gallery の card grid と preview height に narrow viewport 向けの最小調整を追加
- アクセシビリティ確認: embedded preview に `title` を付け、各 section の見出しと比較観点を分離

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- static mockup asset と README 導線の追加のみで、runtime code、public API、shipped stylesheet には触れていません

## 補足

- `#360` の README 冒頭スクリーンショット/GIF 追加や `#442` の copy/language policy 整理は混ぜていません
- reviewer が必要に応じて各 full mockup を開ける構成に留め、playground 化はしていません