### PR TITLE
design: add lightweight return nav to focused mockups

### DIFF
--- a/docs/mockups/default-tree.css
+++ b/docs/mockups/default-tree.css
@@ -40,6 +40,37 @@ h2 {
   margin-top: 0;
 }
 
+.mock-return-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 0 0 20px;
+}
+
+.mock-return-nav__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.2rem;
+  padding: 0.4rem 0.8rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-return-nav__link:hover,
+.mock-return-nav__link:focus {
+  background: #eff6ff;
+  text-decoration: none;
+}
+
+.mock-return-nav__link--secondary {
+  color: #334155;
+}
+
 .tree-view-table {
   min-width: 100%;
   width: 100%;

--- a/docs/mockups/default-tree.html
+++ b/docs/mockups/default-tree.html
@@ -17,6 +17,11 @@
       </p>
     </header>
 
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
     <section class="mock-section" aria-labelledby="static-tree-heading">
       <h2 id="static-tree-heading">Standard table structure</h2>
       <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">

--- a/docs/mockups/empty-state.html
+++ b/docs/mockups/empty-state.html
@@ -19,6 +19,11 @@
       </p>
     </header>
 
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
     <section class="mock-section" aria-labelledby="no-root-items-heading">
       <h2 id="no-root-items-heading">No root items</h2>
       <p class="mock-empty-note">

--- a/docs/mockups/interaction-states.html
+++ b/docs/mockups/interaction-states.html
@@ -17,6 +17,11 @@
       </p>
     </header>
 
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
     <section class="mock-section" aria-labelledby="lazy-heading">
       <h2 id="lazy-heading">Lazy loading and retry states</h2>
       <table class="tree-view-table" data-controller="tree-view-state tree-view-remote-state">

--- a/docs/mockups/narrow-sidebar-tree.html
+++ b/docs/mockups/narrow-sidebar-tree.html
@@ -17,6 +17,11 @@
       </p>
     </header>
 
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
     <section class="mock-section" aria-labelledby="sidebar-width-heading">
       <h2 id="sidebar-width-heading">22rem sidebar frame</h2>
       <p class="mock-narrow-note">

--- a/docs/mockups/resource-table-bridge.html
+++ b/docs/mockups/resource-table-bridge.html
@@ -186,6 +186,11 @@
       </p>
     </header>
 
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
     <section class="mock-section mock-bridge-grid" aria-labelledby="bridge-principles-heading">
       <div>
         <h2 id="bridge-principles-heading">Bridge responsibilities at a glance</h2>

--- a/docs/mockups/toolbar-actions.html
+++ b/docs/mockups/toolbar-actions.html
@@ -245,6 +245,11 @@
       </p>
     </header>
 
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
     <section class="mock-section mock-toolbar-grid" aria-labelledby="toolbar-overview-heading">
       <div class="mock-toolbar-surface">
         <div>


### PR DESCRIPTION
## 対応Issue

- Closes #562

## 採用した方針

- スケジュール実行のため、`review-gallery.html` を俯瞰ハブとして保ったまま、6つの focused mockup page 冒頭に shared CSS ベースの軽量 return nav を追加する low-risk 案を採用しました。
- gallery 本体や README の review flow を作り替えるのではなく、`default-tree.css` と各 focused page の先頭差分に閉じて、単独で開いたときの戻り導線だけを補っています。

## 比較した案

- 案A: 各 focused page 冒頭に `review-gallery.html` と `docs/mockups/README.md` へ戻る共通 nav を追加する。
- 案B: `review-gallery.html` 側を再構成し、focused page への往復導線も gallery 内の説明やカード構成で吸収する。
- 案C: `README.md` の review flow だけを厚くして、個別 page 自体は触らない。
- 今回は案Aを採用しました。Issue #562 の受け入れ条件を最小差分で満たせて、mockup 本文への視線干渉も抑えやすいためです。

## 変更内容

- `docs/mockups/default-tree.css`
  - shared return nav の pill-style link を追加
  - narrow width でも折り返せる軽量レイアウトに調整
- `docs/mockups/default-tree.html`
- `docs/mockups/resource-table-bridge.html`
- `docs/mockups/toolbar-actions.html`
- `docs/mockups/narrow-sidebar-tree.html`
- `docs/mockups/interaction-states.html`
- `docs/mockups/empty-state.html`
  - 各 page の header 直後に `review-gallery.html` と `README.md` へ戻る共通 nav を追加

## 変更した画面・コンポーネント

- focused mockup pages
- shared mockup CSS (`default-tree.css`)

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: `main...design/562-mockup-return-nav-main-current` compare で差分が mockup HTML 6 files と shared CSS 1 file に閉じていることを確認
- レスポンシブ確認: return nav は `flex-wrap` 前提で narrow width でも折り返せるようにしている
- アクセシビリティ確認: nav に `aria-label` を付け、リンク文言だけで戻り先が分かることを確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- static HTML/CSS に閉じた変更で、mockup policy・host-app responsibility・review-gallery の役割分担は維持しています

## 補足

- この環境では GitHub への通常 clone が `CONNECT tunnel failed, response 403` で使えないため、確認は GitHub 上の file diff / compare ベースです
- branch は current `main` と file-level conflict は見えていませんが、base 作成後に `main` が 1 commit 進んでいるため、最終 mergeability は PR 上で再確認をお願いします