### PR TITLE
test: 生成系 tree pattern helper で diagnostics 異常構造を guard する

### DIFF
--- a/spec/lib/tree_view/generated_tree_patterns_spec.rb
+++ b/spec/lib/tree_view/generated_tree_patterns_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+RSpec.describe "TreeView generated abnormal structure patterns" do
+  def pattern_signature(pattern, seed:)
+    generated_tree_pattern(pattern, seed: seed).map do |node|
+      [node.id, node.parent_id, node.label]
+    end
+  end
+
+  it "recreates the same pattern from the same seed" do
+    expect(pattern_signature(:orphan_cluster, seed: 414)).to eq(pattern_signature(:orphan_cluster, seed: 414))
+  end
+
+  it "reports generated orphan clusters through diagnostics warnings" do
+    records = generated_tree_pattern(:orphan_cluster, seed: 414)
+    tree = TreeView::Tree.new(records: records, parent_id_method: :parent_id)
+
+    result = TreeView::Diagnostics.run(tree: tree, checks: [:orphans])
+
+    expect(result).to be_success
+    expect(result.warnings.first).to include(check: :orphans)
+    expect(result.warnings.first[:details].size).to eq(2)
+  end
+
+  it "surfaces duplicate node keys from a generated duplicate-id pattern" do
+    tree = TreeView::Tree.new(
+      records: generated_tree_pattern(:duplicate_id, seed: 414),
+      parent_id_method: :parent_id
+    )
+
+    expect do
+      tree.validate_unique_node_keys!
+    end.to raise_error(TreeView::DuplicateNodeKeyError, /duplicate node_key/)
+  end
+
+  it "treats a generated parent_id type mismatch as an orphan report" do
+    tree = TreeView::Tree.new(
+      records: generated_tree_pattern(:parent_id_type_mismatch, seed: 414),
+      parent_id_method: :parent_id
+    )
+
+    expect(tree.orphan_report).to contain_exactly(
+      include(key: 2, missing_parent_id: "1")
+    )
+  end
+
+  it "surfaces generated cycle pairs through cycle diagnostics" do
+    records = generated_tree_pattern(:cycle_pair, seed: 414)
+    tree = TreeView::Tree.new(records: records, parent_id_method: :parent_id)
+
+    expect(tree.cycle_report.first[:cycle_keys]).to eq(records.map(&:id))
+    expect { tree.validate_no_cycles! }.to raise_error(ArgumentError, /cycle detected/)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require_relative "../app/helpers/tree_view_state_helper"
 require_relative "../app/helpers/tree_view_row_attrs_helper"
 require_relative "../app/helpers/tree_view_breadcrumb_helper"
 
+Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |path| require path }
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.order = :random

--- a/spec/support/tree_pattern_helper.rb
+++ b/spec/support/tree_pattern_helper.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module TreePatternHelper
+  GeneratedTreeNode = Struct.new(:id, :parent_id, :label, keyword_init: true)
+
+  def generated_tree_node(id:, parent_id:, label: nil)
+    GeneratedTreeNode.new(id: id, parent_id: parent_id, label: label || "node-#{id}")
+  end
+
+  def generated_tree_pattern(pattern, seed: 414)
+    random = Random.new(seed)
+
+    case pattern
+    when :deep_chain
+      length = 5 + random.rand(4)
+      Array.new(length) do |index|
+        generated_tree_node(
+          id: index + 1,
+          parent_id: index.zero? ? nil : index,
+          label: "chain-#{index + 1}"
+        )
+      end
+    when :orphan_cluster
+      root_count = 2 + random.rand(2)
+      roots = Array.new(root_count) do |index|
+        generated_tree_node(id: index + 1, parent_id: nil, label: "root-#{index + 1}")
+      end
+      orphans = Array.new(2) do |index|
+        generated_tree_node(
+          id: root_count + index + 1,
+          parent_id: 90 + random.rand(10),
+          label: "orphan-#{index + 1}"
+        )
+      end
+
+      roots + orphans
+    when :duplicate_id
+      shared_id = 10 + random.rand(5)
+      [
+        generated_tree_node(id: shared_id, parent_id: nil, label: "duplicate-a"),
+        generated_tree_node(id: shared_id, parent_id: nil, label: "duplicate-b")
+      ]
+    when :parent_id_type_mismatch
+      [
+        generated_tree_node(id: 1, parent_id: nil, label: "root"),
+        generated_tree_node(id: 2, parent_id: "1", label: "string-parent")
+      ]
+    when :cycle_pair
+      first_id = 1 + random.rand(10)
+      second_id = first_id + 1
+      [
+        generated_tree_node(id: first_id, parent_id: second_id, label: "cycle-a"),
+        generated_tree_node(id: second_id, parent_id: first_id, label: "cycle-b")
+      ]
+    else
+      raise ArgumentError, "unknown tree pattern: #{pattern.inspect}"
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include TreePatternHelper
+end


### PR DESCRIPTION
## 対応 Issue
- Closes #414

## 変更内容
- `spec/support/tree_pattern_helper.rb`
  - seed 固定の軽量 pattern helper を追加
  - `:orphan_cluster` / `:duplicate_id` / `:parent_id_type_mismatch` / `:cycle_pair` を再現可能にした
- `spec/spec_helper.rb`
  - `spec/support/**/*.rb` を自動読み込みするよう更新
- `spec/lib/tree_view/generated_tree_patterns_spec.rb`
  - 同一 seed で同一パターンが再現されること
  - orphan warning
  - duplicate node key
  - parent_id type mismatch
  - cycle diagnostics
  を narrow に guard する spec を追加

## 既存仕様への影響
- なし
- runtime code や public API には触れていません
- spec helper と品質 guard の追加に閉じています

## なぜこの単位か
- `#414` は tree / diagnostics の異常構造を軽量な生成系 helper で再現可能にする first slice です
- VisibleRows / RenderWindow、selection、sorter の lane は混ぜず、issue の責務に合わせて tree / diagnostics だけへ閉じました

## 実施した確認
- existing `tree_spec` / `diagnostics_spec` / `cycle_diagnostics_spec` の責務を壊さず、generated-pattern lane を別 spec へ切り出したことを確認
- helper が seed 固定で同一パターンを再現できる構成にした

## 実行できなかった確認
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル `bundle exec rspec` は未実行です
- 最終確認は GitHub Actions CI 前提です

## リスク
- medium
- spec helper 読み込みと新規 spec 追加に閉じていますが、support 読み込みを `spec/spec_helper.rb` に足しているため CI での読み込み確認が必要です
