### PR TITLE
docs: align empty-state mockup copy with the review baseline

### DIFF
--- a/docs/mockups/empty-state.html
+++ b/docs/mockups/empty-state.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,15 +12,18 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>TreeView empty state mock</h1>
       <p>
-        no root items と no results の代表的な empty row を、Rails を起動せずに確認するための静的HTMLです。
-        final copy、CTA、permission messaging、search condition summary は host app の責務のままにし、ここでは TreeView が提供する wrapper hook と row slot の見え方だけを固定します。
+        This static HTML shows representative empty rows for no-root-items and no-results states
+        without running a Rails app. Final copy, CTA, permission messaging, and filter summaries
+        remain host-app responsibilities. This mockup only fixes the TreeView wrapper hook and
+        the full-width message slot.
       </p>
     </header>
 
     <section class="mock-section" aria-labelledby="no-root-items-heading">
       <h2 id="no-root-items-heading">No root items</h2>
       <p class="mock-empty-note">
-        初回セットアップ直後や、まだ root item が 0 件のときの代表例です。empty state は full-width cell の中に収まり、toggle / selection / row action は出しません。
+        Use this as the baseline state after initial setup or whenever the tree has no root items.
+        The empty row occupies one full-width cell and omits toggle, selection, and row actions.
       </p>
       <table class="tree-view-table">
         <thead>
@@ -53,7 +56,8 @@
         <span class="mock-filter-chip">query: reports</span>
       </div>
       <p class="mock-empty-note">
-        検索や filter の結果が 0 件のときも、same hook を使って row 全体を empty state slot として扱えます。どの filter が効いているかの説明や reset action は host app が持ちます。
+        The same hook also covers zero-result states after search or filtering. Explanations for
+        active filters and reset actions stay in the host app.
       </p>
       <table class="tree-view-table">
         <thead>


### PR DESCRIPTION
## 対応 Issue
Closes #456

## 判定分類
- `docs-stale`

## 変更理由
- `docs/mockups/README.md` では、mockup は short, product-neutral English copy を使う方針になっています。
- 一方で current `docs/mockups/empty-state.html` は `lang="ja"` と日本語説明文が残っており、`default-tree.html` や `narrow-sidebar-tree.html` と横並びで見たときに review surface の言語方針がずれていました。
- empty message 自体はすでに英語だったため、今回は explanatory copy と document language だけを baseline に揃えています。

## 変更内容
- `docs/mockups/empty-state.html`
  - document language を `en` に変更
  - header paragraph を short, product-neutral English copy に更新
  - `No root items` / `No results after filtering` セクションの explanatory note を英語 baseline に更新

## 根拠
- `docs/mockups/README.md`
- `docs/mockups/empty-state.html`
- `docs/mockups/default-tree.html`
- `docs/mockups/narrow-sidebar-tree.html`
- Issue #456

## 確認
- compare `main...docs/456-empty-state-english-baseline` で changed files が `docs/mockups/empty-state.html` 1 ファイルだけに閉じていることを確認
- empty message slot、wrapper hook、DOM structure、shared CSS 参照は変えていません
- runtime code、public API、shipped stylesheet には触れていません
- docs-only 変更のため local test / lint は未実施です

## リスク
- low
- static mockup の explanatory copy と `lang` 属性の整理のみで、runtime behavior や public surface の意味は変えていません