### PR TITLE
docs: breadcrumb helper examples に label_builder を明示する

### DIFF
--- a/docs/en/breadcrumb.md
+++ b/docs/en/breadcrumb.md
@@ -18,10 +18,14 @@ The host app remains responsible for routes, authorization, choosing the current
 ## Minimal example
 
 ```erb
-<%= tree_view_breadcrumb(@tree, @document) %>
+<%= tree_view_breadcrumb(
+  @tree,
+  @document,
+  label_builder: ->(item) { item.name }
+) %>
 ```
 
-When `path_builder` is omitted, TreeView renders plain labels.
+`label_builder:` is required because TreeView does not assume how records should be displayed. When `path_builder` is omitted, TreeView renders plain labels.
 
 ## Breadcrumbs with links
 
@@ -42,6 +46,7 @@ The current item is rendered as a current label instead of a link.
 <%= tree_view_breadcrumb(
   @tree,
   @document,
+  label_builder: ->(item) { item.name },
   list_class: "breadcrumb",
   item_class: "breadcrumb-item",
   link_class: "breadcrumb-link",
@@ -54,7 +59,7 @@ The current item is rendered as a current label instead of a link.
 
 | option | meaning |
 |---|---|
-| `label_builder:` | Callable that returns the display label for each item. |
+| `label_builder:` | Required callable that returns the display label for each item. |
 | `path_builder:` | Callable that returns the URL/path for each item. Plain labels are rendered when omitted. |
 | `list_class:` | Class for the root list element. |
 | `item_class:` | Class for each item element. |

--- a/docs/ja/breadcrumb.md
+++ b/docs/ja/breadcrumb.md
@@ -18,10 +18,14 @@ TreeView gem が担当するのは以下です。
 ## 最小例
 
 ```erb
-<%= tree_view_breadcrumb(@tree, @document) %>
+<%= tree_view_breadcrumb(
+  @tree,
+  @document,
+  label_builder: ->(item) { item.name }
+) %>
 ```
 
-`path_builder` を省略した場合は、各nodeのlabelだけを描画します。
+TreeView は record の表示方法を仮定しないため、`label_builder:` は必須です。`path_builder` を省略した場合は、各nodeのlabelだけを描画します。
 
 ## link付きbreadcrumb
 
@@ -42,6 +46,7 @@ TreeView gem が担当するのは以下です。
 <%= tree_view_breadcrumb(
   @tree,
   @document,
+  label_builder: ->(item) { item.name },
   list_class: "breadcrumb",
   item_class: "breadcrumb-item",
   link_class: "breadcrumb-link",
@@ -54,7 +59,7 @@ TreeView gem が担当するのは以下です。
 
 | option | 意味 |
 |---|---|
-| `label_builder:` | 各itemの表示labelを返すcallable。 |
+| `label_builder:` | 各itemの表示labelを返す必須のcallable。 |
 | `path_builder:` | 各itemのURL/pathを返すcallable。省略時はplain label。 |
 | `list_class:` | root list要素のclass。 |
 | `item_class:` | 各item要素のclass。 |


### PR DESCRIPTION
## 対応 Issue

Closes #705

## Issue ごとの完了内容

- #705
  - `docs/en/breadcrumb.md` / `docs/ja/breadcrumb.md` の最小例に、current helper signature で必須の `label_builder:` を追加しました。
  - class / separator 例にも `label_builder:` を追加し、copy-paste で current API と矛盾しない形に揃えました。
  - `path_builder` 省略時は plain labels になる説明を、`label_builder:` 必須の前提と両立する wording に更新しました。

## 変更内容

- breadcrumb docs の bilingual examples と builder table のみ更新
- helper API、route / authorization policy、breadcrumb mockup には触れていません。

## 改善カテゴリ

- docs-sync
- code-ahead-of-docs

## 既存仕様への影響

- docs-only 変更です。
- runtime behavior、public helper signature、UI、API 契約は変更していません。

## 実施した確認

- GitHub compare: `main...docs/705-breadcrumb-label-builder-fresh`
  - `docs/en/breadcrumb.md` / `docs/ja/breadcrumb.md` のみ変更
  - `behind_by: 0`
- local test: 未実行（通常 git clone / raw fetch が `CONNECT tunnel failed, response 403` で利用できないため）

## リスク評価

- low
- current code の必須 keyword を docs に反映するだけの docs-only correction です。

## 補足

- PR #708 は古い main からの branch だったため close 済みです。この PR は current `main` から切り直した replacement です。