### PR TITLE
docs: add runtime requirements summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ This gem focuses on tree rendering primitives. Host applications are responsible
 
 ## Installation
 
+Minimum supported environment:
+
+- Ruby 3.2 or later
+- Rails 7.0 or later
+
 When you are installing a published release, add the gem normally:
 
 ```ruby


### PR DESCRIPTION
## 対応 Issue
Closes #459

## 判定分類
- `docs-sync`

## 変更理由
- current `README.md` は導入の入口として十分に整理されていますが、最低サポートの Ruby / Rails バージョンは installation docs まで開かないと分かりませんでした。
- `tree_view.gemspec` と `docs/en/installation.md` / `docs/ja/installation.md` にはすでに current requirements があるため、README には quick scan できる要約だけを足すのが最小でした。

## 変更内容
- `README.md`
  - Installation セクションの先頭に minimum supported environment を追加
  - `Ruby 3.2 or later`
  - `Rails 7.0 or later`

## 根拠
- `tree_view.gemspec`
- `docs/en/installation.md`
- `docs/ja/installation.md`
- Issue #459

## 確認
- 変更が `README.md` 1 ファイルだけに閉じていることを確認
- wording が `tree_view.gemspec` の `required_ruby_version` と `railties` dependency、および installation docs の current requirements と矛盾しないことを確認
- docs-only 変更のため local test / lint は未実施

## リスク
- low
- 既存 installation docs の要約追加のみで、runtime code、dependency range、CI 設定には触れていません