### PR TITLE
docs: public API manifest 変更時の release 確認導線を補強する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -85,6 +85,15 @@ When the change touches documented host-app wiring or machine-readable public co
 
 `config/public_api_manifest.yml` remains the machine-readable source of truth for package-root exports, controller identifiers, grouped option keys, and documented event detail keys. Public API and feature docs remain the source of truth for documented wiring attributes and hooks that are intentionally not exported there.
 
+For any public API manifest change, confirm the release-facing trail is complete before tagging:
+
+- the manifest change is reflected in `docs/en/public-api.md`, `docs/ja/public-api.md`, and any affected feature page
+- `CHANGELOG.md` describes the user-visible compatibility surface under the appropriate release category
+- breaking changes, removals, or deprecations include migration notes rather than only manifest or spec wording
+- docs-only manifest guidance changes are listed as Documentation entries and do not imply runtime behavior changes
+
+Documentation files to review when public behavior or public compatibility surfaces change:
+
 - `README.md`
 - `docs/ja/README.md`
 - `docs/en/README.md`
@@ -109,6 +118,8 @@ Use these categories:
 - Deprecated
 - Removed
 - Documentation
+
+Record public API manifest changes by their user-visible effect. Use Added or Changed for backward-compatible public surface updates, Deprecated or Removed for compatibility changes that require migration notes, and Documentation only when the manifest or docs guidance changed without a runtime contract change.
 
 Include migration notes for breaking changes or deprecations.
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -85,6 +85,15 @@ documented な host-app wiring surface または machine-readable public contrac
 
 `config/public_api_manifest.yml` は、package-root export、controller identifier、grouped option key、documented event detail key の machine-readable source of truth です。一方で、そこに export していない documented wiring attribute や hook については、public API docs と feature docs を source of truth として扱います。
 
+public API manifest を変更する場合は、tag を打つ前に release-facing な導線も確認してください。
+
+- manifest の変更が `docs/en/public-api.md`、`docs/ja/public-api.md`、影響する feature page に反映されている
+- `CHANGELOG.md` が、user-visible な compatibility surface を適切な release category で説明している
+- breaking change、削除、deprecation には、manifest や spec の説明だけでなく migration note がある
+- docs-only の manifest guidance 変更は Documentation entry として扱い、runtime behavior の変更を示唆しない
+
+public behavior や public compatibility surface が変わるときに確認する docs:
+
 - `README.md`
 - `docs/ja/README.md`
 - `docs/en/README.md`
@@ -109,6 +118,8 @@ releaseごとに `CHANGELOG.md` へ日付付きentryを追加します。
 - Deprecated
 - Removed
 - Documentation
+
+public API manifest の変更は、user-visible な影響に合わせて記録します。後方互換な public surface 追加や変更は Added / Changed、migration note が必要な互換性変更は Deprecated / Removed、runtime contract を変えない manifest や docs guidance の変更は Documentation に入れてください。
 
 breaking changeやdeprecationにはmigration noteを書きます。
 


### PR DESCRIPTION
## 対応 Issue

Closes #714

## 変更内容

- `docs/en/release.md` に public API manifest 変更時の release-facing 確認点を追加
- `docs/ja/release.md` に同じ確認点を追加
- CHANGELOG category の選び方を、manifest 変更の user-visible effect に合わせて明確化

## 判定分類

- `docs-sync`
- `docs-stale`

## 確認観点

- `AGENTS.md` / `docs/en|ja/development.md` の manifest 変更ルールと矛盾しないこと
- `config/public_api_manifest.yml` や compatibility spec の実装変更へ広げていないこと
- release docs から public API docs / feature docs / CHANGELOG の同期確認へ辿れること

## 確認済み

- GitHub compare: `main...docs/714-public-api-manifest-release-guidance`
  - `ahead_by: 2`
  - `behind_by: 0`
  - 変更は `docs/en/release.md` / `docs/ja/release.md` の 2 files のみ

## リスク

- low
- docs-only の release checklist 補強です。manifest schema、CI、runtime behavior、CHANGELOG 本文には触れていません。