### PR TITLE
docs: toolbar helper の公開入口を current helper surface に揃える

### DIFF
--- a/docs/en/api-overview.md
+++ b/docs/en/api-overview.md
@@ -223,6 +223,10 @@ Records mode provides helpers for inspecting parent paths.
 | `tree_node_dom_id` | Build a node DOM ID through `UiConfig`. |
 | `tree_selection_value` | Build a JSON checkbox value. |
 | `tree_view_breadcrumb` | Render an ancestor breadcrumb. |
+| `tree_view_toolbar` | Render TreeView's bundled toolbar markup. |
+| `tree_view_toolbar_supported_actions` | Return the supported toolbar action symbols for app-owned toolbar builders. |
+| `tree_view_toolbar_actions` | Return toolbar action hashes for host-app-owned toolbar markup. |
+| `tree_view_toolbar_action_metadata` | Return metadata for a supported toolbar action. |
 
 ## JavaScript entrypoint
 

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -39,6 +39,7 @@ Host apps may use these entry points directly:
 - `tree_view_window(render_state, offset:, limit:)`
 - `tree_view_breadcrumb(tree, item, ...)`
 - `tree_view_toolbar(render_state, ...)`
+- `tree_view_toolbar_supported_actions`
 - `tree_view_toolbar_actions(render_state, ...)`
 - `tree_view_toolbar_action_metadata(render_state, action, ...)`
 
@@ -62,6 +63,7 @@ For app-owned toolbar builders, use `tree_view_toolbar_supported_actions`, `tree
 Documented toolbar helpers are part of that public helper surface:
 
 - `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ...)` renders TreeView's bundled toolbar markup.
+- `tree_view_toolbar_supported_actions` returns the supported toolbar action symbols for app-owned toolbar builders.
 - `tree_view_toolbar_actions(render_state, actions: ..., labels: {})` returns action hashes so the host app can render its own toolbar markup.
 - `tree_view_toolbar_action_metadata(render_state, action, label: nil)` returns metadata for one supported action.
 

--- a/docs/ja/api-overview.md
+++ b/docs/ja/api-overview.md
@@ -223,6 +223,10 @@ records modeでは、親方向のpathを確認するhelperを使えます。
 | `tree_node_dom_id` | `UiConfig` 経由でnode DOM IDを作ります。 |
 | `tree_selection_value` | checkbox value用JSONを作ります。 |
 | `tree_view_breadcrumb` | 祖先pathをbreadcrumbとして描画します。 |
+| `tree_view_toolbar` | TreeView bundled toolbar の HTML を描画します。 |
+| `tree_view_toolbar_supported_actions` | app-owned toolbar builder が使ってよい supported toolbar action symbol を返します。 |
+| `tree_view_toolbar_actions` | host app 側 toolbar markup 用の action hash 配列を返します。 |
+| `tree_view_toolbar_action_metadata` | supported toolbar action 1 件分の metadata を返します。 |
 
 ## JavaScript入口
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -39,6 +39,7 @@ host app が直接使ってよい主な入口は以下です。
 - `tree_view_window(render_state, offset:, limit:)`
 - `tree_view_breadcrumb(tree, item, ...)`
 - `tree_view_toolbar(render_state, ...)`
+- `tree_view_toolbar_supported_actions`
 - `tree_view_toolbar_actions(render_state, ...)`
 - `tree_view_toolbar_action_metadata(render_state, action, ...)`
 
@@ -62,6 +63,7 @@ app-owned toolbar builderでは、internal constantを直接参照せず、`tree
 toolbar helper もこの公開helper surfaceに含まれます。
 
 - `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ...)` は TreeView bundled toolbar の HTML を描画します。
+- `tree_view_toolbar_supported_actions` は app-owned toolbar builder が使ってよい supported toolbar action symbol を返します。
 - `tree_view_toolbar_actions(render_state, actions: ..., labels: {})` は host app が独自 toolbar markup を組み立てるための action hash 配列を返します。
 - `tree_view_toolbar_action_metadata(render_state, action, label: nil)` は 1 つの supported action 用 metadata を返します。
 


### PR DESCRIPTION
## 概要
- `docs/en|ja/public-api.md` の stable public entry points に `tree_view_toolbar_supported_actions` を追加
- `docs/en|ja/public-api.md` の helper surface 説明で、toolbar helper family の役割分担を current implementation に合わせて明文化
- `docs/en|ja/api-overview.md` の public helper entrypoints table に toolbar helper family を追加

## 判定
- classification: `docs-stale`

## 根拠
- current `docs/en|ja/public-api.md` は `tree_view_toolbar_supported_actions` を本文中では案内しているが、stable public entry points の列挙からは漏れていた
- current `docs/en|ja/api-overview.md` の public helper entrypoints table は toolbar helper family を案内していなかった
- `app/helpers/tree_view_helper/toolbar.rb` では `tree_view_toolbar_supported_actions` / `tree_view_toolbar_actions` / `tree_view_toolbar_action_metadata` が current helper surface として実装済みで、runtime 変更なしに docs だけで整合回復できる

## 変更範囲
- `docs/en/public-api.md`
- `docs/ja/public-api.md`
- `docs/en/api-overview.md`
- `docs/ja/api-overview.md`

## 確認観点
- `tree_view_toolbar_supported_actions` が stable public entry points と helper overview の両方で見つかること
- toolbar helper family の説明が `app/helpers/tree_view_helper/toolbar.rb` の current implementation と矛盾しないこと
- runtime code や helper behavior の変更が混ざっていないこと

## テスト
- なし（docs only）

Closes #530