### PR TITLE
test: selection / lazy_loading grouped option keys を manifest で追跡する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -55,6 +55,21 @@ grouped_option_keys:
   toggle_scope:
     - max_depth_from_root
     - max_leaf_distance
+  selection:
+    - enabled
+    - visibility
+    - payload_builder
+    - checkbox_name
+    - disabled_builder
+    - disabled_reason_builder
+    - selected_keys
+    - cascade
+    - indeterminate
+    - max_count
+  lazy_loading:
+    - enabled
+    - loaded_keys
+    - scope
 javascript_package_root:
   named_exports:
     - registerTreeViewControllers

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -128,8 +128,8 @@ See [API reference](api.md), [Localized names](localized-names.md), and [Turbo F
 | `initial_expansion` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | When flat keyword options and `initial_expansion:` are both supplied, the flat keyword options still win. |
 | `render_scope` | `max_depth`, `max_leaf_distance` | Mirrors the documented render-depth and leaf-distance controls for `TreeView::RenderState`. |
 | `toggle_scope` | `max_depth_from_root`, `max_leaf_distance` | Mirrors the documented tree-wide toggle depth and toggle leaf-distance controls. |
-
-`selection:` and `lazy_loading:` remain documented public grouped options too, but the manifest-backed grouped-key contract currently focuses on the three `TreeView::RenderState` groups above.
+| `selection` | `enabled`, `visibility`, `payload_builder`, `checkbox_name`, `disabled_builder`, `disabled_reason_builder`, `selected_keys`, `cascade`, `indeterminate`, `max_count` | Mirrors `TreeView::RenderState::SelectionConfig` and keeps grouped selection wiring aligned with the documented flat selection keywords. |
+| `lazy_loading` | `enabled`, `loaded_keys`, `scope` | Mirrors the documented lazy-loading row-state hooks and optional host-app scope passthrough. |
 
 ## Host app extension points
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -128,8 +128,8 @@ toolbar helper もこの公開 helper surface に含まれます。
 | `initial_expansion` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | 個別 keyword option と `initial_expansion:` を併用した場合でも、優先されるのは個別 keyword option です。 |
 | `render_scope` | `max_depth`, `max_leaf_distance` | `TreeView::RenderState` の documented render-depth / leaf-distance control に対応します。 |
 | `toggle_scope` | `max_depth_from_root`, `max_leaf_distance` | tree-wide toggle の documented depth / leaf-distance control に対応します。 |
-
-`selection:` と `lazy_loading:` も引き続き documented public grouped options ですが、manifest-backed grouped-key contract は現時点では上の 3 つの `TreeView::RenderState` group に絞って管理しています。
+| `selection` | `enabled`, `visibility`, `payload_builder`, `checkbox_name`, `disabled_builder`, `disabled_reason_builder`, `selected_keys`, `cascade`, `indeterminate`, `max_count` | `TreeView::RenderState::SelectionConfig` と同じ grouped key を machine-readable に追跡し、documented な flat selection keyword との対応も崩れないようにします。 |
+| `lazy_loading` | `enabled`, `loaded_keys`, `scope` | documented lazy-loading row-state hook と optional な host-app scope passthrough に対応します。 |
 
 ## Host app extension points
 

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -11,10 +11,12 @@ JAVASCRIPT_CONTROLLER_PATHS = {
   "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
   "transfer" => File.expand_path("../app/javascript/tree_view/transfer_controller.js", __dir__)
 }.freeze
-RENDER_STATE_GROUPED_OPTION_CONSTANTS = {
-  "initial_expansion" => :VALID_INITIAL_EXPANSION_KEYS,
-  "render_scope" => :VALID_RENDER_SCOPE_KEYS,
-  "toggle_scope" => :VALID_TOGGLE_SCOPE_KEYS
+RENDER_STATE_GROUPED_OPTION_KEY_RESOLVERS = {
+  "initial_expansion" => -> { TreeView::RenderState::VALID_INITIAL_EXPANSION_KEYS.map(&:to_s) },
+  "render_scope" => -> { TreeView::RenderState::VALID_RENDER_SCOPE_KEYS.map(&:to_s) },
+  "toggle_scope" => -> { TreeView::RenderState::VALID_TOGGLE_SCOPE_KEYS.map(&:to_s) },
+  "selection" => -> { TreeView::RenderState::SelectionConfig::VALID_KEYS.map(&:to_s) },
+  "lazy_loading" => -> { %w[enabled loaded_keys scope] }
 }.freeze
 
 RSpec.describe "Public API compatibility" do
@@ -111,10 +113,9 @@ RSpec.describe "Public API compatibility" do
 
   it "keeps documented RenderState grouped option keys available" do
     public_api_manifest.fetch("grouped_option_keys").each do |group_name, manifest_keys|
-      constant_name = RENDER_STATE_GROUPED_OPTION_CONSTANTS.fetch(group_name)
-      expected_keys = TreeView::RenderState.const_get(constant_name).map(&:to_s)
+      expected_keys = RENDER_STATE_GROUPED_OPTION_KEY_RESOLVERS.fetch(group_name).call
 
-      expect(manifest_keys).to eq(expected_keys), "expected #{group_name} keys to match TreeView::RenderState::#{constant_name}"
+      expect(manifest_keys).to eq(expected_keys), "expected #{group_name} keys to match the documented public grouped option contract"
     end
   end
 


### PR DESCRIPTION
Closes #598

## 対応 Issue 一覧
- #598

## Issue ごとの完了内容
- #598
  - `selection:` と `lazy_loading:` の documented grouped option keys を `config/public_api_manifest.yml` に追加しました
  - `spec/public_api_compatibility_spec.rb` で manifest と current public grouped option contract の整合を確認する guard を広げました
  - `docs/en/public-api.md` と `docs/ja/public-api.md` を、manifest-backed grouped option scope に合わせて更新しました

## 変更内容
- `config/public_api_manifest.yml`
  - grouped option keys に `selection` と `lazy_loading` を追加
- `spec/public_api_compatibility_spec.rb`
  - grouped option key comparison を resolver ベースに整理
  - `selection` は `TreeView::RenderState::SelectionConfig::VALID_KEYS` と照合
  - `lazy_loading` は documented key set (`enabled`, `loaded_keys`, `scope`) を guard
- `docs/en/public-api.md`
- `docs/ja/public-api.md`
  - grouped option table を current manifest-backed scope に同期

## 改善カテゴリ
- public API drift guard の追加
- spec 改善
- docs sync

## 既存仕様への影響
- なし
- runtime behavior や grouped option meaning は変更していません
- documented public grouped option surface と machine-readable manifest / compatibility spec の整合だけを強めています

## 実施した確認
- branch diff が manifest / compatibility spec / 英日 public API docs の 4 files に閉じていることを確認
- `selection` は `TreeView::RenderState::SelectionConfig::VALID_KEYS` と合わせ、runtime 側の documented key set に寄せたことを確認
- `lazy_loading` は current docs と representative behavior が既に前提にしている `enabled` / `loaded_keys` / `scope` に限定したことを確認

## 実行できなかった確認
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル `bundle exec rspec` や `npm run test:entrypoints` は未実行です
- 最終確認は GitHub Actions CI 前提です

## リスク評価
- low
- 変更は manifest / spec / docs に閉じており、runtime code には触れていません

## 補足事項
- issue の非目標どおり、`TreeView::RenderState` option API 自体の再設計や undocumented internal option の manifest 追加には広げていません