### PR TITLE
test: mockup asset inventory の drift guard を追加する

### DIFF
--- a/spec/mockup_inventory_spec.rb
+++ b/spec/mockup_inventory_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "mockup inventory" do
+  let(:repo_root) { File.expand_path("..", __dir__) }
+  let(:mockups_dir) { File.join(repo_root, "docs/mockups") }
+  let(:readme_path) { File.join(mockups_dir, "README.md") }
+  let(:review_gallery_path) { File.join(mockups_dir, "review-gallery.html") }
+  let(:audit_path) { File.join(repo_root, "docs/i18n-audit.md") }
+
+  def actual_mockup_assets
+    Dir.children(mockups_dir)
+      .select { |name| File.file?(File.join(mockups_dir, name)) }
+      .sort
+  end
+
+  def actual_gallery_pages
+    actual_mockup_assets.grep(/\.html\z/) - ["review-gallery.html"]
+  end
+
+  def readme_inventory
+    File.read(readme_path)
+      .scan(/\[([A-Za-z0-9._-]+\.(?:html|css|md))\]\(\1\)/)
+      .flatten
+      .uniq
+      .sort
+  end
+
+  def review_gallery_inventory
+    File.read(review_gallery_path)
+      .scan(/<iframe[^>]+src="([A-Za-z0-9._-]+\.html)"/)
+      .flatten
+      .uniq
+      .sort
+  end
+
+  def audit_inventory
+    File.read(audit_path)
+      .scan(/`docs\/mockups\/([A-Za-z0-9._-]+\.(?:html|css|md))`/)
+      .flatten
+      .uniq
+      .sort
+  end
+
+  it "keeps the mockup README inventory aligned with the actual asset set" do
+    expect(readme_inventory).to eq(actual_mockup_assets - ["README.md"])
+  end
+
+  it "keeps the review gallery previews aligned with the actual HTML mockup pages" do
+    expect(review_gallery_inventory).to eq(actual_gallery_pages)
+  end
+
+  it "keeps the documentation maintenance checklist aligned with the actual mockup assets" do
+    expect(audit_inventory).to eq(actual_mockup_assets)
+  end
+end


### PR DESCRIPTION
Closes #617

## 対応 Issue 一覧
- Closes #617

## Issue ごとの完了内容
- #617
  - `docs/mockups/README.md`、`docs/mockups/review-gallery.html`、`docs/i18n-audit.md` の mockup asset inventory が actual file set とずれたときに RSpec で気づける guard を追加しました
  - primary source を `docs/mockups/` 配下の actual asset set に寄せ、README / gallery / maintenance checklist の 3 surface を compare rule で揃える形にしました

## 変更内容
- `spec/mockup_inventory_spec.rb`
  - actual `docs/mockups/` file set を読む helper を追加
  - `README.md` の inventory link 一覧が actual asset set から `README.md` を除いた構成と一致することを確認
  - `review-gallery.html` の iframe preview 一覧が actual HTML mockup pages と一致することを確認
  - `docs/i18n-audit.md` の technical-assets table が actual mockup asset set 全体と一致することを確認

## 改善カテゴリ
- docs drift guard 追加
- spec 追加

## 既存仕様への影響
- なし
- runtime code、mockup HTML/CSS の見た目、docs prose の意味は変更していません
- drift が起きたときに CI で見つけやすくする quality guard だけです

## なぜこの単位でまとめたか
- issue の主眼は mockup inventory drift の再発防止で、write set を spec 1 file に閉じるのが最も安全でした
- `#579` のような docs sync lane と役割が衝突しないよう、inventory source の更新ではなく detection に寄せています

## 実施した確認
- `docs/mockups/README.md`、`docs/mockups/review-gallery.html`、`docs/i18n-audit.md` の current inventory surface を確認
- compare rule を actual file set 基準に寄せ、3 surface の役割差を保ったまま drift detection に閉じていることを確認

## 実行できなかった確認
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル `bundle exec rspec` は未実行です
- 最終確認は PR CI 前提です

## リスク評価
- low
- spec-only の additive guard で、変更は 1 file に閉じています

## 補足事項
- future mockup page 追加時は、actual file set と 3 surface の inventory のどこがずれたかをこの spec で追える想定です