### PR TITLE
docs: Product Profile の release checklist 導線を current docs map に揃える

### DIFF
--- a/Product Profile.md
+++ b/Product Profile.md
@@ -57,6 +57,7 @@ Use these durable entry points together when you are checking scope, docs sync, 
 - `docs/README.md` for the cross-language docs map and maintainer entry points
 - `docs/en/README.md` or `docs/ja/README.md` for language-specific docs navigation
 - `docs/i18n-audit.md` for cross-language maintenance rules and docs update coverage
+- `docs/en/release.md` or `docs/ja/release.md` for release checklist, release consistency checks, and changelog expectations
 - `CHANGELOG.md` for shipped public changes, compatibility notes, and notable docs additions
 
 ## Recommended first reads
@@ -69,4 +70,5 @@ For maintainers making changes, start in this order:
 4. `docs/en/README.md` or `docs/ja/README.md` for language-specific docs navigation
 5. `docs/en/design-policy.md` or `docs/ja/design-policy.md` for responsibility boundaries
 6. `docs/i18n-audit.md` when the task changes public docs or language coverage
-7. `CHANGELOG.md` when the task affects release-facing public behavior or compatibility notes
+7. `docs/en/release.md` or `docs/ja/release.md` when the task affects release-facing docs, compatibility notes, or package verification workflow
+8. `CHANGELOG.md` when the task affects release-facing public behavior or compatibility notes


### PR DESCRIPTION
## 対応内容
- repo sweep で見つけた maintainer docs map の追従漏れを、`Product Profile.md` 1 ファイルで補正しました

## 概要
- `Maintainer companion docs` に `docs/en/release.md` / `docs/ja/release.md` を追加
- `Recommended first reads` に、release-facing docs / compatibility notes / package verification workflow を触るときの release checklist 参照条件を追加
- `CHANGELOG.md` は release-facing summary であり、release checklist そのものではないという current docs map を保ったまま、導線だけを揃えています

## 判定
- classification: `docs-stale`

## 根拠
- `docs/en/README.md` と `docs/ja/README.md` の maintainer table では、release checklist が maintainer entry point として案内されている
- `AGENTS.md` の durable docs list でも `docs/en/release.md` / `docs/ja/release.md` が release checklist として明示されている
- 一方で current `Product Profile.md` は「scope, docs sync, or release-facing changes を見る companion docs」と言いながら、release checklist 自体は companion docs / first reads に含めていなかった
- runtime code、public API docs、release policy そのものは変えず、maintainer entrypoint の docs map だけで整合回復できる

## 変更範囲
- `Product Profile.md`

## 確認観点
- `Product Profile.md` 単独でも、release-facing changes を見る maintainer が release checklist に辿れること
- `README.md` / `docs/README.md` / `docs/en/README.md` / `docs/ja/README.md` / `AGENTS.md` の current maintainer docs map と矛盾しないこと
- release policy の新規作成や user-facing feature docs の変更を含まないこと

## テスト
- なし（docs only）

## 補足
- own open PR の review follow-up を先に確認し、外部 review / review thread / green 待ちコメント付きで優先すべき open PR は見当たりませんでした