### PR TITLE
design: add drag interactive controls mockup

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -92,6 +92,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
+| `docs/mockups/drag-interactive-controls.html` | Technical asset | No translation needed. |
 | `docs/mockups/windowed-rendering.html` | Technical asset | No translation needed. |
 | `docs/mockups/filtered-tree-modes.html` | Technical asset | No translation needed. |
 | `docs/mockups/form-editing-rows.html` | Technical asset | No translation needed. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -15,6 +15,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [drag-interactive-controls.html](drag-interactive-controls.html) | Focused comparison for native interactive controls, `data-tree-view-interactive`, and `data-tree-view-ignore-drag` inside draggable rows. |
 | [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
@@ -28,11 +29,12 @@ They are **not** a complete Rails application and should not grow into host-app 
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-5. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-6. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-7. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-8. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-9. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+5. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+6. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+7. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+8. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+9. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+10. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/drag-interactive-controls.html
+++ b/docs/mockups/drag-interactive-controls.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView drag interactive controls mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-drag-controls-page {
+  max-width: 1280px;
+}
+
+.mock-drag-controls-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-drag-controls-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-drag-controls-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-drag-controls-toolbar__copy {
+  display: grid;
+  gap: 4px;
+}
+
+.mock-drag-controls-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-drag-controls-toolbar__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-drag-controls-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  font-size: 0.79rem;
+  font-weight: 700;
+}
+
+.mock-drag-controls-chip--drag {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.mock-drag-controls-chip--marker {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.mock-drag-controls-chip--narrow {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-drag-controls-body {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.mock-drag-controls-callout {
+  margin: 0;
+  padding: 0.8rem 0.95rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.mock-drag-controls-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-drag-controls-table th,
+.mock-drag-controls-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.72rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-drag-controls-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mock-drag-controls-stack {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-drag-controls-widget {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #fff;
+  color: #102a43;
+  font-weight: 600;
+}
+
+.mock-drag-controls-widget--interactive {
+  border-color: #c4b5fd;
+  background: #f5f3ff;
+}
+
+.mock-drag-controls-widget--ignore-drag {
+  border-color: #86efac;
+  background: #f0fdf4;
+}
+
+.mock-drag-controls-input,
+.mock-drag-controls-select,
+.mock-drag-controls-button,
+.mock-drag-controls-link {
+  font: inherit;
+}
+
+.mock-drag-controls-input,
+.mock-drag-controls-select {
+  min-height: 2.35rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  color: #102a43;
+  background: #fff;
+}
+
+.mock-drag-controls-button,
+.mock-drag-controls-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.42rem 0.72rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #0f172a;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-drag-controls-link {
+  color: #1d4ed8;
+}
+
+.mock-drag-controls-badge-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-drag-controls-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  font-size: 0.77rem;
+  font-weight: 700;
+}
+
+.mock-drag-controls-badge--native {
+  background: #e0f2fe;
+  color: #0f4c81;
+}
+
+.mock-drag-controls-badge--custom {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.mock-drag-controls-badge--drag {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.mock-drag-controls-badge--safe {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-drag-controls-note-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #334155;
+}
+
+.tree-row.is-dragging-preview {
+  background: #eff6ff;
+}
+
+.tree-row.is-dragging-preview td {
+  border-bottom-color: #bfdbfe;
+}
+
+.tree-row.is-marker-preview {
+  background: #faf5ff;
+}
+
+.tree-row.is-marker-preview td {
+  border-bottom-color: #ddd6fe;
+}
+
+.tree-row.is-ignore-drag-preview {
+  background: #f0fdf4;
+}
+
+.tree-row.is-ignore-drag-preview td {
+  border-bottom-color: #bbf7d0;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-drag-controls-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView drag interactive controls mock</h1>
+      <p>
+        Static reference for comparing draggable rows that contain native controls, custom interactive markers,
+        and drag-only ignore markers. TreeView owns the reusable guard markers and transfer boundary; the host app still owns
+        drag wiring, drop targets, permissions, and business behavior.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-drag-controls-grid" aria-labelledby="drag-controls-heading">
+      <div class="mock-drag-controls-frame">
+        <div class="mock-drag-controls-toolbar">
+          <div class="mock-drag-controls-toolbar__copy">
+            <p class="mock-drag-controls-toolbar__title">Compare drag-start guard surfaces inside draggable rows</p>
+          </div>
+          <div class="mock-drag-controls-toolbar__meta" aria-label="Representative drag marker metadata">
+            <span class="mock-drag-controls-chip mock-drag-controls-chip--drag">behavior: drag start</span>
+            <span class="mock-drag-controls-chip mock-drag-controls-chip--marker">custom marker</span>
+            <span class="mock-drag-controls-chip mock-drag-controls-chip--narrow">narrow ignore marker</span>
+          </div>
+        </div>
+        <div class="mock-drag-controls-body">
+          <p class="mock-drag-controls-callout">
+            Use this page when review needs a focused pass on whether a row should start transfer, or whether an embedded control
+            should stay safe to click, type into, or open without accidental dragging.
+          </p>
+          <table class="tree-view-table" data-controller="tree-view-transfer">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">embedded control</th>
+                <th scope="col">drag-start result</th>
+                <th scope="col">why this state matters</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-dragging-preview" draggable="true" data-tree-node-key="doc:plain" data-tree-transfer-payload='{"key":"doc:plain","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-drag-controls-stack">
+                    <span class="tree-toggle" aria-label="Plain draggable row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">drag</span></span>
+                    </span>
+                    <div class="mock-drag-controls-badge-row">
+                      <span class="mock-drag-controls-badge mock-drag-controls-badge--drag">no marker</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-drag-controls-stack">
+                    <span>Plain row content only</span>
+                    <span class="mock-status mock-status--pending">Pointer down can begin row transfer.</span>
+                  </div>
+                </td>
+                <td><span class="mock-status mock-status--pending">drag starts</span></td>
+                <td>Baseline reference for a row that should remain draggable when the pointer is not inside a control.</td>
+              </tr>
+
+              <tr class="tree-row" draggable="true" data-tree-node-key="doc:native" data-tree-transfer-payload='{"key":"doc:native","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-drag-controls-stack">
+                    <span class="tree-toggle" aria-label="Native control row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">native</span></span>
+                    </span>
+                    <div class="mock-drag-controls-badge-row">
+                      <span class="mock-drag-controls-badge mock-drag-controls-badge--native">native guard</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-drag-controls-stack">
+                    <label>
+                      <span class="sr-only">Owner</span>
+                      <input class="mock-drag-controls-input" type="text" value="Operations" aria-label="Owner">
+                    </label>
+                    <div class="mock-drag-controls-badge-row">
+                      <a class="mock-drag-controls-link" href="#">Open</a>
+                      <button class="mock-drag-controls-button" type="button">Assign</button>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="mock-status mock-status--active">drag ignored</span></td>
+                <td>Inputs, links, buttons, selects, textareas, and editable labels should stay usable without an extra marker.</td>
+              </tr>
+
+              <tr class="tree-row is-marker-preview" draggable="true" data-tree-node-key="doc:interactive" data-tree-transfer-payload='{"key":"doc:interactive","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-drag-controls-stack">
+                    <span class="tree-toggle" aria-label="Custom interactive marker row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">marker</span></span>
+                    </span>
+                    <div class="mock-drag-controls-badge-row">
+                      <span class="mock-drag-controls-badge mock-drag-controls-badge--custom">data-tree-view-interactive</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-drag-controls-stack">
+                    <span class="mock-drag-controls-widget mock-drag-controls-widget--interactive" data-tree-view-interactive="true">
+                      Custom color picker
+                    </span>
+                    <span class="mock-status mock-status--active">Use when the widget is not a native input or button.</span>
+                  </div>
+                </td>
+                <td><span class="mock-status mock-status--active">drag ignored</span></td>
+                <td>Marks a host-app widget as interactive for TreeView behaviors, including drag-start guard.</td>
+              </tr>
+
+              <tr class="tree-row is-ignore-drag-preview" draggable="true" data-tree-node-key="doc:ignore-drag" data-tree-transfer-payload='{"key":"doc:ignore-drag","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-drag-controls-stack">
+                    <span class="tree-toggle" aria-label="Ignore-drag marker row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">drag-safe</span></span>
+                    </span>
+                    <div class="mock-drag-controls-badge-row">
+                      <span class="mock-drag-controls-badge mock-drag-controls-badge--safe">data-tree-view-ignore-drag</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-drag-controls-stack">
+                    <span class="mock-drag-controls-widget mock-drag-controls-widget--ignore-drag" data-tree-view-ignore-drag="true">
+                      Range scrubber
+                    </span>
+                    <span class="mock-status mock-status--active">Ignore drag start only; narrower than the generic interactive marker.</span>
+                  </div>
+                </td>
+                <td><span class="mock-status mock-status--active">drag ignored</span></td>
+                <td>Use when the widget only needs drag protection and other TreeView behaviors may still apply elsewhere in the row.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="drag-controls-boundary-heading">
+      <h2 id="drag-controls-boundary-heading">What this mock compares</h2>
+      <table class="mock-drag-controls-table">
+        <thead>
+          <tr>
+            <th scope="col">Surface</th>
+            <th scope="col">Best for</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Plain draggable row</td>
+            <td>Confirming the baseline row stays draggable when no control marker is present.</td>
+            <td>Drop targets, persistence, authorization, and route wiring.</td>
+          </tr>
+          <tr>
+            <td>Native interactive controls</td>
+            <td>Checking that built-in controls remain safe to click or edit without extra TreeView markers.</td>
+            <td>Host-app validation, save timing, or business copy.</td>
+          </tr>
+          <tr>
+            <td><code>data-tree-view-interactive</code></td>
+            <td>Showing the broad custom-widget marker for non-native controls inside a draggable row.</td>
+            <td>Widget implementation details or unrelated keyboard and row-click policy changes.</td>
+          </tr>
+          <tr>
+            <td><code>data-tree-view-ignore-drag</code></td>
+            <td>Showing the narrower marker when drag start alone should be ignored.</td>
+            <td>Business-specific drag affordances, recovery UI, or drop sequencing rules.</td>
+          </tr>
+        </tbody>
+      </table>
+      <ul class="mock-drag-controls-note-list">
+        <li>These markers are shown as reusable TreeView guard hooks, not as a full drag-and-drop workflow.</li>
+        <li>Final labels, permissions, destination rules, and save behavior remain host-app responsibilities.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, windowed rendering cues, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, drag-safe control markers, windowed rendering cues, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -243,6 +243,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-drag-controls-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused drag guards</p>
+          <h2 id="gallery-drag-controls-heading">Drag interactive controls</h2>
+          <p>
+            Use this surface to compare plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers inside the same tree layout.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Native input, link, and button drag-start guard</li>
+            <li><code>data-tree-view-interactive</code> for custom widgets</li>
+            <li><code>data-tree-view-ignore-drag</code> for narrower drag-safe controls</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="drag-interactive-controls.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -382,6 +403,11 @@
             <td>Interaction states</td>
             <td>Loading, retry, pagination, and drag or drop status cues.</td>
             <td>Real Turbo responses, route wiring, or persistence behavior.</td>
+          </tr>
+          <tr>
+            <td>Drag interactive controls</td>
+            <td>Comparing plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers.</td>
+            <td>Drop targets, widget implementation details, permission rules, or business-specific drag affordances.</td>
           </tr>
           <tr>
             <td>Windowed rendering</td>


### PR DESCRIPTION
Closes #605
Refs #579

## 判定分類
- `docs-missing`
- `docs-sync`

## 変更理由
current `docs/en|ja/drag-and-drop.md` と `docs/en|ja/host-app-extension-points.md` は、draggable row 内の native interactive control、`data-tree-view-interactive`, `data-tree-view-ignore-drag` の責務境界を public guidance として説明しています。一方で current `docs/mockups/` には、その比較だけを focused に見られる static reference がまだありませんでした。

今回の PR は runtime drag/drop 実装や prose docs 本文には広げず、static mockup 1 枚と mockup 導線、さらに `docs/i18n-audit.md` の technical-asset inventory を current set にそろえる narrow docs lane として閉じています。

## 変更内容
- `docs/mockups/drag-interactive-controls.html`
  - plain draggable row
  - native interactive controls
  - `data-tree-view-interactive` custom widget
  - `data-tree-view-ignore-drag` widget
  を並べて比較できる focused mockup page を追加
- `docs/mockups/README.md`
  - file inventory と recommended review flow に新しい focused surface を追加
- `docs/mockups/review-gallery.html`
  - gallery card / iframe preview / comparison row を追加
- `docs/i18n-audit.md`
  - technical-assets table に新しい mockup asset を追加

## 受け入れ条件との対応
- [x] drag-safe interactive control comparison を focused に確認できる mockup page がある
- [x] native interactive control、custom interactive marker、ignore-drag marker、通常 draggable row の representative state を比較できる
- [x] `docs/mockups/README.md` と `review-gallery.html` から新しい surface へ辿れる
- [x] runtime drag/drop 実装や product-specific business behavior には広げていない

## 実施した確認
- `app/javascript/tree_view/interactive.js` の current selector contract を確認
- `docs/en|ja/drag-and-drop.md` と `docs/en|ja/host-app-extension-points.md` の current public guidance を確認
- diff を static mockup 追加 + mockup entry docs + inventory sync の 4 files に限定

## 実行できなかった確認
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や test 実行は未実施です
- docs-only PR のため、最終確認は GitHub 上の diff readability と link reachability 前提です

## リスク
- low
- static docs / technical asset inventory に閉じた変更で、runtime controller behavior、drop target contract、business-specific drag/drop policy には触れていません

## 補足
- `docs/i18n-audit.md` は new focused mockup page 追加時に technical-assets table も同期する current maintenance rule に合わせて同時更新しています
- sibling mockup PR と write set が近いのは `docs/mockups/README.md` / `review-gallery.html` のみで、変更意図は `#605` の drag-safe control review lane に限定しています