### PR TITLE
design: add focused children pagination mockup

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -92,6 +92,10 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
+| `docs/mockups/children-pagination.html` | Technical asset | No translation needed. |
+| `docs/mockups/windowed-rendering.html` | Technical asset | No translation needed. |
+| `docs/mockups/filtered-tree-modes.html` | Technical asset | No translation needed. |
+| `docs/mockups/form-editing-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |
 

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -15,6 +15,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [children-pagination.html](children-pagination.html) | Focused comparison for next-page placeholder placement and load-more affordances within one expanded branch, without host-app cursor or Turbo behavior. |
 | [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
@@ -27,10 +28,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-5. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-6. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-7. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-8. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+5. Use [children-pagination.html](children-pagination.html) when review needs a narrower pass on where next-page placeholder rows and load-more affordances should sit inside one expanded branch.
+6. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+7. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+8. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+9. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/children-pagination.html
+++ b/docs/mockups/children-pagination.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView children pagination mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-pagination-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.mock-pagination-card {
+  display: grid;
+  gap: 14px;
+}
+
+.mock-pagination-card h3,
+.mock-pagination-card p,
+.mock-pagination-card ul {
+  margin: 0;
+}
+
+.mock-pagination-caption {
+  color: #52606d;
+  font-size: 0.94rem;
+}
+
+.mock-pagination-inline-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.35rem;
+  padding: 0.08rem 0.5rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.mock-pagination-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.25rem 0.8rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-pagination-link:hover,
+.mock-pagination-link:focus {
+  background: #eff6ff;
+  text-decoration: none;
+}
+
+.mock-pagination-more-row td {
+  background: #f8fafc;
+}
+
+.mock-pagination-more-row .tree-row-actions {
+  white-space: nowrap;
+}
+
+.mock-pagination-summary {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.9rem 1rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.mock-pagination-summary strong {
+  color: #102a43;
+}
+
+.mock-pagination-comparison {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-pagination-comparison th,
+.mock-pagination-comparison td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-pagination-comparison th {
+  background: #f1f5f9;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView children pagination mock</h1>
+      <p>
+        Focused static HTML for reviewing next-page placeholder placement and load-more affordances without running a Rails app.
+        This page keeps cursors, limits, authorization, Turbo Stream responses, and host-app paging logic out of scope on purpose.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="pagination-purpose-heading">
+      <h2 id="pagination-purpose-heading">What this surface is for</h2>
+      <ul>
+        <li>Compare where the host app places the next-page placeholder row relative to already loaded children.</li>
+        <li>Inspect how a load-more affordance stays visually tied to one parent branch instead of reading like a global toolbar action.</li>
+        <li>Keep the TreeView-owned branch structure visible while leaving cursor semantics and fetch behavior to the host app.</li>
+      </ul>
+    </section>
+
+    <section class="mock-section" aria-labelledby="pagination-states-heading">
+      <h2 id="pagination-states-heading">Representative children pagination states</h2>
+      <div class="mock-pagination-grid">
+        <article class="mock-pagination-card" aria-labelledby="pagination-initial-heading">
+          <h3 id="pagination-initial-heading">1. Initial page with a next-page placeholder</h3>
+          <p class="mock-pagination-caption">
+            The first child page is already appended under the expanded parent, and the placeholder row stays at the bottom of that same branch.
+          </p>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">name</th>
+                <th scope="col">page state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="docs_1" class="tree-row is-expanded" data-tree-node-key="folder:docs" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded folder">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control">
+                      <a class="tree-toggle__action" href="#">hide</a>
+                      <span class="tree-toggle__level">page 1</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Documentation</td>
+                <td><span class="mock-status mock-status--active">40 children loaded</span></td>
+                <td class="tree-row-actions"><button type="button">Refresh branch</button></td>
+              </tr>
+              <tr id="docs_child_1" class="tree-row" data-tree-node-key="page:getting-started" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Getting started</td>
+                <td><span class="mock-status">loaded in current page</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="docs_child_2" class="tree-row" data-tree-node-key="page:api" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>API reference</td>
+                <td><span class="mock-status">loaded in current page</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="docs_more_1" class="tree-row mock-pagination-more-row" data-tree-parent-key="folder:docs" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Next page placeholder row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__level">more</span>
+                      <span class="mock-pagination-inline-note">cursor: docs-002</span>
+                    </span>
+                  </span>
+                </td>
+                <td>More children remain in this branch</td>
+                <td><span class="mock-status mock-status--pending">next page available</span></td>
+                <td class="tree-row-actions"><a class="mock-pagination-link" href="#">Load more</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="mock-pagination-card" aria-labelledby="pagination-placement-heading">
+          <h3 id="pagination-placement-heading">2. Placeholder row stays scoped to the parent branch</h3>
+          <p class="mock-pagination-caption">
+            The placeholder is visually part of the same branch, not a detached footer. That keeps ownership clear when several expanded roots each have their own next page.
+          </p>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">name</th>
+                <th scope="col">page state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="projects_1" class="tree-row is-expanded" data-tree-node-key="folder:projects" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded folder">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control">
+                      <a class="tree-toggle__action" href="#">hide</a>
+                      <span class="tree-toggle__level">page 3</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Projects</td>
+                <td><span class="mock-status mock-status--active">60 children loaded</span></td>
+                <td class="tree-row-actions"><button type="button">Refresh branch</button></td>
+              </tr>
+              <tr id="projects_child_1" class="tree-row" data-tree-node-key="project:alpha" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Alpha rollout</td>
+                <td><span class="mock-status">already appended</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="projects_child_2" class="tree-row" data-tree-node-key="project:beta" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Beta migration</td>
+                <td><span class="mock-status">already appended</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="projects_more_1" class="tree-row mock-pagination-more-row" data-tree-parent-key="folder:projects" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Scoped next page row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__level">more</span>
+                      <span class="mock-pagination-inline-note">host app owns URL</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Next page for this branch only</td>
+                <td><span class="mock-status mock-status--pending">placeholder still in branch</span></td>
+                <td class="tree-row-actions"><a class="mock-pagination-link" href="#">Load more</a></td>
+              </tr>
+              <tr id="teams_1" class="tree-row" data-tree-node-key="folder:teams" data-tree-depth="0" aria-level="1">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Collapsed sibling branch">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                    <span class="tree-toggle__control">
+                      <a class="tree-toggle__action" href="#">load</a>
+                      <span class="tree-toggle__level">idle</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Teams</td>
+                <td><span class="mock-status">separate branch</span></td>
+                <td class="tree-row-actions"><button type="button">Expand</button></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="mock-pagination-card" aria-labelledby="pagination-append-heading">
+          <h3 id="pagination-append-heading">3. After append, the placeholder moves down instead of becoming a global footer</h3>
+          <p class="mock-pagination-caption">
+            A later page adds more children, then re-renders the next-page placeholder in the same branch when another cursor still exists.
+          </p>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">name</th>
+                <th scope="col">page state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="assets_1" class="tree-row is-expanded" data-tree-node-key="folder:assets" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded folder">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control">
+                      <a class="tree-toggle__action" href="#">hide</a>
+                      <span class="tree-toggle__level">page 2</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Assets</td>
+                <td><span class="mock-status mock-status--active">80 children loaded</span></td>
+                <td class="tree-row-actions"><button type="button">Refresh branch</button></td>
+              </tr>
+              <tr id="assets_child_1" class="tree-row" data-tree-node-key="asset:icons" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Icons</td>
+                <td><span class="mock-status">page 1</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="assets_child_2" class="tree-row" data-tree-node-key="asset:illustrations" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Illustrations</td>
+                <td><span class="mock-status">page 1</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="assets_child_3" class="tree-row" data-tree-node-key="asset:logos" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Logos</td>
+                <td><span class="mock-status mock-status--active">newly appended</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="assets_child_4" class="tree-row" data-tree-node-key="asset:templates" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Leaf row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Templates</td>
+                <td><span class="mock-status mock-status--active">newly appended</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="assets_more_1" class="tree-row mock-pagination-more-row" data-tree-parent-key="folder:assets" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Replacement next page row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__level">more</span>
+                      <span class="mock-pagination-inline-note">cursor: assets-003</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Another page remains after append</td>
+                <td><span class="mock-status mock-status--pending">placeholder replaced in place</span></td>
+                <td class="tree-row-actions"><a class="mock-pagination-link" href="#">Load more</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="pagination-boundary-heading">
+      <h2 id="pagination-boundary-heading">Responsibility boundary reminders</h2>
+      <div class="mock-pagination-summary">
+        <strong>TreeView-owned cues in this mock</strong>
+        <span>Branch structure, placeholder-row placement, and the visual distinction between already loaded rows and a branch-scoped next-page affordance.</span>
+      </div>
+      <div class="mock-pagination-summary">
+        <strong>Host-app decisions kept out of scope</strong>
+        <span>Cursor encoding, next-page detection, query limits, authorization, Turbo Stream append or replace behavior, and final button wording.</span>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="pagination-compare-heading">
+      <h2 id="pagination-compare-heading">Review cues</h2>
+      <table class="mock-pagination-comparison">
+        <thead>
+          <tr>
+            <th scope="col">State</th>
+            <th scope="col">Best for checking</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Initial page</td>
+            <td>Whether the placeholder row reads as part of the same expanded branch after the first child page loads.</td>
+            <td>Query ordering, cursor rules, or whether page size should be 25, 40, or 50.</td>
+          </tr>
+          <tr>
+            <td>Scoped placeholder</td>
+            <td>Whether each branch can own its own load-more affordance without looking like a global toolbar or footer action.</td>
+            <td>Real routes, Turbo Stream targets, authorization-aware button copy, or analytics events.</td>
+          </tr>
+          <tr>
+            <td>After append</td>
+            <td>Whether the placeholder moves downward with the branch as more children arrive, instead of drifting outside the tree context.</td>
+            <td>Actual append logic, DOM IDs, cursor persistence, or retry behavior after failures.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, focused children-pagination placement, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -234,7 +234,7 @@
           </p>
           <ul class="mock-gallery-points">
             <li>Loaded, loading, and error or retry rows</li>
-            <li>Children pagination placeholder rows</li>
+            <li>Children pagination placeholder rows in one compact surface</li>
             <li>Dragging, valid drop, and blocked drop states</li>
           </ul>
           <div class="mock-gallery-links">
@@ -243,6 +243,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-children-pagination-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused pagination</p>
+          <h2 id="gallery-children-pagination-heading">Children pagination</h2>
+          <p>
+            Use this surface when review needs a narrower pass on where next-page placeholder rows and load-more affordances should sit inside one expanded branch.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Initial page with a branch-scoped placeholder row</li>
+            <li>Load-more placement that stays tied to one parent branch</li>
+            <li>After-append state where the placeholder moves downward in place</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="children-pagination.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="children-pagination.html" title="Children pagination mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -361,6 +382,11 @@
             <td>Interaction states</td>
             <td>Loading, retry, pagination, and drag or drop status cues.</td>
             <td>Real Turbo responses, route wiring, or persistence behavior.</td>
+          </tr>
+          <tr>
+            <td>Children pagination</td>
+            <td>Next-page placeholder placement, branch-scoped load-more cues, and the after-append handoff to a replacement placeholder row.</td>
+            <td>Cursor encoding, next-page detection, Turbo Stream append or replace logic, and final business copy.</td>
           </tr>
           <tr>
             <td>Windowed rendering</td>


### PR DESCRIPTION
## 対応Issue

- Closes #587
- Refs #579

## 採用した方針

- スケジュール実行のため、children pagination を `interaction-states.html` に追加で詰め込むのではなく、next-page placeholder placement にだけ集中した focused mockup page を 1 枚増やす low-risk 案を採用しました。
- runtime pagination や Turbo Stream 実装には触れず、static HTML/CSS の review lane に閉じています。
- 既存の gallery / mockup index から新しい surface へ辿れる最小導線に加え、maintainer 向け technical-asset inventory も同じ PR で追従させました。

## 比較した案

- 案A: `children-pagination.html` を新設し、initial page、branch-scoped placeholder、after-append の 3 state を比較できるようにする。
- 案B: `interaction-states.html` の pagination section を拡張して済ませる。
- 案C: prose docs だけで placement guidance を補う。
- 今回は案Aを採用しました。Issue #587 の受け入れ条件を最も分かりやすく満たせて、loading / retry / drag-drop と pagination placement の論点が混ざりにくいためです。

## 変更内容

- `docs/mockups/children-pagination.html`
  - focused mockup page を追加
  - initial page、branch-scoped next-page placeholder、after-append の representative state を追加
  - host-app-owned cursor / Turbo behavior を範囲外として明示
- `docs/mockups/README.md`
  - mockup 一覧と recommended review flow に children pagination mockup を追加
- `docs/mockups/review-gallery.html`
  - gallery card と comparison row を追加し、新しい focused surface へ辿れるよう更新
- `docs/i18n-audit.md`
  - technical-assets table に `children-pagination.html` を追加
  - current `main` で増えていた focused mockup rows も取り込みつつ、maintainer inventory を current mockup set に揃える

## 変更した画面・コンポーネント

- mockup docs (`docs/mockups/children-pagination.html`)
- mockup index (`docs/mockups/README.md`)
- review gallery (`docs/mockups/review-gallery.html`)
- documentation maintenance checklist (`docs/i18n-audit.md`)

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: static HTML/CSS と maintenance docs の diff が docs 4 files に閉じていることを確認
- レスポンシブ確認: 既存 mockup と同じ `default-tree.css` ベースで、preview iframe 前提のレイアウトに収まる構成を確認
- アクセシビリティ確認: table structure と branch-scoped placeholder の関係が source 上で読めることを確認
- docs inventory 確認: `docs/mockups/README.md` / `review-gallery.html` / `docs/i18n-audit.md` で children pagination mockup の導線と asset inventory が揃うことを確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- static docs に閉じた変更で、runtime pagination contract、cursor semantics、Turbo Stream behavior には触れていません

## 補足

- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や test 実行は未実施です
- final review では `interaction-states.html` と責務が重なりすぎていないか、children pagination の focused surface として読み分けやすいか、`docs/i18n-audit.md` の inventory 追従が十分かを見てもらえると助かります