### PR TITLE
design: add windowed rendering focused mockup

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -15,6 +15,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
@@ -26,9 +27,10 @@ They are **not** a complete Rails application and should not grow into host-app 
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-5. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-6. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-7. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+5. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+6. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+7. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+8. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -246,6 +246,27 @@
         </div>
       </article>
 
+      <article class="mock-gallery-card" aria-labelledby="gallery-windowed-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused rendering</p>
+          <h2 id="gallery-windowed-heading">Windowed rendering</h2>
+          <p>
+            Use this surface to compare visible-row slices, current-row anchoring, and previous or next availability without introducing host-app paging controls or loading behavior.
+          </p>
+          <ul class="mock-gallery-points">
+            <li><code>offset</code> and <code>limit</code> window slices</li>
+            <li>Current-row anchoring inside the rendered window</li>
+            <li>Boundary between TreeView metadata and host-app paging UI</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="windowed-rendering.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="windowed-rendering.html" title="Windowed rendering mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
       <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading">
         <div class="mock-gallery-copy">
           <p class="mock-gallery-eyebrow">Focused filtering</p>
@@ -340,6 +361,11 @@
             <td>Interaction states</td>
             <td>Loading, retry, pagination, and drag or drop status cues.</td>
             <td>Real Turbo responses, route wiring, or persistence behavior.</td>
+          </tr>
+          <tr>
+            <td>Windowed rendering</td>
+            <td>Visible-row slicing, current-row anchoring, and previous or next metadata framing.</td>
+            <td>Pagination controls, infinite scroll, query state, or data fetching behavior.</td>
           </tr>
           <tr>
             <td>Filtered tree modes</td>

