### PR TITLE
docs: RenderState grouped option keys の public contract を docs から追いやすくする

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -282,6 +282,16 @@ When both flat keyword options and `initial_expansion:` are supplied, the flat k
 
 For focused naming decisions, see [Public Name Decisions](public-name-decisions.md). For ARIA placement, see [Accessibility Semantics](accessibility-semantics.md). For identifier design, see [Node keys](node-keys.md).
 
+### Documented grouped option keys
+
+The exact machine-readable grouped-option contract for `TreeView::RenderState` lives in `config/public_api_manifest.yml`, and `spec/public_api_compatibility_spec.rb` checks that manifest against the current constants and representative behavior.
+
+| Grouped option | Supported keys | Notes |
+|---|---|---|
+| `initial_expansion:` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | Equivalent flat keyword options still take priority when both forms are supplied. |
+| `render_scope:` | `max_depth`, `max_leaf_distance` | Use these grouped keys for the same render-depth and leaf-distance controls documented for `TreeView::RenderState`. |
+| `toggle_scope:` | `max_depth_from_root`, `max_leaf_distance` | Use these grouped keys for the same toggle-depth and toggle leaf-distance controls documented for `TreeView::RenderState`. |
+
 ## TreeView::UiConfig / UiConfigBuilder
 
 Configuration for DOM IDs, toggle mode, path builders, and optional Turbo Frame targeting.

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -109,6 +109,18 @@ Documented Turbo UI options include:
 
 See [API reference](api.md), [Localized names](localized-names.md), and [Turbo Frame option](turbo-frame.md) for details.
 
+### RenderState grouped option keys
+
+`TreeView::RenderState` grouped options are part of the public option surface. The exact machine-readable key set lives in `config/public_api_manifest.yml`, and `spec/public_api_compatibility_spec.rb` checks that manifest against the current `TreeView::RenderState` constants and representative behavior.
+
+| Group | Documented public keys | Notes |
+|---|---|---|
+| `initial_expansion` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | When flat keyword options and `initial_expansion:` are both supplied, the flat keyword options still win. |
+| `render_scope` | `max_depth`, `max_leaf_distance` | Mirrors the documented render-depth and leaf-distance controls for `TreeView::RenderState`. |
+| `toggle_scope` | `max_depth_from_root`, `max_leaf_distance` | Mirrors the documented tree-wide toggle depth and toggle leaf-distance controls. |
+
+`selection:` and `lazy_loading:` remain documented public grouped options too, but the manifest-backed grouped-key contract currently focuses on the three `TreeView::RenderState` groups above.
+
 ## Host app extension points
 
 Host apps are expected to provide these pieces:

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -282,6 +282,16 @@ render_state = TreeView::RenderState.new(
 
 公開名の判断は [Public Name Decisions](public-name-decisions.md)、ARIA配置は [Accessibility Semantics](accessibility-semantics.md) を参照してください。識別子設計は [Node keys](node-keys.md) を参照してください。
 
+### Documented grouped option keys
+
+`TreeView::RenderState` の grouped-option contract の exact key set は `config/public_api_manifest.yml` を machine-readable source of truth にし、`spec/public_api_compatibility_spec.rb` が current constant と representative behavior に対してその manifest を照合します。
+
+| Grouped option | supported keys | 補足 |
+|---|---|---|
+| `initial_expansion:` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | 個別keyword option と両方書いた場合でも、優先されるのは個別keyword optionです。 |
+| `render_scope:` | `max_depth`, `max_leaf_distance` | `TreeView::RenderState` でdocumentedされている render-depth / leaf-distance control と同じ契約です。 |
+| `toggle_scope:` | `max_depth_from_root`, `max_leaf_distance` | `TreeView::RenderState` でdocumentedされている toggle-depth / toggle leaf-distance control と同じ契約です。 |
+
 ## TreeView::UiConfig / UiConfigBuilder
 
 DOM ID、toggle mode、path builder、任意の Turbo Frame target をまとめる設定objectです。

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -109,6 +109,18 @@ toolbar helper もこの公開helper surfaceに含まれます。
 
 詳細は [API仕様](api.md)、[Localized names](localized-names.md)、[Turbo Frame option](turbo-frame.md) を参照してください。
 
+### RenderState grouped option keys
+
+`TreeView::RenderState` の grouped options も public option surface の一部です。exact key set の machine-readable source of truth は `config/public_api_manifest.yml` にあり、`spec/public_api_compatibility_spec.rb` が current `TreeView::RenderState` constant と representative behavior に対してその manifest を照合します。
+
+| Group | documented public keys | 補足 |
+|---|---|---|
+| `initial_expansion` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | 個別keyword option と `initial_expansion:` を併用した場合でも、優先されるのは個別keyword optionです。 |
+| `render_scope` | `max_depth`, `max_leaf_distance` | `TreeView::RenderState` の documented render-depth / leaf-distance control に対応します。 |
+| `toggle_scope` | `max_depth_from_root`, `max_leaf_distance` | tree-wide toggle の documented depth / leaf-distance control に対応します。 |
+
+`selection:` と `lazy_loading:` も引き続き documented public grouped options ですが、manifest-backed grouped-key contract は現時点では上の 3 つの `TreeView::RenderState` group に絞って管理しています。
+
 ## Host app extension points
 
 host app が提供する主な拡張点は以下です。


### PR DESCRIPTION
## 概要
- `RenderState` grouped option keys の exact key set を public docs から追いやすくしました
- `config/public_api_manifest.yml` と `spec/public_api_compatibility_spec.rb` が source of truth / guard であることを明記しました
- `initial_expansion` だけでなく `render_scope` / `toggle_scope` も英日 API docs から一覧で確認できるようにしました

Closes #580

## 判定
- classification: `docs-stale`
- classification: `docs-sync`

## 根拠
- current `config/public_api_manifest.yml` は `initial_expansion` / `render_scope` / `toggle_scope` の grouped key set を machine-readable に持っています
- current `spec/public_api_compatibility_spec.rb` は、それらの key が `TreeView::RenderState` 定数と representative behavior に一致することを guard しています
- 一方で `docs/en|ja/public-api.md` は grouped options が public surface だと述べつつ、exact key set と source-of-truth の関係が弱く、`docs/en|ja/api.md` でも `render_scope` / `toggle_scope` の grouped key contract を一箇所で見直しにくい状態でした

## 変更内容
- `docs/en/public-api.md`
- `docs/ja/public-api.md`
  - `RenderState grouped option keys` 節を追加
  - manifest / compatibility spec を source of truth として明記
  - `initial_expansion` / `render_scope` / `toggle_scope` の documented public keys を一覧化
- `docs/en/api.md`
- `docs/ja/api.md`
  - `TreeView::RenderState` 節に grouped option keys の一覧を追加
  - flat keyword options が grouped options より優先される点を、そのまま維持して明記

## 確認観点
- `initial_expansion` / `render_scope` / `toggle_scope` の exact key set を docs から追えること
- `config/public_api_manifest.yml` の grouped key 一覧と docs の記述が矛盾していないこと
- flat options と grouped options の documented priority を変えていないこと
- 変更が docs 4 files に閉じていること

## テスト
- なし（docs only）