### PR TITLE
feat: expand/collapse toolbar 用の action metadata helper を追加

### DIFF
--- a/app/helpers/tree_view_helper/toolbar.rb
+++ b/app/helpers/tree_view_helper/toolbar.rb
@@ -16,38 +16,56 @@ module TreeViewHelper
     }.freeze
 
     def tree_view_toolbar(render_state, actions: DEFAULT_TREE_VIEW_TOOLBAR_ACTIONS, labels: {}, class_name: "tree-view-toolbar", button_class_name: "tree-view-toolbar__button")
-      normalized_actions = normalize_tree_view_toolbar_actions(actions)
-      normalized_labels = labels.to_h.transform_keys(&:to_sym)
-
       content_tag(:div, class: class_name, data: {tree_view_toolbar: true}) do
         safe_join(
-          normalized_actions.filter_map do |action|
-            tree_view_toolbar_action(render_state, action, normalized_labels, button_class_name)
+          tree_view_toolbar_actions(render_state, actions: actions, labels: labels).map do |action|
+            tree_view_toolbar_action_tag(action, button_class_name)
           end
         )
       end
     end
 
-    private
+    def tree_view_toolbar_actions(render_state, actions: DEFAULT_TREE_VIEW_TOOLBAR_ACTIONS, labels: {})
+      normalized_labels = labels.to_h.transform_keys(&:to_sym)
 
-    def normalize_tree_view_toolbar_actions(actions)
-      Array(actions).map do |action|
-        normalized_action = action.to_sym
-        next normalized_action if TREE_VIEW_TOOLBAR_ACTIONS.include?(normalized_action)
-
-        raise TreeView::ConfigurationError, "unknown tree_view_toolbar action: #{action}; supported actions are: #{TREE_VIEW_TOOLBAR_ACTIONS.join(", ")}"
+      normalize_tree_view_toolbar_actions(actions).map do |action|
+        tree_view_toolbar_action_metadata(render_state, action, label: normalized_labels[action])
       end
     end
 
-    def tree_view_toolbar_action(render_state, action, labels, button_class_name)
-      path = tree_view_toolbar_path(render_state, action)
-      label = labels.fetch(action, TREE_VIEW_TOOLBAR_LABELS.fetch(action))
-      data = {tree_view_toolbar_action: action}
+    def tree_view_toolbar_action_metadata(render_state, action, label: nil)
+      normalized_action = normalize_tree_view_toolbar_action(action)
+      path = tree_view_toolbar_path(render_state, normalized_action)
+      disabled = path.nil?
 
-      if path
-        link_to(label, path, class: button_class_name, data: data)
+      {
+        action: normalized_action,
+        state: TREE_VIEW_TOOLBAR_STATES.fetch(normalized_action),
+        label: label || TREE_VIEW_TOOLBAR_LABELS.fetch(normalized_action),
+        path: path,
+        disabled: disabled,
+        data: tree_view_toolbar_action_data(normalized_action, disabled: disabled)
+      }
+    end
+
+    private
+
+    def normalize_tree_view_toolbar_actions(actions)
+      Array(actions).map { |action| normalize_tree_view_toolbar_action(action) }
+    end
+
+    def normalize_tree_view_toolbar_action(action)
+      normalized_action = action.to_sym
+      return normalized_action if TREE_VIEW_TOOLBAR_ACTIONS.include?(normalized_action)
+
+      raise TreeView::ConfigurationError, "unknown tree_view_toolbar action: #{action}; supported actions are: #{TREE_VIEW_TOOLBAR_ACTIONS.join(", ")}"
+    end
+
+    def tree_view_toolbar_action_tag(action, button_class_name)
+      if action[:path]
+        link_to(action[:label], action[:path], class: button_class_name, data: action[:data])
       else
-        button_tag(label, type: "button", class: button_class_name, disabled: true, data: data.merge(tree_view_toolbar_disabled: true))
+        button_tag(action[:label], type: "button", class: button_class_name, disabled: true, data: action[:data])
       end
     end
 
@@ -55,6 +73,13 @@ module TreeViewHelper
       return nil unless render_state.ui_config.respond_to?(:toggle_all_path)
 
       render_state.ui_config.toggle_all_path(state: TREE_VIEW_TOOLBAR_STATES.fetch(action))
