### PR TITLE
docs: release checklist の CI lane 説明を現行 workflow に合わせる

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -65,7 +65,7 @@ Pull request CI checks:
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
-- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile` and `gemfiles/rails_8_0.gemfile`
+- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - JavaScript tests through `npm install`, Playwright browser setup, and `npm run test:js`
 
 Main-push CI checks:

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -65,7 +65,7 @@ Pull Request CI の確認項目:
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
-- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile` と `gemfiles/rails_8_0.gemfile`
+- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
 - JavaScript tests: `npm install`、Playwright browser setup、`npm run test:js`
 
 `main` push CI の確認項目:


### PR DESCRIPTION
Superseded by #575 after `main` advanced with unrelated mockup-doc commits.

The replacement PR carries the same release-checklist wording update on top of current `main` so reviewers can read a clean docs-only diff.