### PR TITLE
docs: clarify temporary npm install guidance in development docs

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -18,6 +18,8 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
+Keep using `npm install` for now. The repository has a committed `package-lock.json`, but it is not yet refreshed in sync with `package.json`, so local setup and pull-request CI stay on `npm install` until that lockfile refresh is completed in a registry-enabled environment. See [Installation](installation.md) for the current CI and install-path summary.
+
 ## Common commands
 
 ```bash

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -18,6 +18,8 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
+現状は `npm install` を使い続けてください。repo には `package-lock.json` を commit していますが、まだ `package.json` と同期していないため、ローカルセットアップと Pull Request CI は、registry-enabled な環境で lockfile refresh が完了するまで `npm install` を前提にしています。現在の CI と install path の整理は [導入手順](installation.md) を参照してください。
+
 ## よく使うコマンド
 
 ```bash


### PR DESCRIPTION
Closes #609

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
current `README.md` と `docs/en|ja/installation.md` には、committed `package-lock.json` がまだ `package.json` と同期しておらず、当面は `npm install` を使うという暫定方針が書かれています。一方で `docs/en|ja/development.md` の setup section はコマンドだけが先にあり、なぜ `npm install` を使い続けているのかが読み取りにくい状態でした。

今回の PR は current `main` の事実に合わせて development docs に短い補足を追加し、既存の installation docs へ案内する narrow docs-only lane です。lockfile refresh 本体や CI workflow 変更には広げていません。

## 変更内容
- `docs/en/development.md`
  - setup section に temporary `npm install` guidance を追加
  - committed lockfile が未同期であること、PR CI も同じ前提で動いていること、詳細は installation docs を見ることを明記
- `docs/ja/development.md`
  - 同じ guidance を日本語で追加

## 受け入れ条件との対応
- [x] `README.md` と `docs/en|ja/development.md` の暫定 install guidance が同じ前提で読める
- [x] installation docs へ current npm setup の事情を辿れる
- [x] 説明が temporary guidance であることが分かる
- [x] `package-lock.json` refresh や workflow change には広げていない

## 実施した確認
- current `README.md` の Development section と `docs/en|ja/installation.md` の lockfile note を照合
- diff が `docs/en/development.md` と `docs/ja/development.md` の 2 files に閉じていることを確認

## 実行できなかった確認
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や test 実行は未実施です
- docs-only PR のため、最終確認は GitHub 上の diff readability と link reachability 前提です

## リスク
- low
- current `main` の install policy を説明し直す docs-only change で、runtime code、lockfile、CI definition には触れていません