### PR TITLE
docs: align release and maintenance docs with current repo state

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -48,25 +48,29 @@ Minimum release conditions:
 
 ## Code and tests
 
+The committed `package-lock.json` is not yet in sync with `package.json`, so both local setup and CI still use `npm install` for the JavaScript lane. Switch these release checks back to `npm ci` after the lockfile refresh work lands.
+
 Local checks:
 
 ```bash
 bundle exec standardrb
 bundle exec rake
 bundle exec rake build
-npm test
+npm run test:js
 ```
 
 Pull request CI checks:
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
+- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile` and `gemfiles/rails_8_0.gemfile`
+- JavaScript tests through `npm install`, Playwright browser setup, and `npm run test:js`
 
 Main-push CI checks:
 
 - Ruby version matrix
 - Rails version matrix
-- JavaScript tests through `npm ci`
+- JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
 - Gem package verification
 
 PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes compatibility matrices, JavaScript coverage, and package verification.

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -85,8 +85,11 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | Asset | Status | Notes |
 |---|---|---|
 | `docs/mockups/README.md` | Technical asset | Index for static mockup assets. Short bilingual-style prose is acceptable; no separate translation needed. |
+| `docs/mockups/review-gallery.html` | Technical asset | Comparison hub for the current static mockup set. No translation needed. |
 | `docs/mockups/default-tree.html` | Technical asset | No translation needed. |
+| `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
+| `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |
 
 ## Ongoing maintenance

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -48,25 +48,29 @@ Minimum release conditions:
 
 ## Code and tests
 
+committed `package-lock.json` はまだ `package.json` と同期していないため、JavaScript lane は local setup / CI ともに現時点では `npm install` 前提です。lockfile refresh 作業が入ったら、release checks も `npm ci` 前提へ戻します。
+
 Local checks:
 
 ```bash
 bundle exec standardrb
 bundle exec rake
 bundle exec rake build
-npm test
+npm run test:js
 ```
 
 Pull Request CI checks:
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
+- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile` と `gemfiles/rails_8_0.gemfile`
+- JavaScript tests: `npm install`、Playwright browser setup、`npm run test:js`
 
 Main-push CI checks:
 
 - Ruby version matrix
 - Rails version matrix
-- JavaScript tests through `npm ci`
+- JavaScript tests through `npm install` and `npm run test:js` until `package-lock.json` is refreshed in sync with `package.json`
 - Gem package verification
 
 merge前にPR CIを通します。互換性matrix、JavaScript coverage、package verificationを含むため、release判定にはより広い `main` CIを使います。


### PR DESCRIPTION
## 対応 Issue
Closes #466
Closes #467

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
- `docs/en/release.md` と `docs/ja/release.md` が、現行 workflow より先に `npm ci` 前提へ進んでおり、current CI / local setup contract とずれていました。
- `docs/i18n-audit.md` の technical assets table も、current `docs/mockups/README.md` に並んでいる mockup setの一部が未反映でした。
- どちらもコード変更なしで truth を current repository state に戻せる docs drift だったため、同じ maintainer-docs sweep として 1 PR にまとめています。

## 変更内容
- `docs/en/release.md`
- `docs/ja/release.md`
  - JavaScript lane が現時点では `npm install` 前提であることを明記
  - local release checks の入口を `npm run test:js` に更新
  - PR / main-push CI の JavaScript checks 説明を current `.github/workflows/ci.yml` と `package.json` に合わせて整理
- `docs/i18n-audit.md`
  - technical assets table に `review-gallery.html`、`narrow-sidebar-tree.html`、`empty-state.html` を追加
  - current mockup set の static asset inventory を `docs/mockups/README.md` と一致させた

## 根拠
- `README.md`
- `package.json`
- `.github/workflows/ci.yml`
- `docs/en/release.md`
- `docs/ja/release.md`
- `docs/i18n-audit.md`
- `docs/mockups/README.md`
- Issue #466
- Issue #467

## 確認
- compare `main...docs/466-467-release-and-i18n-sync` で差分が docs 3 ファイルだけに閉じていることを確認
- release docs の JavaScript wording が current README 注記、workflow comment、`npm run test:js` script contract と矛盾しないことを確認
- technical assets table が current mockup file list を漏れなく反映していることを確認
- docs-only 変更のため local test / lint は未実施

## リスク
- low
- current repository state に docs を追従させるだけで、workflow、lockfile、mockup asset 本体、runtime code には触れていません

## 補足
- root `AGENTS.md` と `Product Profile.md` は current `main` に存在し、今回の sweep では追加修正不要と判断しました
- root `README.md` の Development quick command 修正は open PR #465 で進行中のため重ねていません