### PR TITLE
Add current-path toolbar action to design mockups

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -21,7 +21,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [breadcrumb-paths.html](breadcrumb-paths.html) | Focused comparison for breadcrumb-path context beside the tree's own current-row cue, without modeling host-app routes or Turbo navigation. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
-| [toolbar-actions.html](toolbar-actions.html) | Expand-all / collapse-all toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
+| [toolbar-actions.html](toolbar-actions.html) | Expand-all, collapse-all, and collapse-to-current-path toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
 
@@ -38,7 +38,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 9. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
 10. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
 11. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-12. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on tree-wide expand / collapse affordances instead of row-by-row hierarchy layout.
+12. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
 13. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -377,12 +377,12 @@
           <p class="mock-gallery-eyebrow">Focused controls</p>
           <h2 id="gallery-toolbar-heading">Toolbar actions</h2>
           <p>
-            Use this surface to compare tree-wide expand and collapse affordances, including enabled, current, and disabled states, without adding real routes or authorization copy.
+            Use this surface to compare tree-wide expand, collapse, and collapse-to-current-path affordances, including enabled, current, and disabled states, without adding real routes or authorization copy.
           </p>
           <ul class="mock-gallery-points">
-            <li>Mixed-tree dual-action state</li>
+            <li>Mixed-tree all-actions state</li>
             <li>All-expanded and all-collapsed variants</li>
-            <li>Current and disabled affordance cues</li>
+            <li>Current-path-preserving cue beside full collapse</li>
           </ul>
           <div class="mock-gallery-links">
             <a href="toolbar-actions.html">Open full mockup</a>
@@ -478,8 +478,8 @@
           </tr>
           <tr>
             <td>Toolbar actions</td>
-            <td>Tree-wide expand and collapse affordances across enabled, current, and disabled states.</td>
-            <td>Authorization, route names, or action sequencing rules.</td>
+            <td>Tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</td>
+            <td>Authorization, route names, current-path semantics, or action sequencing rules.</td>
           </tr>
           <tr>
             <td>Empty state</td>

--- a/docs/mockups/toolbar-actions.html
+++ b/docs/mockups/toolbar-actions.html
@@ -240,7 +240,7 @@
       <p class="mock-kicker">tree_view-rails</p>
       <h1>Toolbar action states mock</h1>
       <p>
-        Static reference for tree-wide expand and collapse actions. This page keeps the review surface focused on
+        Static reference for tree-wide expand, collapse, and current-path-preserving actions. This page keeps the review surface focused on
         enabled, disabled, and current-state cues without bringing in host-app routes, authorization, or business wording.
       </p>
     </header>
@@ -263,7 +263,7 @@
           <div class="mock-toolbar">
             <div class="mock-toolbar__copy">
               <p class="mock-toolbar__eyebrow">State A</p>
-              <p class="mock-toolbar__title">Mixed tree, both actions available</p>
+              <p class="mock-toolbar__title">Mixed tree, every action available</p>
             </div>
             <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
               <a class="mock-toolbar-button" href="#" data-mock-state="expand-enabled">
@@ -273,6 +273,10 @@
               <a class="mock-toolbar-button" href="#" data-mock-state="collapse-enabled">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
                 <span>Collapse all</span>
+              </a>
+              <a class="mock-toolbar-button" href="#" data-mock-state="current-path-enabled">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
+                <span>Collapse to current path</span>
               </a>
             </div>
           </div>
@@ -284,7 +288,20 @@
                   <strong>Platform</strong>
                   <div class="mock-toolbar-node__meta">
                     <span class="mock-toolbar-pill">root</span>
-                    <span class="mock-toolbar-pill">3 open branches</span>
+                    <span class="mock-toolbar-pill">current path stays open</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Operations</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">child</span>
+                    <span class="mock-toolbar-pill">current branch</span>
                   </div>
                 </div>
               </div>
@@ -294,10 +311,10 @@
               <div class="mock-toolbar-node__tree">
                 <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
                 <div>
-                  <strong>Operations</strong>
+                  <strong>Finance</strong>
                   <div class="mock-toolbar-node__meta">
-                    <span class="mock-toolbar-pill">child</span>
-                    <span class="mock-toolbar-pill">12 hidden rows</span>
+                    <span class="mock-toolbar-pill">sibling</span>
+                    <span class="mock-toolbar-pill">collapsed away from current path</span>
                   </div>
                 </div>
               </div>
@@ -320,6 +337,10 @@
               <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="collapse-current">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
                 <span>Collapse all</span>
+              </a>
+              <a class="mock-toolbar-button" href="#" data-mock-state="current-path-available">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
+                <span>Collapse to current path</span>
               </a>
             </div>
           </div>
@@ -368,6 +389,10 @@
                 <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
                 <span>Collapse all</span>
               </button>
