### PR TITLE
Add focused mockup for row status and depth label boundaries

### DIFF
--- a/docs/en/depth-labels.md
+++ b/docs/en/depth-labels.md
@@ -63,6 +63,12 @@ Common values:
 | `tree` | Current tree. |
 | `render_state` | Current RenderState. |
 
+## Focused visual reference
+
+For a static comparison of depth cues beside row-wide status states, see [row-status-depth-labels.html](../mockups/row-status-depth-labels.html).
+
+That mockup keeps labels product-neutral so you can review hierarchy cues separately from host-app business wording and authorization meaning.
+
 ## Responsibility boundary
 
 | Area | TreeView | Host app |

--- a/docs/en/row-status.md
+++ b/docs/en/row-status.md
@@ -77,6 +77,12 @@ render_state = TreeView::RenderState.new(
 | Disable a checkbox | `selection[:disabled_builder]` |
 | Show an entire row as disabled or readonly | `row_status_builder` |
 
+## Focused visual reference
+
+For a static comparison of row-wide disabled or readonly cues, checkbox-only disabled reasons, and the structural role of depth labels, see [row-status-depth-labels.html](../mockups/row-status-depth-labels.html).
+
+Use that mockup as a visual companion to this guide. Business wording, authorization decisions, and action policy still belong to the host app.
+
 ## Responsibility boundary
 
 | Area | TreeView | Host app |

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -109,6 +109,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/README.md` | Technical asset | Index for static mockup assets. Short bilingual-style prose is acceptable; no separate translation needed. |
 | `docs/mockups/review-gallery.html` | Technical asset | Comparison hub for the current static mockup set. No translation needed. |
 | `docs/mockups/default-tree.html` | Technical asset | No translation needed. |
+| `docs/mockups/row-status-depth-labels.html` | Technical asset | No translation needed. |
 | `docs/mockups/resource-table-bridge.html` | Technical asset | No translation needed. |
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |

--- a/docs/ja/depth-labels.md
+++ b/docs/ja/depth-labels.md
@@ -63,6 +63,12 @@ depth_label_builder = ->(_item, context) {
 | `tree` | 現在のtree。 |
 | `render_state` | 現在のRenderState。 |
 
+## Focused visual reference
+
+depth cue と row-wide status state の見え方を静的に見比べたい場合は [row-status-depth-labels.html](../mockups/row-status-depth-labels.html) を参照してください。
+
+この mockup では label を product-neutral に保ち、階層の手がかりと host app 側の業務文言や認可意味付けを分けて確認しやすくしています。
+
 ## 責務範囲
 
 | Area | TreeView | Host app |

--- a/docs/ja/row-status.md
+++ b/docs/ja/row-status.md
@@ -77,6 +77,12 @@ row status は行全体の見た目や状態を表すためのhookです。
 | checkboxを選択不可にする | `selection[:disabled_builder]` |
 | 行全体をdisabled / readonly風に見せる | `row_status_builder` |
 
+## Focused visual reference
+
+行全体の disabled / readonly cue、checkbox だけの disabled reason、depth label が持つ構造的な役割を静的に見比べたい場合は [row-status-depth-labels.html](../mockups/row-status-depth-labels.html) を参照してください。
+
+この mockup は guide 本文の補助となる visual reference です。業務文言、認可判断、操作ポリシーは引き続き host app 側で扱います。
+
 ## 責務範囲
 
 | Area | TreeView | Host app |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -12,6 +12,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 |---|---|
 | [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the current baseline and focused mockup references, with embedded previews and links to each full page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide disabled/readonly cues, selection checkbox disabled reasons, and depth-label boundaries without host-app business wording. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
@@ -28,18 +29,19 @@ They are **not** a complete Rails application and should not grow into host-app 
 ## Recommended review flow
 
 1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the current mockup set.
-2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
-3. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-4. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-5. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-6. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-7. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-8. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-9. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-10. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-11. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-12. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-13. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+2. Open [row-status-depth-labels.html](row-status-depth-labels.html) when review needs a focused pass on row-wide status cues, disabled checkbox reasons, or how depth labels stay separate from host-app business meaning.
+3. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
+4. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
+5. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+6. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+7. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+8. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+9. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+10. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+11. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+12. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+13. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+14. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, row-status and depth-label boundaries, narrow layouts, interaction states, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -180,6 +180,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-row-status-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused cue boundaries</p>
+          <h2 id="gallery-row-status-heading">Row status and depth labels</h2>
+          <p>
+            Use this surface to compare row-wide disabled or readonly cues against disabled selection checkboxes, while keeping depth labels clearly structural and host-app meaning outside the mock.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Row-wide status versus checkbox-disabled responsibility</li>
+            <li>Depth labels as structural cues, not business wording</li>
+            <li>Combined cues without implying extra runtime behavior</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="row-status-depth-labels.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -430,6 +451,11 @@
             <td>Default tree</td>
             <td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td>
             <td>Host-app CRUD, queries, business labels, or authorization behavior.</td>
+          </tr>
+          <tr>
+            <td>Row status and depth labels</td>
+            <td>Comparing row-wide status cues, disabled selection reasons, and structural depth labels without mixing their responsibilities.</td>
+            <td>Authorization decisions, business wording, checkbox payload semantics, or broader selection-controller behavior.</td>
           </tr>
           <tr>
             <td>Resource table bridge</td>

--- a/docs/mockups/row-status-depth-labels.html
+++ b/docs/mockups/row-status-depth-labels.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Row status and depth labels mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.tree-row--readonly {
+  background: #f8fafc;
+}
+
+.tree-row--disabled {
+  background: #fff1f2;
+}
+
+.mock-inline-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.45rem;
+  color: #52606d;
+  font-size: 0.82rem;
+}
+
+.mock-inline-note strong {
+  color: #102a43;
+}
+
+.mock-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.mock-boundary-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #52606d;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Row status and depth labels</h1>
+      <p>
+        Focused static reference for comparing row-wide status cues, disabled selection checkboxes, and depth labels without turning the mockup into a host-app authorization or business-copy example.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="row-status-heading">
+      <h2 id="row-status-heading">Row status stays row-wide</h2>
+      <p>
+        Compare row-wide disabled and readonly cues against a disabled checkbox state. The status badge colors the row context; the checkbox-disabled reason only explains why selection is blocked for that row.
+      </p>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">select</th>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">status cue</th>
+            <th scope="col">review note</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="tree-row is-expanded" aria-level="1" aria-expanded="true">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" type="checkbox">
+            </td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Normal row expanded">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#">hide</a>
+                  <span class="tree-toggle__level">root</span>
+                </span>
+              </span>
+              <span class="tree-node-marker">folder</span>
+              <span class="tree-depth-label">L0</span>
+            </td>
+            <td>Operations workspace</td>
+            <td><span class="mock-status mock-status--active">active</span></td>
+            <td>Normal row without selection restrictions.</td>
+          </tr>
+          <tr class="tree-row tree-row--readonly" aria-level="2">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" type="checkbox">
+            </td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Readonly child row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">child</span>
+                </span>
+              </span>
+              <span class="tree-node-marker">folder</span>
+              <span class="tree-depth-label">L1</span>
+            </td>
+            <td>Quarter close archive</td>
+            <td><span class="mock-status mock-status--pending">readonly</span></td>
+            <td>The row cue explains the broader state even though selection still uses the ordinary checkbox path.</td>
+          </tr>
+          <tr class="tree-row tree-row--disabled" aria-level="2">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" type="checkbox" disabled title="Disabled rows cannot be selected">
+            </td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Disabled child row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">child</span>
+                </span>
+              </span>
+              <span class="tree-node-marker">folder</span>
+              <span class="tree-depth-label">L1</span>
+            </td>
+            <td>Security hold queue</td>
+            <td><span class="mock-status mock-status--error">disabled</span></td>
+            <td>The blocked checkbox is narrower than the row cue. It only explains selection, not every business action on the row.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="depth-label-heading">
+      <h2 id="depth-label-heading">Depth labels stay structural</h2>
+      <p>
+        Depth labels help reviewers see hierarchy position at a glance. They do not claim business meaning on their own, so the mock keeps them short and product-neutral.
+      </p>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">label cue</th>
+            <th scope="col">what stays outside TreeView</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="tree-row" aria-level="1">
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Root row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">root</span>
+                </span>
+              </span>
+              <span class="tree-node-marker">folder</span>
+            </td>
+            <td><span class="tree-depth-label">L0</span></td>
+            <td>Whether the root means portfolio, region, or category stays host-app owned.</td>
+          </tr>
+          <tr class="tree-row" aria-level="2">
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Child row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">child</span>
+                </span>
+              </span>
+              <span class="tree-node-marker">folder</span>
+            </td>
+            <td><span class="tree-depth-label">L1</span></td>
+            <td>Styling and wording can change in the host app without changing the reusable hierarchy output.</td>
+          </tr>
+          <tr class="tree-row" aria-level="3">
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Leaf row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">leaf</span>
+                </span>
+              </span>
+              <span class="tree-node-marker">file</span>
+            </td>
+            <td><span class="tree-depth-label">L2</span></td>
+            <td>Depth cue remains separate from approval, archive, or permission states.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="combined-heading">
+      <h2 id="combined-heading">Combined cues still keep separate jobs</h2>
+      <div class="mock-grid">
+        <table class="tree-view-table">
+          <thead>
+            <tr>
+              <th scope="col">select</th>
+              <th scope="col">tree</th>
+              <th scope="col">name</th>
+              <th scope="col">status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="tree-row tree-row--readonly" aria-level="3">
+              <td class="tree-selection-cell">
+                <input class="tree-selection-checkbox" type="checkbox" disabled title="Readonly rows are not selectable in this host app">
+              </td>
+              <td class="tree-toggle-cell">
+                <span class="tree-toggle" aria-label="Readonly leaf row">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot has-line"></span>
+                    <span class="tree-toggle__branch-slot has-line"></span>
+                    <span class="tree-toggle__branch-slot is-current is-last"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <span class="tree-toggle__level">leaf</span>
+                  </span>
+                </span>
+                <span class="tree-node-marker">file</span>
+                <span class="tree-depth-label">L2</span>
+                <span class="mock-inline-note"><strong>Disabled checkbox:</strong> selection only</span>
+              </td>
+              <td>Revenue workbook</td>
+              <td><span class="mock-status mock-status--pending">readonly</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <ul class="mock-boundary-list">
+          <li>Row status remains the broad row cue for the host-app state.</li>
+          <li>The disabled checkbox only explains why selection is blocked.</li>
+          <li>The depth label stays structural and does not replace business wording.</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #686
- Closes #691

## 採用した方針

- 既存の `default-tree.html` に責務比較を詰め込みすぎず、差分レビューしやすい sibling mockup を 1 枚追加する低リスク案を採用しました。
- 自動実行のため、既存 mockup の見た目と言葉づかいに寄せつつ、row-wide status cue / disabled checkbox reason / depth label の責務境界だけを focused に比較できる形を優先しました。
- 同テーマの docs follow-up を別 PR に分けず、`docs/en|ja/row-status.md` と `docs/en|ja/depth-labels.md` から新しい focused mockup へ辿れるようにして、prose guide と visual reference の役割分担も同じ PR に揃えました。

## 比較した案

- 案A: focused sibling mockup を追加して比較ポイントを review gallery と README と関連 guide から案内する
- 案B: `default-tree.html` だけを拡張して比較内容を同居させる
- 案C: prose 中心の追記だけで済ませる

## 変更内容

- `docs/mockups/row-status-depth-labels.html` を追加し、row-wide disabled/readonly cue、disabled checkbox reason、depth label の責務分離を比較できる静的 mockup を追加
- `docs/mockups/review-gallery.html` に新しい比較カードと比較表の行を追加
- `docs/mockups/README.md` にファイル説明と review flow を追加
- `docs/en/row-status.md` と `docs/ja/row-status.md` に focused mockup への visual reference を追加
- `docs/en/depth-labels.md` と `docs/ja/depth-labels.md` に focused mockup への visual reference を追加

## 変更した画面・コンポーネント

- `docs/mockups/row-status-depth-labels.html`
- `docs/mockups/review-gallery.html`
- `docs/mockups/README.md`
- `docs/en/row-status.md`
- `docs/ja/row-status.md`
- `docs/en/depth-labels.md`
- `docs/ja/depth-labels.md`

## 確認内容

- lint: 未実施（静的 mockup / docs 変更のみ）
- typecheck: 該当なし
- UI表示確認: HTML/CSS ソースと差分構造を確認
- レスポンシブ確認: 既存 mockup と同じレイアウト前提で source review のみ実施
- アクセシビリティ確認: row cue と checkbox cue の役割分離、depth label の構造的な扱いを source review で確認
- docs導線確認: row-status / depth-labels guide から focused mockup へ辿れることを source review で確認

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low

## 補足

- 静的 mockup / docs のみの変更で、runtime の TreeView 挙動は変えていません。
- 既存デザインに沿う低リスク案として、review gallery と prose guide の両方から辿れる focused mockup に整理しました.