### PR TITLE
feat: selection checkbox hook を public export から参照できるようにする

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -41,6 +41,11 @@ export const TreeViewControllerIdentifiers = Object.freeze({
   remoteState: "tree-view-remote-state"
 })
 
+export const TreeViewSelectionCheckboxHooks = Object.freeze({
+  checkboxSelector: ".tree-selection-checkbox",
+  disabledReasonAttribute: "data-tree-selection-disabled-reason"
+})
+
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
   application.register("tree-view-client", TreeViewClientController)

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -74,12 +74,16 @@ javascript_package_root:
   named_exports:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
+    - TreeViewSelectionCheckboxHooks
     - TreeViewStateController
     - TreeViewClientController
     - TreeViewSelectionController
     - TreeViewTransferController
     - TreeViewRemoteStateController
     - TreeViewEventNames
+  selection_checkbox_hooks:
+    checkbox_selector: .tree-selection-checkbox
+    disabled_reason_attribute: data-tree-selection-disabled-reason
   controller_registrations:
     - key: state
       identifier: tree-view-state

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -157,6 +157,7 @@ Stable enough for host apps to use:
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
 - `TreeViewControllerIdentifiers`
+- `TreeViewSelectionCheckboxHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -170,6 +171,7 @@ Stable enough for host apps to use:
 
 `TreeViewEventNames` exposes the documented event names as a machine-readable package-root export. Use it when wiring host-app listeners and you want to avoid hand-copying event-name strings such as `TreeViewEventNames.selection.change` or `TreeViewEventNames.transfer.drop`.
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
+`TreeViewSelectionCheckboxHooks` exposes the documented selection-checkbox DOM hooks as a machine-readable object. Use `checkboxSelector` for browser assertions or lightweight DOM integration that needs the bundled checkbox selector, and use `disabledReasonAttribute` when reading the documented disabled-reason data hook without hand-copying attribute names.
 
 Documented keys on `TreeViewControllerIdentifiers`:
 
@@ -179,6 +181,11 @@ Documented keys on `TreeViewControllerIdentifiers`:
 - `transfer`
 - `remoteState`
 
+Documented keys on `TreeViewSelectionCheckboxHooks`:
+
+- `checkboxSelector`
+- `disabledReasonAttribute`
+
 The `tree-view-selection` controller's documented host-element value attributes are also part of the stable host-app wiring surface:
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -186,7 +193,7 @@ The `tree-view-selection` controller's documented host-element value attributes 
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
+Use those attributes when configuring the controller on the host element. Use `TreeViewSelectionCheckboxHooks` when host-app code needs the row-level checkbox selector or disabled-reason data attribute. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
 The machine-readable source of truth for the package-root JavaScript exports and bundled controller identifiers lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 

--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -107,6 +107,19 @@ document.addEventListener("tree-view-selection:change", (event) => {
 
 Only checked and enabled `.tree-selection-checkbox` elements are included. Invalid JSON values are skipped and reported through `tree-view-selection:invalid-payload`.
 
+If host-side JavaScript needs to locate rendered selection checkboxes or read the disabled-reason attribute, use `TreeViewSelectionCheckboxHooks` from the package root instead of copying the selector or attribute name into app code.
+
+```js
+import { TreeViewSelectionCheckboxHooks } from "tree_view"
+
+const checkbox = document.querySelector(TreeViewSelectionCheckboxHooks.checkboxSelector)
+const disabledReason = checkbox?.getAttribute(
+  TreeViewSelectionCheckboxHooks.disabledReasonAttribute
+)
+```
+
+See [Public API](./public-api.md) for the supported hook contract and compatibility boundary.
+
 ## Hidden input sync for regular form submit
 
 When the tree sits inside a normal HTML form, the same controller can mirror checked payloads into hidden inputs on the nearest form.

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -157,6 +157,7 @@ host app が使ってよい入口:
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
 - `TreeViewControllerIdentifiers`
+- `TreeViewSelectionCheckboxHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -170,6 +171,7 @@ host app が使ってよい入口:
 
 `TreeViewEventNames` は documented event names を machine-readable に参照するための package-root export です。host app 側で listener を配線するとき、`TreeViewEventNames.selection.change` や `TreeViewEventNames.transfer.drop` のように使うことで event name string の写経を避けられます。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
+`TreeViewSelectionCheckboxHooks` は、documented selection checkbox DOM hook を machine-readable な object として公開します。bundled checkbox selector が必要な browser assertion や軽い DOM integration では `checkboxSelector` を使い、documented disabled-reason data hook を読むときは `disabledReasonAttribute` を使って attribute 名の写経を避けてください。
 
 `TreeViewControllerIdentifiers` の documented key:
 
@@ -179,6 +181,11 @@ host app が使ってよい入口:
 - `transfer`
 - `remoteState`
 
