### PR TITLE
feat: toolbar helper に HTML 属性拡張を追加する

### DIFF
--- a/app/helpers/tree_view_helper/toolbar.rb
+++ b/app/helpers/tree_view_helper/toolbar.rb
@@ -15,11 +15,11 @@ module TreeViewHelper
       collapse_all_except_current_path: :current_path
     }.freeze
 
-    def tree_view_toolbar(render_state, actions: DEFAULT_TREE_VIEW_TOOLBAR_ACTIONS, labels: {}, class_name: "tree-view-toolbar", button_class_name: "tree-view-toolbar__button")
-      content_tag(:div, class: class_name, data: {tree_view_toolbar: true}) do
+    def tree_view_toolbar(render_state, actions: DEFAULT_TREE_VIEW_TOOLBAR_ACTIONS, labels: {}, class_name: "tree-view-toolbar", button_class_name: "tree-view-toolbar__button", html: {}, action_html: nil)
+      content_tag(:div, tree_view_toolbar_html_options(class_name, html)) do
         safe_join(
           tree_view_toolbar_actions(render_state, actions: actions, labels: labels).map do |action|
-            tree_view_toolbar_action_tag(action, button_class_name)
+            tree_view_toolbar_action_tag(action, button_class_name, action_html)
           end
         )
       end
@@ -72,11 +72,13 @@ module TreeViewHelper
       I18n.t("tree_view.toolbar.labels.#{action}", default: default_label)
     end
 
-    def tree_view_toolbar_action_tag(action, button_class_name)
+    def tree_view_toolbar_action_tag(action, button_class_name, action_html)
+      options = tree_view_toolbar_action_html_options(action, button_class_name, action_html)
+
       if action[:path]
-        link_to(action[:label], action[:path], class: button_class_name, data: action[:data])
+        link_to(action[:label], action[:path], options)
       else
-        button_tag(action[:label], type: "button", class: button_class_name, disabled: true, data: action[:data])
+        button_tag(action[:label], options.merge(type: "button", disabled: true))
       end
     end
 
@@ -91,6 +93,32 @@ module TreeViewHelper
         tree_view_toolbar_action: action,
         tree_view_toolbar_disabled: disabled || nil
       }.compact
+    end
+
+    def tree_view_toolbar_html_options(class_name, html)
+      options = html.to_h.dup
+      options[:class] = class_names(class_name, options[:class])
+      options[:data] = options.fetch(:data, {}).to_h.merge(tree_view_toolbar: true)
+      options
+    end
+
+    def tree_view_toolbar_action_html_options(action, button_class_name, action_html)
+      options = resolve_tree_view_toolbar_action_html(action, action_html).to_h.dup
+      options[:class] = class_names(button_class_name, options[:class])
+      options[:data] = options.fetch(:data, {}).to_h.merge(action.fetch(:data))
+      options
+    end
+
+    def resolve_tree_view_toolbar_action_html(action, action_html)
+      case action_html
+      when nil
+        {}
+      when Proc
+        action_html.call(action) || {}
+      else
+        options = action_html.to_h
+        options.fetch(action.fetch(:action), options.fetch(action.fetch(:action).to_s, options))
+      end
     end
   end
 end

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -77,10 +77,12 @@ For host apps that own lazy-loading placeholder regions, these three lazy-loadin
 For app-owned toolbar builders, use `tree_view_toolbar_supported_actions`, `tree_view_toolbar_actions`, and `tree_view_toolbar_action_metadata` rather than internal constants.
 Documented toolbar helpers are part of that public helper surface:
 
-- `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ...)` renders TreeView's bundled toolbar markup.
+- `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ..., html: ..., action_html: ...)` renders TreeView's bundled toolbar markup and accepts documented additive HTML attributes for the toolbar container and action elements.
 - `tree_view_toolbar_supported_actions` returns the supported toolbar action symbols for app-owned toolbar builders.
 - `tree_view_toolbar_actions(render_state, actions: ..., labels: {})` returns action hashes so the host app can render its own toolbar markup.
 - `tree_view_toolbar_action_metadata(render_state, action, label: nil)` returns metadata for one supported action.
