### PR TITLE
design: add filtered tree modes focused mockup

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -13,9 +13,10 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the current baseline and focused mockup references, with embedded previews and links to each full page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
-| [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
+| [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
 
@@ -24,8 +25,10 @@ They are **not** a complete Rails application and should not grow into host-app 
 1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the current mockup set.
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-4. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-5. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+5. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+6. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+7. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/filtered-tree-modes.html
+++ b/docs/mockups/filtered-tree-modes.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView filtered tree modes mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-filtered-page {
+  max-width: 1240px;
+}
+
+.mock-filtered-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-filtered-state {
+  display: grid;
+  gap: 16px;
+}
+
+.mock-filtered-state__header {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-filtered-state__eyebrow {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-filtered-note {
+  margin: 0;
+  color: #52606d;
+}
+
+.mock-filtered-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-filtered-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-filtered-toolbar__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.mock-filtered-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-filtered-toolbar__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-filtered-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0f4c81;
+  font-size: 0.79rem;
+  font-weight: 700;
+}
+
+.mock-filtered-chip--mode {
+  background: #e9ecef;
+  color: #334155;
+}
+
+.mock-filtered-summary {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  background: #fff;
+}
+
+.mock-filtered-summary ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.mock-filtered-callout {
+  margin: 0;
+  padding: 0.8rem 0.95rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.tree-row.is-match {
+  background: #ecfdf5;
+}
+
+.tree-row.is-context {
+  background: #fffaf0;
+}
+
+.tree-row.is-descendant {
+  background: #eef2ff;
+}
+
+.tree-node-badge--match {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.tree-node-badge--context {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.tree-node-badge--descendant {
+  background: #e0e7ff;
+  color: #4338ca;
+}
+
+.mock-filtered-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-filtered-table th,
+.mock-filtered-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-filtered-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-filtered-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Filtered tree modes mock</h1>
+      <p>
+        Static reference for comparing how filtered trees keep only matches, matches with ancestors,
+        or matches with descendants. The page stays focused on reusable TreeView output and keeps
+        search forms, ranking, highlighting, and authorization copy outside the mock.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-filtered-grid" aria-labelledby="filtered-modes-heading">
+      <div class="mock-filtered-state">
+        <div class="mock-filtered-state__header">
+          <p class="mock-filtered-state__eyebrow">Mode A</p>
+          <h2 id="filtered-modes-heading">Matched only</h2>
+          <p class="mock-filtered-note">
+            Use this when the host app wants the narrowest result set and does not need surrounding hierarchy for review.
+          </p>
+        </div>
+
+        <div class="mock-filtered-frame">
+          <div class="mock-filtered-toolbar">
+            <div class="mock-filtered-toolbar__copy">
+              <p class="mock-filtered-toolbar__title">Only the matched node stays visible</p>
+            </div>
+            <div class="mock-filtered-toolbar__meta" aria-label="Representative filter context">
+              <span class="mock-filtered-chip">query: billing</span>
+              <span class="mock-filtered-chip mock-filtered-chip--mode">mode: matched_only</span>
+            </div>
+          </div>
+          <div class="mock-filtered-summary">
+            <p class="mock-filtered-callout">
+              TreeView keeps the matching row itself. Any explanation of why it matched or how to refine the query stays in the host app.
+            </p>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">owner</th>
+                  <th scope="col">state</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-match" aria-level="1">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Matched node">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">leaf</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--match">match</span>
+                  </td>
+                  <td>Billing reports</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status mock-status--active">matched</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-filtered-state">
+        <div class="mock-filtered-state__header">
+          <p class="mock-filtered-state__eyebrow">Mode B</p>
+          <h2>Matched with ancestors</h2>
+          <p class="mock-filtered-note">
+            Use this when reviewers need the path back to the root so the matching result keeps its hierarchy context.
+          </p>
+        </div>
+
+        <div class="mock-filtered-frame">
+          <div class="mock-filtered-toolbar">
+            <div class="mock-filtered-toolbar__copy">
+              <p class="mock-filtered-toolbar__title">Matched node plus the path that leads to it</p>
+            </div>
+            <div class="mock-filtered-toolbar__meta" aria-label="Representative filter context">
+              <span class="mock-filtered-chip">query: billing</span>
+              <span class="mock-filtered-chip mock-filtered-chip--mode">mode: with_ancestors</span>
+            </div>
+          </div>
+          <div class="mock-filtered-summary">
+            <p class="mock-filtered-callout">
+              Ancestors remain visible so the host app can show where the result lives, but the mock still avoids highlighting or ranked result copy.
+            </p>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">owner</th>
+                  <th scope="col">state</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-context" aria-level="1">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Ancestor node">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-toggle__action tree-toggle__action--pending">open</span>
+                        <span class="tree-toggle__level">root</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--context">ancestor</span>
+                  </td>
+                  <td>Operations</td>
+                  <td>Platform</td>
+                  <td><span class="mock-status mock-status--pending">context</span></td>
+                </tr>
+                <tr class="tree-row is-match" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Matched node with ancestor">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-last"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--match">match</span>
+                  </td>
+                  <td>Billing reports</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status mock-status--active">matched</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-filtered-state">
+        <div class="mock-filtered-state__header">
+          <p class="mock-filtered-state__eyebrow">Mode C</p>
+          <h2>Matched with descendants</h2>
+          <p class="mock-filtered-note">
+            Use this when the host app wants the matching parent to stay visible together with its visible children or follow-on rows.
+          </p>
+        </div>
+
+        <div class="mock-filtered-frame">
+          <div class="mock-filtered-toolbar">
+            <div class="mock-filtered-toolbar__copy">
+              <p class="mock-filtered-toolbar__title">Matched parent plus the rows underneath it</p>
+            </div>
+            <div class="mock-filtered-toolbar__meta" aria-label="Representative filter context">
+              <span class="mock-filtered-chip">query: billing</span>
+              <span class="mock-filtered-chip mock-filtered-chip--mode">mode: with_descendants</span>
+            </div>
+          </div>
+          <div class="mock-filtered-summary">
+            <p class="mock-filtered-callout">
+              Descendants stay visible after the match so reviewers can inspect downstream rows, while sort order and query semantics remain host-app choices.
+            </p>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">owner</th>
+                  <th scope="col">state</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-match" aria-level="1">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Matched parent node">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-toggle__action tree-toggle__action--pending">open</span>
+                        <span class="tree-toggle__level">root</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--match">match</span>
+                  </td>
+                  <td>Billing</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status mock-status--active">matched</span></td>
+                </tr>
+                <tr class="tree-row is-descendant" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Descendant node">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--descendant">descendant</span>
+                  </td>
+                  <td>Invoices</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr class="tree-row is-descendant" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Descendant node">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-last"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--descendant">descendant</span>
+                  </td>
+                  <td>Refund queue</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="filtered-boundary-heading">
+      <h2 id="filtered-boundary-heading">What this mock compares</h2>
+      <table class="mock-filtered-table">
+        <thead>
+          <tr>
+            <th scope="col">Mode</th>
+            <th scope="col">Best for</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>:matched_only</code></td>
+            <td>The tightest result set when only the matched row itself should remain visible.</td>
+            <td>Result ranking, highlighting, and final search-result messaging.</td>
+          </tr>
+          <tr>
+            <td><code>:with_ancestors</code></td>
+            <td>Keeping the path back to the root visible for hierarchy review.</td>
+            <td>Authorization, breadcrumb wording, and query explanations.</td>
+          </tr>
+          <tr>
+            <td><code>:with_descendants</code></td>
+            <td>Keeping a matched parent together with visible rows beneath it.</td>
+            <td>Downstream sorting rules, pagination, or fetch behavior.</td>
+          </tr>
+        </tbody>
+      </table>
+      <ul>
+        <li><code>:with_ancestors_and_descendants</code> remains part of the documented API and can combine these cues in a host app.</li>
+        <li>This focused page keeps the minimum comparison set narrow so reviewers can inspect mode differences without extra product behavior.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -246,6 +246,27 @@
         </div>
       </article>
 
+      <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused filtering</p>
+          <h2 id="gallery-filtered-heading">Filtered tree modes</h2>
+          <p>
+            Use this surface to compare how `filtered_tree_for` keeps only matches, matches with ancestors, or matches with descendants without adding host-app search UI.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Matched-only versus ancestor or descendant context</li>
+            <li>Representative mode framing without highlighting</li>
+            <li>Clear boundary between TreeView output and host-app search behavior</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="filtered-tree-modes.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
         <div class="mock-gallery-copy">
           <p class="mock-gallery-eyebrow">Focused controls</p>
@@ -319,6 +340,11 @@
             <td>Interaction states</td>
             <td>Loading, retry, pagination, and drag or drop status cues.</td>
             <td>Real Turbo responses, route wiring, or persistence behavior.</td>
+          </tr>
+          <tr>
+            <td>Filtered tree modes</td>
+            <td>Comparing matched-only, ancestor-retaining, and descendant-retaining output.</td>
+            <td>Search forms, highlighting, ranking, and authorization-aware filtering.</td>
           </tr>
           <tr>
             <td>Toolbar actions</td>


### PR DESCRIPTION
## 対応Issue

- Closes #577

## 採用した方針

- スケジュール実行のため、`filtered_tree_for` の mode 差分を static mockup 1 面で比較できる low-risk 案を採用しました。
- `docs/en|ja/filtered-trees.md` を source of truth にしつつ、runtime filtering 実装や search UI には広げず、`docs/mockups/` 配下の focused page と最小限の導線更新だけに閉じています。

## 比較した案

- 案A: `docs/mockups/filtered-tree-modes.html` を追加し、`matched_only` / `with_ancestors` / `with_descendants` を静的比較できるようにする。
- 案B: `interaction-states.html` や `empty-state.html` に filtered-tree mode の説明を追記して済ませる。
- 案C: real search form や highlighting 風 UI まで足して filtered experience 全体を mockup 化する。
- 今回は案Aを採用しました。Issue #577 の受け入れ条件を最小差分で満たせて、TreeView 側の reusable output と host-app responsibility の境界も崩さずに済むためです。

## 変更内容

- `docs/mockups/filtered-tree-modes.html`
  - 新しい focused mockup page を追加
  - `matched_only`、`with_ancestors`、`with_descendants` の representative state を比較できる static surface を追加
  - `:with_ancestors_and_descendants` は docs 上の contract として補足だけを残し、比較面は最低限の 3 mode に絞りました
- `docs/mockups/README.md`
  - file table に filtered-tree focused page を追加
  - recommended review flow に filtered-tree mode comparison の使い分けを追記
- `docs/mockups/review-gallery.html`
  - filtered-tree mode comparison 用の gallery card を追加
  - comparison cues table に filtered-tree surface の役割を追加

## 変更した画面・コンポーネント

- TreeView mockups index (`docs/mockups/README.md`)
- TreeView mockup review gallery (`docs/mockups/review-gallery.html`)
- 新規 focused mockup (`docs/mockups/filtered-tree-modes.html`)

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: static HTML/CSS diff 上で mode ごとの差と導線更新が読めることを確認
- レスポンシブ確認: 既存 mock-page / table-first mockup 構造に沿っており、既存 focused pages と同じ narrow return-nav / section layout で組んでいます
- アクセシビリティ確認: product-neutral copy を保ちつつ、mode 差分を table と badge で比較しやすいことを確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- docs/mockups 配下の static reference に閉じた変更で、runtime filtering 実装、docs 本文の全面改稿、host-app search behavior には触れていません

## 補足

- 近接 issue の `#573` は同じ mockup family ですが、windowed rendering の比較軸は filtered tree mode とは別なので、この PR では bundle せず review slice を narrow に保っています
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や browser check は未実施です
- docs-only lane のため、最終確認は PR diff review 前提です