### PR TITLE
feat: toolbar helper の default label を I18n で解決できるようにする

### DIFF
--- a/app/helpers/tree_view_helper/toolbar.rb
+++ b/app/helpers/tree_view_helper/toolbar.rb
@@ -41,7 +41,7 @@ module TreeViewHelper
       {
         action: normalized_action,
         state: TREE_VIEW_TOOLBAR_STATES.fetch(normalized_action),
-        label: label || TREE_VIEW_TOOLBAR_LABELS.fetch(normalized_action),
+        label: label || tree_view_toolbar_default_label(normalized_action),
         path: path,
         disabled: disabled,
         data: tree_view_toolbar_action_data(normalized_action, disabled: disabled)
@@ -59,6 +59,13 @@ module TreeViewHelper
       return normalized_action if TREE_VIEW_TOOLBAR_ACTIONS.include?(normalized_action)
 
       raise TreeView::ConfigurationError, "unknown tree_view_toolbar action: #{action}; supported actions are: #{TREE_VIEW_TOOLBAR_ACTIONS.join(", ")}"
+    end
+
+    def tree_view_toolbar_default_label(action)
+      default_label = TREE_VIEW_TOOLBAR_LABELS.fetch(action)
+      return default_label unless defined?(I18n)
+
+      I18n.t("tree_view.toolbar.labels.#{action}", default: default_label)
     end
 
     def tree_view_toolbar_action_tag(action, button_class_name)

--- a/config/locales/tree_view.toolbar.en.yml
+++ b/config/locales/tree_view.toolbar.en.yml
@@ -1,0 +1,7 @@
+en:
+  tree_view:
+    toolbar:
+      labels:
+        expand_all: "Expand all"
+        collapse_all: "Collapse all"
+        collapse_all_except_current_path: "Collapse all except current path"

--- a/config/locales/tree_view.toolbar.ja.yml
+++ b/config/locales/tree_view.toolbar.ja.yml
@@ -1,0 +1,7 @@
+ja:
+  tree_view:
+    toolbar:
+      labels:
+        expand_all: "すべて展開"
+        collapse_all: "すべて折りたたむ"
+        collapse_all_except_current_path: "現在の経路以外を折りたたむ"

--- a/docs/en/localized-names.md
+++ b/docs/en/localized-names.md
@@ -76,6 +76,22 @@ en:
 
 If the translation is missing, TreeView falls back to a humanized `node_type` value.
 
+## Toolbar action labels
+
+The bundled toolbar helpers also use I18n-backed default labels.
+
+```yaml
+en:
+  tree_view:
+    toolbar:
+      labels:
+        expand_all: "Expand all"
+        collapse_all: "Collapse all"
+        collapse_all_except_current_path: "Collapse all except current path"
+```
+
+`tree_view_toolbar`, `tree_view_toolbar_actions`, and `tree_view_toolbar_action_metadata` read these keys for the current locale unless the host app passes an explicit `labels:` override. Missing translations fall back to the built-in English copy.
+
 ## NodePresenter example
 
 ```ruby

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -62,6 +62,8 @@ Path builders only build URLs. The host app owns controller actions, Turbo Strea
 
 If the host app wants to build its own toolbar instead of using TreeView's bundled HTML helper, ask TreeView for action metadata and render links or buttons in app-owned markup.
 
+By default, `tree_view_toolbar`, `tree_view_toolbar_actions`, and `tree_view_toolbar_action_metadata` resolve labels through `tree_view.toolbar.labels.*` for the current locale and fall back to the built-in English copy. Pass `labels:` only when a screen needs app-specific wording.
+
 ```erb
 <% tree_view_toolbar_actions(@render_state).each do |action| %>
   <% if action[:path] %>

--- a/docs/ja/localized-names.md
+++ b/docs/ja/localized-names.md
@@ -74,6 +74,22 @@ ja:
 
 translation が見つからない場合は、`node_type` の値を humanize します。
 
+## Toolbar action labels
+
+bundled toolbar helper の default label も I18n 経由で解決できます。
+
+```yaml
+ja:
+  tree_view:
+    toolbar:
+      labels:
+        expand_all: "すべて展開"
+        collapse_all: "すべて折りたたむ"
+        collapse_all_except_current_path: "現在の経路以外を折りたたむ"
+```
+
+`tree_view_toolbar`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` は、host app が `labels:` override を明示しない限り current locale のこれらの key を参照します。translation が無い場合は built-in の英語copyへ fallback します。
+
 ## NodePresenter example
 
 ```ruby

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -58,6 +58,31 @@ tree_ui = TreeView::UiConfigBuilder.new(
 
 path builderはURLを作るだけです。実際のcontroller action、Turbo Stream response、認可、server-side queryはhost app側の責務です。
 
+bundled HTML helper の代わりに host app 側で toolbar markup を組みたい場合は、TreeView から action metadata を受け取り、app-owned markup で link / button を描画できます。
+
+`tree_view_toolbar`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` の default label は current locale の `tree_view.toolbar.labels.*` を参照し、translation が無い場合は built-in の英語copyへ fallback します。画面固有の文言が必要な場合だけ `labels:` を渡してください。
+
+```erb
+<% tree_view_toolbar_actions(@render_state).each do |action| %>
+  <% if action[:path] %>
+    <%= link_to action[:label], action[:path], data: action[:data] %>
+  <% else %>
+    <%= button_tag action[:label], type: "button", disabled: true, data: action[:data] %>
+  <% end %>
+<% end %>
+```
+
+各 action hash には以下が含まれます。
+
+- `:action` 例: `:expand_all`
+- `:state` 例: `:expanded`
+- `:label`
+- `:path`。tree-wide toggle を使わない mode では `nil`
+- `:disabled`
+- host app 側の link / button に渡せる `:data`
+
+TreeView が提供するのは metadata までです。最終的な HTML 構造、style、icon、authorization rule は host app 側で決めます。
+
 ## client-side開閉
 
 `max_render_depth` / `max_leaf_distance` の範囲内のnodeを初期HTMLに含めても問題ない小〜中規模treeでは、`build_client_side` を使えます。Turbo routeやTurbo Stream responseを用意せず、browser内だけで開閉します。

--- a/spec/helpers/tree_view_toolbar_helper_spec.rb
+++ b/spec/helpers/tree_view_toolbar_helper_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe "tree_view_toolbar helper" do
     instance_double(TreeView::RenderState, ui_config: ui_config)
   end
 
+  around do |example|
+    original_available_locales = I18n.available_locales
+    I18n.available_locales = original_available_locales | %i[toolbar_test_ja toolbar_test_missing]
+    example.run
+  ensure
+    I18n.available_locales = original_available_locales
+  end
+
   it "returns toolbar action metadata for host-app-owned controls" do
     actions = helper.tree_view_toolbar_actions(render_state, actions: [:expand_all, :collapse_all], labels: {expand_all: "Open all"})
 

--- a/spec/helpers/tree_view_toolbar_helper_spec.rb
+++ b/spec/helpers/tree_view_toolbar_helper_spec.rb
@@ -53,6 +53,50 @@ RSpec.describe "tree_view_toolbar helper" do
     )
   end
 
+  it "uses I18n toolbar labels when a translation is available" do
+    I18n.backend.store_translations(:toolbar_test_ja, {
+      tree_view: {
+        toolbar: {
+          labels: {
+            expand_all: "すべて展開"
+          }
+        }
+      }
+    })
+
+    action = I18n.with_locale(:toolbar_test_ja) do
+      helper.tree_view_toolbar_action_metadata(render_state, :expand_all)
+    end
+
+    expect(action[:label]).to eq("すべて展開")
+  end
+
+  it "prefers an explicit label override over the I18n default" do
+    I18n.backend.store_translations(:toolbar_test_ja, {
+      tree_view: {
+        toolbar: {
+          labels: {
+            expand_all: "すべて展開"
+          }
+        }
+      }
+    })
+
+    actions = I18n.with_locale(:toolbar_test_ja) do
+      helper.tree_view_toolbar_actions(render_state, actions: [:expand_all], labels: {expand_all: "Open all now"})
+    end
+
+    expect(actions.first[:label]).to eq("Open all now")
+  end
+
+  it "falls back to the built-in English label when no translation exists" do
+    action = I18n.with_locale(:toolbar_test_missing) do
+      helper.tree_view_toolbar_action_metadata(render_state, :collapse_all_except_current_path)
+    end
+
+    expect(action[:label]).to eq("Collapse all except current path")
+  end
+
   it "returns disabled metadata when the ui does not expose toggle_all_path" do
     static_ui_config = TreeView::UiConfig.new(
       node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },

--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
       "app/javascript/tree_view/**/*",
       "app/views/tree_view/**/*",
       "config/importmap.tree_view.rb",
+      "config/locales/**/*",
       "docs/**/*",
       "lib/**/*",
       "CHANGELOG.md",


### PR DESCRIPTION
toolbar helper / metadata helper の default label を current locale から解決できるようにします。

## 対応 Issue
- Closes #482

## 変更内容
- `app/helpers/tree_view_helper/toolbar.rb`
  - `tree_view_toolbar_action_metadata` の default label を `tree_view.toolbar.labels.*` から解決するよう更新
  - `labels:` override は引き続き最優先にし、translation が無いときは built-in の英語copyへ fallback する additive change に留めた
- `config/locales/tree_view.toolbar.en.yml`
- `config/locales/tree_view.toolbar.ja.yml`
  - bundled toolbar helper 用の default label translation を追加
- `tree_view.gemspec`
  - `config/locales/**/*` を package 対象へ追加し、gem 配布物に toolbar locale files が含まれるよう更新
- `spec/helpers/tree_view_toolbar_helper_spec.rb`
  - I18n label、explicit override 優先、missing translation fallback を guard 追加
- `docs/en/usage.md`
- `docs/ja/usage.md`
  - app-owned toolbar markup 例の近くに locale default label と `labels:` override の責務を追記
- `docs/en/localized-names.md`
- `docs/ja/localized-names.md`
  - toolbar action label translation keys を追加

## 受け入れ条件との対応
- [x] `tree_view_toolbar` / `tree_view_toolbar_actions` / `tree_view_toolbar_action_metadata` の default label が I18n から解決される
- [x] `labels:` override を渡した場合は current と同じく explicit label が優先される
- [x] I18n key が未定義でも current English label に fallback し、既存 host app を壊さない
- [x] docs から default label の locale 責務と override 方法が分かる

## 変更範囲
- toolbar helper
- toolbar locale files
- helper spec
- 日英 docs
- gemspec の package 対象

## 実施した確認
- compare `main...feat/482-toolbar-i18n-default-labels` で差分が issue 対象の 9 ファイルに閉じていることを確認
- helper spec に I18n default / explicit override / fallback の3観点を追加

## 実行できなかった確認
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル `bundle exec rspec` / lint は未実施です
- 最終確認は PR CI 前提です

## リスク
- medium
- host app が `labels:` を渡す既存経路は維持したまま、default label 解決だけを locale-aware にした additive change です
- gemspec に `config/locales/**/*` を追加したため、release artifact の file set が 1 directory 分だけ増えます

## 未対応・補足
- host app 固有の wording や authorization policy は引き続き host app 側責務です
- toolbar action surface 自体の追加や bundled toolbar component redesign には広げていません