### PR TITLE
docs: docs-only CI shortcut guidance を current workflow に揃える

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ GitHub Actions runs the following on pull requests:
 - representative Rails compatibility checks via `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - `npm run test:js`
 
-Docs-only pull requests that touch only `README.md` and `docs/**` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
+Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile.md`, `CHANGELOG.md`, and `AGENTS.md` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
 
 Pushes to `main` also run the broader compatibility and release checks:
 

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -81,7 +81,7 @@ Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-
 - Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - JavaScript entrypoint, unit, and browser smoke tests through `npm run test:js`
 
-Docs-only pull requests that touch only `README.md` and `docs/**` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
+Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile.md`, `CHANGELOG.md`, and `AGENTS.md` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
 
 Pushes to `main` also run the broader compatibility and release checks:
 
@@ -113,7 +113,7 @@ Pushes to `main` also run the broader compatibility and release checks:
 - Keep Japanese and English docs in sync when practical.
 - Update `docs/i18n-audit.md`.
 - Decide whether root compatibility docs should remain or point to language-specific docs.
-- When a pull request touches only `README.md` and `docs/**`, confirm that the docs-only CI short-circuit is still the intended policy before relying on it.
+- When a pull request touches only `README.md`, `docs/**`, `Product Profile.md`, `CHANGELOG.md`, and `AGENTS.md`, confirm that the docs-only CI short-circuit is still the intended policy before relying on it.
 - If a pull request also changes `.github/workflows/**`, treat it as a full CI change rather than a docs-only shortcut candidate.
 
 ## Before release

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -81,7 +81,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
 - JavaScript entrypoint、unit、browser smoke tests: `npm run test:js`
 
-`README.md` と `docs/**` だけに触れる docs-only Pull Request では、`lint` と `pr_specs` はそのまま残しつつ、representative Rails job と JavaScript job を short-circuit します。branch protection のため、check 名はそのまま維持します。`.github/workflows/**` も変更する Pull Request ではこの shortcut を使わず、通常の PR lanes を確認します。
+`README.md`、`docs/**`、`Product Profile.md`、`CHANGELOG.md`、`AGENTS.md` だけに触れる docs-only Pull Request では、`lint` と `pr_specs` はそのまま残しつつ、representative Rails job と JavaScript job を short-circuit します。branch protection のため、check 名はそのまま維持します。`.github/workflows/**` も変更する Pull Request ではこの shortcut を使わず、通常の PR lanes を確認します。
 
 `main` へのpushでは、より広い互換性確認とrelease向けのchecksも実行します。
 
@@ -113,7 +113,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 - 日本語・英語の対応関係を確認する
 - `docs/i18n-audit.md` を更新する
 - root互換docを残すか、言語別docへ誘導するかを判断する
-- `README.md` と `docs/**` だけのPRでは、docs-only CI short-circuit が今回も妥当かを確認してから使う
+- `README.md`、`docs/**`、`Product Profile.md`、`CHANGELOG.md`、`AGENTS.md` だけのPRでは、docs-only CI short-circuit が今回も妥当かを確認してから使う
 - `.github/workflows/**` も含むPRは、docs-only shortcut の候補ではなく full CI change として扱う
 
 ## release前の確認


### PR DESCRIPTION
## 概要
- docs-only CI short-circuit の対象ファイル説明を current workflow に合わせました
- `README.md` / `docs/**` だけでなく `AGENTS.md` / `Product Profile.md` / `CHANGELOG.md` も docs-only 扱いであることを maintainer docs に反映しました
- 実装や workflow 定義は変えず、説明だけを同期しています

## 判定
- classification: `docs-stale`
- classification: `docs-sync`

## 根拠
- current `.github/workflows/ci.yml` の `changes` job は `README.md`、`docs/*`、`Product Profile.md`、`CHANGELOG.md`、`AGENTS.md` を docs-only change として扱っています
- 一方で `AGENTS.md` と `docs/en|ja/development.md` は `README.md` と `docs/**` だけを shortcut 条件として案内していました
- maintainer docs の説明だけが current workflow に追従できていなかったため、docs-only で整合を戻せます

## 変更内容
- `AGENTS.md`
- `docs/en/development.md`
- `docs/ja/development.md`
  - docs-only CI shortcut の対象ファイル説明を current `.github/workflows/ci.yml` に合わせて更新
  - `.github/workflows/**` を触る PR は従来どおり full CI 扱いである点は維持

## 確認観点
- docs-only shortcut の対象ファイル説明が current `.github/workflows/ci.yml` と矛盾していないこと
- 変更が maintainer docs 3 files に閉じていること
- workflow behavior 自体は変えていないこと

## テスト
- なし（docs only）