### PR TITLE
fix: quote docs-only workflow echo steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only PR: skipping representative Rails compatibility lane."
+        run: 'echo "Docs-only PR: skipping representative Rails compatibility lane."'
       - if: needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
       - if: needs.changes.outputs.docs_only != 'true'
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only PR: skipping JavaScript browser and entrypoint checks."
+        run: 'echo "Docs-only PR: skipping JavaScript browser and entrypoint checks."'
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'


### PR DESCRIPTION
## 対応 Issue
- Closes #477

## Issue ごとの完了内容
- `#477`
  - docs-only short-circuit の `run:` 行 2 箇所を YAML-safe な quoting に修正
  - docs-only PR でも workflow parse error で無反応になりにくい状態へ戻す最小修正に留めた

## 変更内容
- `.github/workflows/ci.yml`
  - `pr_rails_matrix` の docs-only skip step を quoted scalar に修正
  - `javascript` の docs-only skip step を quoted scalar に修正

## 改善カテゴリ
- CI 改善
- workflow syntax fix

## 既存仕様への影響
- なし
- docs-only 判定条件、job 名、skip 方針、`npm install` 前提は変更していません
- YAML として安全に解釈されるようにしただけです

## 実施した確認
- issue 本文で指摘されていた 2 箇所が current `main` に残っていることを確認
- 変更範囲を `.github/workflows/ci.yml` 1 ファイルの 2 行に限定
- workflow policy や lockfile 論点は混ぜていません

## 実行できなかった確認
- この実行環境では GitHub への local clone が `CONNECT tunnel failed, response 403` で使えないため、ローカルで workflow lint や branch checkout は未実施です
- 最終確認は PR 上の GitHub Actions 前提です

## リスク評価
- low
- workflow-only の syntax fix で、app code や test policy には触れていません

## 補足事項
- open PR `#475` に incidental に入っていた同種修正を、quality issue `#477` の専用 slice として切り出しました
- `#413` の lockfile / `npm ci` 論点には踏み込んでいません