### PR TITLE
docs: Turbo Frame / Persisted State の入口導線を補う

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Key documents:
 | Usage | [Usage](docs/en/usage.md) | [使い方](docs/ja/usage.md) |
 | Toolbar helper (`tree_view_toolbar`) | [Toolbar helper](docs/en/toolbar.md) | [Toolbar helper](docs/ja/toolbar.md) |
 | Turbo Frame option | [Turbo Frame option](docs/en/turbo-frame.md) | [Turbo Frame オプション](docs/ja/turbo-frame.md) |
+| Persisted State | [Persisted State](docs/en/persisted-state.md) | [Persisted State](docs/ja/persisted-state.md) |
 | Decision guide | [Decision guide](docs/en/decision-guide.md) | [API判断ガイド](docs/ja/decision-guide.md) |
 | FAQ | [FAQ](docs/en/faq.md) | [FAQ](docs/ja/faq.md) |
 | Troubleshooting | [Troubleshooting](docs/en/troubleshooting.md) | [Troubleshooting](docs/ja/troubleshooting.md) |

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Key documents:
 | Minimal usage | [Minimal usage](docs/en/minimal-usage.md) | [最小利用例](docs/ja/minimal-usage.md) |
 | Usage | [Usage](docs/en/usage.md) | [使い方](docs/ja/usage.md) |
 | Toolbar helper (`tree_view_toolbar`) | [Toolbar helper](docs/en/toolbar.md) | [Toolbar helper](docs/ja/toolbar.md) |
+| Turbo Frame option | [Turbo Frame option](docs/en/turbo-frame.md) | [Turbo Frame オプション](docs/ja/turbo-frame.md) |
 | Decision guide | [Decision guide](docs/en/decision-guide.md) | [API判断ガイド](docs/ja/decision-guide.md) |
 | FAQ | [FAQ](docs/en/faq.md) | [FAQ](docs/ja/faq.md) |
 | Troubleshooting | [Troubleshooting](docs/en/troubleshooting.md) | [Troubleshooting](docs/ja/troubleshooting.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
 - [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure and interaction states. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
+- [English Turbo Frame option](en/turbo-frame.md): target TreeView Turbo toggle links at a host-app Turbo Frame without custom JavaScript.
+- [日本語Turbo Frame オプション](ja/turbo-frame.md): TreeView の Turbo toggle link を host app の Turbo Frame に向ける設定。
 - [English resource table bridge](en/resource-table-bridge.md): bridge TreeView row rendering with a separate table layer that owns columns and table state.
 - [日本語Resource table bridge](ja/resource-table-bridge.md): 別table layerが列推論やtable stateを持つ場合のTreeView連携。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@
 - [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure and interaction states. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
 - [English Turbo Frame option](en/turbo-frame.md): target TreeView Turbo toggle links at a host-app Turbo Frame without custom JavaScript.
 - [日本語Turbo Frame オプション](ja/turbo-frame.md): TreeView の Turbo toggle link を host app の Turbo Frame に向ける設定。
+- [English Persisted State](en/persisted-state.md): save and restore TreeView expansion state through host-app-owned storage.
+- [日本語Persisted State](ja/persisted-state.md): TreeView の開閉状態を host app 側の保存先で保存・復元するための入口。
 - [English resource table bridge](en/resource-table-bridge.md): bridge TreeView row rendering with a separate table layer that owns columns and table state.
 - [日本語Resource table bridge](ja/resource-table-bridge.md): 別table layerが列推論やtable stateを持つ場合のTreeView連携。
 


### PR DESCRIPTION
## 対応範囲

- Closes #727
- PR-scoped docs sync として、既存の `docs/en/turbo-frame.md` / `docs/ja/turbo-frame.md` への root-level entrypoint を補う変更を含みます
- #727 の docs-only scope として、既存の `docs/en/persisted-state.md` / `docs/ja/persisted-state.md` への root-level entrypoint も同じ README / docs index diff にまとめました
- 関連する先行作業: `#707` / `#716` で Turbo Frame target mockup が追加済みのため、Turbo Frame option docs への入口導線を root README / docs index からも揃えます

## 変更内容

- root `README.md` の Key documents に Turbo Frame option guide と Persisted State guide の日英リンクを追加
- `docs/README.md` の Recommended entry points に日英 Turbo Frame option guide と日英 Persisted State guide の入口を追加
- 詳細説明は既存の日英 guide に任せ、root-level docs は入口導線に限定

## 判定分類

- `docs-sync`
- `docs-stale`

## 根拠

- `docs/en/README.md` / `docs/ja/README.md` には Turbo Frame option が利用者向け entry point として既に掲載済み
- `docs/en/turbo-frame.md` / `docs/ja/turbo-frame.md` は current docs として存在し、TreeView の Turbo toggle link に `data-turbo-frame` を付ける責務境界を説明している
- `README.md` の Features には persisted expansion state が掲載済みで、`docs/en/persisted-state.md` / `docs/ja/persisted-state.md` も current guide として存在する
- root README と root docs index からだけ入口が薄かったため、既存 docs へのリンク追加に限定

## 確認観点

- runtime、API、generator、Turbo behavior、mockup HTML/CSS には触れていないこと
- 既存の日英 Turbo Frame docs / Persisted State docs とリンク先が一致していること
- root-level docs は入口導線に留まり、詳細説明を重複させていないこと

## 確認済み

- GitHub compare: `main...docs/turbo-frame-entrypoints-main-fresh`
  - `ahead_by: 3`
  - `behind_by: 0`
  - 変更は `README.md` / `docs/README.md` の 2 files のみ
- head `944074569350c3bb926d9bfe870868d03043d831` の CI run `#956`: success
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: docs-only skip path success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: docs-only skip path success
- merge freshness: `mergeable: true`

## リスク

- low
- docs-only の入口導線追加です。コード、設定、CI、依存関係は変更していません。