### PR TITLE
quality: Node 22 guidance を package.json に追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "tree_view",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",


### PR DESCRIPTION
## 対応 Issue

Closes #696

## Issue ごとの完了内容

- #696
  - `package.json` に `engines.node: "22.x"` を追加し、local tooling / editor / package manager からも Node 22 前提を読み取れるようにしました。
  - `.nvmrc`、CI、README / development docs は既に Node 22 を source of truth として案内しているため、その方針に合わせた machine-readable guidance に閉じています。

## 変更内容

- `package.json`
  - `engines.node` を追加

## 改善カテゴリ

- devops / tooling guidance
- small metadata quality improvement

## 既存仕様への影響

- runtime code、Ruby code、CI workflow、dependency versions、`package-lock.json` は変更していません。
- `package.json` は `private: true` のままで、npm package publish contract は変更していません。

## 実施した確認

- GitHub compare: `main...quality/696-node22-package-engines`
  - `package.json` のみ変更
  - `behind_by: 0`
- local test: 未実行（通常 git clone / fetch が `CONNECT tunnel failed, response 403` で利用できないため）

## リスク評価

- low
- metadata-only の追加で、既存の Node 22 guidance と矛盾しない変更です。

## 補足

- dependency upgrade と lockfile refresh には広げていません。