### PR TITLE
docs: add page-level translation priority to i18n audit

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -16,6 +16,27 @@ Documentation is organized around language-specific directories.
 
 Root-level prose docs should stay limited to intentional entry points, maintenance notes, or technical assets. Canonical prose docs belong under `docs/ja/` and `docs/en/`.
 
+## Page-level language coverage and translation priority
+
+Use this table when you need a quick answer to "which user-facing pages must stay aligned first?".
+
+Japanese remains the more complete canonical prose source when English wording lags, but the pages below are the current cross-language planning baseline promised by `docs/en/README.md`, `docs/ja/README.md`, and `docs/README.md`.
+
+| Docs lane | Current coverage status | Priority | Maintenance expectation |
+|---|---|---|---|
+| `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` | Published entry points for cross-language navigation and language-status guidance | High | Update in the same docs lane whenever reading order, docs map, or language-status promises change |
+| `docs/en/installation.md`, `docs/ja/installation.md` | Published in both trees | High | Keep setup, asset, importmap, and first-run instructions aligned before release-facing docs changes land |
+| `docs/en/minimal-usage.md`, `docs/ja/minimal-usage.md` | Published in both trees | High | Keep the first working host-app example aligned with installation and usage docs |
+| `docs/en/usage.md`, `docs/ja/usage.md` | Published in both trees | High | Keep the baseline user-facing behavior and responsibility guidance aligned |
+| `docs/en/api-overview.md`, `docs/ja/api-overview.md` | Published in both trees | High | Keep the first API-orientation page aligned when public entry points or recommended reading order change |
+| `docs/en/decision-guide.md`, `docs/ja/decision-guide.md` | Published in both trees | Follow-up | Revisit when API selection guidance or responsibility boundaries change materially |
+| `docs/en/faq.md`, `docs/ja/faq.md` and `docs/en/troubleshooting.md`, `docs/ja/troubleshooting.md` | Published in both trees | Follow-up | Revisit when common integration misunderstandings, symptoms, or rescue paths change |
+| `docs/en/public-api.md`, `docs/ja/public-api.md`, `docs/en/api.md`, `docs/ja/api.md`, `docs/en/js-events.md`, `docs/ja/js-events.md` | Published in both trees | Follow-up | Revisit in the same PR when public API wording, compatibility promises, or machine-readable public contract surfaces change |
+| Feature guides such as `resource-table-bridge.md`, `form-editing.md`, `selection.md`, `lazy-loading.md`, `windowed-rendering.md`, and `persisted-state.md` under both language trees | Published in both trees, but English detail can lag behind Japanese | Follow-up | Revisit when the related feature meaning, host-app responsibility boundary, or recommended pattern changes materially |
+| Release-facing and maintainer-facing guides such as `release.md`, `migration.md`, `development.md`, `design-policy.md`, and `code-quality.md` under both language trees | Published in both trees | Follow-up | Revisit when release expectations, compatibility policy, CI workflow, or maintainer rules change |
+
+If a page outside the High lane changes first, do not block the docs PR automatically. Instead, leave a visible note in the changed page or PR and add the follow-up to the next bilingual maintenance sweep.
+
 ## When to update both Japanese and English docs
 
 Update both language trees when the change affects user-facing behavior, public options, responsibility boundaries, or guidance that a reader would reasonably expect to match across languages.
@@ -102,5 +123,6 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 
 - Keep `docs/ja/` and `docs/en/` in sync for future user-facing changes.
 - If a temporary mismatch is unavoidable, leave a visible note and plan the follow-up.
+- Treat the High lane in the page-level coverage table above as the minimum same-sweep translation set promised by the language READMEs.
 - When `docs/mockups/` gains a new focused reference page, update this technical-assets table and confirm `docs/mockups/README.md` plus `docs/mockups/review-gallery.html` still describe the current set.
 - Prefer updating this checklist by replacement when the maintenance rule changes, instead of stacking stale release-specific notes on top of it.


### PR DESCRIPTION
Closes #601

## 対応 Issue
- #601

## 変更内容
- `docs/i18n-audit.md` に `Page-level language coverage and translation priority` セクションを追加
- language README 群が約束している優先レーンを、High / Follow-up の page-level table として明記
- `docs/en/README.md` / `docs/ja/README.md` / `docs/README.md` と矛盾しないよう、High lane を entry docs / installation / minimal usage / usage / API overview に固定
- ongoing maintenance に「High lane を same-sweep translation の最小集合として扱う」ルールを追記

## 受け入れ条件との対応
- [x] `docs/i18n-audit.md` に page-level language coverage を見られる table を追加
- [x] high-priority user-facing docs と follow-up docs の translation priority が分かる
- [x] `docs/en/README.md` / `docs/ja/README.md` の language-status 説明と矛盾しない
- [x] mockup technical assets や release-specific tracker の再設計には広げていない

## 変更範囲
- `docs/i18n-audit.md` のみ

## 実施した確認
- current `docs/en/README.md` / `docs/ja/README.md` / `docs/README.md` が案内している優先 docs lane と wording を照合
- existing update matrix / technical-assets table / root-level docs policy を壊さず、inventory / priority 表現だけを追加した
- diff が docs maintenance checklist 1 ファイルに閉じていることを確認

## 実行できなかった確認
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル checkout ベースの preview や test 実行は未実施です
- docs-only PR なので、最終確認は GitHub 上の diff readability 前提です

## リスク
- low
- translation priority の見える化に閉じた docs-only change で、runtime behavior や public API には触れていません

## 補足
- High lane は language README 群がすでに約束している entry docs を source of truth にしており、translation 本文の追加や docs tree の再構成には広げていません