### PR TITLE
design: add focused selection visibility mockup

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -88,6 +88,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/README.md` | Technical asset | Index for static mockup assets. Short bilingual-style prose is acceptable; no separate translation needed. |
 | `docs/mockups/review-gallery.html` | Technical asset | Comparison hub for the current static mockup set. No translation needed. |
 | `docs/mockups/default-tree.html` | Technical asset | No translation needed. |
+| `docs/mockups/selection-visibility.html` | Technical asset | No translation needed. |
 | `docs/mockups/resource-table-bridge.html` | Technical asset | No translation needed. |
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -12,6 +12,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 |---|---|
 | [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the current baseline and focused mockup references, with embedded previews and links to each full page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [selection-visibility.html](selection-visibility.html) | Focused comparison for `selection[:visibility]`, disabled checkboxes, disabled reasons, and mixed parent cues without submit or business-action behavior. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
@@ -26,13 +27,14 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the current mockup set.
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
-3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-5. Use [children-pagination.html](children-pagination.html) when review needs a narrower pass on where next-page placeholder rows and load-more affordances should sit inside one expanded branch.
-6. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-7. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-8. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-9. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+3. Use [selection-visibility.html](selection-visibility.html) when review needs a focused pass on checkbox visibility modes, disabled reasons, or mixed parent cues.
+4. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
+5. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+6. Use [children-pagination.html](children-pagination.html) when review needs a narrower pass on where next-page placeholder rows and load-more affordances should sit inside one expanded branch.
+7. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+8. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+9. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+10. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, focused children-pagination placement, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, selection visibility and disabled-state cues, narrow layouts, interaction states, focused children-pagination placement, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -180,6 +180,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-selection-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused selection</p>
+          <h2 id="gallery-selection-heading">Selection visibility</h2>
+          <p>
+            Use this surface to compare checkbox visibility modes, disabled reasons, and mixed parent cues without adding hidden-input sync, submit flow, or business actions.
+          </p>
+          <ul class="mock-gallery-points">
+            <li><code>:all</code>, <code>:roots</code>, <code>:leaves</code>, and <code>:none</code> in one pass</li>
+            <li>Disabled checkbox and disabled-reason treatment</li>
+            <li>Mixed parent cue kept separate from host-app bulk action behavior</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="selection-visibility.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="selection-visibility.html" title="Selection visibility mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -367,6 +388,11 @@
             <td>Default tree</td>
             <td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td>
             <td>Host-app CRUD, queries, business labels, or authorization behavior.</td>
+          </tr>
+          <tr>
+            <td>Selection visibility</td>
+            <td>Comparing <code>:all</code>, <code>:roots</code>, <code>:leaves</code>, and <code>:none</code> alongside disabled reasons and mixed parent cues.</td>
+            <td>Hidden input sync, submit semantics, bulk action policy, and business-specific authorization copy.</td>
           </tr>
           <tr>
             <td>Resource table bridge</td>

--- a/docs/mockups/selection-visibility.html
+++ b/docs/mockups/selection-visibility.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Selection visibility and disabled-state mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-visibility-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.mock-state-card {
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 16px;
+}
+
+.mock-state-card h3,
+.mock-state-card p,
+.mock-state-card ul {
+  margin-top: 0;
+}
+
+.mock-state-card h3 {
+  margin-bottom: 0.35rem;
+}
+
+.mock-state-card p {
+  color: #52606d;
+}
+
+.mock-state-card .tree-view-table {
+  background: #fff;
+}
+
+.mock-selection-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1rem;
+  color: #94a3b8;
+  font-weight: 700;
+}
+
+.mock-disabled-reason {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.35rem;
+  padding: 0.08rem 0.4rem;
+  border-radius: 999px;
+  background: #fff1f2;
+  color: #9f1239;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.mock-selection-note {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.92rem;
+}
+
+.mock-scope-table td:first-child,
+.mock-scope-table th:first-child {
+  width: 4rem;
+  text-align: center;
+}
+
+.mock-scope-table td:nth-child(2),
+.mock-scope-table th:nth-child(2) {
+  width: 7rem;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Selection visibility and disabled-state mock</h1>
+      <p>
+        Static HTML for reviewing how TreeView selection cells change across visibility modes,
+        disabled checkbox rules, and mixed parent cues without wiring real forms, submit flows,
+        or host-app bulk actions.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="visibility-heading">
+      <h2 id="visibility-heading">Visibility modes</h2>
+      <p>
+        Each card keeps the same representative root, child, and leaf rows so reviewers can compare
+        which rows render checkboxes when <code>selection[:visibility]</code> changes.
+      </p>
+      <div class="mock-visibility-grid">
+        <article class="mock-state-card">
+          <h3><code>:all</code></h3>
+          <p>All rendered rows keep checkboxes, including expandable branches and leaves.</p>
+          <table class="tree-view-table mock-scope-table" aria-label="Selection visibility all">
+            <thead>
+              <tr>
+                <th scope="col">select</th>
+                <th scope="col">level</th>
+                <th scope="col">name</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded">
+                <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" aria-label="Select root"></td>
+                <td><span class="tree-toggle__level">root</span></td>
+                <td>Portfolio</td>
+              </tr>
+              <tr class="tree-row is-expanded is-selected">
+                <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" checked aria-label="Select child"></td>
+                <td><span class="tree-toggle__level">child</span></td>
+                <td>Operations board</td>
+              </tr>
+              <tr class="tree-row is-leaf">
+                <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" aria-label="Select leaf"></td>
+                <td><span class="tree-toggle__level">leaf</span></td>
+                <td>Runbook</td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="mock-state-card">
+          <h3><code>:roots</code></h3>
+          <p>Only root rows keep checkboxes. Descendants still reserve the same cell so columns stay aligned.</p>
+          <table class="tree-view-table mock-scope-table" aria-label="Selection visibility roots">
+            <thead>
+              <tr>
+                <th scope="col">select</th>
+                <th scope="col">level</th>
+                <th scope="col">name</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded">
+                <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" aria-label="Select root only"></td>
+                <td><span class="tree-toggle__level">root</span></td>
+                <td>Portfolio</td>
+              </tr>
+              <tr class="tree-row is-expanded">
+                <td class="tree-selection-cell"><span class="mock-selection-placeholder" aria-hidden="true">-</span></td>
+                <td><span class="tree-toggle__level">child</span></td>
+                <td>Operations board</td>
+              </tr>
+              <tr class="tree-row is-leaf">
+                <td class="tree-selection-cell"><span class="mock-selection-placeholder" aria-hidden="true">-</span></td>
+                <td><span class="tree-toggle__level">leaf</span></td>
+                <td>Runbook</td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="mock-state-card">
+          <h3><code>:leaves</code></h3>
+          <p>Leaf rows keep checkboxes while branch rows become structural only.</p>
+          <table class="tree-view-table mock-scope-table" aria-label="Selection visibility leaves">
+            <thead>
+              <tr>
+                <th scope="col">select</th>
+                <th scope="col">level</th>
+                <th scope="col">name</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded">
+                <td class="tree-selection-cell"><span class="mock-selection-placeholder" aria-hidden="true">-</span></td>
+                <td><span class="tree-toggle__level">root</span></td>
+                <td>Portfolio</td>
+              </tr>
+              <tr class="tree-row is-expanded">
+                <td class="tree-selection-cell"><span class="mock-selection-placeholder" aria-hidden="true">-</span></td>
+                <td><span class="tree-toggle__level">child</span></td>
+                <td>Operations board</td>
+              </tr>
+              <tr class="tree-row is-leaf is-selected">
+                <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" checked aria-label="Select leaf only"></td>
+                <td><span class="tree-toggle__level">leaf</span></td>
+                <td>Runbook</td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="mock-state-card">
+          <h3><code>:none</code></h3>
+          <p>No rendered row exposes a checkbox, but the empty cells stay in place for table consistency.</p>
+          <table class="tree-view-table mock-scope-table" aria-label="Selection visibility none">
+            <thead>
+              <tr>
+                <th scope="col">select</th>
+                <th scope="col">level</th>
+                <th scope="col">name</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded">
+                <td class="tree-selection-cell"><span class="mock-selection-placeholder" aria-hidden="true">-</span></td>
+                <td><span class="tree-toggle__level">root</span></td>
+                <td>Portfolio</td>
+              </tr>
+              <tr class="tree-row is-expanded">
+                <td class="tree-selection-cell"><span class="mock-selection-placeholder" aria-hidden="true">-</span></td>
+                <td><span class="tree-toggle__level">child</span></td>
+                <td>Operations board</td>
+              </tr>
+              <tr class="tree-row is-leaf">
+                <td class="tree-selection-cell"><span class="mock-selection-placeholder" aria-hidden="true">-</span></td>
+                <td><span class="tree-toggle__level">leaf</span></td>
+                <td>Runbook</td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="disabled-heading">
+      <h2 id="disabled-heading">Disabled and mixed states</h2>
+      <p>
+        This table focuses on disabled checkboxes, disabled reasons, and a parent row that stays visually mixed
+        while child business actions remain outside TreeView's reusable scope.
+      </p>
+      <table class="tree-view-table" aria-label="Disabled and mixed selection states">
+        <thead>
+          <tr>
+            <th scope="col">select</th>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">state cue</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="tree-row is-expanded">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" type="checkbox" checked aria-checked="mixed" aria-label="Mixed parent selection">
+            </td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">root</span>
+                </span>
+              </span>
+            </td>
+            <td>Operations board</td>
+            <td><span class="tree-node-badge tree-node-badge--info">mixed</span></td>
+          </tr>
+          <tr class="tree-row is-leaf is-selected">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" type="checkbox" checked aria-label="Enabled child selection">
+            </td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">leaf</span>
+                </span>
+              </span>
+            </td>
+            <td>Current checklist</td>
+            <td><span class="mock-status mock-status--active">selected</span></td>
+          </tr>
+          <tr class="tree-row is-leaf is-collapsed">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" type="checkbox" disabled title="Archived items cannot be selected" aria-label="Disabled archived child selection">
+            </td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">leaf</span>
+                </span>
+              </span>
+            </td>
+            <td>
+              Archived checklist
+              <span class="mock-disabled-reason">disabled reason</span>
+            </td>
+            <td><span class="mock-status mock-status--archived">archived</span></td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="mock-selection-note">
+        TreeView can render the checkbox, disabled reason, and mixed row cue. Bulk action wording,
+        hidden input sync, submit handling, and max-count messaging still belong to the host app.
+      </p>
+    </section>
+
+    <section class="mock-section" aria-labelledby="coverage-heading">
+      <h2 id="coverage-heading">What this mock covers</h2>
+      <ul>
+        <li>Representative checkbox visibility for <code>:all</code>, <code>:roots</code>, <code>:leaves</code>, and <code>:none</code></li>
+        <li>Disabled checkbox rendering and disabled reason placement</li>
+        <li>Mixed parent state as a visual cue rather than a business action workflow</li>
+        <li>Clear boundary between reusable TreeView output and host-app-owned submit behavior</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #596
- Closes #579
- Refs #587

## 採用した方針

- スケジュール/自動進行の通常方針に従い、selection docs 本文や controller 実装には広げず、static mockup を 1 枚増やして visibility mode と disabled-state comparison を focused に見せる low-risk 案を採用しました。
- same-day の mockup sibling と `README.md` / `review-gallery.html` が衝突しやすいため、base は `design/587-children-pagination-mockup-main-head` に重ねています。
- `#579` が求めていた technical-assets sync も同じ mockup family の最小追従として、この branch の `docs/i18n-audit.md` に吸収しました。

