### PR TITLE
docs: surface TreeViewSelectionValueAttributes from selection guides

### DIFF
--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -131,6 +131,19 @@ With `data-tree-view-selection-hidden-input-name-value`, TreeView writes one hid
 - Disabled checkboxes and invalid JSON payloads are skipped, matching the existing event payload behavior.
 - If the tree is not inside a form, TreeView keeps dispatching selection events and does not create hidden inputs.
 
+## Machine-readable value attribute names
+
+If the host app already imports `tree_view/index.js`, prefer `TreeViewSelectionValueAttributes` for JavaScript wiring and browser assertions instead of hand-copying selection-controller host-element attribute names. The raw HTML attribute names remain part of the documented contract.
+
+| Export key | Raw attribute | Used for |
+|---|---|---|
+| `TreeViewSelectionValueAttributes.hiddenInputName` | `data-tree-view-selection-hidden-input-name-value` | Hidden-input sync into the nearest form |
+| `TreeViewSelectionValueAttributes.maxCount` | `data-tree-view-selection-max-count-value` | Client-side selection limit |
+| `TreeViewSelectionValueAttributes.cascade` | `data-tree-view-selection-cascade-value` | Rendered-row cascade behavior |
+| `TreeViewSelectionValueAttributes.indeterminate` | `data-tree-view-selection-indeterminate-value` | Parent mixed-state updates |
+
+Use those host-element value attributes to configure the Stimulus controller. Keep row-level payload meaning, disabled-state decisions, and checkbox visibility in the render-state `selection:` builders.
+
 ## Selection max count
 
 Host apps can limit the number of checked boxes on the JavaScript controller.

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -131,6 +131,19 @@ tree が通常の HTML form の中にある場合、同じ controller で checke
 - disabled checkbox と不正な JSON payload は既存 event と同じく skip されます。
 - tree が form の外にある場合は、selection event だけを dispatch し、hidden input は生成しません。
 
+## machine-readable な value attribute 名
+
+host app がすでに `tree_view/index.js` を import しているなら、selection controller の host-element attribute 名を写経する代わりに `TreeViewSelectionValueAttributes` を使ってください。raw の HTML attribute 名も引き続き documented contract の一部です。
+
+| Export key | Raw attribute | 用途 |
+|---|---|---|
+| `TreeViewSelectionValueAttributes.hiddenInputName` | `data-tree-view-selection-hidden-input-name-value` | 最寄り form への hidden input sync |
+| `TreeViewSelectionValueAttributes.maxCount` | `data-tree-view-selection-max-count-value` | client-side の最大選択数制限 |
+| `TreeViewSelectionValueAttributes.cascade` | `data-tree-view-selection-cascade-value` | 描画済み行どうしの cascade 挙動 |
+| `TreeViewSelectionValueAttributes.indeterminate` | `data-tree-view-selection-indeterminate-value` | 親 checkbox の mixed-state 更新 |
+
+これらの host-element value attribute は Stimulus controller の設定に使います。row ごとの payload 意味づけ、disabled-state 判定、checkbox visibility は render-state 側の `selection:` builder に残してください。
+
 ## 最大選択数
 
 JavaScript controller側で、checked checkboxの最大数を制限できます。


### PR DESCRIPTION
Refs #640
Stacked on #633

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
`PR #633` では `TreeViewSelectionValueAttributes` が public export として追加されていますが、selection wiring を最初に読む利用者向けの `docs/en|ja/selection.md` からは、その machine-readable entrypoint にまだ辿りにくい状態でした。

今回は runtime behavior や host-app extension docs 全体には広げず、selection guide 本文だけに raw attribute 名と export key の対応を足す narrow sibling docs lane に留めています。

## 変更内容
- `docs/en/selection.md`
  - `TreeViewSelectionValueAttributes` の説明を追加
  - hidden input sync / max count / cascade / indeterminate の raw attribute 名と export key の対応表を追加
- `docs/ja/selection.md`
  - 同じ machine-readable entrypoint guidance を日本語側にも追加

## 確認したこと
- diff が英日 `selection.md` の 2 files に閉じていることを確認
- `PR #633` の `docs/en|ja/public-api.md` と矛盾しないことを確認
- selection controller behavior、event payload、business-specific submit flow には触れていないことを確認

## 実行できなかった確認
- docs-only update のためローカル test / lint は実行していません
- stacked follow-up のため最終確認は parent lane を含む GitHub CI と review 前提です

## リスク
- low
- docs-only の導線補強で、runtime behavior や public export の shape 自体は変更していません