### PR TITLE
docs: release checklist の CI lane 説明を現行 workflow に合わせる

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -65,7 +65,7 @@ Pull request CI checks:
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
-- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile` and `gemfiles/rails_8_0.gemfile`
+- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - JavaScript tests through `npm install`, Playwright browser setup, and `npm run test:js`
 
 Main-push CI checks:

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -65,7 +65,7 @@ Pull Request CI の確認項目:
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
-- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile` と `gemfiles/rails_8_0.gemfile`
+- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
 - JavaScript tests: `npm install`、Playwright browser setup、`npm run test:js`
 
 `main` push CI の確認項目:


### PR DESCRIPTION
## 概要
- `docs/en/release.md` と `docs/ja/release.md` の PR CI 説明を current workflow に合わせて更新しました
- representative Rails compatibility checks に `gemfiles/rails_7_2.gemfile` を追加し、`AGENTS.md` / `docs/en/development.md` / `docs/ja/development.md` / `.github/workflows/ci.yml` と説明をそろえました

## 判定
- classification: `docs-stale`
- classification: `docs-sync`

## 根拠
- current `.github/workflows/ci.yml` の `pr_rails_matrix` は `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile` を representative Rails lane として実行しています
- current `AGENTS.md` と `docs/en/development.md` / `docs/ja/development.md` はすでに 7.0 / 7.2 / 8.0 の current PR lanes を案内しています
- 一方で current `docs/en/release.md` / `docs/ja/release.md` だけは representative Rails compatibility checks を 7.0 / 8.0 のまま説明していました

## 変更内容
- `docs/en/release.md`
  - PR CI の representative Rails compatibility checks を 7.0 / 7.2 / 8.0 に更新
- `docs/ja/release.md`
  - 同じ説明を日本語側にも反映

## 確認観点
- release checklist を読んだ maintainer が current PR CI lane を誤解しないこと
- `AGENTS.md`、development docs、workflow 定義との説明が一致していること
- 差分が release-facing docs 2 ファイルに閉じていること

## テスト
- なし（docs only）

## 補足
- 新規 docs sweep 前に own open PR を確認し、review follow-up を優先すべき open PR は見当たりませんでした
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、確認は GitHub 上の current docs と workflow 定義ベースで行っています