### PR TITLE
docs: row status / depth labels guide の mockup 導線を current main で復旧する

### DIFF
--- a/docs/en/depth-labels.md
+++ b/docs/en/depth-labels.md
@@ -14,6 +14,8 @@ TreeView is responsible for:
 
 The host app decides the label text, business meaning of each depth, and CSS styling.
 
+For a visual comparison of depth labels beside row-wide status cues and selection disabled state, see the [row status and depth label mockup](../mockups/row-status-depth-labels.html). The mockup is a static reference; this guide remains the source for API and responsibility-boundary wording.
+
 ## Basic example
 
 ```ruby

--- a/docs/en/row-status.md
+++ b/docs/en/row-status.md
@@ -14,6 +14,8 @@ TreeView is responsible for:
 
 Business rules, action blocking, authorization, and persistence remain host app responsibilities.
 
+For a visual comparison of row-wide status cues, selection checkbox disabled state, and depth labels, see the [row status and depth label mockup](../mockups/row-status-depth-labels.html). The mockup is a static reference; this guide remains the source for API and responsibility-boundary wording.
+
 ## Basic example
 
 ```ruby

--- a/docs/ja/depth-labels.md
+++ b/docs/ja/depth-labels.md
@@ -14,6 +14,8 @@ TreeView gem が担当するのは以下です。
 
 どのdepthにどの文言を出すか、業務上の意味付け、CSS表現はhost app側で決めます。
 
+depth labelを行全体のstatus cueやselection disabled stateと並べて確認したい場合は、[row status and depth label mockup](../mockups/row-status-depth-labels.html) を参照してください。mockupはstatic referenceであり、APIと責務境界の説明はこのguideを正とします。
+
 ## 基本例
 
 ```ruby

--- a/docs/ja/row-status.md
+++ b/docs/ja/row-status.md
@@ -14,6 +14,8 @@ TreeView gem が担当するのは以下です。
 
 実際の業務ルール、操作制御、認可、保存処理はhost app側で実装します。
 
+行全体のstatus cue、selection checkboxのdisabled state、depth labelを並べて確認したい場合は、[row status and depth label mockup](../mockups/row-status-depth-labels.html) を参照してください。mockupはstatic referenceであり、APIと責務境界の説明はこのguideを正とします。
+
 ## 基本例
 
 ```ruby


### PR DESCRIPTION
## 対応Issue

- Closes #691
- Follow-up for #725 review comment

## 変更内容

- `docs/en/row-status.md` / `docs/ja/row-status.md` から `docs/mockups/row-status-depth-labels.html` への導線を追加
- `docs/en/depth-labels.md` / `docs/ja/depth-labels.md` から同じ focused mockup への導線を追加
- #719 merge 後の current `main` から作り直し、最終差分が 4 guide files の cross-reference 追加だけになるよう整理

## CI Fix Summary

### Failed check
- なし。open PR の head CI は確認範囲では success でした。

### Cause
- ci:unknown ではなく review follow-up。#725 は #719 squash merge 後に branch が diverged し、main 向け compare に #719 側の mockup / gallery / inventory 差分が再び含まれる状態になっていました。

### Fix
- 既存 #725 branch への force update は避け、current `main` から replacement branch を作成
- #725 の Issue-scope 内の 4 guide file cross-reference だけを replay

### Verification
- [ ] local test: 未実行（通常 git access が `CONNECT tunnel failed, response 403` のため）
- [x] lint: CI run #959 success
- [ ] typecheck: 該当なし
- [x] CI rerun checked: head `3955252cf27f504210771329d15172ee9c6c2fda` の CI run #959 success
- [x] GitHub compare: `main...docs/691-row-status-depth-guide-links-main-v2` が `ahead_by: 4`, `behind_by: 0`, 変更 4 files のみ
- [x] merge freshness: `mergeable: true`

### Risk
- low

### Notes
- docs-only の cross-reference 追加です。runtime、public API、CI workflow、依存関係には触れていません。
- #725 は履歴書き換えを避けるため、この PR に置き換えてレビューしてください。