### PR TITLE
docs: selection controller の documented host-element attributes を入口 docs から見つけやすくする

### DIFF
--- a/docs/en/host-app-extension-points.md
+++ b/docs/en/host-app-extension-points.md
@@ -85,6 +85,29 @@ selection: {
 }
 ```
 
+`selection:` config covers row-level payload generation, disabled-state decisions, selected keys, and checkbox visibility inside `TreeView::RenderState`.
+
+When the host app configures the `tree-view-selection` controller on the host element, these documented value attributes are part of the stable wiring surface:
+
+- `data-tree-view-selection-hidden-input-name-value` for hidden-input sync into the nearest form
+- `data-tree-view-selection-max-count-value` for client-side selection limits
+- `data-tree-view-selection-cascade-value` for rendered-row cascade behavior
+- `data-tree-view-selection-indeterminate-value` for parent mixed-state updates
+
+```erb
+<tbody
+  data-controller="tree-view-selection"
+  data-action="change->tree-view-selection#toggle"
+  data-tree-view-selection-hidden-input-name-value="selected_nodes[]"
+  data-tree-view-selection-max-count-value="10"
+  data-tree-view-selection-cascade-value="true"
+  data-tree-view-selection-indeterminate-value="true">
+  <%= tree_view_rows(@render_state) %>
+</tbody>
+```
+
+Use the render-state `selection:` options for what each row means, and use the host-element value attributes for how the Stimulus controller mirrors or constrains already-rendered checkboxes. For complete event and behavior details, see [Selection](selection.md).
+
 ## Path builders
 
 Turbo and lazy-loading URLs are provided by the host app.

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -179,13 +179,22 @@ Documented keys on `TreeViewControllerIdentifiers`:
 - `transfer`
 - `remoteState`
 
+The `tree-view-selection` controller's documented host-element value attributes are also part of the stable host-app wiring surface:
+
+- `data-tree-view-selection-hidden-input-name-value`
+- `data-tree-view-selection-max-count-value`
+- `data-tree-view-selection-cascade-value`
+- `data-tree-view-selection-indeterminate-value`
+
+Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md#hidden-input-sync-for-regular-form-submit), [Selection](selection.md#selection-max-count), [Selection](selection.md#linked-checkbox-behavior), and [Host app extension points](host-app-extension-points.md#selection-builders).
+
 The machine-readable source of truth for the package-root JavaScript exports and bundled controller identifiers lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 
 Internal by default:
 
 - private controller methods
 - file layout under `app/javascript/tree_view/`
-- undocumented `data-*` attributes
+- undocumented `data-*` attributes outside the documented host-app wiring surface
 - DOM traversal details inside controllers
 
 ## CSS and DOM surface

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -186,7 +186,7 @@ The `tree-view-selection` controller's documented host-element value attributes 
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md#hidden-input-sync-for-regular-form-submit), [Selection](selection.md#selection-max-count), [Selection](selection.md#linked-checkbox-behavior), and [Host app extension points](host-app-extension-points.md#selection-builders).
+Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
 The machine-readable source of truth for the package-root JavaScript exports and bundled controller identifiers lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 

--- a/docs/ja/host-app-extension-points.md
+++ b/docs/ja/host-app-extension-points.md
@@ -85,6 +85,29 @@ selection: {
 }
 ```
 
