### PR TITLE
docs: mockup review flow に empty-state の入口を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -35,8 +35,9 @@ They are **not** a complete Rails application and should not grow into host-app 
 7. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
 8. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
 9. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-10. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-11. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+10. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+11. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+12. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 


### PR DESCRIPTION
Closes #626

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
`docs/mockups/README.md` の `Files` table と `review-gallery.html` には `empty-state.html` が含まれていますが、`Recommended review flow` だけが empty-state surface をいつ開くべきか案内していませんでした。

mockup 本体や gallery は current `main` で整っているため、今回は review entry guidance の抜けだけを docs-only で補います。

## 変更内容
- `docs/mockups/README.md`
  - `Recommended review flow` に `empty-state.html` を追加
  - no-root-items / no-results rows、reusable empty-row wrapper hook、host-app-owned copy boundary を見たいときの入口だと明記
  - 後続の番号だけ調整し、他の mockup file table や policy には広げていない

## 確認したこと
- 自分の open PR を確認し、review follow-up を優先すべき reviewer comment / review thread がないことを先に確認
- current `main` の `README.md` / `AGENTS.md` / `Product Profile.md` は今回の観点では追従済みであることを確認
- `docs/mockups/README.md` の `Files` table、`docs/mockups/review-gallery.html` の `Empty state` card、`docs/mockups/empty-state.html` の役割説明が整合していることを確認
- diff が docs 1 file に閉じていることを確認

## 実行できなかった確認
- docs-only 変更のため test / lint / typecheck は未実行です

## リスク
- low
- mockup review 導線の補強だけで、HTML/CSS 本体や product wording には触れていません