### PR TITLE
docs: Product Profile の maintainer entrypoints を current docs map に揃える

### DIFF
--- a/Product Profile.md
+++ b/Product Profile.md
@@ -18,8 +18,10 @@ When implementation and docs drift, use this order:
 
 1. Current code in `lib/`, `app/helpers/`, `app/views/`, `app/assets/`, and `app/javascript/`
 2. Explicit decisions in the relevant issue and pull request
-3. Durable docs under `docs/en/` and `docs/ja/`
-4. Entry-point summaries in `README.md`, `docs/README.md`, and `AGENTS.md`
+3. Durable docs under `docs/`, especially the relevant guides in `docs/en/` and `docs/ja/`
+4. Entry-point summaries in `README.md`, `docs/README.md`, `AGENTS.md`, and this profile
+
+Treat `CHANGELOG.md` as a release-facing summary of shipped public changes, not as the primary source for current behavior.
 
 ## What TreeView owns
 
@@ -46,12 +48,25 @@ When implementation and docs drift, use this order:
 - A full virtual scrolling engine or host-app query planner
 - Demo app business logic or seed data as part of the gem's public contract
 
+## Maintainer companion docs
+
+Use these durable entry points together when you are checking scope, docs sync, or release-facing changes:
+
+- `AGENTS.md` for repository workflow and documentation update rules
+- `README.md` for public positioning and quick entry points
+- `docs/README.md` for the cross-language docs map and maintainer entry points
+- `docs/en/README.md` or `docs/ja/README.md` for language-specific docs navigation
+- `docs/i18n-audit.md` for cross-language maintenance rules and docs update coverage
+- `CHANGELOG.md` for shipped public changes, compatibility notes, and notable docs additions
+
 ## Recommended first reads
 
 For maintainers making changes, start in this order:
 
 1. `AGENTS.md` for repository-specific workflow and documentation update rules
 2. `README.md` for public positioning and quick entry points
-3. `docs/README.md` for the docs map
-4. `docs/en/README.md` or `docs/ja/README.md` for language-specific docs
+3. `docs/README.md` for the docs map and maintainer entry points
+4. `docs/en/README.md` or `docs/ja/README.md` for language-specific docs navigation
 5. `docs/en/design-policy.md` or `docs/ja/design-policy.md` for responsibility boundaries
+6. `docs/i18n-audit.md` when the task changes public docs or language coverage
+7. `CHANGELOG.md` when the task affects release-facing public behavior or compatibility notes


### PR DESCRIPTION
## 対応 Issue
- Closes #538

## 概要
- `Product Profile.md` の source-of-truth 説明を current docs structure に合わせて整理
- maintainer が併読すべき durable docs と、その役割を `Maintainer companion docs` として明文化
- `Recommended first reads` に `docs/i18n-audit.md` と `CHANGELOG.md` の参照条件を追加し、README / docs index / AGENTS と入口の粒度を揃える

## 判定
- classification: `docs-stale`

## 根拠
- current `README.md` / `docs/README.md` / `docs/en/README.md` / `docs/ja/README.md` / `AGENTS.md` では、maintainer entry points として `docs/i18n-audit.md` や `CHANGELOG.md` まで辿れる
- current `Product Profile.md` は repository positioning と source-of-truth order は持っているが、maintainer が docs sync や release-facing change を見るときの companion docs と first-read order が一段薄かった
- runtime code や public API docs を変更せず、maintainer guidance だけで整合回復できる

## 変更範囲
- `Product Profile.md`

## 受け入れ条件との対応
- [x] `Product Profile.md` 単独でも maintainer が `AGENTS.md` / `README.md` / `docs/README.md` / `docs/i18n-audit.md` / `CHANGELOG.md` へ迷わず辿れる
- [x] `CHANGELOG.md` を current behavior の primary source と誤解させず、release-facing summary として位置付けている
- [x] runtime code や user-facing API docs の変更を含めない
- [x] maintainer entrypoint の整理が `docs/README.md` / `docs/en/README.md` / `docs/ja/README.md` と矛盾しない

## テスト
- なし（docs only）