### PR TITLE
docs: sync release guidance for public JS wiring surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added public name decision docs in Japanese and English.
 - Added render log level docs in Japanese and English.
 - Added JavaScript event contract docs in Japanese and English for public Stimulus events and payload details.
+- Clarified release checklist guidance for documented JavaScript wiring surfaces, including `data-tree-view-*` integration hooks and selection controller host-element value attributes, alongside machine-readable package-root exports.
 - Added migration guides in Japanese and English to summarize compatibility promises, deprecations, rename handling, and release-note expectations.
 - Clarified the CI policy split between pull request Ruby checks and broader `main` / release checks.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -81,7 +81,9 @@ PR CI must pass before merge. Use the broader `main` CI for release decisions be
 
 When public usage or public options change, update related docs and CHANGELOG.
 
-When the change touches machine-readable public contract surfaces such as package-root JavaScript exports, controller identifiers, grouped option keys, or documented event names/detail keys, review `config/public_api_manifest.yml` together with the public API docs and any affected feature pages.
+When the change touches documented host-app wiring or machine-readable public contract surfaces such as package-root JavaScript exports, controller identifiers, grouped option keys, documented event names/detail keys, documented `data-tree-view-*` integration hooks, or selection controller host-element value attributes, review `config/public_api_manifest.yml` together with the public API docs and any affected feature pages.
+
+`config/public_api_manifest.yml` remains the machine-readable source of truth for package-root exports, controller identifiers, grouped option keys, and documented event detail keys. Public API and feature docs remain the source of truth for documented wiring attributes and hooks that are intentionally not exported there.
 
 - `README.md`
 - `docs/ja/README.md`

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -81,7 +81,9 @@ merge前にPR CIを通します。互換性matrix、JavaScript coverage、packag
 
 Public usageや公開optionを変えた場合は、関連docsとCHANGELOGを更新します。
 
-package-root JavaScript export、controller identifier、grouped option key、documented event name / detail key のような machine-readable public contract surface を変える場合は、public API docs や関連feature page と一緒に `config/public_api_manifest.yml` も見直してください。
+documented な host-app wiring surface または machine-readable public contract surface、たとえば package-root JavaScript export、controller identifier、grouped option key、documented event name / detail key、documented `data-tree-view-*` integration hook、selection controller の host-element value attribute を変更する場合は、public API docs や関連feature page と一緒に `config/public_api_manifest.yml` も見直してください。
+
+`config/public_api_manifest.yml` は、package-root export、controller identifier、grouped option key、documented event detail key の machine-readable source of truth です。一方で、そこに export していない documented wiring attribute や hook については、public API docs と feature docs を source of truth として扱います。
 
 - `README.md`
 - `docs/ja/README.md`


### PR DESCRIPTION
Closes #631

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
current `docs/en/public-api.md` / `docs/ja/public-api.md` は、package-root export だけでなく documented `data-tree-view-*` integration hook と selection controller host-element value attribute も stable host-app wiring surface として扱っています。一方、release-facing docs 側は machine-readable export family の review までは触れていても、export されていない documented wiring surface の確認観点が少し弱いままでした。

この PR では、未マージ lane を先回りで断定せず、current `main` にすでにある public wiring surface の確認観点だけを release docs と changelog wording に戻します。

## 変更内容
- `docs/en/release.md`
  - release review で見直す public JavaScript / host-app wiring surface に、documented `data-tree-view-*` integration hooks と selection controller host-element value attributes を追加
  - `config/public_api_manifest.yml` が machine-readable source of truth になる範囲と、public API / feature docs が source of truth になる範囲を分けて明記
- `docs/ja/release.md`
  - 英語版と同じ観点で release checklist を追従
- `CHANGELOG.md`
  - release checklist guidance が documented JavaScript wiring surfaces までカバーすることを `Documentation` に追記

## 根拠
- `docs/en/public-api.md`
- `docs/ja/public-api.md`
- `docs/en/selection.md`
- `docs/ja/selection.md`
- `config/public_api_manifest.yml`
- issue #631

## 確認したこと
- 自分の open docs PR `#630` / `#603` は green CI かつ review follow-up 対象がないことを先に確認
- current `README.md` / `docs/README.md` / `AGENTS.md` / `Product Profile.md` では今回の release-facing gap は見当たらず、更新範囲を `CHANGELOG.md` と `docs/en|ja/release.md` の 3 files に限定した
- compare `main...docs/631-release-js-surface-sync` で `behind_by: 0` と docs-only 3-file diff を確認
- 未マージの `TreeViewIntegrationHooks` / selection attribute export lane そのものは changelog や release notes に追加せず、current `main` に already documented な wiring surface だけを対象にした

## 実行できなかった確認
- docs-only 変更のため test / lint / typecheck は未実行です
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview や link checker は未実施です

## リスク
- low
- release-facing docs wording の整合回復だけで、runtime behavior、public export、manifest schema には触れていません