### PR TITLE
docs: ResourceTableRenderState と table layer の責務境界を補強する

### DIFF
--- a/docs/en/resource-table-bridge.md
+++ b/docs/en/resource-table-bridge.md
@@ -50,6 +50,8 @@ This keeps the responsibilities separate:
 - TreeView owns tree structure and hierarchical row rendering.
 - The host app can override partials for presentation, queries, authorization, and business behavior.
 
+For host apps that use both a regular table and a tree-table, start here to decide what TreeView owns, then read the table preferences layer docs for column state, widths, presets, export metadata, and preference UI. Keep TreeView responsible for row hierarchy, visible row order, expansion state, and rendering hooks; keep the table layer responsible for table-wide column and preference state.
+
 For a focused visual reference that compares shared hierarchy rows across fuller and narrower visible-column sets without adding host-app table logic, see [resource-table-bridge.html](../mockups/resource-table-bridge.html).
 
 ## When to use it

--- a/docs/ja/resource-table-bridge.md
+++ b/docs/ja/resource-table-bridge.md
@@ -50,6 +50,8 @@ render_state = TreeView::ResourceTableRenderState.call(
 - TreeView: tree構造と階層行の描画
 - host app: 必要に応じたpartial差し替え、query、認可、業務処理
 
+通常 table と tree-table の両方を使う host app では、まずこのページで TreeView が担当する範囲を決め、column state、width、preset、export metadata、preference UI の詳細は table preferences layer 側の docs を確認してください。TreeView には row hierarchy、visible row order、expansion state、rendering hook を任せ、table layer には table 全体の column / preference state を任せると、責務が重複しにくくなります。
+
 shared hierarchy rows と、より多い visible column / より少ない visible column の比較を host app 側の table logic なしで見たい場合は [resource-table-bridge.html](../mockups/resource-table-bridge.html) を参照してください。
 
 ## 使うべき場面


### PR DESCRIPTION
## 対応Issue

Closes #697

## 分類

- `docs-sync`
- `docs-stale`

## 変更内容

- `docs/en/resource-table-bridge.md` に、通常 table と tree-table を併用する host app 向けの first reading path を追加しました。
- `docs/ja/resource-table-bridge.md` に同じ責務境界を追加しました。
- TreeView が row hierarchy / visible row order / expansion state / rendering hooks を持ち、table preferences layer が column state / width / preset / export metadata / preference UI を持つ、という分担を短く補強しました。

## 確認観点

- 変更は bilingual resource table bridge docs の2ファイルのみです。
- `ResourceTableRenderState` API、runtime code、mockup、`rails_table_preferences` 側、docs-portal 側には触れていません。
- Rails Table Preferences は具体例として扱い、TreeView 側 contract を広げていません。

## リスク

- low

## 確認

- GitHub compare: `main...docs/697-resource-table-boundary` は `docs/en/resource-table-bridge.md` / `docs/ja/resource-table-bridge.md` のみ変更、`behind_by: 0`。