### PR TITLE
quality: add Rails 7.2 to the PR representative matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
           - rails: "7.0"
             gemfile: gemfiles/rails_7_0.gemfile
             ruby-version: "3.2"
+          - rails: "7.2"
+            gemfile: gemfiles/rails_7_2.gemfile
+            ruby-version: "3.2"
           - rails: "8.0"
             gemfile: gemfiles/rails_8_0.gemfile
             ruby-version: "3.3"

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -34,6 +34,8 @@ For the Rails version matrix:
 ```bash
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
 ```
 
 ## Public API compatibility specs
@@ -72,7 +74,7 @@ Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
-- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile` and `gemfiles/rails_8_0.gemfile`
+- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - JavaScript entrypoint, unit, and browser smoke tests through `npm run test:js`
 
 Docs-only pull requests that touch only `README.md` and `docs/**` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -34,6 +34,8 @@ Rails version matrixを確認する場合:
 ```bash
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
 ```
 
 ## Public API compatibility specs
@@ -72,7 +74,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
-- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile` と `gemfiles/rails_8_0.gemfile`
+- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
 - JavaScript entrypoint、unit、browser smoke tests: `npm run test:js`
 
 `README.md` と `docs/**` だけに触れる docs-only Pull Request では、`lint` と `pr_specs` はそのまま残しつつ、representative Rails job と JavaScript job を short-circuit します。branch protection のため、check 名はそのまま維持します。`.github/workflows/**` も変更する Pull Request ではこの shortcut を使わず、通常の PR lanes を確認します。


### PR DESCRIPTION
## 対応 Issue
- Closes #520

## Issue ごとの完了内容
- #520: pull request 向け representative Rails matrix を maintainer baseline に寄せ、PR でも Rails 7.2 line を確認できるようにしました。

## 変更内容
- `.github/workflows/ci.yml`
  - `pr_rails_matrix` に Rails 7.2 lane を追加
  - docs-only short-circuit 方針や既存 job 名は維持
- `docs/en/development.md`
- `docs/ja/development.md`
  - local Rails matrix command 例に Rails 7.2 を追加
  - PR representative Rails checks の列挙を current workflow に追従

## 改善カテゴリ
- CI 改善
- docs 改善

## 既存仕様への影響
- 公開 API、UI、render behavior、docs-only skip policy は変更していません。
- PR 段階で見る representative Rails line を 1 本増やしただけです。

## 実施した確認
- diff が workflow と英日 development docs の 3 ファイルに閉じていることを確認
- `main` push 向け full matrix や JavaScript job の current policyを巻き戻していないことを確認
- この実行環境では GitHub への通常 clone が使えないため、ローカル `bundle exec rake` は未実施
- PR CI で最終確認予定

## リスク評価
- `risk: medium`
- 変更は representative lane の追加に限定され、主なリスクは CI 時間と dependency solve のみです。

## 補足
- Rails 7.1 lane も `main` push 側には残っていますが、この issue では PR representative baseline を narrow に改善する範囲へ閉じています。