+
+`html:` adds container attributes such as `class`, `data`, or `aria` while preserving TreeView's required toolbar data hook. `action_html:` adds attributes to each action link or disabled button through an action-aware Proc, action-keyed Hash, or flat Hash while preserving TreeView's required action and disabled data hooks. Use custom rendering helpers when the host app needs different markup, authorization copy, or additional controls.
 
 Supported toolbar action symbols are `:expand_all`, `:collapse_all`, and `:collapse_all_except_current_path`.
 

--- a/docs/en/toolbar.md
+++ b/docs/en/toolbar.md
@@ -51,7 +51,7 @@ For a static comparison of expand-all, collapse-all, and current-path-preserving
 
 Use that mockup as a visual companion to this helper boundary: it highlights action affordances and the `:current_path` contract without defining routes, authorization copy, or Turbo response behavior.
 
-## Custom labels and classes
+## Custom labels, classes, and attributes
 
 ```erb
 <%= tree_view_toolbar(
@@ -59,9 +59,27 @@ Use that mockup as a visual companion to this helper boundary: it highlights act
   actions: [:expand_all],
   labels: { expand_all: "Open all" },
   class_name: "documents-toolbar",
-  button_class_name: "documents-toolbar__button"
+  button_class_name: "documents-toolbar__button",
+  html: {
+    data: { controller: "toolbar-analytics" },
+    aria: { label: "Document tree actions" }
+  },
+  action_html: ->(action) {
+    {
+      data: {
+        analytics_action: action.fetch(:action),
+        turbo_frame: "documents_tree"
+      }
+    }
+  }
 ) %>
 ```
+
+Use `html:` for additional attributes on the toolbar container. Its `class` is appended after `class_name`, and its `data` values are merged while keeping TreeView's `data-tree-view-toolbar="true"` hook.
+
+Use `action_html:` for additional attributes on each rendered action link or disabled button. It may be a Proc that receives the action metadata hash, an action-keyed Hash such as `{ expand_all: { data: ... } }`, or a flat Hash applied to every action. Host app attributes are merged with the existing action metadata, but TreeView keeps ownership of `data-tree-view-toolbar-action` and `data-tree-view-toolbar-disabled`.
+
+For heavier markup changes, custom authorization copy, extra controls, or a different button/link structure, keep using `tree_view_toolbar_actions` or `tree_view_toolbar_action_metadata` and render the toolbar in the host app.
 
 ## Responsibility boundary
 
@@ -74,4 +92,5 @@ Host apps own:
 - authorization
 - persistence of expanded keys
 - semantics of `:current_path`
