### PR TITLE
design: Turbo Frame target mockup を追加する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -23,7 +23,7 @@ Use this table when you need a quick answer to "which user-facing pages must sta
 Japanese remains the more complete canonical prose source when English wording lags, but the pages below are the current cross-language planning baseline promised by `docs/en/README.md`, `docs/ja/README.md`, and `docs/README.md`.
 
 | Docs lane | Current coverage status | Priority | Maintenance expectation |
-|---|---|---|---|
+|---|---|---|
 | `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` | Published entry points for cross-language navigation and language-status guidance | High | Update in the same docs lane whenever reading order, docs map, or language-status promises change |
 | `docs/en/installation.md`, `docs/ja/installation.md` | Published in both trees | High | Keep setup, asset, importmap, and first-run instructions aligned before release-facing docs changes land |
 | `docs/en/minimal-usage.md`, `docs/ja/minimal-usage.md` | Published in both trees | High | Keep the first working host-app example aligned with installation and usage docs |
@@ -113,6 +113,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
+| `docs/mockups/turbo-frame-target.html` | Technical asset | No translation needed. |
 | `docs/mockups/drag-interactive-controls.html` | Technical asset | No translation needed. |
 | `docs/mockups/interactive-marker-behaviors.html` | Technical asset | No translation needed. |
 | `docs/mockups/windowed-rendering.html` | Technical asset | No translation needed. |

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -23,7 +23,7 @@ Use this table when you need a quick answer to "which user-facing pages must sta
 Japanese remains the more complete canonical prose source when English wording lags, but the pages below are the current cross-language planning baseline promised by `docs/en/README.md`, `docs/ja/README.md`, and `docs/README.md`.
 
 | Docs lane | Current coverage status | Priority | Maintenance expectation |
