### PR TITLE
design: add focused interactive marker behavior mockup

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -114,6 +114,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
 | `docs/mockups/drag-interactive-controls.html` | Technical asset | No translation needed. |
+| `docs/mockups/interactive-marker-behaviors.html` | Technical asset | No translation needed. |
 | `docs/mockups/windowed-rendering.html` | Technical asset | No translation needed. |
 | `docs/mockups/breadcrumb-paths.html` | Technical asset | No translation needed. |
 | `docs/mockups/filtered-tree-modes.html` | Technical asset | No translation needed. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -16,6 +16,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [drag-interactive-controls.html](drag-interactive-controls.html) | Focused comparison for native interactive controls, `data-tree-view-interactive`, and `data-tree-view-ignore-drag` inside draggable rows. |
+| [interactive-marker-behaviors.html](interactive-marker-behaviors.html) | Focused comparison for `data-tree-view-interactive`, `data-tree-view-ignore-keyboard`, `data-tree-view-ignore-row-click`, and `data-tree-view-ignore-drag`, including the reserved host-app row-click boundary. |
 | [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
 | [breadcrumb-paths.html](breadcrumb-paths.html) | Focused comparison for breadcrumb-path context beside the tree's own current-row cue, without modeling host-app routes or Turbo navigation. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
@@ -31,13 +32,14 @@ They are **not** a complete Rails application and should not grow into host-app 
 3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
 5. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-6. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-7. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-8. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-9. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-10. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-11. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-12. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+6. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+7. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+8. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+9. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+10. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+11. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+12. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+13. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/interactive-marker-behaviors.html
+++ b/docs/mockups/interactive-marker-behaviors.html
@@ -1,0 +1,478 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView interactive marker behavior mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-marker-page {
+  max-width: 1320px;
+}
+
+.mock-marker-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-marker-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-marker-toolbar__copy {
+  display: grid;
+  gap: 4px;
+}
+
+.mock-marker-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-marker-toolbar__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-marker-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  font-size: 0.79rem;
+  font-weight: 700;
+}
+
+.mock-marker-chip--broad {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.mock-marker-chip--keyboard {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.mock-marker-chip--row-click {
+  background: #e0f2fe;
+  color: #0f4c81;
+}
+
+.mock-marker-chip--drag {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-marker-body {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.mock-marker-callout {
+  margin: 0;
+  padding: 0.8rem 0.95rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.mock-marker-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-marker-table th,
+.mock-marker-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.72rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-marker-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mock-marker-stack {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-marker-badge-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-marker-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  font-size: 0.77rem;
+  font-weight: 700;
+}
+
+.mock-marker-badge--broad {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.mock-marker-badge--keyboard {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.mock-marker-badge--row-click {
+  background: #e0f2fe;
+  color: #0f4c81;
+}
+
+.mock-marker-badge--drag {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-marker-widget {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #fff;
+  color: #102a43;
+  font-weight: 600;
+}
+
+.mock-marker-widget--broad {
+  border-color: #c4b5fd;
+  background: #f5f3ff;
+}
+
+.mock-marker-widget--keyboard {
+  border-color: #fcd34d;
+  background: #fffbeb;
+}
+
+.mock-marker-widget--row-click {
+  border-color: #7dd3fc;
+  background: #f0f9ff;
+}
+
+.mock-marker-widget--drag {
+  border-color: #86efac;
+  background: #f0fdf4;
+}
+
+.mock-marker-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  font-size: 0.77rem;
+  font-weight: 700;
+  background: #e2e8f0;
+  color: #334155;
+}
+
+.mock-marker-status--safe {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-marker-status--mixed {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.mock-marker-status--reserved {
+  background: #e0f2fe;
+  color: #0f4c81;
+}
+
+.mock-marker-note-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #334155;
+}
+
+.tree-row.is-marker-broad-preview {
+  background: #faf5ff;
+}
+
+.tree-row.is-marker-broad-preview td {
+  border-bottom-color: #ddd6fe;
+}
+
+.tree-row.is-marker-keyboard-preview {
+  background: #fffbeb;
+}
+
+.tree-row.is-marker-keyboard-preview td {
+  border-bottom-color: #fde68a;
+}
+
+.tree-row.is-marker-row-click-preview {
+  background: #f0f9ff;
+}
+
+.tree-row.is-marker-row-click-preview td {
+  border-bottom-color: #bae6fd;
+}
+
+.tree-row.is-marker-drag-preview {
+  background: #f0fdf4;
+}
+
+.tree-row.is-marker-drag-preview td {
+  border-bottom-color: #bbf7d0;
+}
+
+@media (max-width: 980px) {
+  .mock-marker-table {
+    display: block;
+    overflow-x: auto;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-marker-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView interactive marker behavior mock</h1>
+      <p>
+        Static reference for comparing the broad interactive marker against the narrower keyboard, row-click,
+        and drag behavior markers inside the same TreeView row family. TreeView owns the reusable marker contract;
+        host apps still own final row-click wiring, business actions, and widget implementation details.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="marker-grid-heading">
+      <div class="mock-marker-frame">
+        <div class="mock-marker-toolbar">
+          <div class="mock-marker-toolbar__copy">
+            <p class="mock-marker-toolbar__title">Compare broad and behavior-specific markers inside one row surface</p>
+          </div>
+          <div class="mock-marker-toolbar__meta" aria-label="Representative marker categories">
+            <span class="mock-marker-chip mock-marker-chip--broad">broad interactive</span>
+            <span class="mock-marker-chip mock-marker-chip--keyboard">keyboard-only</span>
+            <span class="mock-marker-chip mock-marker-chip--row-click">row-click boundary</span>
+            <span class="mock-marker-chip mock-marker-chip--drag">drag-only</span>
+          </div>
+        </div>
+        <div class="mock-marker-body">
+          <p class="mock-marker-callout">
+            Use this page when review needs to answer "which TreeView behavior should ignore this control?" without
+            expanding into host-app saves, modal flows, or product-specific permissions.
+          </p>
+          <table class="tree-view-table" data-controller="tree-view-client tree-view-transfer">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">embedded control</th>
+                <th scope="col">keyboard navigation</th>
+                <th scope="col">row click</th>
+                <th scope="col">drag start</th>
+                <th scope="col">best use</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-marker-broad-preview" draggable="true" data-tree-node-key="doc:broad" data-tree-transfer-payload='{"key":"doc:broad","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-marker-stack">
+                    <span class="tree-toggle" aria-label="Broad interactive marker row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">broad</span></span>
+                    </span>
+                    <div class="mock-marker-badge-row">
+                      <span class="mock-marker-badge mock-marker-badge--broad">data-tree-view-interactive</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-marker-stack">
+                    <span class="mock-marker-widget mock-marker-widget--broad" data-tree-view-interactive="true">Custom palette picker</span>
+                    <span class="mock-marker-status mock-marker-status--safe">Non-native widget is treated as broadly interactive.</span>
+                  </div>
+                </td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td>Use when one custom control should opt out of every TreeView interaction guard, not only a single behavior.</td>
+              </tr>
+
+              <tr class="tree-row is-marker-keyboard-preview" draggable="true" data-tree-node-key="doc:keyboard" data-tree-transfer-payload='{"key":"doc:keyboard","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-marker-stack">
+                    <span class="tree-toggle" aria-label="Keyboard-ignore marker row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">keys</span></span>
+                    </span>
+                    <div class="mock-marker-badge-row">
+                      <span class="mock-marker-badge mock-marker-badge--keyboard">data-tree-view-ignore-keyboard</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-marker-stack">
+                    <span class="mock-marker-widget mock-marker-widget--keyboard" data-tree-view-ignore-keyboard="true">Chip input shell</span>
+                    <span class="mock-marker-status mock-marker-status--mixed">Arrow, space, and enter stay with the control.</span>
+                  </div>
+                </td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td><span class="mock-marker-status">still available</span></td>
+                <td><span class="mock-marker-status">still available</span></td>
+                <td>Use when the widget needs its own key handling, but row click and drag should stay available elsewhere in the row.</td>
+              </tr>
+
+              <tr class="tree-row is-marker-row-click-preview" draggable="true" data-tree-node-key="doc:row-click" data-tree-transfer-payload='{"key":"doc:row-click","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-marker-stack">
+                    <span class="tree-toggle" aria-label="Row-click-ignore marker row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">click</span></span>
+                    </span>
+                    <div class="mock-marker-badge-row">
+                      <span class="mock-marker-badge mock-marker-badge--row-click">data-tree-view-ignore-row-click</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-marker-stack">
+                    <span class="mock-marker-widget mock-marker-widget--row-click" data-tree-view-ignore-row-click="true">Inline preview toggle</span>
+                    <span class="mock-marker-status mock-marker-status--reserved">Reserved for host-app row-click integrations.</span>
+                  </div>
+                </td>
+                <td><span class="mock-marker-status">still available</span></td>
+                <td><span class="mock-marker-status mock-marker-status--reserved">host-app should ignore</span></td>
+                <td><span class="mock-marker-status">still available</span></td>
+                <td>Use when a host app adds row-click activation and one control inside the row must stay clickable without triggering that app-owned action.</td>
+              </tr>
+
+              <tr class="tree-row is-marker-drag-preview" draggable="true" data-tree-node-key="doc:drag" data-tree-transfer-payload='{"key":"doc:drag","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-marker-stack">
+                    <span class="tree-toggle" aria-label="Drag-ignore marker row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">drag</span></span>
+                    </span>
+                    <div class="mock-marker-badge-row">
+                      <span class="mock-marker-badge mock-marker-badge--drag">data-tree-view-ignore-drag</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-marker-stack">
+                    <span class="mock-marker-widget mock-marker-widget--drag" data-tree-view-ignore-drag="true">Range scrubber</span>
+                    <span class="mock-marker-status mock-marker-status--safe">Drag start stays with the widget instead of the row transfer.</span>
+                  </div>
+                </td>
+                <td><span class="mock-marker-status">still available</span></td>
+                <td><span class="mock-marker-status">still available</span></td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td>Use when a control only needs drag protection and should not broaden into keyboard or row-click opt-outs.</td>
+              </tr>
+
+              <tr class="tree-row" draggable="true" data-tree-node-key="doc:native" data-tree-transfer-payload='{"key":"doc:native","type":"Document"}' aria-level="1">
+                <td class="tree-toggle-cell">
+                  <div class="mock-marker-stack">
+                    <span class="tree-toggle" aria-label="Native control row">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">native</span></span>
+                    </span>
+                    <div class="mock-marker-badge-row">
+                      <span class="mock-marker-badge">implicit interactive target</span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="mock-marker-stack">
+                    <button class="tree-toggle__action" type="button">Edit</button>
+                    <span class="mock-marker-status">Native controls already count as interactive targets.</span>
+                  </div>
+                </td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td><span class="mock-marker-status mock-marker-status--safe">ignored</span></td>
+                <td>Use as the baseline reminder that native inputs, buttons, links, selects, and editable labels do not need extra marker attributes.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="marker-summary-heading">
+      <h2 id="marker-summary-heading">What this mock compares</h2>
+      <table class="mock-marker-table">
+        <thead>
+          <tr>
+            <th scope="col">Surface</th>
+            <th scope="col">Best for</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>data-tree-view-interactive</code></td>
+            <td>Showing the broad custom-widget marker when a non-native control should opt out of every TreeView behavior guard.</td>
+            <td>Widget implementation details, final business logic, or route wiring.</td>
+          </tr>
+          <tr>
+            <td><code>data-tree-view-ignore-keyboard</code></td>
+            <td>Comparing widgets that need arrow, space, or enter for themselves without claiming the broader row-click or drag boundaries.</td>
+            <td>Keyboard policy redesign, shortcuts outside the widget, or product-specific editor behavior.</td>
+          </tr>
+          <tr>
+            <td><code>data-tree-view-ignore-row-click</code></td>
+            <td>Highlighting the reserved boundary for host-app row-click integrations so one inner control can stay clickable.</td>
+            <td>Implementing the host-app row-click action itself or changing current TreeView runtime policy.</td>
+          </tr>
+          <tr>
+            <td><code>data-tree-view-ignore-drag</code></td>
+            <td>Showing the narrow drag-start opt-out for sliders, scrubbers, or other controls that only need transfer protection.</td>
+            <td>Drop target rules, persistence, or drag-and-drop workflow design.</td>
+          </tr>
+          <tr>
+            <td>Native controls</td>
+            <td>Confirming that standard inputs, buttons, links, selects, textareas, and editable labels already behave like interactive targets.</td>
+            <td>Validation, save timing, or business copy owned by the host app.</td>
+          </tr>
+        </tbody>
+      </table>
+      <ul class="mock-marker-note-list">
+        <li>These markers only opt a control out of TreeView behavior. Validation, persistence, permissions, and CRUD flows remain host-app responsibilities.</li>
+        <li>`data-tree-view-ignore-row-click` is shown as the documented boundary for app-owned row-click integrations, not as a full runtime feature demonstration.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, drag-safe control markers, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -264,6 +264,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-marker-behavior-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused behavior markers</p>
+          <h2 id="gallery-marker-behavior-heading">Interactive marker behaviors</h2>
+          <p>
+            Use this surface to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers without expanding into host-app wiring.
+          </p>
+          <ul class="mock-gallery-points">
+            <li><code>data-tree-view-interactive</code> as the broad opt-out</li>
+            <li><code>data-tree-view-ignore-keyboard</code> for key handling only</li>
+            <li><code>data-tree-view-ignore-row-click</code> and <code>data-tree-view-ignore-drag</code> as narrower boundaries</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="interactive-marker-behaviors.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -429,6 +450,11 @@
             <td>Drag interactive controls</td>
             <td>Comparing plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers.</td>
             <td>Drop targets, widget implementation details, permission rules, or business-specific drag affordances.</td>
+          </tr>
+          <tr>
+            <td>Interactive marker behaviors</td>
+            <td>Comparing the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.</td>
+            <td>Host-app row-click implementation, widget internals, or broader keyboard and drag policy changes.</td>
           </tr>
           <tr>
             <td>Windowed rendering</td>


### PR DESCRIPTION
Closes #629

## 判定分類
- `docs-missing`
- `docs-sync`

## 変更理由
current `docs/en|ja/host-app-extension-points.md` と `docs/en|ja/usage.md` は、`data-tree-view-interactive` に加えて `data-tree-view-ignore-keyboard`、`data-tree-view-ignore-row-click`、`data-tree-view-ignore-drag` という behavior-specific marker をすでに documented extension point として案内しています。一方で current `docs/mockups/` は `drag-interactive-controls.html` までで、keyboard guard と row-click boundary の違いを focused に比較する静的 surface がありませんでした。

この PR では runtime や public export を変えず、既存 docs にある marker contract を focused mockup と導線で補います。

## 変更内容
- `docs/mockups/interactive-marker-behaviors.html`
  - broad `data-tree-view-interactive` と、`data-tree-view-ignore-keyboard` / `data-tree-view-ignore-row-click` / `data-tree-view-ignore-drag` の違いを比較できる focused mockup page を追加
  - native control が implicit interactive target であることも同じ比較面で確認できるよう追加
  - `data-tree-view-ignore-row-click` は host-app row-click integration 向けの reserved boundary として扱い、runtime feature 実装には広げていない
- `docs/mockups/README.md`
  - file inventory と recommended review flow に新しい focused surface を追加
- `docs/mockups/review-gallery.html`
  - gallery card / iframe preview / comparison row を追加
- `docs/i18n-audit.md`
  - technical-assets table に新しい mockup asset を追加

## 根拠
- `app/javascript/tree_view/interactive.js`
- `docs/en/host-app-extension-points.md`
- `docs/ja/host-app-extension-points.md`
- `docs/en/usage.md`
- `docs/ja/usage.md`
- issue #629

## 確認したこと
- 自分の open PR 群を review follow-up 観点で先に確認し、green + reviewer comment / review thread 起点の優先対応対象がないことを確認
- current `main` の `README.md` / `docs/README.md` / `AGENTS.md` / `Product Profile.md` は今回の観点では追従済みであることを確認
- compare `main...design/629-interactive-marker-behavior-mock` で diff が docs 4 files に閉じていることを確認
- `interactive.js` の selector contract と `docs/en|ja/usage.md` / `host-app-extension-points.md` の documented marker meaning に矛盾しないことを確認

## 実行できなかった確認
- docs-only 変更のため test / lint / typecheck は未実行です
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や browser rendering check は未実施です

## リスク
- low
- static mockup と docs inventory の追加に閉じており、runtime keyboard policy、row-click integration 実装、drag/drop workflow には触れていません