## 比較した案

- 案A: `selection-visibility.html` を新設し、`selection[:visibility]` の 4 mode と disabled / mixed cue を 1 ページで比較できるようにする。
- 案B: `default-tree.html` や `interaction-states.html` に selection-specific section を足して済ませる。
- 案C: prose docs だけで visibility / disabled-state の違いを補う。
- 今回は案Aを採用しました。selection-specific visual review が他の論点と混ざりにくく、issue の完了条件を最も読みやすく満たせるためです。

## 変更内容

- `docs/mockups/selection-visibility.html`
  - focused mockup page を追加
  - `:all` / `:roots` / `:leaves` / `:none` の representative state を比較できるよう追加
  - disabled checkbox / disabled reason / mixed parent cue を static HTML で比較できるよう追加
- `docs/mockups/README.md`
  - file inventory と recommended review flow に selection visibility mockup を追加
- `docs/mockups/review-gallery.html`
  - gallery card と comparison row を追加し、新しい focused surface へ辿れるよう更新
- `docs/i18n-audit.md`
  - technical-assets table に `selection-visibility.html` を追加
  - current branch 上の mockup inventory を `README.md` / `review-gallery.html` と揃える narrow maintenance sync を追加

## 変更した画面・コンポーネント

- mockup docs (`docs/mockups/selection-visibility.html`)
- mockup index (`docs/mockups/README.md`)
- review gallery (`docs/mockups/review-gallery.html`)
- documentation maintenance checklist (`docs/i18n-audit.md`)

## 確認内容

- lint: 未実施
- typecheck: 該当なし
- UI表示確認: static HTML/CSS と maintenance docs の diff が mockup family 4 files に閉じていることを確認
- レスポンシブ確認: review gallery card と focused page の grid が既存 mockup と同じ CSS 前提で崩れにくい構成に留めた
- アクセシビリティ確認: visibility mode 名、disabled reason cue、mixed parent cue が source 上で読み取れることを確認
- docs inventory 確認: `docs/mockups/README.md` / `review-gallery.html` / `docs/i18n-audit.md` が current branch 上の focused mockup set と食い違わないことを確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low
- static docs に閉じた変更で、selection controller behavior、hidden input sync、submit flow、bulk action policy には触れていません

## 補足

- local preview や test 実行は未実施です
- final review では `default-tree.html` と責務が重なりすぎていないか、selection-specific comparison surface として読み分けやすいかを見てもらえると助かります