### PR TITLE
docs: mockup README の review flow に narrow sidebar lane を追加

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -29,17 +29,18 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the current mockup set.
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
-3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-5. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-6. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-7. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-8. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-9. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-10. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-11. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-12. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-13. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+3. Use [narrow-sidebar-tree.html](narrow-sidebar-tree.html) when review needs a focused pass on 22rem or 18rem frames where hierarchy cues stay visible while secondary metadata wraps below the primary label.
+4. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
+5. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+6. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+7. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+8. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+9. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+10. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+11. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+12. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+13. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+14. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 


### PR DESCRIPTION
Closes #688

## 判定分類
- `docs-stale`
- `docs-sync`

## 変更理由
current `docs/mockups/README.md` は file inventory と `review-gallery.html` では `narrow-sidebar-tree.html` を current mockup set の一部として案内していますが、`Recommended review flow` からは narrow sidebar lane へ直接辿れませんでした。

今回は existing mockup asset と gallery copy を正本にして、review flow に narrow-width review の入口だけを追加しています。mockup HTML/CSS 本体や review-gallery の wording には広げていません。

## 変更内容
- `docs/mockups/README.md`
  - `Recommended review flow` に `narrow-sidebar-tree.html` への案内を追加
  - 22rem / 18rem frame で hierarchy cue を保ちながら secondary metadata が wrap する review intent を一文で補足

## 確認したこと
- `Files` table にある `narrow-sidebar-tree.html` の説明と矛盾しないことを確認
- `review-gallery.html` の `Narrow sidebar` card が案内している 22rem / 18rem comparison surface と wording を揃えた
- diff が `docs/mockups/README.md` の 1 file に閉じていることを確認

## 実行できなかった確認
- docs-only update のため test / lint は実行していません
- この環境では通常 clone が使えないため、ローカル preview は未実施です

## リスク
- low
- existing mockup への導線追加だけで、visual asset や host-app responsive policy 自体は変更していません