### PR TITLE
docs: AGENTS の CI ガイダンスを現行 PR lanes に合わせる

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm test
+npm run test:entrypoints
 npm run test:browser
 ```
 
@@ -122,8 +123,10 @@ GitHub Actions runs the following on pull requests:
 
 - `bundle exec standardrb`
 - `bundle exec rspec`
-- representative Rails compatibility checks via `gemfiles/rails_7_0.gemfile` and `gemfiles/rails_8_0.gemfile`
+- representative Rails compatibility checks via `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - `npm run test:js`
+
+Docs-only pull requests that touch only `README.md` and `docs/**` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
 
 Pushes to `main` also run the broader compatibility and release checks:
 


### PR DESCRIPTION
## 概要
- `AGENTS.md` の Testing セクションを current maintainer docs と CI 実行結果に合わせて更新しました
- 実装変更時に案内する JavaScript コマンドへ `npm run test:entrypoints` を追加しました
- PR CI の representative Rails lane に `gemfiles/rails_7_2.gemfile` を含め、docs-only PR の short-circuit policy を追記しました

## 判定
- classification: `docs-stale`
- classification: `docs-sync`

## 根拠
- current `docs/en/development.md` / `docs/ja/development.md` は実装変更時の確認コマンドとして `npm run test:entrypoints` を含めています
- current CI run #801 (`AGENTS.md` の docs-only branch に相当する PR check) では `pr_rails_matrix (7.0, gemfiles/rails_7_0.gemfile, 3.2)`、`pr_rails_matrix (7.2, gemfiles/rails_7_2.gemfile, 3.2)`、`pr_rails_matrix (8.0, gemfiles/rails_8_0.gemfile, 3.3)` が同じ check 名のまま docs-only short-circuit されています
- current `AGENTS.md` は representative Rails compatibility checks を 7.0 / 8.0 のみとしており、docs-only PR の short-circuit policy も案内していませんでした

## 変更範囲
- `AGENTS.md`

## 確認観点
- maintainer が `AGENTS.md` だけ読んでも current PR CI lanes と docs-only shortcut policy を誤解しないこと
- `docs/en/development.md` / `docs/ja/development.md` と CI 実行結果の説明順に矛盾がないこと

## テスト
- なし（docs only）

## 補足
- 新規 docs sweep 前に own open PR を確認し、review follow-up を優先すべき open docs PR は見当たりませんでした
- repository clone はこの環境で `CONNECT tunnel failed, response 403` になるため、確認は GitHub 上の current docs / workflow run jobs ベースで行っています