### PR TITLE
design: add partially-loaded selection boundary mockup

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -16,6 +16,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [children-pagination.html](children-pagination.html) | Focused comparison for next-page placeholder placement and load-more affordances within one expanded branch, without host-app cursor or Turbo behavior. |
+| [children-pagination-selection-boundary.html](children-pagination-selection-boundary.html) | Focused comparison for loaded-row selection, mixed parent cues, and bulk-action framing when more descendants are still outside the current DOM page. |
 | [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
@@ -29,10 +30,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
 5. Use [children-pagination.html](children-pagination.html) when review needs a narrower pass on where next-page placeholder rows and load-more affordances should sit inside one expanded branch.
-6. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-7. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-8. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
-9. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+6. Use [children-pagination-selection-boundary.html](children-pagination-selection-boundary.html) when review needs to compare loaded-row selection, mixed parent cues, and bulk-action scope while a branch still has unloaded descendants.
+7. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+8. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+9. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+10. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/children-pagination-selection-boundary.html
+++ b/docs/mockups/children-pagination-selection-boundary.html
@@ -1,0 +1,444 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView partially-loaded selection boundary mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-selection-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.mock-selection-card {
+  display: grid;
+  gap: 14px;
+}
+
+.mock-selection-card h3,
+.mock-selection-card p,
+.mock-selection-card ul {
+  margin: 0;
+}
+
+.mock-selection-caption {
+  color: #52606d;
+  font-size: 0.94rem;
+}
+
+.mock-selection-inline-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.35rem;
+  padding: 0.08rem 0.5rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.mock-selection-summary {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.9rem 1rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.mock-selection-summary strong {
+  color: #102a43;
+}
+
+.mock-selection-comparison {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-selection-comparison th,
+.mock-selection-comparison td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-selection-comparison th {
+  background: #f1f5f9;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mock-selection-more-row td {
+  background: #f8fafc;
+}
+
+.mock-selection-bulk-note {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.3rem;
+  padding: 0.08rem 0.45rem;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView partially-loaded selection boundary mock</h1>
+      <p>
+        Focused static HTML for reviewing how selection, cascade cues, and bulk-action framing should read when a branch still has unloaded descendants.
+        This page keeps hidden-input sync, real submit handling, cursor logic, authorization, and business workflow decisions out of scope on purpose.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="selection-purpose-heading">
+      <h2 id="selection-purpose-heading">What this surface is for</h2>
+      <ul>
+        <li>Compare loaded-row selection cues against a next-page placeholder in the same expanded branch.</li>
+        <li>Show that cascade and indeterminate state stop at rendered rows unless the host app computes a broader server-side selection intent.</li>
+        <li>Keep bulk-action framing honest so a loaded-row action does not look like it automatically includes unloaded descendants.</li>
+      </ul>
+    </section>
+
+    <section class="mock-section" aria-labelledby="selection-states-heading">
+      <h2 id="selection-states-heading">Representative partially-loaded selection states</h2>
+      <div class="mock-selection-grid">
+        <article class="mock-selection-card" aria-labelledby="selection-loaded-heading">
+          <h3 id="selection-loaded-heading">1. Loaded rows are selected, but more descendants are still off-page</h3>
+          <p class="mock-selection-caption">
+            The action cue stays scoped to the loaded rows that are visibly checked. The next-page placeholder makes it clear that the branch continues beyond the current DOM.
+          </p>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">select</th>
+                <th scope="col">tree</th>
+                <th scope="col">name</th>
+                <th scope="col">selection state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="records_1" class="tree-row is-expanded" data-tree-node-key="folder:records" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" aria-label="Select Records branch"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded folder">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control">
+                      <a class="tree-toggle__action" href="#">hide</a>
+                      <span class="tree-toggle__level">page 1</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Records</td>
+                <td>
+                  <span class="mock-status mock-status--pending">2 loaded rows selected</span>
+                  <span class="mock-selection-inline-note">more descendants still unloaded</span>
+                </td>
+                <td class="tree-row-actions"><button type="button">Refresh branch</button></td>
+              </tr>
+              <tr id="records_child_1" class="tree-row is-selected" data-tree-node-key="record:a" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" checked aria-label="Select Policy overview"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Loaded selected row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Policy overview</td>
+                <td><span class="mock-status mock-status--active">loaded and selected</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="records_child_2" class="tree-row is-selected" data-tree-node-key="record:b" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" checked aria-label="Select Review notes"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Loaded selected row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Review notes</td>
+                <td><span class="mock-status mock-status--active">loaded and selected</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="records_more_1" class="tree-row mock-selection-more-row" data-tree-parent-key="folder:records" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Next page placeholder row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__level">more</span>
+                      <span class="mock-selection-inline-note">cursor: records-002</span>
+                    </span>
+                  </span>
+                </td>
+                <td>More descendants are still outside the DOM</td>
+                <td><span class="mock-status mock-status--pending">selection does not imply these rows</span></td>
+                <td class="tree-row-actions"><button type="button">Load more</button></td>
+              </tr>
+              <tr>
+                <td colspan="5">
+                  <strong>Bulk action cue:</strong>
+                  Archive loaded rows
+                  <span class="mock-selection-bulk-note">acts on 2 checked rows, not the unseen remainder</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="mock-selection-card" aria-labelledby="selection-cascade-heading">
+          <h3 id="selection-cascade-heading">2. Cascade and indeterminate state stop at rendered rows</h3>
+          <p class="mock-selection-caption">
+            The parent row can look mixed because the rendered children disagree, while the placeholder row keeps the unloaded descendants explicitly unknown.
+          </p>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">select</th>
+                <th scope="col">tree</th>
+                <th scope="col">name</th>
+                <th scope="col">selection state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="cases_1" class="tree-row is-expanded" data-tree-node-key="folder:cases" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" aria-label="Select Cases branch"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded branch with mixed state">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control">
+                      <a class="tree-toggle__action" href="#">hide</a>
+                      <span class="tree-toggle__level">mixed</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Cases</td>
+                <td>
+                  <span class="mock-status mock-status--pending">indeterminate from rendered rows</span>
+                  <span class="mock-selection-inline-note">unloaded descendants remain unknown</span>
+                </td>
+                <td class="tree-row-actions"><button type="button">Refresh branch</button></td>
+              </tr>
+              <tr id="cases_child_1" class="tree-row is-selected" data-tree-node-key="case:open" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" checked aria-label="Select Open review"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Selected rendered child">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Open review</td>
+                <td><span class="mock-status mock-status--active">selected in rendered page</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="cases_child_2" class="tree-row" data-tree-node-key="case:archived" data-tree-depth="1" aria-level="2" aria-disabled="true">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" disabled aria-label="Archived case cannot be selected"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Disabled rendered child">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>Archived case</td>
+                <td><span class="mock-status mock-status--archived">disabled in rendered page</span></td>
+                <td class="tree-row-actions"><button type="button" disabled>Blocked</button></td>
+              </tr>
+              <tr id="cases_more_1" class="tree-row mock-selection-more-row" data-tree-parent-key="folder:cases" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Unknown descendants placeholder">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__level">more</span>
+                      <span class="mock-selection-inline-note">server decides broader semantics</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Additional descendants have not been rendered yet</td>
+                <td><span class="mock-status mock-status--pending">do not infer cascade beyond the DOM</span></td>
+                <td class="tree-row-actions"><button type="button">Load more</button></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="mock-selection-card" aria-labelledby="selection-bulk-heading">
+          <h3 id="selection-bulk-heading">3. Bulk-action framing can stay honest about loaded versus query-backed scope</h3>
+          <p class="mock-selection-caption">
+            A host app can keep the visible tree action scoped to loaded rows, then present a separate server-backed action when the product wants to include the entire filtered child set.
+          </p>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">select</th>
+                <th scope="col">tree</th>
+                <th scope="col">name</th>
+                <th scope="col">selection state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="invoices_1" class="tree-row is-expanded" data-tree-node-key="folder:invoices" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" aria-label="Select Invoices branch"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded branch">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control">
+                      <a class="tree-toggle__action" href="#">hide</a>
+                      <span class="tree-toggle__level">filtered</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Invoices</td>
+                <td><span class="mock-status mock-status--pending">3 loaded rows checked</span></td>
+                <td class="tree-row-actions"><button type="button">Refresh branch</button></td>
+              </tr>
+              <tr id="invoices_child_1" class="tree-row is-selected" data-tree-node-key="invoice:a" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" checked aria-label="Select January invoice"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Selected invoice row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>January invoice</td>
+                <td><span class="mock-status mock-status--active">loaded and selected</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="invoices_child_2" class="tree-row is-selected" data-tree-node-key="invoice:b" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"><input type="checkbox" class="tree-selection-checkbox" checked aria-label="Select February invoice"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Selected invoice row">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                    </span>
+                    <span class="tree-toggle__control"><span class="tree-depth-label">leaf</span></span>
+                  </span>
+                </td>
+                <td>February invoice</td>
+                <td><span class="mock-status mock-status--active">loaded and selected</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr id="invoices_more_1" class="tree-row mock-selection-more-row" data-tree-parent-key="folder:invoices" data-tree-depth="1" aria-level="2">
+                <td class="tree-selection-cell"></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="More filtered rows placeholder">
+                    <span class="tree-toggle__branches" aria-hidden="true">
+                      <span class="tree-toggle__branch-slot has-line"></span>
+                      <span class="tree-toggle__branch-slot is-current is-last"></span>
+                    </span>
+                    <span class="tree-toggle__control">
+                      <span class="tree-toggle__level">more</span>
+                      <span class="mock-selection-inline-note">additional filtered rows off-page</span>
+                    </span>
+                  </span>
+                </td>
+                <td>Unloaded descendants still match the filter</td>
+                <td><span class="mock-status mock-status--pending">visible bulk action should not silently include them</span></td>
+                <td class="tree-row-actions"><button type="button">Load more</button></td>
+              </tr>
+              <tr>
+                <td colspan="5">
+                  <strong>Loaded-row action:</strong>
+                  Process 3 checked rows
+                  <span class="mock-selection-bulk-note">DOM-backed and intentionally narrow</span>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="5">
+                  <strong>Host-app query action:</strong>
+                  Process all filtered descendants
+                  <span class="mock-selection-bulk-note">separate server intent, not implied by visible checkboxes</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="selection-boundary-heading">
+      <h2 id="selection-boundary-heading">Responsibility boundary reminders</h2>
+      <div class="mock-selection-summary">
+        <strong>TreeView-owned cues in this mock</strong>
+        <span>Rendered-row checkboxes, branch structure, placeholder placement, and the DOM-only nature of cascade or indeterminate state.</span>
+      </div>
+      <div class="mock-selection-summary">
+        <strong>Host-app decisions kept out of scope</strong>
+        <span>Hidden-input submit policy, server-backed query actions, authorization, cursor logic, and whether a product should offer a whole-filter action at all.</span>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="selection-compare-heading">
+      <h2 id="selection-compare-heading">Review cues</h2>
+      <table class="mock-selection-comparison">
+        <thead>
+          <tr>
+            <th scope="col">State</th>
+            <th scope="col">Best for checking</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Loaded rows selected</td>
+            <td>Whether the checked rows and action cue read as a DOM-backed subset while the placeholder still signals unseen descendants.</td>
+            <td>Real form submission, hidden-input mirroring, or exact business wording.</td>
+          </tr>
+          <tr>
+            <td>Mixed parent state</td>
+            <td>Whether indeterminate and cascade cues stop at rendered rows instead of claiming knowledge about unloaded descendants.</td>
+            <td>Server-side cascade policy, cross-page counting, or event payload details.</td>
+          </tr>
+          <tr>
+            <td>Separate bulk-action framing</td>
+            <td>Whether a loaded-row action and a query-backed action read as deliberately different scopes.</td>
+            <td>Authorization, workflow approval rules, or real query execution.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, focused children-pagination placement, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, focused children-pagination placement, partially-loaded selection boundaries, windowed rendering cues, filtered-tree mode differences, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -264,6 +264,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="children-pagination.html" title="Children pagination mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-selection-boundary-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused selection boundary</p>
+          <h2 id="gallery-selection-boundary-heading">Partially-loaded selection boundary</h2>
+          <p>
+            Use this surface when review needs to compare loaded-row selection, mixed parent cues, and bulk-action framing while a branch still has unloaded descendants.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Checked rows stay scoped to the loaded DOM subset</li>
+            <li>Indeterminate and cascade cues stop at rendered rows</li>
+            <li>Loaded-row actions stay distinct from query-backed whole-filter actions</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="children-pagination-selection-boundary.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="children-pagination-selection-boundary.html" title="Partially-loaded selection boundary mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -387,6 +408,11 @@
             <td>Children pagination</td>
             <td>Next-page placeholder placement, branch-scoped load-more cues, and the after-append handoff to a replacement placeholder row.</td>
             <td>Cursor encoding, next-page detection, Turbo Stream append or replace logic, and final business copy.</td>
+          </tr>
+          <tr>
+            <td>Partially-loaded selection boundary</td>
+            <td>Loaded-row selection scope, mixed parent cues, and the difference between DOM-backed actions and server-backed whole-filter actions.</td>
+            <td>Hidden-input sync, real submit workflow, authorization, and whole-filter business rules.</td>
           </tr>
           <tr>
             <td>Windowed rendering</td>


### PR DESCRIPTION
Refs #628
Refs #595

## 判定分類
- `docs-missing`
- `docs-sync`

## 変更理由
current `docs/en/children-pagination.md` は、未読込 descendants が残る branch では checkbox selection / cascade / bulk action の意味を host app 側で明示すべきだと説明しています。一方、current mockup family は next-page placeholder placement までは focused に見せていても、loaded rows だけを選択している状態と unloaded descendants の境界を静的に見比べる surface がありませんでした。

この PR では `#595` の children pagination placement lane を土台にしつつ、`#624` の controller-side wiring mockup へは広げず、partially-loaded descendants を含む selection / bulk-action boundary だけを focused mockup と導線更新で補います。

## 変更内容
- `docs/mockups/children-pagination-selection-boundary.html`
  - loaded rows だけが選択されている state
  - rendered rows にだけ cascade / indeterminate が効いている state
  - loaded-row action と query-backed action を読み分ける state
  を比較できる focused page を追加
- `docs/mockups/README.md`
  - mockup file inventory と recommended review flow に新しい surface を追加
- `docs/mockups/review-gallery.html`
  - gallery card、preview iframe、comparison cues に partially-loaded selection boundary を追加

## 根拠
- `docs/en/children-pagination.md`
- `docs/en/selection.md`
- issue #628
- base PR #595 の `children-pagination.html`

## 確認したこと
- 自分の open docs PR `#632` と `#603` には review thread / submitted review がなく、優先 review follow-up 対象がないことを先に確認
- `#628` の planner handoff が求めている変更範囲に合わせ、`docs/i18n-audit.md` は今回は触らず `README.md` / `review-gallery.html` / new focused page の 3 files に閉じた
- base を `design/587-children-pagination-mockup-main-head` にして、existing children pagination lane と index files の競合を main 上で増やさない形にした
- hidden-input sync、real form submit、cursor semantics、authorization、business workflow には広げていない

## 実行できなかった確認
- static docs 変更のため test / lint / typecheck は未実行です
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview は未実施です

## リスク
- low
- static HTML/CSS と docs index 導線に閉じた変更です
- `#595` の stacked follow-up なので merge 順序だけは人間レビューで見てもらう前提です

## 補足
- `#628` の planner handoff が明示していた通り、`#587` の placement comparison や `#624` の controller-side state comparison は吸収していません
- current branch 上の mockup family を前提にした narrow sibling lane です