### PR TITLE
design: expand/collapse toolbar 状態の静的 mockup を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only PR: skipping representative Rails compatibility lane."
+        run: 'echo "Docs-only PR: skipping representative Rails compatibility lane."'
       - if: needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
       - if: needs.changes.outputs.docs_only != 'true'
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only PR: skipping JavaScript browser and entrypoint checks."
+        run: 'echo "Docs-only PR: skipping JavaScript browser and entrypoint checks."'
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -12,6 +12,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 |---|---|
 | [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the default, narrow, interaction, and empty-state mockups, with embedded previews and links to each full reference page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
@@ -22,8 +23,9 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the main mockup surfaces.
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
-3. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-4. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
+4. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+5. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -12,6 +12,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 |---|---|
 | [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the default, narrow, interaction, and empty-state mockups, with embedded previews and links to each full reference page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
@@ -21,7 +22,8 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the main mockup surfaces.
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
-3. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+3. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+4. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/resource-table-bridge.html
+++ b/docs/mockups/resource-table-bridge.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView resource table bridge mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-bridge-page {
+  max-width: 1240px;
+}
+
+.mock-bridge-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.mock-bridge-principles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.mock-bridge-principle {
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  padding: 16px;
+}
+
+.mock-bridge-principle h2,
+.mock-bridge-principle p,
+.mock-bridge-table-card h2,
+.mock-bridge-table-card p,
+.mock-bridge-note,
+.mock-bridge-checklist th,
+.mock-bridge-checklist td {
+  margin: 0;
+}
+
+.mock-bridge-principle h2 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.mock-bridge-table-card {
+  display: grid;
+  gap: 14px;
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+  padding: 18px;
+}
+
+.mock-bridge-table-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mock-bridge-eyebrow {
+  color: #52606d;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-bridge-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-bridge-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.8rem;
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.mock-bridge-pill--muted {
+  background: #f1f5f9;
+  color: #334155;
+}
+
+.mock-bridge-table-wrap {
+  overflow-x: auto;
+  border: 1px solid #dde4ec;
+  border-radius: 10px;
+}
+
+.mock-bridge-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  background: #fff;
+}
+
+.mock-bridge-table th,
+.mock-bridge-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.mock-bridge-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mock-bridge-table td.is-muted {
+  color: #52606d;
+}
+
+.mock-bridge-section-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #334155;
+  font-weight: 700;
+}
+
+.mock-bridge-section-label::before {
+  content: "";
+  inline-size: 0.75rem;
+  block-size: 0.75rem;
+  border-radius: 999px;
+  background: #93c5fd;
+}
+
+.mock-bridge-note {
+  color: #52606d;
+}
+
+.mock-bridge-checklist {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-bridge-checklist th,
+.mock-bridge-checklist td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-bridge-checklist th {
+  background: #f1f5f9;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .mock-bridge-table {
+    min-width: 640px;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-bridge-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Resource table bridge mock</h1>
+      <p>
+        Static reference for the bridge-style presentation where a table layer owns columns and visible column state,
+        while TreeView renders only the hierarchy rows. This page keeps the review surface product-neutral and focused on
+        column sharing, indentation, and row readability.
+      </p>
+    </header>
+
+    <section class="mock-section mock-bridge-grid" aria-labelledby="bridge-principles-heading">
+      <div>
+        <h2 id="bridge-principles-heading">Bridge responsibilities at a glance</h2>
+        <p class="mock-bridge-note">
+          Use this mock when review needs a visual reference for table-owned columns plus TreeView-owned hierarchy cues,
+          without pulling in controllers, persistence, or host-app business actions.
+        </p>
+      </div>
+
+      <div class="mock-bridge-principles">
+        <article class="mock-bridge-principle">
+          <h2>Table layer owns columns</h2>
+          <p>Column order, visibility, labels, and saved table state stay outside TreeView.</p>
+        </article>
+        <article class="mock-bridge-principle">
+          <h2>TreeView owns hierarchy rows</h2>
+          <p>Indent guides, toggle controls, row depth, and parent or child shape stay consistent across column sets.</p>
+        </article>
+        <article class="mock-bridge-principle">
+          <h2>Host app owns final actions</h2>
+          <p>Queries, routes, permissions, badges with business meaning, and workflow-specific labels remain app concerns.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section mock-bridge-grid" aria-labelledby="bridge-full-heading">
+      <article class="mock-bridge-table-card">
+        <div class="mock-bridge-table-header">
+          <div>
+            <p class="mock-bridge-eyebrow">State A</p>
+            <h2 id="bridge-full-heading">Shared desktop column set</h2>
+            <p class="mock-bridge-note">
+              Use this surface to review the baseline where the surrounding table layer exposes several descriptive columns
+              and TreeView contributes the hierarchy cell in the first data column.
+            </p>
+          </div>
+          <div class="mock-bridge-pill-row" aria-label="Visible columns summary">
+            <span class="mock-bridge-pill">visible_columns: name</span>
+            <span class="mock-bridge-pill">owner</span>
+            <span class="mock-bridge-pill">region</span>
+            <span class="mock-bridge-pill">updated</span>
+            <span class="mock-bridge-pill">status</span>
+          </div>
+        </div>
+
+        <div class="mock-bridge-table-wrap">
+          <table class="mock-bridge-table">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Owner</th>
+                <th scope="col">Region</th>
+                <th scope="col">Updated</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-selected">
+                <td class="tree-toggle-cell">
+                  <div class="tree-toggle" aria-label="Depth 0 expanded row">
+                    <span class="tree-toggle__branches" aria-hidden="true"></span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__action">-</span>
+                      <span class="tree-toggle__level">L0</span>
+                      <strong>Platform rollout</strong>
+                      <span class="tree-node-badge tree-node-badge--info">current</span>
+                    </span>
+                  </div>
+                </td>
+                <td>Core delivery</td>
+                <td>Global</td>
+                <td class="is-muted">2 hours ago</td>
+                <td><span class="mock-status mock-status--active">Active</span></td>
+              </tr>
+              <tr>
+                <td class="tree-toggle-cell">
+                  <div class="tree-toggle" aria-label="Depth 1 expanded row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__action">-</span>
+                      <span class="tree-toggle__level">L1</span>
+                      <strong>North America launch</strong>
+                    </span>
+                  </div>
+                </td>
+                <td>Regional program</td>
+                <td>NA</td>
+                <td class="is-muted">Yesterday</td>
+                <td><span class="mock-status mock-status--pending">In progress</span></td>
+              </tr>
+              <tr class="tree-row is-collapsed">
+                <td class="tree-toggle-cell">
+                  <div class="tree-toggle" aria-label="Depth 2 collapsed row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__action">+</span>
+                      <span class="tree-toggle__level">L2</span>
+                      <strong>Warehouse checklist</strong>
+                      <span class="tree-toggle__hidden-count">4</span>
+                    </span>
+                  </div>
+                </td>
+                <td>Operations</td>
+                <td>Toronto</td>
+                <td class="is-muted">3 days ago</td>
+                <td><span class="mock-status mock-status--archived">Blocked</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </article>
+
+      <article class="mock-bridge-table-card">
+        <div class="mock-bridge-table-header">
+          <div>
+            <p class="mock-bridge-eyebrow">State B</p>
+            <h2>Compact visible column variant</h2>
+            <p class="mock-bridge-note">
+              Use this surface to review how the same hierarchy cell still reads clearly when the surrounding table layer
+              hides auxiliary columns and keeps only the compact scan fields.
+            </p>
+          </div>
+          <div class="mock-bridge-pill-row" aria-label="Visible columns summary">
+            <span class="mock-bridge-pill">visible_columns: name</span>
+            <span class="mock-bridge-pill">status</span>
+            <span class="mock-bridge-pill">updated</span>
+            <span class="mock-bridge-pill mock-bridge-pill--muted">hidden: owner</span>
+            <span class="mock-bridge-pill mock-bridge-pill--muted">hidden: region</span>
+          </div>
+        </div>
+
+        <div class="mock-bridge-table-wrap">
+          <table class="mock-bridge-table">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Status</th>
+                <th scope="col">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-selected">
+                <td class="tree-toggle-cell">
+                  <div class="tree-toggle" aria-label="Depth 0 expanded row">
+                    <span class="tree-toggle__branches" aria-hidden="true"></span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__action">-</span>
+                      <span class="tree-toggle__level">L0</span>
+                      <strong>Platform rollout</strong>
+                      <span class="tree-node-badge tree-node-badge--info">current</span>
+                    </span>
+                  </div>
+                </td>
+                <td><span class="mock-status mock-status--active">Active</span></td>
+                <td class="is-muted">2 hours ago</td>
+              </tr>
+              <tr>
+                <td class="tree-toggle-cell">
+                  <div class="tree-toggle" aria-label="Depth 1 expanded row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__action">-</span>
+                      <span class="tree-toggle__level">L1</span>
+                      <strong>North America launch</strong>
+                    </span>
+                  </div>
+                </td>
+                <td><span class="mock-status mock-status--pending">In progress</span></td>
+                <td class="is-muted">Yesterday</td>
+              </tr>
+              <tr class="tree-row is-collapsed">
+                <td class="tree-toggle-cell">
+                  <div class="tree-toggle" aria-label="Depth 2 collapsed row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__action">+</span>
+                      <span class="tree-toggle__level">L2</span>
+                      <strong>Warehouse checklist</strong>
+                      <span class="tree-toggle__hidden-count">4</span>
+                    </span>
+                  </div>
+                </td>
+                <td><span class="mock-status mock-status--archived">Blocked</span></td>
+                <td class="is-muted">3 days ago</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </article>
+    </section>
+
+    <section class="mock-section" aria-labelledby="bridge-review-heading">
+      <h2 id="bridge-review-heading">Review checklist</h2>
+      <table class="mock-bridge-checklist">
+        <thead>
+          <tr>
+            <th scope="col">Review concern</th>
+            <th scope="col">What this mock should answer</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Column sharing</td>
+            <td>The same tree rows stay readable across a fuller and a narrower visible column set.</td>
+            <td>Automatic column inference, saved preference UI, or table personalization controls.</td>
+          </tr>
+          <tr>
+            <td>Hierarchy cues</td>
+            <td>Indent guides, toggles, current-row emphasis, and hidden-child counts remain legible in the first data column.</td>
+            <td>Real expand or collapse behavior, controller wiring, or asynchronous loading.</td>
+          </tr>
+          <tr>
+            <td>Responsibility boundary</td>
+            <td>TreeView owns the hierarchy presentation while the table layer owns which non-tree columns appear.</td>
+            <td>Host-app query strategy, authorization, routing, and business-specific row actions.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/toolbar-actions.html
+++ b/docs/mockups/toolbar-actions.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView toolbar actions mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-toolbar-page {
+  max-width: 1160px;
+}
+
+.mock-toolbar-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-toolbar-surface {
+  display: grid;
+  gap: 16px;
+}
+
+.mock-toolbar-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-toolbar__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.mock-toolbar__eyebrow {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-toolbar__actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.mock-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 2.4rem;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #102a43;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-toolbar-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1.2rem;
+  block-size: 1.2rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #334155;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.mock-toolbar-button--current {
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.mock-toolbar-button--current .mock-toolbar-button__icon {
+  background: #bfdbfe;
+  color: #1d4ed8;
+}
+
+.mock-toolbar-button[aria-disabled="true"],
+.mock-toolbar-button:disabled {
+  border-style: dashed;
+  color: #94a3b8;
+  background: #f8fafc;
+}
+
+.mock-toolbar-button[aria-disabled="true"] .mock-toolbar-button__icon,
+.mock-toolbar-button:disabled .mock-toolbar-button__icon {
+  background: #e2e8f0;
+  color: #94a3b8;
+}
+
+.mock-toolbar-button[aria-disabled="true"] {
+  pointer-events: none;
+}
+
+.mock-toolbar-note {
+  margin: 0;
+  color: #52606d;
+}
+
+.mock-toolbar-preview {
+  padding: 16px;
+  background: #fff;
+}
+
+.mock-toolbar-node {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid #e4e7eb;
+  border-radius: 10px;
+  margin-bottom: 10px;
+  background: #fff;
+}
+
+.mock-toolbar-node:last-child {
+  margin-bottom: 0;
+}
+
+.mock-toolbar-node.is-collapsed {
+  background: #fffaf0;
+}
+
+.mock-toolbar-node.is-expanded {
+  background: #eff6ff;
+}
+
+.mock-toolbar-node__tree {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.mock-toolbar-node__caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1.8rem;
+  block-size: 1.8rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #334155;
+  font-weight: 800;
+}
+
+.mock-toolbar-node__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #52606d;
+  font-size: 0.92rem;
+}
+
+.mock-toolbar-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.14rem 0.5rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #334155;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.mock-toolbar-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-toolbar-table th,
+.mock-toolbar-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-toolbar-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .mock-toolbar {
+    align-items: flex-start;
+  }
+
+  .mock-toolbar__actions {
+    inline-size: 100%;
+  }
+
+  .mock-toolbar-button {
+    flex: 1 1 11rem;
+    justify-content: center;
+  }
+
+  .mock-toolbar-node {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-toolbar-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Toolbar action states mock</h1>
+      <p>
+        Static reference for tree-wide expand and collapse actions. This page keeps the review surface focused on
+        enabled, disabled, and current-state cues without bringing in host-app routes, authorization, or business wording.
+      </p>
+    </header>
+
+    <section class="mock-section mock-toolbar-grid" aria-labelledby="toolbar-overview-heading">
+      <div class="mock-toolbar-surface">
+        <div>
+          <h2 id="toolbar-overview-heading">Representative toolbar states</h2>
+          <p class="mock-toolbar-note">
+            The mock keeps copy short and product-neutral. Final labels, routing, and permission messaging remain host-app responsibilities.
+          </p>
+        </div>
+
+        <div class="mock-toolbar-frame">
+          <div class="mock-toolbar">
+            <div class="mock-toolbar__copy">
+              <p class="mock-toolbar__eyebrow">State A</p>
+              <p class="mock-toolbar__title">Mixed tree, both actions available</p>
+            </div>
+            <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
+              <a class="mock-toolbar-button" href="#" data-mock-state="expand-enabled">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+                <span>Expand all</span>
+              </a>
+              <a class="mock-toolbar-button" href="#" data-mock-state="collapse-enabled">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+                <span>Collapse all</span>
+              </a>
+            </div>
+          </div>
+          <div class="mock-toolbar-preview" aria-label="Mixed tree preview">
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Platform</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">root</span>
+                    <span class="mock-toolbar-pill">3 open branches</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+            <div class="mock-toolbar-node is-collapsed">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+                <div>
+                  <strong>Operations</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">child</span>
+                    <span class="mock-toolbar-pill">12 hidden rows</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">collapsed</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="mock-toolbar-frame">
+          <div class="mock-toolbar">
+            <div class="mock-toolbar__copy">
+              <p class="mock-toolbar__eyebrow">State B</p>
+              <p class="mock-toolbar__title">Everything already expanded</p>
+            </div>
+            <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
+              <button class="mock-toolbar-button" type="button" aria-disabled="true">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+                <span>Expand all</span>
+              </button>
+              <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="collapse-current">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+                <span>Collapse all</span>
+              </a>
+            </div>
+          </div>
+          <div class="mock-toolbar-preview" aria-label="All expanded tree preview">
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Accounts</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">root</span>
+                    <span class="mock-toolbar-pill">no hidden descendants</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Invoices</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">child</span>
+                    <span class="mock-toolbar-pill">children visible</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="mock-toolbar-frame">
+          <div class="mock-toolbar">
+            <div class="mock-toolbar__copy">
+              <p class="mock-toolbar__eyebrow">State C</p>
+              <p class="mock-toolbar__title">Everything already collapsed</p>
+            </div>
+            <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
+              <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="expand-current">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+                <span>Expand all</span>
+              </a>
+              <button class="mock-toolbar-button" type="button" aria-disabled="true">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+                <span>Collapse all</span>
+              </button>
+            </div>
+          </div>
+          <div class="mock-toolbar-preview" aria-label="All collapsed tree preview">
+            <div class="mock-toolbar-node is-collapsed">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+                <div>
+                  <strong>Support</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">root</span>
+                    <span class="mock-toolbar-pill">8 hidden rows</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">collapsed</span>
+            </div>
+            <div class="mock-toolbar-node is-collapsed">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+                <div>
+                  <strong>Billing</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">child</span>
+                    <span class="mock-toolbar-pill">4 hidden rows</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">collapsed</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="toolbar-cues-heading">
+      <h2 id="toolbar-cues-heading">State cues to review</h2>
+      <table class="mock-toolbar-table">
+        <thead>
+          <tr>
+            <th scope="col">Variant</th>
+            <th scope="col">What it shows</th>
+            <th scope="col">What stays out of scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Enabled pair</td>
+            <td>Both actions available while the tree contains a mix of expanded and collapsed branches.</td>
+            <td>Route names, Turbo wiring, or action sequencing rules.</td>
+          </tr>
+          <tr>
+            <td>Expand disabled</td>
+            <td>The tree is already fully expanded, so only collapse remains actionable.</td>
+            <td>Business copy about why a branch is open or who may collapse it.</td>
+          </tr>
+          <tr>
+            <td>Collapse disabled</td>
+            <td>The tree is already fully collapsed, so only expand remains actionable.</td>
+            <td>Authorization, saved preferences, or persistence across visits.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #464
- Closes #471
- supersedes #469

## 採用した方針

- current `main` から見てレビューしやすい docs/mockups の focused surface を 1 本にまとめる方針を維持しました。
- 既存の toolbar actions mockup はそのまま残しつつ、同じ mockup family に属する resource table bridge reference を同 PR に追加し、README 導線だけを最小更新する low-risk 案を採用しています。
- runtime helper、review gallery 全体、resource table bridge の実装や public API docs には広げていません。

## 比較した案

- 案A: `#464` の toolbar actions mockup だけに留め、`#471` は別 PR に分ける。
- 案B: `#471` のために review gallery や bridge docs までまとめて広く更新する。
- 案C: 同じ `docs/mockups` surface に閉じた resource table bridge mockup を既存 PR に追加し、README 導線だけ更新する。
- 今回は案Cを採用しました。既存 PR と write set / review観点が近く、比較対象を 1 本の mockup lane にまとめた方が Reviewer が見やすいためです。

## 変更内容

- `docs/mockups/toolbar-actions.html`
  - expand-all / collapse-all の代表 3 状態を確認できる静的 mockup を追加
  - enabled pair / expand disabled / collapse disabled を product-neutral な copy と簡易 tree preview で比較できるよう追加
- `docs/mockups/resource-table-bridge.html`
  - TreeView が hierarchy rows を描き、table layer が visible columns を持つ bridge 利用形の静的 reference を追加
  - fuller column set と compact visible-column variant を並べ、同じ tree rows が列構成差分の中でも読めることを確認できるよう追加
  - host app 固有の route / authorization / persistence を含めず、canonical source を HTML/CSS に留めた
- `docs/mockups/README.md`
  - toolbar actions mockup と resource table bridge mockup を files 一覧 / review flow に追加
  - focused review surface として辿る導線を更新

## 受け入れ条件との対応

- [x] expand / collapse toolbar 状態を独立して確認できる focused static mockup がある
- [x] resource table bridge の代表状態を見せる静的リファレンスがある
- [x] `docs/mockups/README.md` から両方の focused surface を辿れる
- [x] host app 固有の route / authorization / persistence は持ち込んでいない
- [x] static HTML/CSS と README 導線の差分に閉じている

## 変更した画面・コンポーネント

- `docs/mockups/toolbar-actions.html`
- `docs/mockups/resource-table-bridge.html`
- `docs/mockups/README.md`

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: GitHub diff 上で static HTML/CSS の state 差分と README 導線を確認
- レスポンシブ確認: narrow wrap 用 CSS は含めたが、実ブラウザ確認は未実施
- アクセシビリティ確認: hierarchy cues / current cues / visible-columns summary が静的 markup で読めることを確認

## リスク

- low
- static mockup と docs 導線の追加のみで、runtime helper、route、authorization、Turbo behavior には触れていません

## 補足

- `#469` は親PRマージ後の branch history に引きずられて `main` 基準の review がしづらくなっていたため、current `main` へ clean replay した superseding PR に切り替えています
- `#471` は同じ `docs/mockups` family の narrow design slice として、この PR にまとめて扱っています
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル表示確認は未実施です