-|---|---|---|
+|---|---|---|---|
 | `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` | Published entry points for cross-language navigation and language-status guidance | High | Update in the same docs lane whenever reading order, docs map, or language-status promises change |
 | `docs/en/installation.md`, `docs/ja/installation.md` | Published in both trees | High | Keep setup, asset, importmap, and first-run instructions aligned before release-facing docs changes land |
 | `docs/en/minimal-usage.md`, `docs/ja/minimal-usage.md` | Published in both trees | High | Keep the first working host-app example aligned with installation and usage docs |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -15,6 +15,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [turbo-frame-target.html](turbo-frame-target.html) | Focused Turbo Frame target boundary showing `data-turbo-frame` on TreeView toggle links beside the host-app-owned frame wrapper. |
 | [drag-interactive-controls.html](drag-interactive-controls.html) | Focused comparison for native interactive controls, `data-tree-view-interactive`, and `data-tree-view-ignore-drag` inside draggable rows. |
 | [interactive-marker-behaviors.html](interactive-marker-behaviors.html) | Focused comparison for `data-tree-view-interactive`, `data-tree-view-ignore-keyboard`, `data-tree-view-ignore-row-click`, and `data-tree-view-ignore-drag`, including the reserved host-app row-click boundary. |
 | [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
@@ -32,15 +33,16 @@ They are **not** a complete Rails application and should not grow into host-app 
 3. Use [narrow-sidebar-tree.html](narrow-sidebar-tree.html) when review needs a focused pass on 22rem or 18rem frames where hierarchy cues stay visible while secondary metadata wraps below the primary label.
 4. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 5. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-6. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-7. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-8. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-9. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-10. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-11. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-12. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-13. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-14. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+6. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+7. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+8. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+9. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+10. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+11. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+12. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+13. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+14. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+15. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, Turbo Frame target boundaries, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -243,6 +243,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-turbo-frame-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused Turbo boundary</p>
+          <h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2>
+          <p>
+            Use this surface to compare the configured <code>data-turbo-frame</code> toggle-link attribute against the host-app-owned frame wrapper and response boundary.
+          </p>
+          <ul class="mock-gallery-points">
+            <li><code>&lt;turbo-frame id="documents_tree"&gt;</code> wrapper as host-app markup</li>
+            <li>Expand and collapse links targeting <code>documents_tree</code></li>
+            <li>Route, authorization, and Turbo response kept outside the mockup</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="turbo-frame-target.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -445,6 +466,11 @@
             <td>Interaction states</td>
             <td>Loading, retry, pagination, and drag or drop status cues.</td>
             <td>Real Turbo responses, route wiring, or persistence behavior.</td>
+          </tr>
+          <tr>
+            <td>Turbo Frame target</td>
+            <td>Configured <code>data-turbo-frame</code> link attributes beside the host-app-owned target frame.</td>
+            <td>Turbo Stream responses, Rails routes, controller actions, authorization, or frame placement policy.</td>
           </tr>
           <tr>
             <td>Drag interactive controls</td>

--- a/docs/mockups/turbo-frame-target.html
+++ b/docs/mockups/turbo-frame-target.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView Turbo Frame target mockup</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.turbo-frame-shell {
+  display: grid;
+  gap: 18px;
+}
+
+.turbo-frame-demo-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.turbo-frame-box {
+  border: 2px solid #93c5fd;
+  border-radius: 14px;
+  background: #eff6ff;
+  overflow: hidden;
+}
+
+.turbo-frame-label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid #bfdbfe;
+  color: #1e3a8a;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.turbo-frame-label code,
+.turbo-link-marker code,
+.turbo-boundary-card code {
+  padding: 0.08rem 0.35rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.75);
+  color: inherit;
+}
+
+.turbo-frame-content {
+  padding: 12px;
+  background: #fff;
+}
+
+.turbo-link-marker {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.35rem;
+  color: #1d4ed8;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.turbo-boundary-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.turbo-boundary-card {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.turbo-boundary-card h3,
+.turbo-boundary-card p {
+  margin: 0;
+}
+
+.turbo-boundary-card h3 {
+  color: #102a43;
+  font-size: 1rem;
+}
+
+.turbo-boundary-card p {
+  color: #52606d;
+}
+
+.turbo-frame-note {
+  margin: 0;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #334e68;
+}
+
+@media (max-width: 820px) {
+  .turbo-frame-demo-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <nav class="mock-return-nav" aria-label="Mockup navigation">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Mockup README</a>
+    </nav>
+
+    <header class="mock-header">
+      <p class="mock-kicker">Focused Turbo Frame boundary</p>
+      <h1>Turbo Frame target mockup</h1>
+      <p>
+        Static reference for the boundary between the TreeView-owned toggle link attribute and the host-app-owned Turbo Frame target, controller response, and authorization checks.
+      </p>
+    </header>
+
+    <section class="mock-section turbo-frame-shell" aria-labelledby="turbo-frame-target-heading">
+      <div>
+        <h2 id="turbo-frame-target-heading">Target frame and link attribute</h2>
+        <p>
+          The frame placement is supplied by the host app. TreeView only adds the configured <code>data-turbo-frame</code> value to expand or collapse links.
+        </p>
+      </div>
+
+      <div class="turbo-frame-demo-grid">
+        <div class="turbo-frame-box" aria-label="turbo-frame documents_tree static boundary">
+          <div class="turbo-frame-label">
+            <span>Host app frame target</span>
+            <code>&lt;turbo-frame id="documents_tree"&gt;</code>
+          </div>
+          <div class="turbo-frame-content">
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">Document</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Owner</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-selected">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle">
+                      <span class="tree-toggle__branches"></span>
+                      <span class="tree-toggle__control">
+                        <a class="tree-toggle__action" href="#" data-turbo-frame="documents_tree">Collapse</a>
+                        <span class="tree-node-title">Documents</span>
+                        <span class="tree-node-badge tree-node-badge--info">Current</span>
+                        <span class="turbo-link-marker"><code>data-turbo-frame="documents_tree"</code></span>
+                      </span>
+                    </span>
+                  </td>
+                  <td><span class="mock-status mock-status--active">Open</span></td>
+                  <td>Records team</td>
+                </tr>
+                <tr class="tree-row">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle">
+                      <span class="tree-toggle__branches">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <a class="tree-toggle__action" href="#" data-turbo-frame="documents_tree">Expand</a>
+                        <span class="tree-node-title">Policies</span>
+                        <span class="turbo-link-marker"><code>data-turbo-frame="documents_tree"</code></span>
+                      </span>
+                    </span>
+                  </td>
+                  <td><span class="mock-status mock-status--pending">Collapsed</span></td>
+                  <td>Compliance</td>
+                </tr>
+                <tr class="tree-row">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle">
+                      <span class="tree-toggle__branches">
+                        <span class="tree-toggle__branch-slot is-current is-last"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-depth-label">Leaf</span>
+                        <span class="tree-node-title">Quarterly review.pdf</span>
+                      </span>
+                    </span>
+                  </td>
+                  <td><span class="mock-status mock-status--archived">Read only</span></td>
+                  <td>Finance</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <aside class="turbo-boundary-stack" aria-label="Responsibility boundary notes">
+          <article class="turbo-boundary-card">
+            <h3>TreeView owns</h3>
+            <p>The configured <code>turbo_frame: "documents_tree"</code> value is rendered on toggle links as <code>data-turbo-frame</code>.</p>
+          </article>
+          <article class="turbo-boundary-card">
+            <h3>Host app owns</h3>
+            <p>The surrounding <code>&lt;turbo-frame&gt;</code>, route, controller action, authorization, and Turbo Stream or HTML response stay outside the gem.</p>
+          </article>
+          <article class="turbo-boundary-card">
+            <h3>Review focus</h3>
+            <p>Use this page to confirm that reviewers can see which links target the frame without implying that TreeView supplies navigation behavior.</p>
+          </article>
+        </aside>
+      </div>
+
+      <p class="turbo-frame-note">
+        This mockup is static. It does not perform Turbo navigation, fetch children, or model host-app permission copy.
+      </p>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #707

## 採用した方針

- 自動実行のため、低リスクで既存 mockup set に沿う案として、Turbo Frame target 境界だけを扱う focused static mockup を追加しました。
- TreeView 側が owns する `data-turbo-frame` link attribute と、host app 側が owns する `<turbo-frame>` wrapper / route / controller / authorization / response の境界を見せることに閉じています。
- 実 Turbo navigation、Rails controller、route、authorization、`turbo_frame:` API 変更には踏み込んでいません。

## 比較した案

- 案A: `interaction-states.html` に Turbo Frame の注記だけを追加する
  - 既存 state surface に近い一方、lazy loading / retry / drag state と混ざり、target frame boundary が埋もれやすい
- 案B: focused static page を追加し、README と review gallery から導線を張る
  - `data-turbo-frame` と target `<turbo-frame>` の関係だけを集中して比較でき、既存 mockup の責務を増やさずに済む
  - 今回採用
- 案C: docs/en|ja/turbo-frame.md まで広く同期する
  - discoverability は上がるが、既存 docs は既に responsibility boundary を説明しているため、この PR では mockup entrypoint の追加に留めた

## 変更内容

- `docs/mockups/turbo-frame-target.html` を追加
  - `documents_tree` target frame wrapper の static boundary
  - expand / collapse toggle links の `data-turbo-frame="documents_tree"` 表示
  - TreeView owns / Host app owns / Review focus の responsibility cards
- `docs/mockups/README.md` に file list と recommended review flow の導線を追加
- `docs/mockups/review-gallery.html` に gallery card と comparison cues row を追加

## 変更した画面・コンポーネント

- `docs/mockups/turbo-frame-target.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`

## 確認内容

- lint: 未実行（static HTML / docs のみ）
- typecheck: 該当なし
- UI表示確認: GitHub compare で static mockup と mockup index 導線のみに閉じていることを確認
- レスポンシブ確認: 新規 mockup に 820px 以下で 1 column に落ちる CSS を含めた
- アクセシビリティ確認: `main` / `section` / heading 構造、navigation label、table headings、boundary aside label を持つ static reference に限定

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得

## リスク

- low

## 補足

- compare `main...design/707-turbo-frame-target-mockup`: `ahead_by: 3` / `behind_by: 0`
- 通常 git access は `CONNECT tunnel failed, response 403` のため、GitHub connector の file / compare を正本として確認しました。
