### PR TITLE
test: 設定ミス時の error message quality を guard する

### DIFF
--- a/docs/en/errors.md
+++ b/docs/en/errors.md
@@ -15,6 +15,18 @@ TreeView exposes a small public error hierarchy for host apps that need to rescu
 
 `TreeView::Error` intentionally inherits from `ArgumentError` for compatibility with existing host apps that already rescue TreeView's previous validation failures as `ArgumentError`.
 
+## Representative messages
+
+These examples show the level of detail host apps should expect from common validation failures:
+
+- `render_scope contains unknown keys: max_depths; supported keys are: max_depth, max_leaf_distance`
+- `initial_state must be one of: expanded, collapsed; use :expanded or :collapsed`
+- `expanded_keys and collapsed_keys cannot include the same keys: "node:1"; remove each key from one side`
+- `duplicate node_key detected: "document:42"; configure node_key_resolver or ensure records expose unique IDs before rendering`
+- `offset must be a non-negative Integer; pass 0 or a positive row offset`
+
+Wording can improve over time, but the same information should remain available: what failed, which value or key is involved, and what direction usually fixes it.
+
 ## Rescue examples
 
 Rescue all TreeView validation/configuration failures:

--- a/docs/ja/errors.md
+++ b/docs/ja/errors.md
@@ -15,6 +15,18 @@ TreeView は、host app が TreeView 由来の失敗を他の application error 
 
 `TreeView::Error` は、既存 host app が TreeView の従来の validation failure を `ArgumentError` として rescue している場合の互換性を保つため、意図的に `ArgumentError` を継承します。
 
+## 代表的な message
+
+次の例は、よくある validation failure で host app が受け取れる message の粒度を示します。
+
+- `render_scope contains unknown keys: max_depths; supported keys are: max_depth, max_leaf_distance`
+- `initial_state must be one of: expanded, collapsed; use :expanded or :collapsed`
+- `expanded_keys and collapsed_keys cannot include the same keys: "node:1"; remove each key from one side`
+- `duplicate node_key detected: "document:42"; configure node_key_resolver or ensure records expose unique IDs before rendering`
+- `offset must be a non-negative Integer; pass 0 or a positive row offset`
+
+文言自体は今後改善されてよいですが、少なくとも「何が失敗したか」「どの値や key が関係しているか」「どう直す方向か」は同じ粒度で読める状態を保つのが方針です。
+
 ## rescue 例
 
 TreeView の validation / configuration failure をまとめて扱う例:

--- a/spec/error_message_quality_spec.rb
+++ b/spec/error_message_quality_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "TreeView error message quality" do
     tree = build_tree([build_node(1)])
 
     expect do
