### PR TITLE
design: add form-editing rows focused mockup

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -92,6 +92,9 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
+| `docs/mockups/windowed-rendering.html` | Technical asset | No translation needed. |
+| `docs/mockups/filtered-tree-modes.html` | Technical asset | No translation needed. |
+| `docs/mockups/form-editing-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |
 

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -17,6 +17,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
+| [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
@@ -29,8 +30,9 @@ They are **not** a complete Rails application and should not grow into host-app 
 4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
 5. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
 6. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-7. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-8. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+7. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+8. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+9. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/form-editing-rows.html
+++ b/docs/mockups/form-editing-rows.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView form-editing rows mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-editing-page {
+  max-width: 1280px;
+}
+
+.mock-editing-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-editing-state {
+  display: grid;
+  gap: 16px;
+}
+
+.mock-editing-state__header {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-editing-eyebrow {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-editing-note {
+  margin: 0;
+  color: #52606d;
+}
+
+.mock-editing-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-editing-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-editing-toolbar__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.mock-editing-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-editing-toolbar__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-editing-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0f4c81;
+  font-size: 0.79rem;
+  font-weight: 700;
+}
+
+.mock-editing-chip--secondary {
+  background: #e9ecef;
+  color: #334155;
+}
+
+.mock-editing-body {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.mock-editing-callout {
+  margin: 0;
+  padding: 0.8rem 0.95rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.mock-editing-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-editing-table th,
+.mock-editing-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-editing-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mock-editing-input,
+.mock-editing-select,
+.mock-editing-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #fff;
+  color: #102a43;
+  font: inherit;
+}
+
+.mock-editing-input,
+.mock-editing-select {
+  min-height: 2.4rem;
+  padding: 0.45rem 0.65rem;
+}
+
+.mock-editing-textarea {
+  min-height: 4.4rem;
+  padding: 0.6rem 0.65rem;
+  resize: vertical;
+}
+
+.mock-editing-stack {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-editing-field-meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-editing-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  font-size: 0.77rem;
+  font-weight: 700;
+}
+
+.mock-editing-badge--selection {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.mock-editing-badge--business {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-editing-badge--interactive {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.mock-editing-badge--mode {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.mock-editing-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #102a43;
+}
+
+.mock-editing-choice input {
+  inline-size: 1rem;
+  block-size: 1rem;
+}
+
+.mock-editing-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-editing-actions a,
+.mock-editing-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.46rem 0.72rem;
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0f172a;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-editing-actions .is-primary {
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.mock-editing-actions .is-danger {
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.tree-row.is-editing-row {
+  background: #fffbeb;
+}
+
+.tree-row.is-editing-row td {
+  border-bottom-color: #fde68a;
+}
+
+.tree-row.is-current-preview {
+  background: #eff6ff;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-editing-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView form-editing rows mock</h1>
+      <p>
+        Static reference for comparing editing-oriented row layouts without turning the mock into a real form workflow.
+        TreeView owns the row structure, hierarchy cues, and selection surface. The host app still owns edit mode, validation, persistence, and final action wiring.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-editing-grid" aria-labelledby="editing-states-heading">
+      <div class="mock-editing-state">
+        <div class="mock-editing-state__header">
+          <p class="mock-editing-eyebrow">Mode A</p>
+          <h2 id="editing-states-heading">Bulk edit rows</h2>
+          <p class="mock-editing-note">
+            Use this state when every visible row is editable and the host app submits them together.
+          </p>
+        </div>
+
+        <div class="mock-editing-frame">
+          <div class="mock-editing-toolbar">
+            <div class="mock-editing-toolbar__copy">
+              <p class="mock-editing-toolbar__title">Selection for row choice, inputs for business edits</p>
+            </div>
+            <div class="mock-editing-toolbar__meta" aria-label="Representative edit metadata">
+              <span class="mock-editing-chip">mode: bulk_edit</span>
+              <span class="mock-editing-chip mock-editing-chip--secondary">save: single submit</span>
+            </div>
+          </div>
+          <div class="mock-editing-body">
+            <p class="mock-editing-callout">
+              The first checkbox column is TreeView selection. Business fields stay inside host-app-owned cells and use their own params.
+            </p>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">status</th>
+                  <th scope="col">featured</th>
+                  <th scope="col">notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-expanded" aria-level="1" aria-expanded="true">
+                  <td class="tree-toggle-cell">
+                    <div class="mock-editing-stack">
+                      <label class="mock-editing-choice">
+                        <input type="checkbox" checked>
+                        <span>Select row</span>
+                      </label>
+                      <span class="mock-editing-badge mock-editing-badge--selection">TreeView selection</span>
+                      <span class="tree-toggle" aria-label="Root row">
+                        <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                        <span class="tree-toggle__control">
+                          <a class="tree-toggle__action" href="#">hide</a>
+                          <span class="tree-toggle__level">root</span>
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="mock-editing-stack">
+                      <input class="mock-editing-input" type="text" value="Operations manual" data-tree-view-interactive="true">
+                      <div class="mock-editing-field-meta">
+                        <span class="mock-editing-badge mock-editing-badge--interactive">interactive marker</span>
+                        <span class="mock-editing-badge mock-editing-badge--mode">row_partial field</span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <select class="mock-editing-select" data-tree-view-interactive="true">
+                      <option>draft</option>
+                      <option selected>review</option>
+                      <option>published</option>
+                    </select>
+                  </td>
+                  <td>
+                    <div class="mock-editing-stack">
+                      <label class="mock-editing-choice">
+                        <input type="checkbox" checked data-tree-view-interactive="true">
+                        <span>Featured</span>
+                      </label>
+                      <span class="mock-editing-badge mock-editing-badge--business">Business field</span>
+                    </div>
+                  </td>
+                  <td>
+                    <textarea class="mock-editing-textarea" data-tree-view-interactive="true">Visible in the bulk editor. Validation and persistence remain host-app responsibilities.</textarea>
+                  </td>
+                </tr>
+                <tr class="tree-row" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <div class="mock-editing-stack">
+                      <label class="mock-editing-choice">
+                        <input type="checkbox">
+                        <span>Select row</span>
+                      </label>
+                      <span class="tree-toggle" aria-label="Child row">
+                        <span class="tree-toggle__branches" aria-hidden="true">
+                          <span class="tree-toggle__branch-slot has-line"></span>
+                          <span class="tree-toggle__branch-slot is-current is-last"></span>
+                        </span>
+                        <span class="tree-toggle__control">
+                          <span class="tree-depth-label">child</span>
+                        </span>
+                      </span>
+                    </div>
+                  </td>
+                  <td><input class="mock-editing-input" type="text" value="Approval checklist" data-tree-view-interactive="true"></td>
+                  <td>
+                    <select class="mock-editing-select" data-tree-view-interactive="true">
+                      <option selected>draft</option>
+                      <option>review</option>
+                      <option>published</option>
+                    </select>
+                  </td>
+                  <td>
+                    <label class="mock-editing-choice">
+                      <input type="checkbox" data-tree-view-interactive="true">
+                      <span>Featured</span>
+                    </label>
+                  </td>
+                  <td><textarea class="mock-editing-textarea" data-tree-view-interactive="true">Child rows can edit their own fields without reusing the TreeView selection checkbox.</textarea></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-editing-state">
+        <div class="mock-editing-state__header">
+          <p class="mock-editing-eyebrow">Mode B</p>
+          <h2>Per-row edit action placement</h2>
+          <p class="mock-editing-note">
+            Use this state when the host app swaps a single row into editing UI while neighboring rows stay in display mode.
+          </p>
+        </div>
+
+        <div class="mock-editing-frame">
+          <div class="mock-editing-toolbar">
+            <div class="mock-editing-toolbar__copy">
+              <p class="mock-editing-toolbar__title">Display rows stay readable while one row enters edit mode</p>
+            </div>
+            <div class="mock-editing-toolbar__meta" aria-label="Representative row edit metadata">
+              <span class="mock-editing-chip">mode: per_row_edit</span>
+              <span class="mock-editing-chip mock-editing-chip--secondary">swap target: host app</span>
+            </div>
+          </div>
+          <div class="mock-editing-body">
+            <p class="mock-editing-callout">
+              TreeView can keep hierarchy cues and row actions in place, but the host app decides when a row enters edit mode and how the save or cancel response returns.
+            </p>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">owner</th>
+                  <th scope="col">actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row" aria-level="1">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Display row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <a class="tree-toggle__action" href="#">hide</a>
+                        <span class="tree-toggle__level">root</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Policy library</td>
+                  <td>Knowledge team</td>
+                  <td>
+                    <div class="mock-editing-actions">
+                      <a class="is-primary" href="#" data-tree-view-interactive="true">Edit</a>
+                      <a href="#" data-tree-view-interactive="true">Show</a>
+                    </div>
+                  </td>
+                </tr>
+                <tr class="tree-row is-editing-row is-current-preview" aria-level="2" aria-current="page">
+                  <td class="tree-toggle-cell">
+                    <div class="mock-editing-stack">
+                      <span class="tree-toggle" aria-label="Editing row">
+                        <span class="tree-toggle__branches" aria-hidden="true">
+                          <span class="tree-toggle__branch-slot has-line"></span>
+                          <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                        </span>
+                        <span class="tree-toggle__control">
+                          <span class="tree-depth-label">child</span>
+                        </span>
+                      </span>
+                      <span class="mock-editing-badge mock-editing-badge--mode">editing row</span>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="mock-editing-stack">
+                      <input class="mock-editing-input" type="text" value="Escalation matrix" data-tree-view-interactive="true">
+                      <label class="mock-editing-choice">
+                        <input type="checkbox" checked data-tree-view-interactive="true">
+                        <span>Billable review</span>
+                      </label>
+                    </div>
+                  </td>
+                  <td>
+                    <select class="mock-editing-select" data-tree-view-interactive="true">
+                      <option>Knowledge team</option>
+                      <option selected>Operations</option>
+                      <option>Compliance</option>
+                    </select>
+                  </td>
+                  <td>
+                    <div class="mock-editing-actions">
+                      <button type="button" class="is-primary" data-tree-view-interactive="true">Save</button>
+                      <button type="button" data-tree-view-interactive="true">Cancel</button>
+                      <button type="button" class="is-danger" data-tree-view-interactive="true">Delete</button>
+                    </div>
+                  </td>
+                </tr>
+                <tr class="tree-row" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Sibling row">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-last"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">child</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>Training checklist</td>
+                  <td>Operations</td>
+                  <td>
+                    <div class="mock-editing-actions">
+                      <a href="#" data-tree-view-interactive="true">Edit</a>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="editing-boundary-heading">
+      <h2 id="editing-boundary-heading">What this mock compares</h2>
+      <table class="mock-editing-table">
+        <thead>
+          <tr>
+            <th scope="col">Surface</th>
+            <th scope="col">Best for</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Bulk edit rows</td>
+            <td>Selection versus business-field separation, editable cells, and all-rows submit framing.</td>
+            <td>Validation persistence, params parsing, authorization, and save semantics.</td>
+          </tr>
+          <tr>
+            <td>Per-row edit placement</td>
+            <td>Showing one editing row beside display rows without losing hierarchy cues.</td>
+            <td>Turbo replacement timing, dirty-state guards, and optimistic update behavior.</td>
+          </tr>
+        </tbody>
+      </table>
+      <ul>
+        <li><code>data-tree-view-interactive="true"</code> is shown as a representative marker only. Event handling still belongs to the host app.</li>
+        <li>Selection checkboxes belong to TreeView row-selection payloads. Business checkboxes belong to the host app form.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, windowed rendering cues, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -288,6 +288,27 @@
         </div>
       </article>
 
+      <article class="mock-gallery-card" aria-labelledby="gallery-editing-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused editing</p>
+          <h2 id="gallery-editing-heading">Form-editing rows</h2>
+          <p>
+            Use this surface to compare bulk edit rows, per-row edit placement, and the boundary between TreeView row selection and host-app business form controls.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Selection checkbox versus business checkbox roles</li>
+            <li>Editable text, select, and textarea cells inside rows</li>
+            <li>Per-row action placement without modeling save behavior</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="form-editing-rows.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
         <div class="mock-gallery-copy">
           <p class="mock-gallery-eyebrow">Focused controls</p>
@@ -371,6 +392,11 @@
             <td>Filtered tree modes</td>
             <td>Comparing matched-only, ancestor-retaining, and descendant-retaining output.</td>
             <td>Search forms, highlighting, ranking, and authorization-aware filtering.</td>
+          </tr>
+          <tr>
+            <td>Form-editing rows</td>
+            <td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td>
+            <td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td>
           </tr>
           <tr>
             <td>Toolbar actions</td>


### PR DESCRIPTION
## 対応Issue

- Closes #592

## 判定

- classification: `docs-missing`
- classification: `docs-sync`

## 背景と根拠

- current `docs/en/form-editing.md` / `docs/ja/form-editing.md` は bulk edit table pattern、per-row edit pattern、selection checkbox と business checkbox の分離、interactive control marker を具体的に説明しています
- 一方で `docs/mockups/README.md` と `docs/mockups/review-gallery.html` の current mockup set には、editing-oriented row layout を focused に比較できる static reference がありませんでした
- runtime editing workflow や validation / persistence を作らず、static mockup と導線更新だけで docs gap を埋められます

## 変更内容

- `docs/mockups/form-editing-rows.html`
  - bulk edit rows と per-row edit placement を比較できる focused mockup page を追加
  - TreeView selection checkbox と host-app business checkbox の役割差、editable text/select/textarea cells、interactive marker を static HTML/CSS で比較できるようにした
  - save semantics、Turbo response、dirty-state guard は host app responsibility として mock 内でも境界を維持した
- `docs/mockups/README.md`
  - file table と recommended review flow に新しい focused page を追加
- `docs/mockups/review-gallery.html`
  - gallery card と comparison cues に form-editing rows surface を追加
- `docs/i18n-audit.md`
  - technical assets table に新しい mockup file を追加

## 確認観点

- `form-editing-rows.html` から bulk edit rows と per-row edit placement の違いを focused に比較できること
- selection checkbox と business checkbox を混同しない visual separation があること
- `docs/mockups/README.md`、`review-gallery.html`、`docs/i18n-audit.md` が current mockup set と矛盾しないこと
- 変更が `docs/mockups/` と maintenance checklist に閉じていること

## テスト

- なし（docs only）

## 補足

- 新規 Issue 着手前に own open PR (`#593`, `#589`, `#568`, `#559`, `#545`) を確認し、external review / review thread 起点で優先すべき review follow-up は見当たりませんでした
- compare `main...docs/592-form-editing-mock-main-head` で差分が `docs/mockups/form-editing-rows.html`, `docs/mockups/README.md`, `docs/mockups/review-gallery.html`, `docs/i18n-audit.md` に閉じていることを確認しています
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や browser check は未実施です