+`selection:` 設定は、`TreeView::RenderState` 内で row ごとの payload 生成、disabled-state 判定、selected keys、checkbox visibility を決める側の設定です。
+
+host element に `tree-view-selection` controller を設定するときは、次の documented value attribute が stable な wiring surface に含まれます。
+
+- `data-tree-view-selection-hidden-input-name-value`: 最寄り form への hidden input sync
+- `data-tree-view-selection-max-count-value`: client-side の最大選択数制限
+- `data-tree-view-selection-cascade-value`: 描画済み行どうしの cascade 挙動
+- `data-tree-view-selection-indeterminate-value`: 親 checkbox の mixed-state 更新
+
+```erb
+<tbody
+  data-controller="tree-view-selection"
+  data-action="change->tree-view-selection#toggle"
+  data-tree-view-selection-hidden-input-name-value="selected_nodes[]"
+  data-tree-view-selection-max-count-value="10"
+  data-tree-view-selection-cascade-value="true"
+  data-tree-view-selection-indeterminate-value="true">
+  <%= tree_view_rows(@render_state) %>
+</tbody>
+```
+
+row ごとの意味づけは render-state 側の `selection:` option で行い、Stimulus controller が既に描画された checkbox をどう同期・制約するかは host-element value attribute 側で設定します。event や挙動の詳細は [Selection](selection.md) を参照してください。
+
 ## path builders
 
 Turboやlazy loadingのURLはhost appが作ります。

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -186,7 +186,7 @@ host app が使ってよい入口:
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md#通常form送信用の-hidden-input-同期)、[Selection](selection.md#最大選択数)、[Selection](selection.md#連動checkbox挙動)、[Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
+これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
 package-root の JavaScript export と bundled controller identifier の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -179,13 +179,22 @@ host app が使ってよい入口:
 - `transfer`
 - `remoteState`
 
+`tree-view-selection` controller の documented host-element value attribute も、stable な host-app wiring surface の一部です。
+
+- `data-tree-view-selection-hidden-input-name-value`
+- `data-tree-view-selection-max-count-value`
+- `data-tree-view-selection-cascade-value`
+- `data-tree-view-selection-indeterminate-value`
+
+これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md#通常form送信用の-hidden-input-同期)、[Selection](selection.md#最大選択数)、[Selection](selection.md#連動checkbox挙動)、[Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
+
 package-root の JavaScript export と bundled controller identifier の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 
 内部扱い:
 
 - private controller methods
 - `app/javascript/tree_view/` 以下の file layout
-- undocumented `data-*` attributes
+- documented host-app wiring surface に含まれない undocumented `data-*` attributes
 - controller 内部の DOM traversal details
 
 ## CSS and DOM surface


### PR DESCRIPTION
Closes #619

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
current `main` では `docs/en|ja/selection.md` に `tree-view-selection` controller の host-element value attributes が整理されていますが、入口 docs である `docs/en|ja/public-api.md` と `docs/en|ja/host-app-extension-points.md` からは、その surface が documented host-app wiring だと辿りにくい状態でした。

この PR では runtime や public export を変えず、既存 docs の見つけやすさだけを補います。

## 変更内容
- `docs/en/public-api.md`
- `docs/ja/public-api.md`
  - `tree-view-selection` controller の documented host-element value attributes を stable host-app wiring surface として明記
  - row-level `selection:` render-state builder と host-element controller config の責務分担を追記
- `docs/en/host-app-extension-points.md`
- `docs/ja/host-app-extension-points.md`
  - `selection:` builder が担う範囲を補足
  - `data-tree-view-selection-hidden-input-name-value`
  - `data-tree-view-selection-max-count-value`
  - `data-tree-view-selection-cascade-value`
  - `data-tree-view-selection-indeterminate-value`
    を使う representative wiring 例を追加
  - 詳細は `selection.md` を参照する導線を追加

## 根拠
- `docs/en/selection.md`
- `docs/ja/selection.md`
- current `main` の `docs/en|ja/public-api.md`
- current `main` の `docs/en|ja/host-app-extension-points.md`
- issue #619

## 変更範囲
- docs 4 files のみ
- runtime behavior、JavaScript export、public API 追加には触れていません

## 実施した確認
- 自分の open PR 群について review thread / review submission / issue comment を確認し、review follow-up 優先対象がないことを先に確認
- compare `main...docs/619-selection-controller-attrs-entrypoints` で diff が docs 4 files に閉じていることを確認
- `selection.md` 本文に既にある documented wiring と矛盾せず、入口 docs 側の visibility 改善に留まっていることを確認

## 実行できなかった確認
- docs-only 変更のため test / lint / typecheck は未実行です
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview は未実施です

## リスク
- low
- 既存 docs の cross-reference 補強だけで、behavior や compatibility policy の意味は変えていません