+    end
+
+    def tree_view_toolbar_action_data(action, disabled:)
+      {
+        tree_view_toolbar_action: action,
+        tree_view_toolbar_disabled: disabled || nil
+      }.compact
     end
   end
 end

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -60,6 +60,29 @@ tree_ui = TreeView::UiConfigBuilder.new(
 
 Path builders only build URLs. The host app owns controller actions, Turbo Stream responses, authorization, and server-side queries.
 
+If the host app wants to build its own toolbar instead of using TreeView's bundled HTML helper, ask TreeView for action metadata and render links or buttons in app-owned markup.
+
+```erb
+<% tree_view_toolbar_actions(@render_state).each do |action| %>
+  <% if action[:path] %>
+    <%= link_to action[:label], action[:path], data: action[:data] %>
+  <% else %>
+    <%= button_tag action[:label], type: "button", disabled: true, data: action[:data] %>
+  <% end %>
+<% end %>
+```
+
+Each action hash includes:
+
+- `:action` such as `:expand_all`
+- `:state` such as `:expanded`
+- `:label`
+- `:path`, or `nil` when the current mode does not support tree-wide toggling
+- `:disabled`
+- `:data` for host-app buttons or links
+
+TreeView only supplies the metadata. Final HTML structure, styling, icons, and authorization rules stay in the host app.
+
 ## Client-side expand/collapse
 
 Use `build_client_side` when all nodes in the render scope can be included in the initial HTML and you only need browser-local expand/collapse.

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -2,7 +2,7 @@
 
 This page explains the main ways to render TreeView rows in a Rails host app.
 
-During the migration to language-specific docs, the detailed legacy guide remains available at [root usage guide](../usage.md).
+For the language-specific docs index and related guides, see the [documentation index](../README.md).
 
 ## Basic flow
 
@@ -203,6 +203,8 @@ For windowed rendering, pass `window:`.
 ```erb
 <%= tree_view_rows(@render_state, window: { offset: 0, limit: 50 }) %>
 ```
+
+For current-row anchoring and offset handoff across Turbo refreshes, see [Windowed Rendering](windowed-rendering.md).
 
 ## Row partial
 

--- a/spec/helpers/tree_view_toolbar_helper_spec.rb
+++ b/spec/helpers/tree_view_toolbar_helper_spec.rb
@@ -28,6 +28,51 @@ RSpec.describe "tree_view_toolbar helper" do
     instance_double(TreeView::RenderState, ui_config: ui_config)
   end
 
+  it "returns toolbar action metadata for host-app-owned controls" do
+    actions = helper.tree_view_toolbar_actions(render_state, actions: [:expand_all, :collapse_all], labels: {expand_all: "Open all"})
+
+    expect(actions).to eq(
+      [
+        {
+          action: :expand_all,
+          state: :expanded,
+          label: "Open all",
+          path: "/tree?state=expanded",
+          disabled: false,
+          data: {tree_view_toolbar_action: :expand_all}
+        },
+        {
+          action: :collapse_all,
+          state: :collapsed,
+          label: "Collapse all",
+          path: "/tree?state=collapsed",
+          disabled: false,
+          data: {tree_view_toolbar_action: :collapse_all}
+        }
+      ]
+    )
+  end
+
+  it "returns disabled metadata when the ui does not expose toggle_all_path" do
+    static_ui_config = TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" }
+    )
+    static_render_state = instance_double(TreeView::RenderState, ui_config: static_ui_config)
+
+    action = helper.tree_view_toolbar_action_metadata(static_render_state, :expand_all)
+
+    expect(action).to eq(
+      action: :expand_all,
+      state: :expanded,
+      label: "Expand all",
+      path: nil,
+      disabled: true,
+      data: {tree_view_toolbar_action: :expand_all, tree_view_toolbar_disabled: true}
+    )
+  end
+
   it "renders expand and collapse links by default" do
     html = helper.tree_view_toolbar(render_state)
 
@@ -76,6 +121,12 @@ RSpec.describe "tree_view_toolbar helper" do
   it "rejects unknown actions" do
     expect do
       helper.tree_view_toolbar(render_state, actions: [:unknown])
+    end.to raise_error(TreeView::ConfigurationError, /unknown tree_view_toolbar action/)
+  end
+
+  it "rejects unknown metadata actions" do
+    expect do
+      helper.tree_view_toolbar_action_metadata(render_state, :unknown)
     end.to raise_error(TreeView::ConfigurationError, /unknown tree_view_toolbar action/)
   end
 end


### PR DESCRIPTION
最新 `main` をベースに、stale になっていた `#449` の変更を作り直しました。

## 対応 Issue
- Closes #438
- Supersedes #449

## 変更理由
- host app が expand/collapse toolbar を独自 markup で組むとき、現在は `toggle_all_path_builder` の state / label / disabled 判定を毎回なぞる必要がありました。
- 既存の bundled HTML helper を置き換えるのではなく、その helper 自身が使っている最小 metadata を public に出すだけの additive change に留めています。
- stale PR `#449` には docs 末尾の破損が混ざっていたため、最新 `main` ベースで 3 ファイルだけに閉じて作り直しました。

## 変更内容
- `app/helpers/tree_view_helper/toolbar.rb`
  - `tree_view_toolbar_actions` を追加し、複数 action の metadata 配列を返すようにした
  - `tree_view_toolbar_action_metadata` を追加し、単一 action の `action` / `state` / `label` / `path` / `disabled` / `data` を返すようにした
  - 既存 `tree_view_toolbar` は上記 metadata を使って link / disabled button を描画する形へ寄せた
- `spec/helpers/tree_view_toolbar_helper_spec.rb`
  - metadata shape
  - `toggle_all_path_builder` 未設定時の disabled metadata
  - unknown action guard
  を追加
- `docs/en/usage.md`
  - host app が action metadata から独自 toolbar を描画する最小例を追記

## 受け入れ条件との対応
- [x] expand-all / collapse-all action metadata を返す public helper を追加
- [x] host app が戻り値から独自 toolbar link / button を組み立てられる
- [x] unsupported mode / path builder 未設定では `path: nil` と `disabled: true` を返し、例外で壊さない
- [x] docs に最小利用例を残し、最終的な HTML / style / authorization policy は host app 側責務のままにした

## 変更範囲
- toolbar helper
- helper spec
- English usage guide

## 実施した確認
- compare `main...feat/438-toolbar-action-metadata-refresh` で変更が issue 対象の 3 ファイルに閉じていることを確認
- metadata helper が既存 `toggle_all_path_builder` の state contract をそのまま再利用していることを確認

## 実行できなかった確認
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル `bundle exec rspec` は未実施です
- 最終確認は PR CI 前提です

## リスク
- medium
- public helper surface を 2 つ追加する変更だが、返り値は toolbar action metadata に限定し、HTML 構造や認可判断までは持ち込んでいません

## 未対応・補足
- completed toolbar component や design system は追加していません
- current path 以外の複雑 action や route policy には広げていません