-      build_render_state(tree: tree, render_scope: { max_depths: 2 })
+      build_render_state(tree: tree, render_scope: {max_depths: 2})
     end.to raise_error(
       TreeView::ConfigurationError,
       /render_scope contains unknown keys: max_depths; supported keys are: max_depth, max_leaf_distance/

--- a/spec/error_message_quality_spec.rb
+++ b/spec/error_message_quality_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+TreeViewErrorMessageSpecNode = Struct.new(:id, :parent_id, keyword_init: true)
+
+RSpec.describe "TreeView error message quality" do
+  def build_node(id, parent_id = nil)
+    TreeViewErrorMessageSpecNode.new(id: id, parent_id: parent_id)
+  end
+
+  def build_tree(records, **options)
+    TreeView::Tree.new(records: records, parent_id_method: :parent_id, **options)
+  end
+
+  def ui_config
+    TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "node_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "node_show_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
+    )
+  end
+
+  def build_render_state(tree:, **options)
+    TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "documents/tree_row",
+      ui_config: ui_config,
+      **options
+    )
+  end
+
+  it "describes unknown grouped option keys with supported keys" do
+    tree = build_tree([build_node(1)])
+
+    expect do
+      build_render_state(tree: tree, render_scope: { max_depths: 2 })
+    end.to raise_error(
+      TreeView::ConfigurationError,
+      /render_scope contains unknown keys: max_depths; supported keys are: max_depth, max_leaf_distance/
+    )
+  end
+
+  it "describes invalid enum-like initial_state values with allowed choices" do
+    tree = build_tree([build_node(1)])
+
+    expect do
+      build_render_state(tree: tree, initial_state: :sideways)
+    end.to raise_error(
+      TreeView::ConfigurationError,
+      /initial_state must be one of: expanded, collapsed; use :expanded or :collapsed/
+    )
+  end
+
+  it "describes non-boolean boolean options with a fix direction" do
+    tree = build_tree([build_node(1)])
+
+    expect do
+      build_render_state(tree: tree, auto_expand_ancestors: "yes")
+    end.to raise_error(
+      TreeView::ConfigurationError,
+      /auto_expand_ancestors must be true or false; pass true, false, or nil/
+    )
+  end
+
+  it "describes conflicting expansion keys with the offending key" do
+    tree = build_tree([build_node(1)])
+
+    expect do
+      build_render_state(tree: tree, expanded_keys: ["node:1"], collapsed_keys: ["node:1"])
+    end.to raise_error(
+      TreeView::ConfigurationError,
+      /expanded_keys and collapsed_keys cannot include the same keys: "node:1"; remove each key from one side/
+    )
+  end
+
+  it "describes non-callable builders with the expected contract" do
+    expect do
+      build_tree([build_node(1)], sorter: Object.new)
+    end.to raise_error(
+      TreeView::ConfigurationError,
+      /sorter must respond to call; pass a callable such as ->\(items, tree\) \{ items \}/
+    )
+  end
+
+  it "describes invalid orphan strategies with allowed values" do
+    expect do
+      build_tree([build_node(1)], orphan_strategy: :lift)
+    end.to raise_error(
+      TreeView::ConfigurationError,
+      /orphan_strategy must be one of: ignore, as_root, raise, orphans_only; choose how records with missing parents should be handled/
+    )
+  end
+
+  it "describes duplicate node keys with the offending key and next step" do
+    tree = build_tree([build_node(1), build_node(1)])
+
+    expect do
+      tree.validate_unique_node_keys!
+    end.to raise_error(
+      TreeView::DuplicateNodeKeyError,
+      /duplicate node_key detected: 1; configure node_key_resolver or ensure records expose unique IDs before rendering/
+    )
+  end
+
+  it "describes invalid render-window offsets with the valid range" do
+    expect do
+      TreeView::RenderWindow.new([], offset: -1, limit: 10)
+    end.to raise_error(
+      TreeView::InvalidRenderWindowError,
+      /offset must be a non-negative Integer; pass 0 or a positive row offset/
+    )
+  end
+
+  it "describes invalid render-window limits with the expected meaning" do
+    expect do
+      TreeView::RenderWindow.new([], offset: 0, limit: 0)
+    end.to raise_error(
+      TreeView::InvalidRenderWindowError,
+      /limit must be a positive Integer; pass the maximum number of rows to render/
+    )
+  end
+end


### PR DESCRIPTION
## 対応 Issue
- Closes #366

## Issue ごとの完了内容
- #366
  - 代表的な configuration / validation failure の message を spec で固定しました
  - docs の error hierarchy に representative message 例を追加し、host app が期待すべき情報粒度を明文化しました

## 変更内容
- `spec/error_message_quality_spec.rb`
  - grouped option unknown key
  - invalid `initial_state`
  - non-boolean `auto_expand_ancestors`
  - conflicting `expanded_keys` / `collapsed_keys`
  - non-callable sorter
  - invalid `orphan_strategy`
  - duplicate node key
  - invalid render-window `offset` / `limit`
  の representative message quality を guard
- `docs/en/errors.md`
- `docs/ja/errors.md`
  - representative message 例と、今後も残すべき情報粒度を追記

## 改善カテゴリ
- test 追加・改善
- docs 改善

## 既存仕様への影響
- なし
- validation rule 自体や public API の動作は変えていません
- 既存の failure が、修正判断に必要な情報を落とさないように spec と docs を追加しただけです

## 実施した確認
- own open PR の review follow-up を先に確認し、今回優先すべき external follow-up はありませんでした
- current `main` から診断系の代表 failure source を確認し、変更を spec / docs に閉じました

## 実行できなかった確認
- この環境では GitHub への通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル `bundle exec rspec` は未実施です
- 最終確認は PR CI 前提です

## リスク評価
- medium
- message wording を固定しすぎないよう全文一致ではなく必要情報の粒度に寄せています

## 補足事項
- docs の example は representative sample であり、将来 wording を改善しても同じ情報が読めることを優先します