### PR TITLE
docs: replace stale usage migration links with docs index entrypoints

### DIFF
--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -2,7 +2,7 @@
 
 This page explains the main ways to render TreeView rows in a Rails host app.
 
-During the migration to language-specific docs, the detailed legacy guide remains available at [root usage guide](../usage.md).
+For the language-specific docs index and related guides, see the [documentation index](../README.md).
 
 ## Basic flow
 

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -2,7 +2,7 @@
 
 このページでは、Rails host app でTreeViewの行を描画する基本的な流れを説明します。
 
-より詳細な既存ガイドは、移行期間中は [root usage guide](../usage.md) も参照してください。
+language-specific docs 全体の入口と関連ガイドは [docs index](../README.md) を参照してください。
 
 ## 基本の流れ
 


### PR DESCRIPTION
## 対応 Issue
Closes #453

## 判定分類
- `docs-stale`

## 変更理由
- `docs/en/usage.md` と `docs/ja/usage.md` の冒頭には、移行期間向けの案内として `../usage.md` への link が残っていました。
- しかし current `main` には `docs/usage.md` が存在せず、language-specific docs から辿ると broken link になっていました。
- `docs/README.md` では `docs/ja/` / `docs/en/` を主導線とし、root-level docs は intentional entry point に限る方針なので、usage guide 冒頭も current entrypoint に揃える必要がありました。

## 変更内容
- `docs/en/usage.md`
  - 存在しない `../usage.md` への migration note を削除
  - language-specific docs 全体の入口として `../README.md` を案内
- `docs/ja/usage.md`
  - 同じ整理を日本語版にも反映

## 根拠
- `docs/en/usage.md`
- `docs/ja/usage.md`
- `docs/README.md`
- Issue #453

## 確認
- compare `main...docs/453-language-doc-entry-links` で変更が `docs/en/usage.md` と `docs/ja/usage.md` の 2 ファイルだけに閉じていることを確認
- `docs/README.md` の policy と矛盾しない repo 内 entrypoint (`../README.md`) だけを案内する wording に留めた
- current `main` に `docs/usage.md` が存在しないことを確認
- docs-only 変更のため local test / lint は未実施

## 補足
- open PR `#421` も同じ usage guides を触っていますが、こちらは broken entry link の除去だけに scope を絞った別 issue の narrow docs fix です

## リスク
- low
- wording と link target の更新のみで、runtime code、public API、CI 設定には触れていません