### PR TITLE
docs: row status / depth labels guide から mockup 導線を補う

### DIFF
--- a/docs/en/depth-labels.md
+++ b/docs/en/depth-labels.md
@@ -14,6 +14,8 @@ TreeView is responsible for:
 
 The host app decides the label text, business meaning of each depth, and CSS styling.
 
+For a visual comparison of depth labels beside row-wide status cues and selection disabled state, see the [row status and depth label mockup](../mockups/row-status-depth-labels.html). The mockup is a static reference; this guide remains the source for API and responsibility-boundary wording.
+
 ## Basic example
 
 ```ruby

--- a/docs/en/row-status.md
+++ b/docs/en/row-status.md
@@ -14,6 +14,8 @@ TreeView is responsible for:
 
 Business rules, action blocking, authorization, and persistence remain host app responsibilities.
 
+For a visual comparison of row-wide status cues, selection checkbox disabled state, and depth labels, see the [row status and depth label mockup](../mockups/row-status-depth-labels.html). The mockup is a static reference; this guide remains the source for API and responsibility-boundary wording.
+
 ## Basic example
 
 ```ruby

--- a/docs/ja/depth-labels.md
+++ b/docs/ja/depth-labels.md
@@ -14,6 +14,8 @@ TreeView gem が担当するのは以下です。
 
 どのdepthにどの文言を出すか、業務上の意味付け、CSS表現はhost app側で決めます。
 
+depth labelを行全体のstatus cueやselection disabled stateと並べて確認したい場合は、[row status and depth label mockup](../mockups/row-status-depth-labels.html) を参照してください。mockupはstatic referenceであり、APIと責務境界の説明はこのguideを正とします。
+
 ## 基本例
 
 ```ruby

--- a/docs/ja/row-status.md
+++ b/docs/ja/row-status.md
@@ -14,6 +14,8 @@ TreeView gem が担当するのは以下です。
 
 実際の業務ルール、操作制御、認可、保存処理はhost app側で実装します。
 
+行全体のstatus cue、selection checkboxのdisabled state、depth labelを並べて確認したい場合は、[row status and depth label mockup](../mockups/row-status-depth-labels.html) を参照してください。mockupはstatic referenceであり、APIと責務境界の説明はこのguideを正とします。
+
 ## 基本例
 
 ```ruby


### PR DESCRIPTION
## 対応Issue

- Closes #691
- Stacked on #719

## 変更内容

- `docs/en/row-status.md` / `docs/ja/row-status.md` から `docs/mockups/row-status-depth-labels.html` への導線を追加
- `docs/en/depth-labels.md` / `docs/ja/depth-labels.md` から同じ focused mockup への導線を追加
- prose guide は API / responsibility boundary、mockup は representative visual comparison という役割分担を明記

## 判定分類

- `docs-sync`
- `docs-missing`

## 確認観点

- runtime builder behavior、mockup HTML/CSS 本体、README / gallery の broad redesign には広げていないこと
- #719 の `row-status-depth-labels.html` とリンク先が一致していること
- 日本語 / 英語の対応 guide に同じ導線が入っていること

## 確認済み

- GitHub compare: `design/686-row-status-depth-label-mockup-refresh...docs/691-row-status-depth-guide-mockup-links`
  - `ahead_by: 4`
  - `behind_by: 0`
  - 変更は `docs/en/depth-labels.md`, `docs/en/row-status.md`, `docs/ja/depth-labels.md`, `docs/ja/row-status.md` の 4 files のみ
- CI run `#952`: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: docs-only skip path success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: docs-only skip path success
- merge freshness: `mergeable: true`

## リスク

- low
- docs-only の cross-reference 追加です。コード、設定、CI、依存関係は変更していません。