### PR TITLE
docs: toolbar と resource-table bridge guide から focused mockup への導線を補う

### DIFF
--- a/docs/en/resource-table-bridge.md
+++ b/docs/en/resource-table-bridge.md
@@ -50,6 +50,8 @@ This keeps the responsibilities separate:
 - TreeView owns tree structure and hierarchical row rendering.
 - The host app can override partials for presentation, queries, authorization, and business behavior.
 
+For a focused visual reference that compares shared hierarchy rows across fuller and narrower visible-column sets without adding host-app table logic, see [resource-table-bridge.html](../mockups/resource-table-bridge.html).
+
 ## When to use it
 
 For a regular TreeView integration, `TreeView::RenderState` is still the default choice.

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -89,6 +89,8 @@ Each action hash includes:
 
 TreeView only supplies the metadata. Final HTML structure, styling, icons, and authorization rules stay in the host app.
 
+For a focused visual reference of enabled, disabled, and current-state toolbar variants without host-app routes or authorization copy, see [toolbar-actions.html](../mockups/toolbar-actions.html).
+
 ## Client-side expand/collapse
 
 Use `build_client_side` when all nodes in the render scope can be included in the initial HTML and you only need browser-local expand/collapse.

--- a/docs/ja/resource-table-bridge.md
+++ b/docs/ja/resource-table-bridge.md
@@ -50,6 +50,8 @@ render_state = TreeView::ResourceTableRenderState.call(
 - TreeView: tree構造と階層行の描画
 - host app: 必要に応じたpartial差し替え、query、認可、業務処理
 
+shared hierarchy rows と、より多い visible column / より少ない visible column の比較を host app 側の table logic なしで見たい場合は [resource-table-bridge.html](../mockups/resource-table-bridge.html) を参照してください。
+
 ## 使うべき場面
 
 通常のTreeViewでは、従来通り `TreeView::RenderState` を直接使って問題ありません。

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -97,6 +97,8 @@ TreeView はmetadataだけを提供します。最終的なHTML構造、style、
 
 TreeView が提供するのは metadata までです。最終的な HTML 構造、style、icon、authorization rule は host app 側で決めます。
 
+enabled / disabled / current-state の toolbar variation を、host app の route や authorization copy なしで見比べたい場合は [toolbar-actions.html](../mockups/toolbar-actions.html) を参照してください。
+
 ## client-side開閉
 
 `max_render_depth` / `max_leaf_distance` の範囲内のnodeを初期HTMLに含めても問題ない小〜中規模treeでは、`build_client_side` を使えます。Turbo routeやTurbo Stream responseを用意せず、browser内だけで開閉します。


### PR DESCRIPTION
Closes #648

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
- current `docs/mockups/README.md` は `toolbar-actions.html` と `resource-table-bridge.html` を focused visual reference として inventory / review flow に載せています
- 一方で `docs/en|ja/usage.md` の toolbar helper section と `docs/en|ja/resource-table-bridge.md` の本文からは、それぞれの mockup へ直接たどる導線がありませんでした
- current code / existing docs / issue 本文の範囲で責務は十分に説明されているため、今回は runtime behavior や mockup HTML 本体には触れず、guide 本文から既存 mockup への最小 cross-reference 追加に閉じています

## 変更内容
- `docs/en/usage.md`
- `docs/ja/usage.md`
  - app-owned toolbar markup の説明直後に、enabled / disabled / current-state variants を見比べる focused reference として `toolbar-actions.html` への導線を追加
- `docs/en/resource-table-bridge.md`
- `docs/ja/resource-table-bridge.md`
  - shared hierarchy rows と fuller / narrower visible-column sets を見比べる focused reference として `resource-table-bridge.html` への導線を追加

## 確認したこと
- 新規 Issue 着手前に own open docs PR `#647` と `#636` を review follow-up 観点で先に確認し、review thread / submitted review がなく、head CI (`#868`, `#861`) が success のまま review 待ちであることを確認
- current `README.md` / `docs/README.md` / `AGENTS.md` / `Product Profile.md` も見直し、今回の観点では追加の safe docs gap を見つけず、`#648` の 4 files に scope を限定
- 作業中に `main` が進んだため current head `52b3a0744762e05d3810b55f5223309201f39412` から branch を切り直し、compare `main...docs/648-toolbar-resource-table-mockup-links-main-current-v2` で `behind_by: 0` と 4-file docs-only diff を確認

## 実行できなかった確認
- docs-only 変更のため test / lint / typecheck は未実行です
- PR 作成前の時点では、この head SHA に紐づく workflow run はまだ見つかっていません
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル preview は未実施です

## リスク
- low
- 既存 mockup への導線追加だけで、runtime helper behavior、public API、mockup HTML/CSS 本体には触れていません