### PR TITLE
ci: treat maintainer prose docs as docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only PR: skipping representative Rails compatibility lane."
+        run: 'echo "Docs-only PR: skipping representative Rails compatibility lane."'
       - if: needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
       - if: needs.changes.outputs.docs_only != 'true'
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only PR: skipping JavaScript browser and entrypoint checks."
+        run: 'echo "Docs-only PR: skipping JavaScript browser and entrypoint checks."'
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
           docs_only=true
           while IFS= read -r file; do
             [ -z "$file" ] && continue
+            # Root maintainer prose docs linked from the docs indexes are still docs-only changes.
             case "$file" in
-              README.md|docs/*) ;;
+              README.md|docs/*|Product\ Profile.md|CHANGELOG.md|AGENTS.md) ;;
               *)
                 docs_only=false
                 break


### PR DESCRIPTION
## 対応 Issue
- Closes #483

## Issue ごとの完了内容
- `#483`
  - docs-only 判定に root の maintainer prose docs を追加
  - `Product Profile.md` / `CHANGELOG.md` / `AGENTS.md` だけの PR が full CI に流れ続けないようにした

## 変更内容
- `.github/workflows/ci.yml`
  - `changes` job の docs-only 判定に `Product Profile.md` / `CHANGELOG.md` / `AGENTS.md` を追加
  - docs index から参照される maintainer prose docs も docs-only とみなす意図をコメントで明記

## 改善カテゴリ
- CI 改善
- workflow maintenance

## 既存仕様への影響
- なし
- app code / helper / package / workflow 実行内容は変更していません
- docs-only と判定する対象を、現状の maintainer-facing prose assets まで狭く拡張しただけです

## 実施した確認
- current `docs/en/README.md` と `docs/ja/README.md` が `Product Profile` を maintainer entry として参照していることを確認
- 変更範囲を workflow 1 ファイルに限定
- lockfile / `npm ci` / docs-only skip policy 全体の再設計は混ぜていません

## 実行できなかった確認
- この実行環境では GitHub への local clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル workflow lint は未実施です
- 最終確認は PR 上の GitHub Actions 前提です

## リスク評価
- low
- docs-only 判定の対象追加だけで、実際の job 名や実行コマンドは変えていません

## 補足事項
- open PR `#480` の quoting fix がまだ `main` に入っていないため、この PR は `quality/477-docs-only-ci-run-quoting` を base にした stacked follow-up です
- merge 順は `#480` → この PR を想定しています