### PR TITLE
docs: i18n audit の mockup asset inventory を current set に揃える

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -87,6 +87,8 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/README.md` | Technical asset | Index for static mockup assets. Short bilingual-style prose is acceptable; no separate translation needed. |
 | `docs/mockups/review-gallery.html` | Technical asset | Comparison hub for the current static mockup set. No translation needed. |
 | `docs/mockups/default-tree.html` | Technical asset | No translation needed. |
+| `docs/mockups/resource-table-bridge.html` | Technical asset | No translation needed. |
+| `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
@@ -96,4 +98,5 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 
 - Keep `docs/ja/` and `docs/en/` in sync for future user-facing changes.
 - If a temporary mismatch is unavoidable, leave a visible note and plan the follow-up.
+- When `docs/mockups/` gains a new focused reference page, update this technical-assets table and confirm `docs/mockups/README.md` plus `docs/mockups/review-gallery.html` still describe the current set.
 - Prefer updating this checklist by replacement when the maintenance rule changes, instead of stacking stale release-specific notes on top of it.


### PR DESCRIPTION
## 対応 Issue
- Closes #541

## 概要
- `docs/i18n-audit.md` の `Technical assets` table に `resource-table-bridge.html` と `toolbar-actions.html` を追加
- focused mockup reference が増えたときは `docs/mockups/README.md` と `docs/mockups/review-gallery.html` も一緒に見直す maintenance note を追記

## 判定
- classification: `docs-stale`

## 根拠
- current `docs/mockups/README.md` は `resource-table-bridge.html` と `toolbar-actions.html` を focused mockup assets として案内している
- current `docs/mockups/` directory にも両ファイルが存在する
- current `docs/i18n-audit.md` の technical assets inventory には上記 2 ファイルの entry がなく、maintenance checklist が current asset set に追従できていなかった
- runtime code や mockup HTML/CSS を変更せず、docs 1 ファイルだけで整合回復できる

## 変更範囲
- `docs/i18n-audit.md`

## 確認観点
- `docs/i18n-audit.md` から current mockup asset 一覧として `resource-table-bridge.html` と `toolbar-actions.html` を辿れること
- focused mockup asset が増えたときの見直し先として `docs/mockups/README.md` と `docs/mockups/review-gallery.html` が明示されていること
- `docs/mockups/README.md` の current file list / review flow と矛盾しないこと

## テスト
- なし（docs only）