### PR TITLE
docs: align English resource table bridge guidance with Japanese docs

### DIFF
--- a/docs/en/resource-table-bridge.md
+++ b/docs/en/resource-table-bridge.md
@@ -48,4 +48,22 @@ This keeps the responsibilities separate:
 
 - Rails Table Preferences owns column inference, labels, saved table state, and preference UI.
 - TreeView owns tree structure and hierarchical row rendering.
-- The host app can override partials for presentation.
+- The host app can override partials for presentation, queries, authorization, and business behavior.
+
+## When to use it
+
+For a regular TreeView integration, `TreeView::RenderState` is still the default choice.
+
+Use `ResourceTableRenderState` when:
+
+- you want a standard table and a tree-table to share the same column definitions or table state
+- another layer such as Rails Table Preferences already decides `visible_columns`
+- you want TreeView to stay responsible only for hierarchy and row rendering
+
+## When not to use it
+
+Avoid `ResourceTableRenderState` when:
+
+- TreeView alone is enough for a simple tree
+- you do not need column visibility settings or saved table state
+- the host app already fully owns the row partial and table presentation as a separate implementation


### PR DESCRIPTION
## 対応 Issue
Closes #470

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
- `docs/en/resource-table-bridge.md` は basic usage と Rails Table Preferences integration までは揃っていましたが、日本語版にある「通常の `TreeView::RenderState` とどう使い分けるか」の guidance が不足していました。
- root `README.md` と `docs/en/README.md` は `Resource table bridge` を主要な利用者向け docs として案内しているため、英語版でも導入判断の入口をそろえる必要がありました。

## 変更内容
- `docs/en/resource-table-bridge.md`
  - host app が presentation / query / authorization / business behavior を持つ責務境界を、日本語版と同じ粒度で補強
  - `When to use it` を追加し、通常の `TreeView::RenderState` ではなく `ResourceTableRenderState` を選ぶ場面を明記
  - `When not to use it` を追加し、単純な tree や separate table implementation では bridge を使わない判断ができるよう整理

## 根拠
- `docs/en/resource-table-bridge.md`
- `docs/ja/resource-table-bridge.md`
- `docs/en/README.md`
- `README.md`

## 確認
- compare `main...docs/470-resource-table-bridge-guidance` で差分が `docs/en/resource-table-bridge.md` 1ファイルだけに閉じていることを確認
- 追加した guidance が current 日本語版の責務境界説明と矛盾しないことを確認
- docs-only 変更のため local test / lint は未実施

## リスク
- low
- 既存 API や row partial contract は変更せず、英語版 docs の利用判断 guidance だけを補っています

## 補足
- current `main` には root `AGENTS.md` と `Product Profile.md` が存在し、今回の sweep では追加修正不要と判断しました
- `docs/mockups` 系の追加論点は open PR `#469` と write set が近いため、今回の PR には混ぜていません