### PR TITLE
docs: installation workflow guidance を current docs map に揃える

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -133,7 +133,7 @@ When asset or JavaScript paths change, check these items before release:
 
 - `tree_view.gemspec` includes CSS, JavaScript, and importmap files
 - README installation examples match this file
-- the package checklist in `docs/en/release.md` or `docs/release.md` is updated
+- the package checklist in `docs/en/release.md` is updated
 - static rendering still works without JavaScript
 - JavaScript-dependent features document their importmap pin and data attributes
 
@@ -147,10 +147,10 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm install
-npm test
+npm run test:js
 ```
 
-Use `npm install` here for the same reason as CI: the committed `package-lock.json` still needs a refresh before `npm ci` can be trusted.
+Use `npm install` here for the same reason as CI: the committed `package-lock.json` still needs a refresh before `npm ci` can be trusted. `npm run test:js` runs the entrypoint smoke, Vitest suite, and Playwright browser smoke checks documented in the CI lane.
 
 Rails compatibility Gemfiles live under `gemfiles/`.
 

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -131,7 +131,7 @@ asset または JavaScript の配置を変更した場合は、release 前に以
 
 - `tree_view.gemspec` がCSS、JavaScript、importmapファイルを含んでいる
 - README の導入例がこのファイルと一致している
-- `docs/ja/release.md` または `docs/release.md` の package checklist が更新されている
+- `docs/ja/release.md` の package checklist が更新されている
 - static表示がJavaScriptなしでも利用できる、という前提を壊していない
 - JavaScriptが必要な機能は、必要なimportmap pinやdata属性をdocsに書いている
 
@@ -145,10 +145,10 @@ bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
 npm install
-npm test
+npm run test:js
 ```
 
-ローカル手順も CI と同じく `npm install` を使います。理由は、commit 済みの `package-lock.json` を `npm ci` で安全に使うには、まだ lockfile refresh が必要だからです。
+ローカル手順も CI と同じく `npm install` を使います。理由は、commit 済みの `package-lock.json` を `npm ci` で安全に使うには、まだ lockfile refresh が必要だからです。`npm run test:js` は CI lane と同じく entrypoint smoke、Vitest suite、Playwright browser smoke をまとめて実行します。
 
 Rails互換性確認用のGemfileは `gemfiles/` 配下にあります。
 


### PR DESCRIPTION
## 対応Issue

Closes #695

## 分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/installation.md` の release checklist 参照から、存在しない root `docs/release.md` fallback を削除しました。
- `docs/ja/installation.md` も同じく `docs/ja/release.md` への参照に揃えました。
- local development setup の JavaScript command を `npm test` から `npm run test:js` に更新し、entrypoint smoke / Vitest / Playwright browser smoke をまとめる CI lane と一致させました。

## 確認観点

- 差分は bilingual installation docs の2ファイルのみです。
- `package-lock.json` refresh、CI install command、package dependencies には触れていません。
- current `package.json` では `test:js` が `test:entrypoints && npm test && test:browser` を実行するため、README / CI の案内と矛盾しません。

## リスク

- low

## 確認

- GitHub compare: `main...docs/695-installation-workflow-sync` は `docs/en/installation.md` / `docs/ja/installation.md` のみ変更、`behind_by: 0`。