### PR TITLE
docs: add entry-point nav to mockup review gallery

### DIFF
--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -10,6 +10,31 @@
   max-width: 1320px;
 }
 
+.mock-gallery-return-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.mock-gallery-return-nav a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #0f172a;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-gallery-return-nav a:hover,
+.mock-gallery-return-nav a:focus {
+  border-color: #1d4ed8;
+  color: #1d4ed8;
+}
+
 .mock-gallery-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -121,6 +146,10 @@
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
         Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
+      <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
+        <a href="README.md">Back to mockup README</a>
+        <a href="../README.md">Open docs index</a>
+      </nav>
     </header>
 
     <section class="mock-section" aria-labelledby="gallery-usage-heading">


### PR DESCRIPTION
## 対応Issue

- Closes #571

## 判定

- classification: `docs-stale`
- classification: `docs-sync`

## 根拠

- current `docs/mockups/README.md` は `review-gallery.html` を mockup family の first-look hub として案内している
- current `review-gallery.html` からは full mockup pages へ移動できる一方で、`docs/mockups/README.md` や `docs/README.md` へ戻る明示的な導線が無かった
- focused pages 側には PR #569 で gallery / mockup index へ戻る導線が追加されており、hub 側だけ reverse direction が薄い状態だった

## 変更内容

- `docs/mockups/review-gallery.html`
  - header 直下に `docs/mockups/README.md` へ戻る lightweight nav を追加
  - あわせて `docs/README.md` へ戻る docs entry-point link を追加
  - gallery の比較ハブとしての本文構成や各 mockup card / iframe は変更していない

## 確認観点

- gallery を単独で開いた reviewer が mockup policy と上位 docs map へすぐ戻れること
- static mockup / product-neutral policy を壊していないこと
- 差分が `docs/mockups/review-gallery.html` 1 ファイルに閉じていること

## テスト

- なし（docs/static HTML only）

## リスク

- low
- static HTML 内の導線追加だけで、mockup 本文・host-app responsibility・review flow の役割分担は維持している

## 補足

- この環境では GitHub への通常 clone が `CONNECT tunnel failed, response 403` で使えないため、確認は GitHub 上の current docs と compare ベースで行っています