+`TreeViewSelectionCheckboxHooks` の documented key:
+
+- `checkboxSelector`
+- `disabledReasonAttribute`
+
 `tree-view-selection` controller の documented host-element value attribute も、stable な host-app wiring surface の一部です。
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -186,7 +193,7 @@ host app が使ってよい入口:
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
+これらの attribute は host element 上で controller を設定するときに使います。行ごとの checkbox selector や disabled-reason data attribute が必要なときは `TreeViewSelectionCheckboxHooks` を使ってください。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
 package-root の JavaScript export と bundled controller identifier の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -107,6 +107,19 @@ document.addEventListener("tree-view-selection:change", (event) => {
 
 対象になるのは、checked かつ enabled な `.tree-selection-checkbox` だけです。不正なJSON値はskipされ、`tree-view-selection:invalid-payload` で通知されます。
 
+host app 側の JavaScript で描画済み selection checkbox を探したり disabled reason attribute を読んだりする必要がある場合は、selector や attribute 名を直接書かず、package root から `TreeViewSelectionCheckboxHooks` を参照してください。
+
+```js
+import { TreeViewSelectionCheckboxHooks } from "tree_view"
+
+const checkbox = document.querySelector(TreeViewSelectionCheckboxHooks.checkboxSelector)
+const disabledReason = checkbox?.getAttribute(
+  TreeViewSelectionCheckboxHooks.disabledReasonAttribute
+)
+```
+
+互換性を含む公開境界は [Public API](./public-api.md) を参照してください。
+
 ## 通常form送信用の hidden input 同期
 
 tree が通常の HTML form の中にある場合、同じ controller で checked payload を最寄りの form に hidden input としてミラーできます。

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -59,6 +59,12 @@ assert(
   "TreeViewControllerIdentifiers export is out of sync"
 )
 
+const expectedSelectionCheckboxHooks = deepCamelizeKeys(javascriptPackageManifest.selection_checkbox_hooks)
+assert(
+  JSON.stringify(entrypointModule.TreeViewSelectionCheckboxHooks) === JSON.stringify(expectedSelectionCheckboxHooks),
+  "TreeViewSelectionCheckboxHooks export is out of sync"
+)
+
 const expectedRegistrations = javascriptPackageManifest.controller_registrations.map(({ identifier, export: exportName }) => {
   assert(exportName in entrypointModule, `${exportName} export is missing`)
   return [identifier, entrypointModule[exportName]]

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -6,6 +6,7 @@ require "yaml"
 PublicApiCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
 PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
 JAVASCRIPT_ENTRYPOINT_PATH = File.expand_path("../app/javascript/tree_view/index.js", __dir__)
+SELECTION_CELL_PARTIAL_PATH = File.expand_path("../app/views/tree_view/_tree_selection_cell.html.erb", __dir__)
 JAVASCRIPT_CONTROLLER_PATHS = {
   "selection" => File.expand_path("../app/javascript/tree_view/selection_controller.js", __dir__),
   "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
@@ -39,13 +40,25 @@ RSpec.describe "Public API compatibility" do
     public_javascript_manifest.fetch("event_detail_keys")
   end
 
+  def public_javascript_selection_checkbox_hooks
+    public_javascript_manifest.fetch("selection_checkbox_hooks")
+  end
+
   def javascript_entrypoint_source
     @javascript_entrypoint_source ||= File.read(JAVASCRIPT_ENTRYPOINT_PATH)
+  end
+
+  def selection_cell_partial_source
+    @selection_cell_partial_source ||= File.read(SELECTION_CELL_PARTIAL_PATH)
   end
 
   def javascript_controller_source(group_name)
     @javascript_controller_sources ||= {}
     @javascript_controller_sources[group_name] ||= File.read(JAVASCRIPT_CONTROLLER_PATHS.fetch(group_name))
+  end
+
+  def camelize_manifest_key(value)
+    value.gsub(/_([a-z])/) { Regexp.last_match(1).upcase }
   end
 
   def event_dispatch_name(event_key)
@@ -217,6 +230,24 @@ RSpec.describe "Public API compatibility" do
       expect(source).to include("#{key}: \"#{identifier}\""),
         "expected TreeViewControllerIdentifiers.#{key} to remain mapped to #{identifier}"
     end
+  end
+
+  it "keeps documented selection checkbox hooks available for host apps" do
+    source = javascript_entrypoint_source
+
+    expect(source).to include("export const TreeViewSelectionCheckboxHooks = Object.freeze({")
+
+    public_javascript_selection_checkbox_hooks.each do |key, value|
+      expect(source).to include(%(#{camelize_manifest_key(key)}: "#{value}")),
+        "expected TreeViewSelectionCheckboxHooks.#{camelize_manifest_key(key)} to remain mapped to #{value}"
+    end
+  end
+
+  it "keeps documented selection checkbox hooks aligned with bundled selection markup" do
+    expect(selection_cell_partial_source).to include(
+      %(class: "#{public_javascript_selection_checkbox_hooks.fetch("checkbox_selector").delete_prefix(".")}")
+    )
+    expect(selection_cell_partial_source).to include("tree_selection_disabled_reason:")
   end
 
   it "keeps documented JavaScript controller identifiers wired through registerTreeViewControllers" do


### PR DESCRIPTION
selection checkbox の参照に必要な hook 名を package root の公開 API から使えるようにしました.

Closes #641

## 対応 Issue

- #641 documented selection checkbox hook 名を public export から参照できるようにする

## 変更内容

- package root に `TreeViewSelectionCheckboxHooks` export を追加
- public API manifest に selection checkbox hook 情報を追加
- package export と manifest の整合を確認する spec / entrypoint test を追加
- selection API / public API ドキュメントを英日で更新

## 受け入れ条件との対応

- documented selection checkbox hook 名を public export から参照可能にした
- export 名と値を manifest / spec / entrypoint test で固定化した
- docs から package root 経由の参照方法を案内した

## 変更範囲

- JavaScript package root export
- public API manifest
- compatibility spec / entrypoint test
- 公開ドキュメント

## 実施した確認

- compare against `main` で差分が Issue 範囲の 8 files に収まることを確認
- public API compatibility spec を追加
- entrypoint manifest assertion を追加

## リスク

- 既存 selector / data attribute 名を public contract に含めるため、今後の変更時は manifest / docs / compatibility test を揃えて更新する必要があります

## 未対応・補足

- この実行環境では repo をローカル clone して test / lint / typecheck を直接実行できなかったため、GitHub 上の差分整合と追加テスト内容を中心に確認しています
- CI 結果は PR 上で継続確認します
