### PR TITLE
docs: surface migration guide from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Key documents:
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |
 | PathTreeBuilder | [PathTreeBuilder](docs/en/path-tree-builder.md) | [PathTreeBuilder](docs/ja/path-tree-builder.md) |
 | Public API | [Public API](docs/en/public-api.md) | [Public API](docs/ja/public-api.md) |
+| Migration guide | [Migration guide](docs/en/migration.md) | [移行ガイド](docs/ja/migration.md) |
 | Release checklist | [Release checklist](docs/en/release.md) | [Release checklist](docs/ja/release.md) |
 
 Additional docs:


### PR DESCRIPTION
current `CHANGELOG.md` と language-specific docs index では migration guide が upgrade / compatibility guidance の入口として扱われていますが、root `README.md` の docs map からだけ落ちていました。root README を起点に public docs をたどる利用者や maintainer が、移行ガイドの存在を見落としにくいように導線を補います。

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `README.md`
  - `Key documents` table に `Migration guide` / `移行ガイド` の行を追加

## 根拠

- `CHANGELOG.md` の Unreleased `Documentation` に migration guide 追加が記載されている
- `docs/README.md` の maintainer entry points に migration guide が含まれている
- `docs/en/README.md` / `docs/ja/README.md` の maintainer docs map に migration guide が含まれている
- current `README.md` の docs map からだけ migration guide が落ちていた

## 変更範囲

- `README.md`

## 確認したこと

- `main...docs/readme-migration-entrypoint-20260528` の差分が `README.md` のみに閉じていることを確認
- current `CHANGELOG.md`、`docs/README.md`、`docs/en/README.md`、`docs/ja/README.md` と矛盾しない docs map に留めたことを確認
- own open docs PR `#658` / `#659` には review thread / submitted review が無く、今回優先すべき review follow-up が無いことを先に確認した

## 実行できなかった確認

- docs-only update のためローカル test / lint は実行していません
- CI は PR 作成後の結果待ちです

## リスク

- low
- 既存 docs の導線補強だけで、runtime behavior や compatibility policy 自体の変更はありません