### PR TITLE
docs: add focused toolbar and bridge previews to review gallery

### DIFF
--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -118,15 +118,16 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>TreeView mockup review gallery</h1>
       <p>
-        Static review hub for comparing the main TreeView mockups without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, and empty-state spacing in one session.
+        Static review hub for comparing the main TreeView mockups and the focused toolbar or resource-table references without running a Rails app.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, empty-state spacing, and newer focused surfaces in one session.
       </p>
     </header>
 
     <section class="mock-section" aria-labelledby="gallery-usage-heading">
       <h2 id="gallery-usage-heading">How to use this gallery</h2>
       <ul>
-        <li>Start here when a review needs quick side-by-side comparison across the main mockup surfaces.</li>
+        <li>Start here when a review needs quick side-by-side comparison across the main TreeView mockup surfaces.</li>
+        <li>Use the focused toolbar and resource-table cards when one review thread is about tree-wide actions or table-owned column context rather than the whole mockup family.</li>
         <li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li>
         <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li>
       </ul>
@@ -216,6 +217,48 @@
           <iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe>
         </div>
       </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused action review</p>
+          <h2 id="gallery-toolbar-heading">Toolbar actions</h2>
+          <p>
+            Use this surface when the review is about tree-wide expand and collapse affordances rather than row-by-row hierarchy layout.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Enabled pair for mixed tree state</li>
+            <li>Expand-disabled and collapse-disabled variants</li>
+            <li>Current-state emphasis without host-app route copy</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="toolbar-actions.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused layout review</p>
+          <h2 id="gallery-bridge-heading">Resource table bridge</h2>
+          <p>
+            Use this surface when the review is about shared hierarchy rows across fuller and narrower visible column sets in a table-owned layout.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Fuller desktop column set and compact visible-column variant</li>
+            <li>Hierarchy cues preserved in the first data column</li>
+            <li>Table-owned column summary without host-app table logic</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="resource-table-bridge.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
     </section>
 
     <section class="mock-section" aria-labelledby="comparison-cues-heading">
@@ -248,6 +291,16 @@
             <td>Empty state</td>
             <td>Spacing, wrapper hooks, and the full-width empty-row slot.</td>
             <td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td>
+          </tr>
+          <tr>
+            <td>Toolbar actions</td>
+            <td>Tree-wide expand and collapse states, including which action stays available in fully expanded or fully collapsed trees.</td>
+            <td>Route names, authorization, or business-specific toolbar copy.</td>
+          </tr>
+          <tr>
+            <td>Resource table bridge</td>
+            <td>Shared hierarchy-row readability when a separate table layer owns visible columns and the layout changes between fuller and compact column sets.</td>
+            <td>Table preference controls, host-app query strategy, or runtime bridge wiring.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## 対応Issue

- Closes #485

## 採用した方針

- 自動実行のため、既存の `review-gallery.html` を comparison hub のまま広げ、`toolbar-actions.html` と `resource-table-bridge.html` を gallery 内プレビュー付きで辿れる low-risk 案を採用しました。
- 新しい focused surface 自体は PR `#475` 側に閉じたままにし、この PR では gallery 導線と比較表だけを更新しています。

## 比較した案

- 案A: `docs/mockups/README.md` のリンク説明だけを増やし、gallery 本体はそのままにする。
- 案B: `review-gallery.html` に focused toolbar / resource-table cards と preview を追加し、main surfaces と同じ比較ハブから辿れるようにする。
- 案C: gallery 全体のレイアウトや shared CSS を大きく組み替え、comparison hub を再設計する。
- 今回は案Bを採用しました。Issue #485 の狙いである「focused surfaces の違いを最小遷移で把握しやすくする」を満たしつつ、既存 mockup family と review flow を崩さないためです。

## 変更内容

- `docs/mockups/review-gallery.html`
  - gallery intro と usage guidance を、focused toolbar / resource-table review を前提に更新
  - `toolbar-actions.html` 用 card を追加し、enabled / disabled / current-state の比較観点を preview 付きで導線化
  - `resource-table-bridge.html` 用 card を追加し、fuller / compact visible column variants を preview 付きで導線化
  - comparison table に focused surfaces 2 行を追加し、各 mockup の役割境界を main surfaces と並べて確認しやすくした

## 変更した画面・コンポーネント

- `docs/mockups/review-gallery.html`

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: branch compare 上で gallery card と comparison table の差分が `review-gallery.html` 1 ファイルに閉じていることを確認
- レスポンシブ確認: 既存 gallery card / iframe pattern の再利用に留め、追加カードも同じ responsive rule に乗ることを確認
- アクセシビリティ確認: preview iframe の title と card heading を focused surface 名へ追従

## スクリーンショット

- 未取得

## リスク

- low
- static mockup gallery の導線整理のみで、runtime helper、host app route、authorization、business behavior には触れていません

## 補足

- PR `#475` が追加した `toolbar-actions.html` / `resource-table-bridge.html` を前提にした stacked follow-up です
- merge 順は `#475` → この PR を想定しています
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル表示確認は未実施です