+              <button class="mock-toolbar-button" type="button" aria-disabled="true">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
+                <span>Collapse to current path</span>
+              </button>
             </div>
           </div>
           <div class="mock-toolbar-preview" aria-label="All collapsed tree preview">
@@ -399,6 +424,70 @@
             </div>
           </div>
         </div>
+
+        <div class="mock-toolbar-frame">
+          <div class="mock-toolbar">
+            <div class="mock-toolbar__copy">
+              <p class="mock-toolbar__eyebrow">State D</p>
+              <p class="mock-toolbar__title">Only the current path stays open</p>
+            </div>
+            <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
+              <a class="mock-toolbar-button" href="#" data-mock-state="expand-from-current-path">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+                <span>Expand all</span>
+              </a>
+              <a class="mock-toolbar-button" href="#" data-mock-state="collapse-from-current-path">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+                <span>Collapse all</span>
+              </a>
+              <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="current-path-current">
+                <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
+                <span>Collapse to current path</span>
+              </a>
+            </div>
+          </div>
+          <div class="mock-toolbar-preview" aria-label="Current path stays open preview">
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Platform</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">root</span>
+                    <span class="mock-toolbar-pill">ancestor path</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+            <div class="mock-toolbar-node is-expanded">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+                <div>
+                  <strong>Operations</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">current branch</span>
+                    <span class="mock-toolbar-pill">child visible</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">expanded</span>
+            </div>
+            <div class="mock-toolbar-node is-collapsed">
+              <div class="mock-toolbar-node__tree">
+                <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+                <div>
+                  <strong>People</strong>
+                  <div class="mock-toolbar-node__meta">
+                    <span class="mock-toolbar-pill">sibling branch</span>
+                    <span class="mock-toolbar-pill">collapsed outside current path</span>
+                  </div>
+                </div>
+              </div>
+              <span class="mock-toolbar-pill">collapsed</span>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -414,19 +503,24 @@
         </thead>
         <tbody>
           <tr>
-            <td>Enabled pair</td>
-            <td>Both actions available while the tree contains a mix of expanded and collapsed branches.</td>
+            <td>Enabled set</td>
+            <td>All three actions remain available while the tree contains a mix of expanded, collapsed, and current-path branches.</td>
             <td>Route names, Turbo wiring, or action sequencing rules.</td>
           </tr>
           <tr>
             <td>Expand disabled</td>
-            <td>The tree is already fully expanded, so only collapse remains actionable.</td>
+            <td>The tree is already fully expanded, so collapse-all and collapse-to-current-path remain actionable.</td>
             <td>Business copy about why a branch is open or who may collapse it.</td>
           </tr>
           <tr>
             <td>Collapse disabled</td>
-            <td>The tree is already fully collapsed, so only expand remains actionable.</td>
+            <td>The tree is already fully collapsed, so collapse-to-current-path also disables until a current branch becomes visible again.</td>
             <td>Authorization, saved preferences, or persistence across visits.</td>
+          </tr>
+          <tr>
+            <td>Current path preserved</td>
+            <td>The current-path action reads as the active state while ancestors stay open and sibling branches collapse away.</td>
+            <td>The semantics of choosing the current path or how the host app stores that state.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## 対応Issue

- Closes #669

## 採用した方針

- 既存の toolbar mockup 群に `collapse_all_except_current_path` の比較軸を足し、review gallery と README も同じ粒度で追従させる low-risk 案を採用しました。
- host app の routing / authorization / current-path semantics には踏み込まず、比較可能な見た目と説明だけを増やしています。

## 比較した案

- 案A: docs/en/toolbar.md だけで action を説明する。
- 案B: `toolbar-actions.html` に current-path 状態を追加し、gallery / README も同時に更新する。
- 案C: mockup だけでなく host-app 風の routing copy や sequencing 例まで広げる。

## 変更内容

- `toolbar-actions.html` に `Collapse to current path` を含む 4 状態比較を追加しました。
- mixed / all-expanded / all-collapsed / current-path-preserving の差分が見えるよう preview と comparison table を更新しました。
- review gallery と README の説明文も 3-action 前提に合わせました。

## 変更した画面・コンポーネント

- `docs/mockups/toolbar-actions.html`
- `docs/mockups/review-gallery.html`
- `docs/mockups/README.md`

## 確認内容

- lint: 未実施（static HTML docs のみ変更）
- typecheck: 未実施（static HTML docs のみ変更）
- UI表示確認: diff と mockup 文脈で確認
- レスポンシブ確認: 既存の narrow breakpoint を維持していることを確認
- アクセシビリティ確認: current / disabled / enabled の区別が aria-disabled と文面で比較できることを確認

## スクリーンショット

- 未添付

## リスク

- low

## 補足

- 自動実行のため、既存デザインに沿って比較面を広げる最小リスク案を採用しました.