### PR TITLE
test: state-changed event detail keys を manifest で守る

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -122,6 +122,10 @@ javascript_package_root:
       invalid_payload: tree-view-transfer:invalid-payload
       invalid_transfer: tree-view-transfer:invalid-transfer
   event_detail_keys:
+    state:
+      state_changed:
+        - viewKey
+        - expandedKeys
     selection:
       change:
         - selectedCount

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -7,6 +7,7 @@ PublicApiCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init
 PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
 JAVASCRIPT_ENTRYPOINT_PATH = File.expand_path("../app/javascript/tree_view/index.js", __dir__)
 JAVASCRIPT_CONTROLLER_PATHS = {
+  "state" => File.expand_path("../app/javascript/tree_view/state_controller.js", __dir__),
   "selection" => File.expand_path("../app/javascript/tree_view/selection_controller.js", __dir__),
   "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
   "transfer" => File.expand_path("../app/javascript/tree_view/transfer_controller.js", __dir__)


### PR DESCRIPTION
## 対応 Issue

Closes #723

## Issue ごとの完了内容

- #723
  - `config/public_api_manifest.yml` の `javascript_package_root.event_detail_keys` に `state.state_changed` を追加
  - documented payload keys として `viewKey` / `expandedKeys` を manifest に収録
  - `spec/public_api_compatibility_spec.rb` の controller source map に `state_controller.js` を追加し、既存の event detail key drift guard が state event も読むようにしました

## 変更内容

- `config/public_api_manifest.yml`
  - `tree-view-state:state-changed` の detail keys を manifest 化
- `spec/public_api_compatibility_spec.rb`
  - manifest の `state` group を `app/javascript/tree_view/state_controller.js` と照合できるように追加

## 改善カテゴリ

- test
- docs / manifest drift guard
- 小さな内部品質改善

## 既存仕様への影響

- runtime JavaScript、event payload、public export、controller behavior は変更していません
- #548 の `TreeViewEventDetailKeys` public export 設計には踏み込んでいません
- manifest と既存互換性specの読み合わせ対象を増やしただけです

## 実施した確認

- GitHub compare: `main...quality/723-state-event-detail-manifest`
  - `ahead_by: 1`
  - `behind_by: 0`
  - 変更ファイルは `config/public_api_manifest.yml` / `spec/public_api_compatibility_spec.rb` の 2 files のみ
- 読み合わせ確認
  - `app/javascript/tree_view/index.js` に `TreeViewEventNames.state.stateChanged` があること
  - `app/javascript/tree_view/state_controller.js` の dispatch detail に `viewKey` / `expandedKeys` があること
  - `docs/en|ja/js-events.md` と `docs/en|ja/persisted-state.md` の documented payload と矛盾しないこと

## 実行していない確認

- この環境では通常 git access が `CONNECT tunnel failed, response 403` で利用できないため、local RSpec は未実行です
- PR CI で `spec/public_api_compatibility_spec.rb` を含む checks を確認します

## リスク評価

- low
- manifest と spec 対象追加のみで、実行時挙動やAPI契約を変えません