### PR TITLE
docs: add language-specific docs maps to root maintainer entry points

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@
 
 ## Maintainer entry points
 
+- [English documentation](en/README.md): full English docs map, reading order, and maintainer-facing entry points within the English tree.
+- [日本語ドキュメント](ja/README.md): 日本語 docs tree の full map、reading order、maintainer-facing entry points。
 - [Product Profile](../Product%20Profile.md): repository positioning, source-of-truth order, host app responsibilities, and non-goals.
 - [AGENTS.md](../AGENTS.md): repository-specific maintainer workflow, first-read order, and documentation update rules.
 - [Documentation maintenance checklist](i18n-audit.md): language-sync rules, technical-asset inventory, and cross-language update coverage.


### PR DESCRIPTION
## 判定分類
- `docs-stale`
- `docs-sync`

## 概要
- `docs/README.md` の `Maintainer entry points` に `docs/en/README.md` と `docs/ja/README.md` を追加
- root docs index から、language-specific docs map と reading order に最短で辿れるよう整理

## 変更理由
- current `Product Profile.md` の `Maintainer companion docs` と `Recommended first reads` は、`docs/en/README.md` / `docs/ja/README.md` を durable な maintainer entry point として扱っています
- 一方で current `docs/README.md` の `Maintainer entry points` からは、その language-specific docs map への direct entry がありませんでした
- runtime code、public API docs 本文、workflow には触れず、root docs index 1 ファイルだけで整合回復できます

## 根拠
- `docs/README.md`
- `docs/en/README.md`
- `docs/ja/README.md`
- `Product Profile.md`

## 確認
- compare `main...docs/language-doc-maps-entrypoints-main-head` で diff が `docs/README.md` の 1 ファイルに閉じていることを確認
- own open docs PR `#636` `#603` `#595` には review thread / submitted review がなく、優先 review follow-up 対象がないことを先に確認
- open mockup docs PR と write set が重ならないことを確認
- docs-only 変更のため local test / lint は未実施です

## リスク
- low
- maintainer 導線の補強だけで、仕様・実装・CI 挙動は変更していません