--- a/docs/mockups/windowed-rendering.html
+++ b/docs/mockups/windowed-rendering.html
@@ -1,0 +1,537 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView windowed rendering mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-windowed-page {
+  max-width: 1260px;
+}
+
+.mock-windowed-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-windowed-state {
+  display: grid;
+  gap: 16px;
+}
+
+.mock-windowed-state__header {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-windowed-eyebrow {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-windowed-note {
+  margin: 0;
+  color: #52606d;
+}
+
+.mock-windowed-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-windowed-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-windowed-toolbar__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.mock-windowed-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-windowed-toolbar__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-windowed-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0f4c81;
+  font-size: 0.79rem;
+  font-weight: 700;
+}
+
+.mock-windowed-chip--secondary {
+  background: #e9ecef;
+  color: #334155;
+}
+
+.mock-windowed-body {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.mock-windowed-callout {
+  margin: 0;
+  padding: 0.8rem 0.95rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.mock-windowed-summary {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-windowed-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.mock-windowed-pagination span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.35rem 0.72rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #334155;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.mock-windowed-pagination .is-available {
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.mock-windowed-pagination .is-muted {
+  border-style: dashed;
+  color: #64748b;
+}
+
+.mock-windowed-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-windowed-table th,
+.mock-windowed-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-windowed-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tree-row.is-window-current {
+  background: #ecfeff;
+}
+
+.tree-node-badge--current {
+  background: #cffafe;
+  color: #155e75;
+}
+
+.tree-row.tree-row--window-hint td {
+  background: #fffbeb;
+  color: #92400e;
+  font-style: italic;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-windowed-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView windowed rendering mock</h1>
+      <p>
+        Static HTML for reviewing representative <code>offset</code> and <code>limit</code> slices, current-row anchoring,
+        and previous or next metadata from windowed rendering. Pagination controls, query state, and data fetching remain host-app responsibilities and are intentionally not modeled here.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-windowed-grid" aria-labelledby="windowed-slices-heading">
+      <div class="mock-windowed-state">
+        <div class="mock-windowed-state__header">
+          <p class="mock-windowed-eyebrow">Mode A</p>
+          <h2 id="windowed-slices-heading">Visible-row slice</h2>
+          <p class="mock-windowed-note">
+            Use this state when the review goal is to inspect a representative <code>offset</code> / <code>limit</code> window without mixing in current-row policy.
+          </p>
+        </div>
+
+        <div class="mock-windowed-frame">
+          <div class="mock-windowed-toolbar">
+            <div class="mock-windowed-toolbar__copy">
+              <p class="mock-windowed-toolbar__title">A middle window of visible rows</p>
+            </div>
+            <div class="mock-windowed-toolbar__meta" aria-label="Representative window metadata">
+              <span class="mock-windowed-chip">offset: 40</span>
+              <span class="mock-windowed-chip">limit: 6</span>
+              <span class="mock-windowed-chip mock-windowed-chip--secondary">total_count: 143</span>
+            </div>
+          </div>
+          <div class="mock-windowed-body">
+            <p class="mock-windowed-callout">
+              TreeView is only showing rows 41 through 46 of the current visible-row list. Route params, toolbar buttons, and infinite-scroll policy still belong to the host app.
+            </p>
+            <div class="mock-windowed-pagination" aria-label="Representative previous and next metadata">
+              <span class="is-available">previous_offset: 34</span>
+              <span>rows: 41-46</span>
+              <span class="is-available">next_offset: 46</span>
+            </div>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">owner</th>
+                  <th scope="col">state</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row tree-row--window-hint" aria-level="1">
+                  <td colspan="4">Earlier visible rows exist before this window, but they are intentionally not rendered here.</td>
+                </tr>
+                <tr id="slice_41" class="tree-row is-expanded" data-tree-node-key="section:41" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Window row 41">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <a class="tree-toggle__action" href="#">hide</a>
+                        <span class="tree-toggle__level">root</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Operations</td>
+                  <td>Shared services</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="slice_42" class="tree-row" data-tree-node-key="section:42" data-tree-parent-key="section:41" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Window row 42">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Billing imports</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="slice_43" class="tree-row" data-tree-node-key="section:43" data-tree-parent-key="section:41" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Window row 43">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Refund queue</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="slice_44" class="tree-row" data-tree-node-key="section:44" data-tree-parent-key="section:41" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Window row 44">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Support escalations</td>
+                  <td>Customer success</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="slice_45" class="tree-row" data-tree-node-key="section:45" data-tree-depth="0" aria-level="1">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Window row 45">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">root</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Analytics</td>
+                  <td>Data</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="slice_46" class="tree-row" data-tree-node-key="section:46" data-tree-parent-key="section:45" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Window row 46">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-last"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Weekly dashboard</td>
+                  <td>Data</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr class="tree-row tree-row--window-hint" aria-level="1">
+                  <td colspan="4">Later visible rows exist after this window, but they are intentionally not rendered here.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-windowed-state">
+        <div class="mock-windowed-state__header">
+          <p class="mock-windowed-eyebrow">Mode B</p>
+          <h2>Current-row anchoring</h2>
+          <p class="mock-windowed-note">
+            Use this state when the review goal is to keep a host-app-defined current row near the middle of the rendered window.
+          </p>
+        </div>
+
+        <div class="mock-windowed-frame">
+          <div class="mock-windowed-toolbar">
+            <div class="mock-windowed-toolbar__copy">
+              <p class="mock-windowed-toolbar__title">Anchored around the current record</p>
+            </div>
+            <div class="mock-windowed-toolbar__meta" aria-label="Representative anchored window metadata">
+              <span class="mock-windowed-chip">current_index: 78</span>
+              <span class="mock-windowed-chip">anchored_offset: 75</span>
+              <span class="mock-windowed-chip mock-windowed-chip--secondary">limit: 6</span>
+            </div>
+          </div>
+          <div class="mock-windowed-body">
+            <p class="mock-windowed-callout">
+              TreeView does not decide what “current” means. The host app owns that choice, then builds a window that keeps the chosen row inside view.
+            </p>
+            <div class="mock-windowed-pagination" aria-label="Anchored window availability">
+              <span class="is-available">previous_offset: 69</span>
+              <span>current row stays in view</span>
+              <span class="is-available">next_offset: 81</span>
+            </div>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">owner</th>
+                  <th scope="col">state</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr id="anchor_75" class="tree-row" data-tree-node-key="record:75" data-tree-depth="0" aria-level="1">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Anchored window row 75">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">root</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Team dashboards</td>
+                  <td>Operations</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="anchor_76" class="tree-row" data-tree-node-key="record:76" data-tree-parent-key="record:75" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Anchored window row 76">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>North America</td>
+                  <td>Ops reporting</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="anchor_77" class="tree-row" data-tree-node-key="record:77" data-tree-parent-key="record:75" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Anchored window row 77">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Europe</td>
+                  <td>Ops reporting</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="anchor_78" class="tree-row is-window-current" data-tree-node-key="record:78" data-tree-depth="0" aria-level="1" aria-current="page">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Current row anchored inside the window">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">root</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--current">current</span>
+                  </td>
+                  <td>Current account review</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status mock-status--active">anchored</span></td>
+                </tr>
+                <tr id="anchor_79" class="tree-row" data-tree-node-key="record:79" data-tree-parent-key="record:78" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Anchored window row 79">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Invoices pending review</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+                <tr id="anchor_80" class="tree-row" data-tree-node-key="record:80" data-tree-parent-key="record:78" data-tree-depth="1" aria-level="2">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Anchored window row 80">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-last"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Escalated refunds</td>
+                  <td>Finance</td>
+                  <td><span class="mock-status">visible</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-windowed-state">
+        <div class="mock-windowed-state__header">
+          <p class="mock-windowed-eyebrow">Mode C</p>
+          <h2>Previous and next availability</h2>
+          <p class="mock-windowed-note">
+            Use this state when the review goal is to show metadata for both directions without turning the mock into a real pagination surface.
+          </p>
+        </div>
+
+        <div class="mock-windowed-frame">
+          <div class="mock-windowed-toolbar">
+            <div class="mock-windowed-toolbar__copy">
+              <p class="mock-windowed-toolbar__title">Metadata-only paging cues</p>
+            </div>
+            <div class="mock-windowed-toolbar__meta" aria-label="Representative boundary metadata">
+              <span class="mock-windowed-chip">offset: 96</span>
+              <span class="mock-windowed-chip">limit: 4</span>
+              <span class="mock-windowed-chip mock-windowed-chip--secondary">window: 97-100</span>
+            </div>
+          </div>
+          <div class="mock-windowed-body">
+            <p class="mock-windowed-callout">
+              The host app can turn previous or next metadata into links, buttons, or infinite-scroll triggers. This mock deliberately stops at the metadata boundary.
+            </p>
+            <div class="mock-windowed-summary">
+              <div class="mock-windowed-pagination" aria-label="Representative boundary availability">
+                <span class="is-available">has_previous?: true</span>
+                <span class="is-muted">previous_offset: 92</span>
+                <span class="is-available">has_next?: true</span>
+                <span class="is-muted">next_offset: 100</span>
+              </div>
+            </div>
+            <table class="mock-windowed-table">
+              <thead>
+                <tr>
+                  <th scope="col">What TreeView gives</th>
+                  <th scope="col">What the host app still owns</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>rows</code>, <code>offset</code>, <code>limit</code>, <code>total_count</code>, <code>has_previous?</code>, and <code>has_next?</code></td>
+                  <td>Whether those values become numbered pages, “load more” controls, or infinite-scroll observers</td>
+                </tr>
+                <tr>
+                  <td>Visible-row slicing after expansion state and render scope are applied</td>
+                  <td>Which interactions preserve offset across refresh, route changes, or Turbo updates</td>
+                </tr>
+                <tr>
+                  <td>Current-row anchoring is possible because TreeView exposes the visible-row list</td>
+                  <td>What counts as the current row and where it should sit inside the window</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #573

## 採用した方針

- スケジュール実行のため、windowed rendering を focused に確認できる static mockup 1 面と、mockups 配下の最小導線更新だけに閉じる low-risk 案を採用しました。
- `docs/en|ja/windowed-rendering.md` を source of truth としつつ、runtime 実装、README 本文、host app paging UI には広げていません。

## 比較した案

- 案A: `docs/mockups/windowed-rendering.html` を追加し、`offset` / `limit` slice、current-row anchoring、previous / next metadata を比較できる focused page にする。
- 案B: `interaction-states.html` に windowed rendering の説明や rows を追記して済ませる。
- 案C: real pagination buttons や infinite-scroll 風 UI まで mockup に含める。
- 今回は案Aを採用しました。issue #573 の受け入れ条件を最小差分で満たせて、`interaction-states.html` の役割も崩さず、host app responsibility との境界を保ちやすいためです。

## 変更内容

- `docs/mockups/windowed-rendering.html`
  - 新しい focused mockup page を追加
  - `offset` / `limit` による visible-row slice を比較できる代表状態を追加
  - current-row anchoring を想定した代表状態を追加
  - previous / next metadata を host app UI に広げず比較できる代表状態を追加
- `docs/mockups/README.md`
  - file table に windowed rendering focused page を追加
  - recommended review flow に visible-row slicing と current-row anchoring の使い分けを追記
- `docs/mockups/review-gallery.html`
  - windowed rendering 用の gallery card を追加
  - comparison cues table に windowed rendering surface の役割を追加

## 変更した画面・コンポーネント

- TreeView mockups index (`docs/mockups/README.md`)
- TreeView mockup review gallery (`docs/mockups/review-gallery.html`)
- 新規 focused mockup (`docs/mockups/windowed-rendering.html`)

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: static HTML/CSS diff 上で `offset` / `limit` slice、current-row anchoring、previous / next metadata の違いが読めることを確認
- レスポンシブ確認: 既存 focused page と同じ `mock-page` / `mock-return-nav` family に沿っており、gallery iframe でも単独 page でも読める構成にしました
- アクセシビリティ確認: product-neutral copy を保ちつつ、window metadata と current row cue を table / chip / badge で拾いやすいことを確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- docs/mockups 配下の static reference に閉じた変更で、runtime windowing implementation、docs 本文、host-app pagination / infinite scroll behavior には触れていません

## 補足

- branch は一度 `main` の進行で stale になったため、current `main` head から `design/573-windowed-rendering-mock-main-head` を切り直しています
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や browser check は未実施です
- docs-only lane のため、最終確認は PR diff review 前提です