### PR TITLE
test: guard grouped RenderState option keys from the public API manifest

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -39,3 +39,18 @@ helper_methods:
   - tree_view_toolbar
   - tree_view_toolbar_actions
   - tree_view_toolbar_action_metadata
+grouped_option_keys:
+  initial_expansion:
+    - default
+    - max_depth
+    - expanded_keys
+    - collapsed_keys
+    - current_item
+    - current_key
+    - auto_expand_ancestors
+  render_scope:
+    - max_depth
+    - max_leaf_distance
+  toggle_scope:
+    - max_depth_from_root
+    - max_leaf_distance

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -5,11 +5,16 @@ require "yaml"
 
 PublicApiCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
 PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+RENDER_STATE_GROUPED_OPTION_CONSTANTS = {
+  "initial_expansion" => :VALID_INITIAL_EXPANSION_KEYS,
+  "render_scope" => :VALID_RENDER_SCOPE_KEYS,
+  "toggle_scope" => :VALID_TOGGLE_SCOPE_KEYS
+}.freeze
 
 RSpec.describe "Public API compatibility" do
   def public_api_manifest
-    # First slice only: Ruby/module/helper entrypoint lists live in the manifest.
-    # Grouped options, JavaScript hooks, and broader docs sync stay explicit here for now.
+    # Ruby/module/helper entrypoint lists and grouped option keys live in the manifest.
+    # Grouped option behavior, JavaScript hooks, and broader docs sync stay explicit here.
     @public_api_manifest ||= YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH)
   end
 
@@ -64,7 +69,16 @@ RSpec.describe "Public API compatibility" do
     expect(builder).to respond_to(:build_client_side)
   end
 
-  it "keeps documented RenderState grouped options available" do
+  it "keeps documented RenderState grouped option keys available" do
+    public_api_manifest.fetch("grouped_option_keys").each do |group_name, manifest_keys|
+      constant_name = RENDER_STATE_GROUPED_OPTION_CONSTANTS.fetch(group_name)
+      expected_keys = TreeView::RenderState.const_get(constant_name).map(&:to_s)
+
+      expect(manifest_keys).to eq(expected_keys), "expected #{group_name} keys to match TreeView::RenderState::#{constant_name}"
+    end
+  end
+
+  it "keeps representative grouped option behavior available" do
     tree = instance_double(TreeView::Tree)
     ui_config = instance_double(TreeView::UiConfig)
 


### PR DESCRIPTION
## 対応 Issue
- Closes #496

## Issue ごとの完了内容
- `#496`
  - `RenderState` の grouped option keys を machine-readable manifest から読めるようにした
  - compatibility spec が `initial_expansion` / `render_scope` / `toggle_scope` の documented key set を manifest 駆動で検証するようにした
  - grouped option の representative behavior check は explicit spec として残し、manifest lane と責務を分けた

## 変更内容
- `config/public_api_manifest.yml`
  - `grouped_option_keys` を additive extension として追加
  - first step として `initial_expansion` / `render_scope` / `toggle_scope` の current key set を列挙
- `spec/public_api_compatibility_spec.rb`
  - grouped option key set を manifest から読み、`TreeView::RenderState` の公開定数と一致することを検証する guard を追加
  - top comment を current manifest scope に合わせて更新
  - selection / lazy-loading を含む representative grouped option behavior check は explicit のまま維持

## 改善カテゴリ
- テスト改善
- docs/spec drift 予防
- source of truth 整理

## 既存仕様への影響
- なし
- runtime behavior、validation message、grouped option precedence は変更していません
- machine-readable manifest と compatibility spec の範囲を narrow に拡張しただけです

## 実施した確認
- compare `6fdf0033b7948d497c8beac08ce991ae407f9582...quality/496-grouped-option-keys-manifest` で差分が 2 ファイルに閉じていることを確認
- `config/public_api_manifest.yml` と `TreeView::RenderState::VALID_*_KEYS` の対応を読み合わせた
- `#490` が main に入った後の additive follow-up として、manifest first slice を壊さない形に留めた

## 実行できなかった確認
- この実行環境では repository clone が `CONNECT tunnel failed, response 403` で失敗するため、ローカル `bundle exec rspec` は未実施です
- 最終確認は PR CI 前提です

## リスク評価
- medium
- 今後 grouped option keys を増やす変更では manifest 更新を忘れない運用が必要です
- ただし selection / lazy-loading や JavaScript surface には広げず、first additive lane に閉じています

## 補足事項
- `#498` の JavaScript public surface manifest lane とは分離しています
- release docs sync や runtime option semantics の再設計はこの PR に含めていません