### PR TITLE
docs: README と docs index の entry points を整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Key documents:
 | Decision guide | [Decision guide](docs/en/decision-guide.md) | [API判断ガイド](docs/ja/decision-guide.md) |
 | FAQ | [FAQ](docs/en/faq.md) | [FAQ](docs/ja/faq.md) |
 | Troubleshooting | [Troubleshooting](docs/en/troubleshooting.md) | [Troubleshooting](docs/ja/troubleshooting.md) |
+| JavaScript event contract | [JavaScript event contract](docs/en/js-events.md) | [JavaScript イベント契約](docs/ja/js-events.md) |
 | Accessibility semantics | [Accessibility Semantics](docs/en/accessibility-semantics.md) | [Accessibility Semantics](docs/ja/accessibility-semantics.md) |
 | Cookbook | [Cookbook](docs/en/cookbook.md) | [Cookbook](docs/ja/cookbook.md) |
 | Forms and editing rows | [Forms and editing rows](docs/en/form-editing.md) | [Form と編集行](docs/ja/form-editing.md) |


### PR DESCRIPTION
## 概要
- root `README.md` の `Key documents` table に `JavaScript event contract` と `Visual reference mockups` の入口を追加
- root README と `docs/README.md` / `docs/en/README.md` / `docs/ja/README.md` で、static visual reference は `review-gallery.html` を first stop として辿れるように整理
- listener wiring を探す人と見た目を先に把握したい人の両方が、README / docs index から迷わず relevant docs に入れるようにする

## 判定
- classification: `docs-stale`

## 根拠
- current `README.md` の `Key documents` table には `docs/en|ja/js-events.md` への直接導線がなかった
- current `README.md` / `docs/README.md` / `docs/en/README.md` / `docs/ja/README.md` では、mockup family 自体の存在は案内している一方で `review-gallery.html` を最初に開く意図が薄かった
- `docs/mockups/README.md` は `review-gallery.html` を single-surface comparison hub として案内しており、runtime 変更なしで docs entry point だけを整えられる

## 変更範囲
- `README.md`
- `docs/README.md`
- `docs/en/README.md`
- `docs/ja/README.md`

## 確認観点
- root README から `docs/en|ja/js-events.md` を自然に辿れること
- root README と docs index から `review-gallery.html` を visual first stop として辿れること
- `docs/mockups/README.md` の existing review flow と矛盾しないこと
- runtime code や event payload shape の変更が混ざっていないこと

## テスト
- なし（docs only）

Closes #527
Closes #524