+- analytics, test hooks, and screen-specific attributes passed through `html:` or `action_html:`
 - visual styling beyond default class names

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -77,10 +77,12 @@ lazy-loading の placeholder region を host app 側で持つ場合、上の 3 h
 app-owned toolbar builder では、internal constant を直接参照せず、`tree_view_toolbar_supported_actions`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` を使ってください。
 toolbar helper もこの公開 helper surface に含まれます。
 
-- `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ...)` は TreeView bundled toolbar の HTML を描画します。
+- `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ..., html: ..., action_html: ...)` は TreeView bundled toolbar の HTML を描画し、toolbar container と action element へ documented な追加 HTML attribute を渡せます。
 - `tree_view_toolbar_supported_actions` は app-owned toolbar builder が使ってよい supported toolbar action symbol を返します。
 - `tree_view_toolbar_actions(render_state, actions: ..., labels: {})` は host app が独自 toolbar markup を組み立てるための action hash 配列を返します。
 - `tree_view_toolbar_action_metadata(render_state, action, label: nil)` は 1 つの supported action 用 metadata を返します。
+
+`html:` は `class`、`data`、`aria` などの container attribute を追加しつつ、TreeView 必須の toolbar data hook を維持します。`action_html:` は action-aware Proc、action-keyed Hash、または flat Hash で各 action link / disabled button に attribute を追加しつつ、TreeView 必須の action / disabled data hook を維持します。markup、authorization copy、追加 control を変える必要がある場合は custom rendering helper を使ってください。
 
 公開されている toolbar action symbol は `:expand_all`、`:collapse_all`、`:collapse_all_except_current_path` です。
 

--- a/docs/ja/toolbar.md
+++ b/docs/ja/toolbar.md
@@ -51,7 +51,7 @@ expand-all、collapse-all、current path を残す toolbar state を静的に見
 
 この mockup は、この helper の責務境界を視覚的に補うためのものです。action の見え方と `:current_path` contract を確認できますが、route、authorization copy、Turbo response behavior 自体を定義するものではありません。
 
-## label と class の変更
+## label、class、attribute の変更
 
 ```erb
 <%= tree_view_toolbar(
@@ -59,9 +59,27 @@ expand-all、collapse-all、current path を残す toolbar state を静的に見
   actions: [:expand_all],
   labels: { expand_all: "Open all" },
   class_name: "documents-toolbar",
-  button_class_name: "documents-toolbar__button"
+  button_class_name: "documents-toolbar__button",
+  html: {
+    data: { controller: "toolbar-analytics" },
+    aria: { label: "Document tree actions" }
+  },
+  action_html: ->(action) {
+    {
+      data: {
+        analytics_action: action.fetch(:action),
+        turbo_frame: "documents_tree"
+      }
+    }
+  }
 ) %>
 ```
+
+`html:` は toolbar container に追加 attribute を渡すために使います。`class` は `class_name` の後ろに追加され、`data` は TreeView の `data-tree-view-toolbar="true"` hook を残したまま merge されます。
+
+`action_html:` は各 action link または disabled button に追加 attribute を渡すために使います。action metadata hash を受け取る Proc、`{ expand_all: { data: ... } }` のような action-keyed Hash、または全 action に適用する flat Hash を渡せます。host app 側の attribute は既存 metadata と merge されますが、`data-tree-view-toolbar-action` と `data-tree-view-toolbar-disabled` は TreeView 側の値を維持します。
+
+markup を大きく変える場合、独自の authorization copy を出す場合、追加 control や別の button/link 構造が必要な場合は、引き続き `tree_view_toolbar_actions` または `tree_view_toolbar_action_metadata` を使って host app 側で toolbar を描画してください。
 
 ## 責務境界
 
@@ -74,4 +92,5 @@ host appは以下を担当します。
 - authorization
 - expanded keys の保存
 - `:current_path` の意味づけ
+- `html:` / `action_html:` で渡す analytics、test hook、screen-specific attribute
 - default class names 以上の見た目調整

--- a/spec/helpers/tree_view_toolbar_helper_spec.rb
+++ b/spec/helpers/tree_view_toolbar_helper_spec.rb
@@ -166,6 +166,70 @@ RSpec.describe "tree_view_toolbar helper" do
     expect(html).to include("Open all")
   end
 
+  it "merges toolbar container HTML attributes without dropping TreeView data hooks" do
+    html = helper.tree_view_toolbar(
+      render_state,
+      actions: [:expand_all],
+      html: {
+        class: "documents-toolbar",
+        data: {controller: "analytics", tree_view_toolbar: "host-override"},
+        aria: {label: "Document tree actions"}
+      }
+    )
+
+    expect(html).to include("class=\"tree-view-toolbar documents-toolbar\"")
+    expect(html).to include("data-controller=\"analytics\"")
+    expect(html).to include("data-tree-view-toolbar=\"true\"")
+    expect(html).to include("aria-label=\"Document tree actions\"")
+  end
+
+  it "merges action HTML attributes from a proc while keeping TreeView action data" do
+    html = helper.tree_view_toolbar(
+      render_state,
+      actions: [:expand_all],
+      action_html: ->(action) {
+        {
+          class: "qa-#{action.fetch(:action)}",
+          data: {analytics_action: action.fetch(:action), tree_view_toolbar_action: "host-override"},
+          aria: {label: "Analytics #{action.fetch(:label)}"}
+        }
+      }
+    )
+
+    expect(html).to include("class=\"tree-view-toolbar__button qa-expand_all\"")
+    expect(html).to include("data-analytics-action=\"expand_all\"")
+    expect(html).to include("data-tree-view-toolbar-action=\"expand_all\"")
+    expect(html).to include("aria-label=\"Analytics Expand all\"")
+  end
+
+  it "merges action-specific HTML attributes for disabled buttons" do
+    static_ui_config = TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" }
+    )
+    static_render_state = instance_double(TreeView::RenderState, ui_config: static_ui_config)
+
+    html = helper.tree_view_toolbar(
+      static_render_state,
+      actions: [:collapse_all],
+      action_html: {
+        collapse_all: {
+          class: "qa-disabled-action",
+          data: {testid: "collapse-all"},
+          aria: {describedby: "toolbar-help"}
+        }
+      }
+    )
+
+    expect(html).to include("class=\"tree-view-toolbar__button qa-disabled-action\"")
+    expect(html).to include("data-testid=\"collapse-all\"")
+    expect(html).to include("data-tree-view-toolbar-action=\"collapse_all\"")
+    expect(html).to include("data-tree-view-toolbar-disabled=\"true\"")
+    expect(html).to include("aria-describedby=\"toolbar-help\"")
+    expect(html).to include("disabled=\"disabled\"")
+  end
+
   it "renders disabled buttons when no toggle_all_path is configured" do
     static_ui_config = TreeView::UiConfig.new(
       node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },


### PR DESCRIPTION
tree_view_toolbar に container / action element 向けの追加 HTML 属性 surface を後方互換で追加します。

## 対応 Issue

Closes #700

## 変更内容

- `tree_view_toolbar` に `html:` と `action_html:` keyword を追加
- `html:` で toolbar container の class / data / aria などを追加できるようにしました
- `action_html:` で action metadata に応じた link / disabled button 属性を追加できるようにしました
- 既存の `data-tree-view-toolbar-action` と `data-tree-view-toolbar-disabled` は TreeView 側の値を優先して保持します
- helper spec に container merge、Proc による action-aware merge、disabled button の action-keyed merge を追加
- `docs/en/toolbar.md` / `docs/ja/toolbar.md` に bundled helper 拡張と custom rendering の使い分けを追記

## 受け入れ条件との対応

- container 追加属性: `html:` で対応
- action link / disabled button 追加属性: `action_html:` で対応。Proc、action-keyed Hash、flat Hash を受けられます
- 既存 action metadata / supported actions / `toggle_all_path(state:)`: 変更なし
- docs: toolbar docs 日英を更新し、重い markup 変更は `tree_view_toolbar_actions` / `tree_view_toolbar_action_metadata` 推奨のままにしています
- 既存呼び出し: 既存 keyword はそのまま維持し、追加 keyword は default 付きです

## 変更範囲

- `app/helpers/tree_view_helper/toolbar.rb`
- `spec/helpers/tree_view_toolbar_helper_spec.rb`
- `docs/en/toolbar.md`
- `docs/ja/toolbar.md`

## 実施した確認

- GitHub compare: `main...feature/700-toolbar-html-options`
  - `ahead_by: 1`
  - `behind_by: 0`
  - 変更は上記 4 files に限定
- local test: 通常 clone / fetch が `CONNECT tunnel failed, response 403` で利用できないため未実行
- CI: PR 作成後に確認します

## リスク

- medium
- public helper API の additive keyword 追加です。既存 data hook を TreeView 側優先で merge し、host app 側の属性追加で必須 hook が消えないようにしています。

## 未対応・補足

- toolbar action の追加、`toggle_all_path` contract 変更、Turbo response / authorization / analytics の具体実装、toolbar visual redesign には広げていません。