### PR TITLE
design: row status と depth label の mockup を current main で復旧する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -121,6 +121,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/filtered-tree-modes.html` | Technical asset | No translation needed. |
 | `docs/mockups/form-editing-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
+| `docs/mockups/row-status-depth-labels.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |
 
 ## Ongoing maintenance

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -14,6 +14,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
+| [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [turbo-frame-target.html](turbo-frame-target.html) | Focused Turbo Frame target boundary showing `data-turbo-frame` on TreeView toggle links beside the host-app-owned frame wrapper. |
 | [drag-interactive-controls.html](drag-interactive-controls.html) | Focused comparison for native interactive controls, `data-tree-view-interactive`, and `data-tree-view-ignore-drag` inside draggable rows. |
@@ -32,17 +33,18 @@ They are **not** a complete Rails application and should not grow into host-app 
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [narrow-sidebar-tree.html](narrow-sidebar-tree.html) when review needs a focused pass on 22rem or 18rem frames where hierarchy cues stay visible while secondary metadata wraps below the primary label.
 4. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-5. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-6. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-7. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-8. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-9. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-10. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-11. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-12. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-13. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-14. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-15. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+5. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly or disabled cues, selection availability, and depth-label meaning boundaries.
+6. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+7. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+8. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+9. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+10. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+11. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+12. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+13. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+14. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+15. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+16. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, narrow layouts, interaction states, Turbo Frame target boundaries, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, row status and depth-label boundaries, narrow layouts, interaction states, Turbo Frame target boundaries, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -180,6 +180,27 @@
         </div>
         <div class="mock-gallery-preview">
           <iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe>
+        </div>
+      </article>
+
+      <article class="mock-gallery-card" aria-labelledby="gallery-status-depth-heading">
+        <div class="mock-gallery-copy">
+          <p class="mock-gallery-eyebrow">Focused status cues</p>
+          <h2 id="gallery-status-depth-heading">Row status and depth labels</h2>
+          <p>
+            Use this surface to compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.
+          </p>
+          <ul class="mock-gallery-points">
+            <li>Normal, readonly, and disabled representative rows</li>
+            <li>Selection availability separated from row-wide status</li>
+            <li>Depth-label meaning kept host-app owned</li>
+          </ul>
+          <div class="mock-gallery-links">
+            <a href="row-status-depth-labels.html">Open full mockup</a>
+          </div>
+        </div>
+        <div class="mock-gallery-preview">
+          <iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe>
         </div>
       </article>
 
@@ -451,6 +472,11 @@
             <td>Default tree</td>
             <td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td>
             <td>Host-app CRUD, queries, business labels, or authorization behavior.</td>
+          </tr>
+          <tr>
+            <td>Row status and depth labels</td>
+            <td>Comparing row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.</td>
+            <td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td>
           </tr>
           <tr>
             <td>Resource table bridge</td>

--- a/docs/mockups/row-status-depth-labels.html
+++ b/docs/mockups/row-status-depth-labels.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView row status and depth label mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-boundary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 16px;
+}
+
+.mock-boundary-card {
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 16px;
+}
+
+.mock-boundary-card h3,
+.mock-boundary-card p {
+  margin: 0;
+}
+
+.mock-boundary-card h3 {
+  margin-bottom: 0.45rem;
+}
+
+.mock-boundary-card p {
+  color: #52606d;
+}
+
+.tree-row.is-readonly {
+  background: #f8fafc;
+}
+
+.tree-row.is-readonly .tree-toggle-cell,
+.tree-row.is-readonly td {
+  color: #52606d;
+}
+
+.tree-row.is-disabled {
+  background: #fff1f2;
+}
+
+.tree-row.is-disabled .tree-toggle-cell,
+.tree-row.is-disabled td {
+  color: #6b7280;
+}
+
+.mock-row-note {
+  margin: 0.45rem 0 0;
+  color: #52606d;
+  font-size: 0.9rem;
+}
+
+.mock-depth-label--team {
+  background: #e0f2fe;
+  color: #075985;
+}
+
+.mock-depth-label--folder {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.mock-depth-label--leaf {
+  background: #ecfdf5;
+  color: #047857;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView row status and depth label mock</h1>
+      <p>
+        This static HTML compares row-wide status cues, selection checkbox disabled state, and depth labels
+        without running a Rails app. Business meaning, authorization rules, final copy, and status styling
+        remain host-app responsibilities.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="status-depth-comparison-heading">
+      <h2 id="status-depth-comparison-heading">Representative comparison</h2>
+      <p>
+        The first column keeps the reusable TreeView hierarchy cue. The selection column shows whether
+        selection is available. The status and depth labels are visible hints only; host apps decide what
+        each status means and when a row becomes readonly or disabled.
+      </p>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">select</th>
+            <th scope="col">tree</th>
+            <th scope="col">row status</th>
+            <th scope="col">depth cue</th>
+            <th scope="col">review note</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="tree-row is-expanded" data-tree-node-key="team:platform" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+            <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" aria-label="Select Platform team"></td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Expanded root">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                  <span class="tree-depth-label mock-depth-label--team">team</span>
+                  <span class="mock-node-title">Platform team</span>
+                </span>
+              </span>
+            </td>
+            <td><span class="mock-status mock-status--active">normal</span></td>
+            <td><span class="tree-depth-label mock-depth-label--team">team</span></td>
+            <td>Selection and row actions remain available.</td>
+          </tr>
+          <tr class="tree-row is-readonly" data-tree-node-key="folder:archive" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+            <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" aria-label="Select Archived folder"></td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Readonly branch">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a>
+                  <span class="tree-depth-label mock-depth-label--folder">folder</span>
+                  <span class="mock-node-title">Archived work</span>
+                </span>
+              </span>
+            </td>
+            <td><span class="mock-status mock-status--pending">readonly</span></td>
+            <td><span class="tree-depth-label mock-depth-label--folder">folder</span></td>
+            <td>Readonly is a row-wide visual cue; selection can still be enabled when the host app allows it.</td>
+          </tr>
+          <tr class="tree-row is-disabled" data-tree-node-key="record:locked" data-tree-depth="2" aria-level="3">
+            <td class="tree-selection-cell"><input class="tree-selection-checkbox" type="checkbox" aria-label="Locked record unavailable" disabled></td>
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Disabled leaf">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">leaf</span>
+                  <span class="tree-depth-label mock-depth-label--leaf">record</span>
+                  <span class="mock-node-title">Locked record</span>
+                </span>
+              </span>
+            </td>
+            <td><span class="mock-status mock-status--error">disabled</span></td>
+            <td><span class="tree-depth-label mock-depth-label--leaf">record</span></td>
+            <td>Disabled row styling and disabled selection are related but separate cues.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="boundary-heading">
+      <h2 id="boundary-heading">Responsibility boundary</h2>
+      <div class="mock-boundary-grid">
+        <article class="mock-boundary-card">
+          <h3>Row status</h3>
+          <p>Use for row-wide visual state such as normal, readonly, or disabled. The host app owns the rule and copy.</p>
+        </article>
+        <article class="mock-boundary-card">
+          <h3>Selection checkbox</h3>
+          <p>Use disabled form state only when selection itself is unavailable. Do not rely on row color alone.</p>
+        </article>
+        <article class="mock-boundary-card">
+          <h3>Depth label</h3>
+          <p>Use as a compact hierarchy cue. Meaning, label text, and color tokens stay host-app owned.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #686

## 状態

この PR は #719 の replacement として作成されましたが、レビュー中に #719 を current main 上で承認し squash merge 済みです。

同じ #686 の focused mockup slice は main に入ったため、この PR を開いたままにすると同一差分の重複候補として残ります。現在の main からも `behind_by: 2` / `mergeable: false` になっているため、再マージ候補として扱わず close します。

再開が必要な場合は、current main から #691 などの follow-up 差分だけを載せ直してください。