### PR TITLE
docs: align README development JS commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm install
-npm test
+npm run test:js
 ```
+
+`npm run test:js` runs the documented JavaScript pull-request checks together: entrypoint smoke (`npm run test:entrypoints`), Vitest (`npm test`), and Playwright browser smoke (`npm run test:browser`). See the [English development guide](docs/en/development.md) and [日本語の開発・保守方針](docs/ja/development.md) for details.
 
 A committed `package-lock.json` is present, but it is not yet in sync with `package.json`, so CI and local setup keep using `npm install` until that lockfile is refreshed in a registry-enabled environment.


### PR DESCRIPTION
## 対応 Issue
Closes #463

## 判定分類
- `docs-stale`

## 変更理由
- root `README.md` の Development 節は maintainer 向け quick scan 入口として有用ですが、JavaScript 側の quick command だけが current contract からずれていました。
- `package.json` では PR 相当の JavaScript checks が `npm run test:js` にまとまっており、`docs/en/development.md` / `docs/ja/development.md` でも同じ前提で説明されています。
- 現状の `npm test` 表記だけだと Vitest だけを見て「JS tests は確認済み」と誤解しやすいため、README の入口だけを最小で追従させます。

## 変更内容
- `README.md`
  - Development の quick command を `npm test` から `npm run test:js` に更新
  - `npm run test:js` が `test:entrypoints` / `npm test` / `test:browser` をまとめて走らせることを 1 文で補足
  - 詳細は `docs/en/development.md` / `docs/ja/development.md` を参照する導線を追加

## 根拠
- `README.md`
- `package.json`
- `docs/en/development.md`
- `docs/ja/development.md`
- Issue #463

## 確認
- compare `main...docs/463-readme-js-test-contract-head` で差分が `README.md` 1 ファイルだけに閉じていることを確認
- JavaScript test script や CI workflow 自体は変更していません
- docs-only 変更のため local test / lint は未実施

## リスク
- low
- 既存の開発導線を current script contract に合わせ直すだけで、runtime behavior や CI policy の追加変更はありません