### PR TITLE
docs: review gallery に focused mockup cards を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -10,7 +10,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 | File | Covers |
 |---|---|
-| [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the default, narrow, interaction, and empty-state mockups, with embedded previews and links to each full reference page. |
+| [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the current baseline and focused mockup references, with embedded previews and links to each full page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
@@ -21,7 +21,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 ## Recommended review flow
 
-1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the main mockup surfaces.
+1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the current mockup set.
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 4. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -118,15 +118,15 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>TreeView mockup review gallery</h1>
       <p>
-        Static review hub for comparing the main TreeView mockups without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, and empty-state spacing in one session.
+        Static review hub for comparing the current TreeView mockup set without running a Rails app.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
     </header>
 
     <section class="mock-section" aria-labelledby="gallery-usage-heading">
       <h2 id="gallery-usage-heading">How to use this gallery</h2>
       <ul>
-        <li>Start here when a review needs quick side-by-side comparison across the main mockup surfaces.</li>
+        <li>Start here when a review needs quick side-by-side comparison across the baseline and focused mockup surfaces.</li>
         <li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li>
         <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li>
       </ul>
@@ -151,6 +151,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused integration</p>
+          <h2 id="gallery-bridge-heading">Resource table bridge</h2>
+          <p>
+            Use this surface when review needs tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Shared desktop and compact column sets</li>
+            <li>Hierarchy readability in the first data column</li>
+            <li>Clear table-versus-tree responsibility boundary</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="resource-table-bridge.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -196,6 +217,27 @@
         </div>
       </article>
 
+      <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused controls</p>
+          <h2 id="gallery-toolbar-heading">Toolbar actions</h2>
+          <p>
+            Use this surface to compare tree-wide expand and collapse affordances, including enabled, current, and disabled states, without adding real routes or authorization copy.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Mixed-tree dual-action state</li>
+            <li>All-expanded and all-collapsed variants</li>
+            <li>Current and disabled affordance cues</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="toolbar-actions.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
       <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading">
         <div class="mock-gallery-copy">
           <p class="mock-gallery-eyebrow">Spacing and fallback</p>
@@ -235,6 +277,11 @@
             <td>Host-app CRUD, queries, business labels, or authorization behavior.</td>
           </tr>
           <tr>
+            <td>Resource table bridge</td>
+            <td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td>
+            <td>Saved table state, host-app queries, or business-specific row actions.</td>
+          </tr>
+          <tr>
             <td>Narrow sidebar</td>
             <td>Hierarchy readability when width shrinks and metadata needs to wrap.</td>
             <td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td>
@@ -243,6 +290,11 @@
             <td>Interaction states</td>
             <td>Loading, retry, pagination, and drag or drop status cues.</td>
             <td>Real Turbo responses, route wiring, or persistence behavior.</td>
+          </tr>
+          <tr>
+            <td>Toolbar actions</td>
+            <td>Tree-wide expand and collapse affordances across enabled, current, and disabled states.</td>
+            <td>Authorization, route names, or action sequencing rules.</td>
           </tr>
           <tr>
             <td>Empty state</td>


### PR DESCRIPTION
## 対応Issue

- Closes #550

## 採用した方針

- スケジュール実行のため、既存 `review-gallery.html` の比較ハブ構成を保ったまま、`resource-table-bridge.html` と `toolbar-actions.html` を first-screen から辿れるようにする low-risk 案を採用しました。
- 個別 mockup の再設計や gallery 全面刷新には広げず、比較カードと index wording の整合だけに閉じています。

## 比較した案

- 案A: `review-gallery.html` に focused mockup cards を追加し、`docs/mockups/README.md` の説明だけ最小追従する。
- 案B: gallery は触らず、README 導線だけで focused pages の存在を補う。
- 案C: gallery の layout / framing を広く組み替えて、baseline と focused surfaces の見せ方を再設計する。

## 変更内容

- `docs/mockups/review-gallery.html`
  - `resource-table-bridge.html` と `toolbar-actions.html` の比較カードを追加
  - gallery intro / usage copy / comparison cues table を current mockup set に合わせて更新
- `docs/mockups/README.md`
  - `review-gallery.html` の説明を current baseline + focused references 前提に更新
  - recommended review flow の first look 説明を gallery 拡張に合わせて更新

## 変更した画面・コンポーネント

- static mockup review hub (`docs/mockups/review-gallery.html`)
- mockup index (`docs/mockups/README.md`)

## 確認内容

- lint: 未実施（docs / static HTML only）
- typecheck: 該当なし
- UI表示確認: compare `main...design/550-review-gallery-focused-cards` で差分が 2 files に閉じていることを確認
- レスポンシブ確認: 既存 gallery grid / iframe min-height の範囲内で cards を追加し、layout rule を増やしていないことを確認
- アクセシビリティ確認: 新規 card preview iframe に title を付け、既存 section / table semantics に合わせて追加していることを確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- static mockup hub と index wording の更新だけで、個別 mockup asset や runtime behavior には触れていません

## 補足

- `docs/mockups/README.md` と `docs/i18n-audit.md` が already 扱っている current technical asset set に、review hub 側を追従させる変更です
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や browser 確認は未実施です