### PR TITLE
docs: docs index の maintainer entry points を current docs map に揃える

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,12 @@
 
 - [Product Profile](../Product%20Profile.md): repository positioning, source-of-truth order, host app responsibilities, and non-goals.
 - [AGENTS.md](../AGENTS.md): repository-specific maintainer workflow, first-read order, and documentation update rules.
+- [Documentation maintenance checklist](i18n-audit.md): language-sync rules, technical-asset inventory, and cross-language update coverage.
+- [Public API](en/public-api.md) / [公開 API](ja/public-api.md): compatibility contract and the surfaces host apps may use directly.
+- [Migration guide](en/migration.md) / [移行ガイド](ja/migration.md): upgrade expectations, deprecations, and release-note reading order.
+- [Design policy](en/design-policy.md) / [設計思想と責務範囲](ja/design-policy.md): repository scope, responsibility boundaries, and non-goals.
+- [Development](en/development.md) / [開発・保守方針](ja/development.md): CI, local checks, documentation update workflow, and maintenance habits.
+- [Code quality](en/code-quality.md) / [コード品質](ja/code-quality.md): lint, tests, error message quality, and documentation quality policy.
 - [Release checklist](en/release.md) / [リリースチェックリスト](ja/release.md): release workflow, CI and package verification, and changelog expectations.
 - [CHANGELOG.md](../CHANGELOG.md): release-facing summary of shipped public changes, compatibility notes, and notable documentation additions.
 
@@ -46,4 +52,4 @@ Documentation language-sync rules and ongoing maintenance checks are tracked in 
 - `docs/ja/` は日本語ドキュメントです。日本語側の内容がより充実している間は、主なcanonical sourceとして扱います。
 - `docs/en/` は英語ドキュメントです。
 - root直下のdocsは、意図した入口、保守メモ、technical asset に限定します。
-- 利用者向けdocsを新規追加または大きく更新する場合は、可能な限り `docs/ja/` と `docs/en/` の両方に追加します。
+- 利用者向けdocsを新規追加または大きく更新する場合は、可能な限り `docs/ja/` と `docs/en/` の両方に追加します.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,4 +52,4 @@ Documentation language-sync rules and ongoing maintenance checks are tracked in 
 - `docs/ja/` は日本語ドキュメントです。日本語側の内容がより充実している間は、主なcanonical sourceとして扱います。
 - `docs/en/` は英語ドキュメントです。
 - root直下のdocsは、意図した入口、保守メモ、technical asset に限定します。
-- 利用者向けdocsを新規追加または大きく更新する場合は、可能な限り `docs/ja/` と `docs/en/` の両方に追加します.
+- 利用者向けdocsを新規追加または大きく更新する場合は、可能な限り `docs/ja/` と `docs/en/` の両方に追加します。


### PR DESCRIPTION
## 対応 Issue
- Closes #554

## 概要
- `docs/README.md` の `Maintainer entry points` に、language-specific README と `Product Profile.md` が前提にしている durable maintainer docs への最短導線を追加しました
- `Public API`、`Migration guide`、`Design policy`、`Development`、`Code quality` に加えて、`Documentation maintenance checklist` も maintainer entry point として明示しました
- root docs index の役割は維持しつつ、`docs/en/README.md` / `docs/ja/README.md` を経由しなくても主要 maintainer docs へ辿れるようにしています

## 判定
- classification: `docs-stale`

## 根拠
- current `docs/README.md` は maintainer entry point を名乗っている一方、`docs/en/README.md` / `docs/ja/README.md` の保守者向け table にある durable docs への入口が不足していました
- `Product Profile.md` の companion docs / recommended first reads でも、`docs/i18n-audit.md` や design / release-facing docs を maintainer の durable entry point として扱っています
- 追加したのは既存 docs へのリンクだけで、runtime code・public contract・language-specific docs 本文は変更していません

## 変更範囲
- `docs/README.md`

## 確認観点
- `docs/README.md` から `docs/en|ja/README.md` を経由せずに主要 maintainer docs へ辿れること
- `docs/en/README.md` / `docs/ja/README.md` の保守者向け map と大きく矛盾しないこと
- `Product Profile.md` の first-read order と逆向きの案内になっていないこと

## テスト
- なし（docs only）

## 補足
- own open PR の review follow-up を先に確認しました。PR `#543` には `review:changes-requested` が残っていますが、release check 実装への code follow-up であり docs-only scope では完結しないため、今回の docs sync とは切り分けています
- open docs PR `#552` も `docs/README.md` を触っていますが、そちらは visual-reference 導線、こちらは maintainer entry points の追従で diff hunk が分かれているため別 PR にしています