### PR TITLE
docs: root docs index の maintainer entry に release checklist を加える

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,8 @@
 
 - [Product Profile](../Product%20Profile.md): repository positioning, source-of-truth order, host app responsibilities, and non-goals.
 - [AGENTS.md](../AGENTS.md): repository-specific maintainer workflow, first-read order, and documentation update rules.
-- [CHANGELOG.md](../CHANGELOG.md): release-facing summary of public changes, compatibility notes, and notable documentation additions.
+- [Release checklist](en/release.md) / [リリースチェックリスト](ja/release.md): release workflow, CI and package verification, and changelog expectations.
+- [CHANGELOG.md](../CHANGELOG.md): release-facing summary of shipped public changes, compatibility notes, and notable documentation additions.
 
 ## Maintenance
 


### PR DESCRIPTION
## 対応 Issue
- Closes #547

## 概要
- `docs/README.md` の `Maintainer entry points` に `docs/en/release.md` / `docs/ja/release.md` を追加
- `docs/README.md` から見たときの maintainer docs map を、`README.md` と `docs/en|ja/README.md` の current entrypoint と揃えました
- `CHANGELOG.md` は shipped public changes の summary、release docs は release workflow / CI / package verification の入口、という役割分担は維持しています

## 判定
- classification: `docs-stale`

## 根拠
- `README.md` の `Key documents` には `Release checklist` が含まれている
- `docs/en/README.md` と `docs/ja/README.md` の maintainer table でも `Release checklist` が entry point として案内されている
- current `docs/README.md` の `Maintainer entry points` は `Product Profile` / `AGENTS.md` / `CHANGELOG.md` までで、release checklist への direct entry が欠けていた
- runtime code、release policy 本文、user-facing feature docs を変えず、root docs index 1 ファイルだけで整合回復できる

## 変更範囲
- `docs/README.md`

## 確認観点
- `docs/README.md` から maintainer が release checklist に直接辿れること
- `README.md` と `docs/en|ja/README.md` の current docs map と矛盾しないこと
- `CHANGELOG.md` と release checklist の役割分担が維持されていること

## テスト
- なし（docs only）

## 補足
- own open PR を先に確認し、review follow-up を優先しましたが、外部 review / review thread / green 待ちコメント付きで先に対応すべき open PR は見当たりませんでした