### PR TITLE
docs: RubyGems metadata に bug_tracker_uri を追加する

### DIFF
--- a/spec/gemspec_files_spec.rb
+++ b/spec/gemspec_files_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe "packaged gem files" do
-  subject(:files) { Gem::Specification.load("tree_view.gemspec").files }
+  let(:specification) { Gem::Specification.load("tree_view.gemspec") }
+
+  subject(:files) { specification.files }
 
   let(:entrypoint_controller_files) do
     %w[
@@ -45,6 +47,15 @@ RSpec.describe "packaged gem files" do
     )
     expect(files.grep(/\ALICENSE/)).not_to be_empty
     expect(files.grep(%r{\Adocs/})).not_to be_empty
+  end
+
+  it "includes bug tracker metadata for RubyGems consumers" do
+    expect(specification.metadata).to include(
+      "homepage_uri" => specification.homepage,
+      "source_code_uri" => specification.homepage,
+      "changelog_uri" => "#{specification.homepage}/blob/main/CHANGELOG.md",
+      "bug_tracker_uri" => "#{specification.homepage}/issues"
+    )
   end
 
   it "excludes development-only files" do

--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
 
   spec.files = Dir.chdir(__dir__) do
     Dir[


### PR DESCRIPTION
## 対応 Issue 一覧
- Closes #671

## Issue ごとの完了内容
- #671
  - `tree_view.gemspec` に `bug_tracker_uri` を追加し、RubyGems metadata から GitHub issue tracker へ直接辿れるようにしました
  - `spec/gemspec_files_spec.rb` に drift guard を追加し、`homepage_uri` / `source_code_uri` / `changelog_uri` / `bug_tracker_uri` の metadata が今後も揃うことを確認できるようにしました

## 変更内容
- `tree_view.gemspec`
  - `spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"` を追加
- `spec/gemspec_files_spec.rb`
  - gemspec metadata をまとめて確認する example を追加

## 改善カテゴリ
- docs / metadata quality
- spec 追加

## 既存仕様への影響
- ありません
- gem runtime、public API、support policy、contact email policy は変更していません
- RubyGems metadata の public entrypoint を 1 つ補うだけです

## 実施した確認
- issue #671 の scope を確認し、contact email policy (`#365`) には広げていません
- diff を `tree_view.gemspec` と `spec/gemspec_files_spec.rb` の 2 files に限定しました
- existing `spec/gemspec_files_spec.rb` に寄せて metadata drift guard を追加しました

## 実行できなかった確認
- この環境では通常 clone が `CONNECT tunnel failed, response 403` で使えないため、ローカル `bundle exec rspec` / `gem build` は未実行です
- 最終確認は GitHub Actions CI 前提です

## リスク評価
- low
- metadata と spec-only の narrow maintenance lane に閉じています

## 補足事項
- README にはすでに repository / troubleshooting 入口があり、今回は source of truth を増やさず RubyGems metadata の direct entry を足すだけに留めました