### PR TITLE
test: add a machine-readable public API manifest first slice

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -1,0 +1,41 @@
+module_methods:
+  - configure
+  - configuration
+  - reset_configuration!
+  - parse_selection_params
+  - node_key
+  - model_name_for
+  - attribute_name_for
+  - type_name_for
+public_constants:
+  - Error
+  - ConfigurationError
+  - InvalidTreeError
+  - DuplicateNodeKeyError
+  - CycleDetectedError
+  - InvalidRenderWindowError
+  - LocalizedNames
+  - Tree
+  - RenderState
+  - ResourceTableRenderState
+  - VisibleRows
+  - RenderWindow
+  - UiConfig
+  - UiConfigBuilder
+  - GraphAdapter
+  - NodePresenter
+  - PathTree
+  - PathTreeBuilder
+  - ReverseTree
+  - PersistedState
+  - StateStore
+  - Diagnostics
+helper_methods:
+  - tree_view_rows
+  - tree_view_window
+  - tree_node_dom_id
+  - tree_selection_value
+  - tree_view_breadcrumb
+  - tree_view_toolbar
+  - tree_view_toolbar_actions
+  - tree_view_toolbar_action_metadata

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "yaml"
 
 PublicApiCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
 
 RSpec.describe "Public API compatibility" do
+  PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+  def public_api_manifest
+    # First slice only: Ruby/module/helper entrypoint lists live in the manifest.
+    # Grouped options, JavaScript hooks, and broader docs sync stay explicit here for now.
+    @public_api_manifest ||= YAML.safe_load(File.read(PUBLIC_API_MANIFEST_PATH))
+  end
+
   def public_ui_config
     TreeView::UiConfig.new(
       node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
@@ -21,14 +30,9 @@ RSpec.describe "Public API compatibility" do
   end
 
   it "keeps documented TreeView module methods available" do
-    expect(TreeView).to respond_to(:configure)
-    expect(TreeView).to respond_to(:configuration)
-    expect(TreeView).to respond_to(:reset_configuration!)
-    expect(TreeView).to respond_to(:parse_selection_params)
-    expect(TreeView).to respond_to(:node_key)
-    expect(TreeView).to respond_to(:model_name_for)
-    expect(TreeView).to respond_to(:attribute_name_for)
-    expect(TreeView).to respond_to(:type_name_for)
+    public_api_manifest.fetch("module_methods").each do |method_name|
+      expect(TreeView).to respond_to(method_name.to_sym), "expected TreeView.#{method_name} to remain public"
+    end
 
     expect(TreeView.node_key(:document, 1)).to eq("document:1")
   end
@@ -47,23 +51,7 @@ RSpec.describe "Public API compatibility" do
   end
 
   it "keeps documented public Ruby constants available" do
-    %i[
-      Tree
-      RenderState
-      VisibleRows
-      RenderWindow
-      UiConfig
-      UiConfigBuilder
-      GraphAdapter
-      LocalizedNames
-      NodePresenter
-      PathTree
-      PathTreeBuilder
-      ReverseTree
-      PersistedState
-      StateStore
-      Diagnostics
-    ].each do |constant_name|
+    public_api_manifest.fetch("public_constants").each do |constant_name|
       expect(TreeView.const_defined?(constant_name)).to be(true), "expected TreeView::#{constant_name} to remain public"
     end
   end
@@ -141,15 +129,8 @@ RSpec.describe "Public API compatibility" do
   end
 
   it "keeps documented helper method names available through TreeViewHelper" do
-    %i[
-      tree_view_rows
-      tree_view_window
-      tree_node_dom_id
-      tree_selection_value
-      tree_view_breadcrumb
-      tree_view_toolbar
-    ].each do |method_name|
-      expect(TreeViewHelper.public_instance_methods).to include(method_name)
+    public_api_manifest.fetch("helper_methods").each do |method_name|
+      expect(TreeViewHelper.public_instance_methods).to include(method_name.to_sym), "expected TreeViewHelper##{method_name} to remain public"
     end
   end
 

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -4,14 +4,13 @@ require "spec_helper"
 require "yaml"
 
 PublicApiCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
+PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
 
 RSpec.describe "Public API compatibility" do
-  PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
-
   def public_api_manifest
     # First slice only: Ruby/module/helper entrypoint lists live in the manifest.
     # Grouped options, JavaScript hooks, and broader docs sync stay explicit here for now.
-    @public_api_manifest ||= YAML.safe_load(File.read(PUBLIC_API_MANIFEST_PATH))
+    @public_api_manifest ||= YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH)
   end
 
   def public_ui_config


### PR DESCRIPTION
## 対応 Issue
- Closes #488

## Issue ごとの完了内容
- `#488`
  - Ruby module methods / public constants / documented helper namesの first-slice manifest を追加
  - `spec/public_api_compatibility_spec.rb` がその manifest を読み、entrypoint 一覧の二重管理を減らす形へ整理
  - grouped options、JavaScript surface、release docs sync は引き続き spec 内の明示チェックや別 issue に残した

## 変更内容
- `config/public_api_manifest.yml`
  - machine-readable manifest を追加
  - first slice として次だけを列挙
    - documented `TreeView` module methods
    - documented public Ruby constants / error classes
    - documented helper method names exposed through `TreeViewHelper`
- `spec/public_api_compatibility_spec.rb`
  - manifest を `YAML.safe_load` で読むよう更新
  - module methods / public constants / helper method names の availability check を manifest 駆動へ変更
  - grouped options、UiConfigBuilder mode methods、representative behavior checks は引き続き explicit spec として残した
  - first slice の境界をコメントで明記した

## 改善カテゴリ
- テスト改善
- 重複定義整理
- docs/spec drift 予防

## 既存仕様への影響
- なし
- runtime code、public API、helper behavior は変更していません
- 互換性 spec の source of truth を一部 manifest 化しただけです

## 実施した確認
- compare `main...quality/488-public-api-manifest-first-slice` で差分が manifest 1ファイルと spec 1ファイルに閉じていることを確認
- current `docs/en/public-api.md`、`docs/ja/public-api.md`、`docs/en/usage.md` を参照し、first slice に含める Ruby / helper entrypoint を整理
- open docs PR `#476` / `#487` と write set をぶつけないよう、今回は docs 本文更新を混ぜず spec comment に留めた

## 実行できなかった確認
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル `bundle exec rspec` は未実施です
- 最終確認は PR CI 前提です

## リスク評価
- medium
- public API manifest を新設するため、今後 entrypoint を増やす change では manifest 更新を忘れない運用が必要です
- ただし first slice を Ruby / helper entrypoint に限定し、scope は狭く保っています

## 補足事項
- `tree_view_toolbar_actions` / `tree_view_toolbar_action_metadata` は current `docs/en/usage.md` で host app-owned toolbar の documented helper name として扱われているため、manifest 側に含めました
- public API docs 自体の追従は open docs lane (`#473` / PR `#476`) に委ねています