### PR TITLE
docs: align Product Profile maintainer reading order with AGENTS

### DIFF
--- a/Product Profile.md
+++ b/Product Profile.md
@@ -48,8 +48,10 @@ When implementation and docs drift, use this order:
 
 ## Recommended first reads
 
-1. `README.md` for public positioning and quick entry points
-2. `docs/README.md` for the docs map
-3. `docs/en/README.md` or `docs/ja/README.md` for language-specific docs
-4. `docs/en/design-policy.md` or `docs/ja/design-policy.md` for responsibility boundaries
-5. `AGENTS.md` for repository-specific maintainer guidance
+For maintainers making changes, start in this order:
+
+1. `AGENTS.md` for repository-specific workflow and documentation update rules
+2. `README.md` for public positioning and quick entry points
+3. `docs/README.md` for the docs map
+4. `docs/en/README.md` or `docs/ja/README.md` for language-specific docs
+5. `docs/en/design-policy.md` or `docs/ja/design-policy.md` for responsibility boundaries


### PR DESCRIPTION
## 対応 Issue
- Closes #506

## 背景

repo sweep の中で、root `Product Profile.md` の `Recommended first reads` が `README.md` 始まりになっている一方、`AGENTS.md` では maintainer が最初に `AGENTS.md` を読む順序を明示していることを確認しました。

確認した事実:

- `AGENTS.md` の `First Read` は `AGENTS.md` → `README.md` → `docs/README.md` → language-specific docs の順序
- `Product Profile.md` の `Recommended first reads` は `README.md` → `docs/README.md` → language-specific docs → design policy → `AGENTS.md` の順序
- どちらも maintainer entry surface として README / docs index から案内されており、読み順の食い違いは current maintainer guidance として stale

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `Product Profile.md`
  - `Recommended first reads` を maintainer 向けの案内として書き直し
  - `AGENTS.md` を最初に読む入口へ移動
  - 以降の順序を `README.md`、`docs/README.md`、language-specific docs、design policy の順にそろえた

## 根拠

- `AGENTS.md`
- `Product Profile.md`
- `README.md`
- `docs/README.md`

## 確認

- compare `main...docs/maintainer-first-read-order` で差分が `Product Profile.md` 1 ファイルだけに閉じていることを確認
- runtime code、workflow、CI、公開 API には触れていません
- docs-only 変更のため local test / lint は未実施です

## リスク

- low
- maintainer entry guidance の整合を取るだけで、repository policy や実装仕様は変更していません