### PR TITLE
docs: interactive marker guides から mockup への導線を補う

### DIFF
--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -80,6 +80,8 @@ Use `data-tree-view-ignore-drag="true"` when only drag start should be ignored a
 
 See [Usage](usage.md#interactive-controls-inside-rows) for keyboard and row interaction markers.
 
+For static visual references, use [drag-interactive-controls.html](../mockups/drag-interactive-controls.html) for draggable rows that mix native controls with `data-tree-view-interactive` or `data-tree-view-ignore-drag`, and [interactive-marker-behaviors.html](../mockups/interactive-marker-behaviors.html) when you need the broader comparison across keyboard, row-click, and drag markers.
+
 ## Drop behavior
 
 Drop targets are implemented by the host app.

--- a/docs/en/host-app-extension-points.md
+++ b/docs/en/host-app-extension-points.md
@@ -46,6 +46,8 @@ The partial can include application-owned controls such as inputs, selects, butt
 
 See [Usage](usage.md#interactive-controls-inside-rows) for complete row-control examples.
 
+For static visual comparisons of these markers, use [interactive-marker-behaviors.html](../mockups/interactive-marker-behaviors.html) to compare the broad interactive marker against the narrower keyboard, row-click, and drag markers, and [drag-interactive-controls.html](../mockups/drag-interactive-controls.html) to inspect draggable rows that mix native controls with drag-safe custom widgets.
+
 ## Row class / data builders
 
 ```ruby

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -80,6 +80,8 @@ Drag startだけを無視し、他のTreeView動作は残したい場合は `dat
 
 keyboardやrow interaction向けのmarkerは [使い方](usage.md#行内のinteractive-control) を参照してください。
 
+静的な見比べ用リファレンスとして、native control と `data-tree-view-interactive` / `data-tree-view-ignore-drag` の共存は [drag-interactive-controls.html](../mockups/drag-interactive-controls.html) を参照し、keyboard・row-click・drag marker まで含めた広い比較が必要なときは [interactive-marker-behaviors.html](../mockups/interactive-marker-behaviors.html) を参照してください。
+
 ## drop処理
 
 drop先はhost app側で実装します。

--- a/docs/ja/host-app-extension-points.md
+++ b/docs/ja/host-app-extension-points.md
@@ -46,6 +46,8 @@ row_partial: "documents/tree_columns"
 
 詳しいrow control例は [使い方](usage.md#行内のinteractive-control) を参照してください。
 
+これらのmarkerを静的に見比べたいときは、広い interactive marker と keyboard / row-click / drag 用の狭い marker の役割差分を [interactive-marker-behaviors.html](../mockups/interactive-marker-behaviors.html) で確認し、draggable row の中で native control と drag-safe custom widget がどう共存するかは [drag-interactive-controls.html](../mockups/drag-interactive-controls.html) を参照してください。
+
 ## row class / data builders
 
 ```ruby


### PR DESCRIPTION
Closes #646

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
- current `docs/mockups/README.md` には `drag-interactive-controls.html` と `interactive-marker-behaviors.html` が inventory / review flow として整理されています
- 一方で `docs/en|ja/host-app-extension-points.md` と `docs/en|ja/drag-and-drop.md` の本文からは、その focused mockup へ直接たどる導線がありませんでした
- interactive marker の説明自体は current docs で足りているため、今回は runtime behavior や mockup HTML には触れず、既存 prose docs から既存 mockup への最小 cross-reference 追加に閉じています

## 変更内容
- `docs/en/host-app-extension-points.md`
- `docs/ja/host-app-extension-points.md`
  - broad interactive marker と narrower keyboard / row-click / drag markers の比較先として `interactive-marker-behaviors.html` を案内
  - draggable row 内で native control と drag-safe custom widget を確認する先として `drag-interactive-controls.html` を案内
- `docs/en/drag-and-drop.md`
- `docs/ja/drag-and-drop.md`
  - drag-focused reference と broader marker comparison の役割分担が分かる mockup link を追加

## 確認したこと
- 新規 Issue 着手前に own open PR の review follow-up を確認し、docs PR `#644` と `#636` には review thread / submitted review / external PR comment が見当たらないことを確認
- compare `main...docs/646-interactive-marker-mockup-links-main-current` で diff が上記 4 files に閉じ、`behind_by: 0` を確認
- `#644` は `public-api` / `selection` docs の別 lane で、今回の 4 files と write set が独立していることを確認

## 実行できなかった確認
- docs-only 変更のため test / lint / typecheck は未実行です
- この環境では通常 clone が使えないため、ローカル preview は未実施です

## リスク
- low
- 既存 mockup への導線追加だけで、runtime behavior / public API / mockup HTML 本体には触れていません