### PR TITLE
docs: add focused mockup assets to i18n audit inventory

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -86,6 +86,8 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 |---|---|---|
 | `docs/mockups/README.md` | Technical asset | Index for static mockup assets. Short bilingual-style prose is acceptable; no separate translation needed. |
 | `docs/mockups/review-gallery.html` | Technical asset | Comparison hub for the current static mockup set. No translation needed. |
+| `docs/mockups/toolbar-actions.html` | Technical asset | Focused static reference for tree-wide expand / collapse toolbar states. No translation needed. |
+| `docs/mockups/resource-table-bridge.html` | Technical asset | Focused static reference for TreeView hierarchy rows inside a separate table layer. No translation needed. |
 | `docs/mockups/default-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
@@ -96,4 +98,5 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 
 - Keep `docs/ja/` and `docs/en/` in sync for future user-facing changes.
 - If a temporary mismatch is unavoidable, leave a visible note and plan the follow-up.
+- When the focused mockup set changes, update this inventory together with `docs/mockups/README.md` and `docs/mockups/review-gallery.html`.
 - Prefer updating this checklist by replacement when the maintenance rule changes, instead of stacking stale release-specific notes on top of it.


### PR DESCRIPTION
## 対応 Issue
- Refs #507

## 前提
- この PR は PR `#489` を base にした stacked docs-only follow-up です
- `toolbar-actions.html` と `resource-table-bridge.html` は PR `#475` / `#489` の mockup family を前提にしています
- merge 順は `#475` → `#489` → この PR を想定しています

## 判定分類
- `docs-stale`
- `docs-sync`
- `docs-ahead-of-code`

## 変更内容
- `docs/i18n-audit.md`
  - `Technical assets` table に `docs/mockups/toolbar-actions.html` を追加
  - `Technical assets` table に `docs/mockups/resource-table-bridge.html` を追加
  - focused mockup set が増えたときは `docs/mockups/README.md` と `docs/mockups/review-gallery.html` も一緒に見直す運用メモを追記

## 根拠
- Issue `#507`
- `docs/i18n-audit.md`
- PR `#475`
- PR `#489`
- `docs/mockups/README.md`

## 確認
- 差分が `docs/i18n-audit.md` 1 ファイルだけに閉じていることを確認
- mockup HTML/CSS、runtime code、README 以外の user-facing docs には触れていません
- docs-only 変更のため local test / lint は未実施です

## リスク
- low
- inventory と maintenance note の追記だけで、public API や runtime behavior は変更していません