### PR TITLE
test: state-changed event detail manifest を current main で復旧する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -122,6 +122,10 @@ javascript_package_root:
       invalid_payload: tree-view-transfer:invalid-payload
       invalid_transfer: tree-view-transfer:invalid-transfer
   event_detail_keys:
+    state:
+      state_changed:
+        - viewKey
+        - expandedKeys
     selection:
       change:
         - selectedCount

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -7,6 +7,7 @@ PublicApiCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init
 PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
 JAVASCRIPT_ENTRYPOINT_PATH = File.expand_path("../app/javascript/tree_view/index.js", __dir__)
 JAVASCRIPT_CONTROLLER_PATHS = {
+  "state" => File.expand_path("../app/javascript/tree_view/state_controller.js", __dir__),
   "selection" => File.expand_path("../app/javascript/tree_view/selection_controller.js", __dir__),
   "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
   "transfer" => File.expand_path("../app/javascript/tree_view/transfer_controller.js", __dir__)


### PR DESCRIPTION
#726 のレビュー指摘に対応し、#723 の manifest / compatibility spec 差分を current main から作り直します。

## 対応 Issue

Closes #723
Follow-up for #726 review comment

## 変更内容

- `config/public_api_manifest.yml` の `javascript_package_root.event_detail_keys` に `state.state_changed` を追加
- documented payload keys として `viewKey` / `expandedKeys` を manifest に収録
- `spec/public_api_compatibility_spec.rb` の controller source map に `state_controller.js` を追加し、既存の event detail key drift guard が state event も読むようにしました
- #726 の差分を current `main` から再作成し、`main...quality/723-state-event-detail-manifest-main-v2` が `behind_by: 0` になるよう整理しました

## 受け入れ条件との対応

- #723 の documented `tree-view-state:state-changed` detail keys を manifest guard に追加
- runtime JavaScript、event payload、public export、controller behavior は変更せず、既存契約の drift guard だけを追加
- #726 の review comment で求められた current main 追従を満たすため、final diff は 2 files の manifest / spec 変更に限定

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_api_compatibility_spec.rb`

## 実施した確認

- GitHub compare: `main...quality/723-state-event-detail-manifest-main-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 2 files のみ
- 読み合わせ確認
  - #726 の既存差分と同じ manifest / spec 追加だけを current main に載せ直したことを確認
  - `tree_view-state:state-changed` の documented payload keys として `viewKey` / `expandedKeys` を対象にしていることを確認

## 未実施の確認

- local RSpec / lint は未実行です。この環境では direct git access が `CONNECT tunnel failed, response 403` で利用できないため、PR CI で確認します。

## リスク

- low
- manifest と spec 対象追加のみで、実行時挙動や API 契約は変更しません。

## 補足

- #726 は `main` から diverged していたため、このPRを replacement としてレビューしてください。