### PR TITLE
test: public API spec の event-name guard を manifest 寄りに整理する

### DIFF
--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe "Public API compatibility" do
     @javascript_controller_sources[group_name] ||= File.read(JAVASCRIPT_CONTROLLER_PATHS.fetch(group_name))
   end
 
+  def camelize_manifest_key(value)
+    value.to_s.gsub(/_([a-z])/) { Regexp.last_match(1).upcase }
+  end
+
+  def event_names_by_export_group
+    public_javascript_event_names.transform_keys { |group_name| camelize_manifest_key(group_name) }
+  end
+
   def event_dispatch_name(event_key)
     event_key.tr("_", "-")
   end
@@ -255,23 +263,12 @@ RSpec.describe "Public API compatibility" do
     source = javascript_entrypoint_source
 
     expect(source).to include("export const TreeViewEventNames = Object.freeze({")
-    expect(source).to include("state: Object.freeze({")
-    expect(source).to include("selection: Object.freeze({")
-    expect(source).to include("remoteState: Object.freeze({")
-    expect(source).to include("hostLifecycle: Object.freeze({")
-    expect(source).to include("transfer: Object.freeze({")
-    expect(source).to include('stateChanged: "tree-view-state:state-changed"')
-    expect(source).to include('limitExceeded: "tree-view-selection:limit-exceeded"')
-    expect(source).to include('invalidPayload: "tree-view-selection:invalid-payload"')
-    expect(source).to include('loading: "tree-view:loading"')
-    expect(source).to include('loaded: "tree-view:loaded"')
-    expect(source).to include('error: "tree-view:error"')
-    expect(source).to include('dragStart: "tree-view-transfer:drag-start"')
-    expect(source).to include('dragOver: "tree-view-transfer:drag-over"')
-    expect(source).to include('invalidTransfer: "tree-view-transfer:invalid-transfer"')
 
-    public_javascript_event_names.each_value do |group|
-      group.each_value do |event_name|
+    event_names_by_export_group.each do |group_name, events|
+      expect(source).to include("#{group_name}: Object.freeze({"),
+        "expected TreeViewEventNames to keep the #{group_name} group"
+
+      events.each_value do |event_name|
         expect(source).to include(%("#{event_name}")),
           "expected TreeViewEventNames to include #{event_name}"
       end


### PR DESCRIPTION
Closes #690

## 対応Issue
- #690

## 変更内容
- `spec/public_api_compatibility_spec.rb`
  - manifest key を export 側の group 名へ寄せる小さな helper を追加
  - `TreeViewEventNames` の group 存在確認を manifest-driven に変更
  - representative event-name string の literal 列挙を減らし、manifest から読む shape に整理

## 変更理由
- current repo では `config/public_api_manifest.yml` を JavaScript public contract の machine-readable source of truth として扱っています
- それに対して spec 側だけが `TreeViewEventNames` の group 名や representative event 名を別 literal で抱えていたため、public contract を 1 つ増やすたびに manifest と spec の二重更新が起きやすい状態でした
- 今回は controller source と documented detail-key の整合を見ている explicit guard は残したまま、event-name guard だけを manifest 寄りに整理しています

## 既存仕様への影響
- ありません
- runtime code、manifest の public contract、docs wording は変更していません
- spec の source-of-truth alignment のみです

## 実施した確認
- diff が `spec/public_api_compatibility_spec.rb` の 1 file に閉じていることを確認
- `config/public_api_manifest.yml` と `script/test_entrypoints.mjs` の current source-of-truth 方針に合わせ、spec でも同じ event-name inventory を読む形に寄せました
- controller dispatch source と documented detail-key の整合チェックはそのまま維持しています

## 実行できなかった確認
- この環境では通常 clone が使えず、ローカル `bundle exec rspec` は未実行です
- 最終確認は GitHub Actions CI 前提です

## リスク
- low
- spec-only の内部整理で、public contract 自体には触れていません