### PR TITLE
design: expand/collapse toolbar 状態の静的 mockup を追加

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -10,6 +10,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 | File | Covers |
 |---|---|
+| [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the default, narrow, interaction, and empty-state mockups, with embedded previews and links to each full reference page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -11,10 +11,18 @@ They are **not** a complete Rails application and should not grow into host-app 
 | File | Covers |
 |---|---|
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
+
+## Recommended review flow
+
+1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the main mockup surfaces.
+2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
+3. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+4. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/toolbar-actions.html
+++ b/docs/mockups/toolbar-actions.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView toolbar actions mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-toolbar-page {
+  max-width: 1160px;
+}
+
+.mock-toolbar-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-toolbar-surface {
+  display: grid;
+  gap: 16px;
+}
+
+.mock-toolbar-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-toolbar__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.mock-toolbar__eyebrow {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-toolbar__actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.mock-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 2.4rem;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #102a43;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-toolbar-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1.2rem;
+  block-size: 1.2rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #334155;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.mock-toolbar-button--current {
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.mock-toolbar-button--current .mock-toolbar-button__icon {
+  background: #bfdbfe;
+  color: #1d4ed8;
+}
+
+.mock-toolbar-button[aria-disabled="true"],
+.mock-toolbar-button:disabled {
+  border-style: dashed;
+  color: #94a3b8;
+  background: #f8fafc;
+}
+
+.mock-toolbar-button[aria-disabled="true"] .mock-toolbar-button__icon,
+.mock-toolbar-button:disabled .mock-toolbar-button__icon {
+  background: #e2e8f0;
+  color: #94a3b8;
+}
+
+.mock-toolbar-button[aria-disabled="true"] {
+  pointer-events: none;
+}
+
+.mock-toolbar-note {
+  margin: 0;
+  color: #52606d;
+}
+
+.mock-toolbar-preview {
+  padding: 16px;
+  background: #fff;
+}
+
+.mock-toolbar-node {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid #e4e7eb;
+  border-radius: 10px;
+  margin-bottom: 10px;
+  background: #fff;
+}
+
+.mock-toolbar-node:last-child {
+  margin-bottom: 0;
+}
+
+.mock-toolbar-node.is-collapsed {
+  background: #fffaf0;
+}
+
+.mock-toolbar-node.is-expanded {
+  background: #eff6ff;
+}
+
+.mock-toolbar-node__tree {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.mock-toolbar-node__caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1.8rem;
+  block-size: 1.8rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #334155;
+  font-weight: 800;
+}
+
+.mock-toolbar-node__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #52606d;
+  font-size: 0.92rem;
+}
+
+.mock-toolbar-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.14rem 0.5rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #334155;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.mock-toolbar-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-toolbar-table th,
+.mock-toolbar-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-toolbar-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .mock-toolbar {
+    align-items: flex-start;
+  }
+
+  .mock-toolbar__actions {
+    inline-size: 100%;
+  }
+
+  .mock-toolbar-button {
+    flex: 1 1 11rem;
+    justify-content: center;
+  }
+
+  .mock-toolbar-node {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-toolbar-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Toolbar action states mock</h1>
+      <p>
+        Static reference for tree-wide expand and collapse actions. This page keeps the review surface focused on
+        enabled, disabled, and current-state cues without bringing in host-app routes, authorization, or business wording.
+      </p>
+    </header>
+
+    <section class="mock-section mock-toolbar-grid" aria-labelledby="toolbar-overview-heading">
+      <div class="mock-toolbar-surface">
+        <div>
+          <h2 id="toolbar-overview-heading">Representative toolbar states</h2>
+          <p class="mock-toolbar-note">
+            The mock keeps copy short and product-neutral. Final labels, routing, and permission messaging remain host-app responsibilities.
+          </p>
+        </div>
+
+        <div class="mock-toolbar-frame">
+          <div class="mock-toolbar">
+            <div class="mock-toolbar__copy">
+              <p class="mock-toolbar__eyebrow">State A</p>
+              <p class="mock-toolbar__title">Mixed tree, both actions available</p>
+            </div>
+            <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
+              <a class="mock-toolbar-button" href="#" data-mock-state="expand-enabled">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+                <span>Expand all</span>
+              </a>
+              <a class="mock-toolbar-button" href="#" data-mock-state="collapse-enabled">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+                <span>Collapse all</span>
+              </a>
+            </div>
+          </div>
+          <div class="mock-toolbar-preview" aria-label="Mixed tree preview">
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Platform</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">root</span>
+                    <span class="mock-toolbar-pill">3 open branches</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+            <div class="mock-toolbar-node is-collapsed">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+                <div>
+                  <strong>Operations</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">child</span>
+                    <span class="mock-toolbar-pill">12 hidden rows</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">collapsed</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="mock-toolbar-frame">
+          <div class="mock-toolbar">
+            <div class="mock-toolbar__copy">
+              <p class="mock-toolbar__eyebrow">State B</p>
+              <p class="mock-toolbar__title">Everything already expanded</p>
+            </div>
+            <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
+              <button class="mock-toolbar-button" type="button" aria-disabled="true">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+                <span>Expand all</span>
+              </button>
+              <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="collapse-current">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+                <span>Collapse all</span>
+              </a>
+            </div>
+          </div>
+          <div class="mock-toolbar-preview" aria-label="All expanded tree preview">
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Accounts</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">root</span>
+                    <span class="mock-toolbar-pill">no hidden descendants</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Invoices</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">child</span>
+                    <span class="mock-toolbar-pill">children visible</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="mock-toolbar-frame">
+          <div class="mock-toolbar">
+            <div class="mock-toolbar__copy">
+              <p class="mock-toolbar__eyebrow">State C</p>
+              <p class="mock-toolbar__title">Everything already collapsed</p>
+            </div>
+            <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
+              <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="expand-current">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+                <span>Expand all</span>
+              </a>
+              <button class="mock-toolbar-button" type="button" aria-disabled="true">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+                <span>Collapse all</span>
+              </button>
+            </div>
+          </div>
+          <div class="mock-toolbar-preview" aria-label="All collapsed tree preview">
+            <div class="mock-toolbar-node is-collapsed">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+                <div>
+                  <strong>Support</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">root</span>
+                    <span class="mock-toolbar-pill">8 hidden rows</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">collapsed</span>
+            </div>
+            <div class="mock-toolbar-node is-collapsed">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+                <div>
+                  <strong>Billing</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">child</span>
+                    <span class="mock-toolbar-pill">4 hidden rows</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">collapsed</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="toolbar-cues-heading">
+      <h2 id="toolbar-cues-heading">State cues to review</h2>
+      <table class="mock-toolbar-table">
+        <thead>
+          <tr>
+            <th scope="col">Variant</th>
+            <th scope="col">What it shows</th>
+            <th scope="col">What stays out of scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Enabled pair</td>
+            <td>Both actions available while the tree contains a mix of expanded and collapsed branches.</td>
+            <td>Route names, Turbo wiring, or action sequencing rules.</td>
+          </tr>
+          <tr>
+            <td>Expand disabled</td>
+            <td>The tree is already fully expanded, so only collapse remains actionable.</td>
+            <td>Business copy about why a branch is open or who may collapse it.</td>
+          </tr>
+          <tr>
+            <td>Collapse disabled</td>
+            <td>The tree is already fully collapsed, so only expand remains actionable.</td>
+            <td>Authorization, saved preferences, or persistence across visits.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #464

## 採用した方針

- 自動実行のため、runtime helper や review gallery 全体の構成には広げず、expand / collapse toolbar 状態だけを独立して見比べられる静的 mockup 1 面を追加する low-risk 案を採用しました。
- 導線は `docs/mockups/README.md` に閉じ、host app 固有の route / authorization / business copy は持ち込まないまま review しやすさを上げています。

## 比較した案

- 案A: `review-gallery.html` にも iframe preview を追加して gallery 全体から辿れるようにする。
- 案B: `toolbar-actions.html` を新設し、`docs/mockups/README.md` に導線を追加する。
- 案C: README 本文に screenshot を追加して visual reference を補う。
- 今回は案Bを採用しました。`#464` の static reference という主題を最小差分で満たせて、open PR `#458` の runtime helper scope とも混ざりにくいためです。

## 変更内容

- `docs/mockups/toolbar-actions.html`
  - expand-all / collapse-all の代表 3 状態を確認できる新しい静的 mockup を追加
  - enabled pair / expand disabled / collapse disabled を product-neutral な copy と簡易 tree preview で比較できるよう追加
  - host app 固有の route / authorization / persistence を含めず、canonical source を HTML/CSS に留めた
- `docs/mockups/README.md`
  - 新しい toolbar actions mockup を files 一覧へ追加
  - focused review surface として辿るための review flow を追記

## 変更した画面・コンポーネント

- `docs/mockups/toolbar-actions.html`
- `docs/mockups/README.md`

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: GitHub diff 上で static HTML/CSS の state 差分を確認
- レスポンシブ確認: narrow toolbar wrap 用の CSS を `toolbar-actions.html` 内に含めたが、実ブラウザ確認は未実施
- アクセシビリティ確認: action state ごとに disabled / current emphasis が読める静的 markup を確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- static mockup と docs 導線の追加のみで、runtime helper、route、authorization、Turbo behavior には触れていません
- `#458` の action metadata naming / state contract を前提にした stacked PR のため、review / merge 順は `#458` -> この PR を想定しています

## 補足

- `review-gallery.html` への追加は今回は見送り、責務を focused surface と README 導線に絞りました
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル表示確認は未実施です