### PR TITLE
test: guard the JavaScript public surface from the API manifest

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -54,3 +54,22 @@ grouped_option_keys:
   toggle_scope:
     - max_depth_from_root
     - max_leaf_distance
+javascript_package_root:
+  named_exports:
+    - registerTreeViewControllers
+    - TreeViewStateController
+    - TreeViewClientController
+    - TreeViewSelectionController
+    - TreeViewTransferController
+    - TreeViewRemoteStateController
+  controller_registrations:
+    - identifier: tree-view-state
+      export: TreeViewStateController
+    - identifier: tree-view-client
+      export: TreeViewClientController
+    - identifier: tree-view-selection
+      export: TreeViewSelectionController
+    - identifier: tree-view-transfer
+      export: TreeViewTransferController
+    - identifier: tree-view-remote-state
+      export: TreeViewRemoteStateController

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -126,6 +126,8 @@ Stable enough for host apps to use:
 
 `registerTreeViewControllers(application)` registers the five controller exports above with the documented identifiers in the bundled entrypoint order.
 
+The machine-readable source of truth for the package-root JavaScript exports and bundled controller identifiers lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+
 Internal by default:
 
 - private controller methods

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -126,6 +126,8 @@ host appが使ってよい入口:
 
 `registerTreeViewControllers(application)` は、上記 5 つの controller export を bundled entrypoint の documented identifier 順に登録します。
 
+package-root の JavaScript export と bundled controller identifier の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+
 内部扱い:
 
 - private controller methods

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -5,6 +5,7 @@ require "yaml"
 
 PublicApiCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
 PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+JAVASCRIPT_ENTRYPOINT_PATH = File.expand_path("../app/javascript/tree_view/index.js", __dir__)
 RENDER_STATE_GROUPED_OPTION_CONSTANTS = {
   "initial_expansion" => :VALID_INITIAL_EXPANSION_KEYS,
   "render_scope" => :VALID_RENDER_SCOPE_KEYS,
@@ -13,9 +14,18 @@ RENDER_STATE_GROUPED_OPTION_CONSTANTS = {
 
 RSpec.describe "Public API compatibility" do
   def public_api_manifest
-    # Ruby/module/helper entrypoint lists and grouped option keys live in the manifest.
-    # Grouped option behavior, JavaScript hooks, and broader docs sync stay explicit here.
+    # The machine-readable manifest covers Ruby/module/helper entrypoints,
+    # grouped option keys, and JavaScript package-root exports. Grouped option
+    # behavior and broader docs sync stay explicit here.
     @public_api_manifest ||= YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH)
+  end
+
+  def public_javascript_manifest
+    public_api_manifest.fetch("javascript_package_root")
+  end
+
+  def javascript_entrypoint_source
+    @javascript_entrypoint_source ||= File.read(JAVASCRIPT_ENTRYPOINT_PATH)
   end
 
   def public_ui_config
@@ -144,6 +154,29 @@ RSpec.describe "Public API compatibility" do
   it "keeps documented helper method names available through TreeViewHelper" do
     public_api_manifest.fetch("helper_methods").each do |method_name|
       expect(TreeViewHelper.public_instance_methods).to include(method_name.to_sym), "expected TreeViewHelper##{method_name} to remain public"
+    end
+  end
+
+  it "keeps documented JavaScript package-root exports available" do
+    source = javascript_entrypoint_source
+
+    expect(source).to include("export function registerTreeViewControllers(application)")
+
+    public_javascript_manifest.fetch("named_exports").reject { |name| name == "registerTreeViewControllers" }.each do |export_name|
+      expect(source).to include("export { #{export_name} } from"),
+        "expected tree_view package root to keep exporting #{export_name}"
+    end
+  end
+
+  it "keeps documented JavaScript controller identifiers wired through registerTreeViewControllers" do
+    source = javascript_entrypoint_source
+
+    public_javascript_manifest.fetch("controller_registrations").each do |registration|
+      export_name = registration.fetch("export")
+      identifier = registration.fetch("identifier")
+
+      expect(source).to include("application.register(\"#{identifier}\", #{export_name})"),
+        "expected registerTreeViewControllers to register #{export_name} as #{identifier}"
     end
   end
 


### PR DESCRIPTION
## 対応 Issue
- Closes #498

## Issue ごとの完了内容
- `#498`
  - JavaScript package-root public surface を `config/public_api_manifest.yml` で machine-readable に定義した
  - compatibility spec が documented export 名と bundled controller identifier registration を manifest 駆動で検証するようにした
  - public API docs からも、その manifest が source of truth であることを追えるようにした

## 変更内容
- `config/public_api_manifest.yml`
  - `javascript_package_root` を追加
  - package-root named exports と bundled controller registrations を列挙
- `spec/public_api_compatibility_spec.rb`
  - `app/javascript/tree_view/index.js` を直接読み、manifest に載せた export 名と `registerTreeViewControllers(...)` の registration wiring を検証する guard を追加
  - grouped option key guard はそのまま維持しつつ、manifest comment を current scope に更新
- `docs/en/public-api.md`
- `docs/ja/public-api.md`
  - package-root JavaScript exports と bundled controller identifiers の source of truth が `config/public_api_manifest.yml` であることを追記

## 改善カテゴリ
- テスト改善
- docs/spec drift 予防
- source of truth 整理

## 既存仕様への影響
- なし
- runtime behavior、controller internals、event payload は変更していません
- manifest / spec / public API docs に閉じた quality slice です

## 実施した確認
- compare `main...quality/498-js-public-surface-manifest` で差分が manifest / compatibility spec / public API docs の 4 ファイルに閉じていることを確認
- current `package.json` の `test:entrypoints` がすでに package-root smoke を持っているため、それを置き換えず complement する manifest lane として追加したことを確認

## 実行できなかった確認
- この実行環境では GitHub への local clone が `CONNECT tunnel failed, response 403` で使えないため、`bundle exec rspec` や `npm run test:entrypoints` のローカル実行は未実施です
- 最終確認は PR CI 前提です

## リスク評価
- low
- machine-readable contract と docs/spec の追加だけで、package runtime や helper/runtime API には触れていません

## 補足事項
- grouped option keys lane や release docs sync policy lane とは責務を分けたまま維持しています