### PR TITLE
docs: render log silencing の旧ページを現行案内へ整理する

### DIFF
--- a/docs/en/render-log-silencing.md
+++ b/docs/en/render-log-silencing.md
@@ -1,72 +1,9 @@
-# Render Log Silencing
+# Render log silencing
 
-TreeView lowers the log level for its own helper-rendered partials by default so host app logs do not fill up with repeated `Rendered tree_view/...` entries.
+This page is kept as a compatibility alias for older links.
 
-This setting only affects partial rendering that goes through TreeView helpers such as `tree_view_rows`. It does not replace the host app's logger policy, business logs, controller logs, SQL logs, or custom instrumentation.
+The current render-log documentation lives at [Render log level](render-log-level.md).
 
-## Default behavior
+Use that page for the maintained description of `TreeView.configuration.render_log_level`, accepted values, the default `:warn` behavior, and the `nil` escape hatch for keeping Rails' normal partial render logging unchanged.
 
-- Default: `:warn`
-- Effect: TreeView wraps helper-rendered partial output in `Rails.logger.silence(...)` when the logger supports it
-- Scope: only TreeView helper-rendered partials
-
-TreeView reads this value from `TreeView.configuration.render_log_level`.
-
-## Configuration
-
-Use `TreeView.configure` to change the level globally.
-
-```ruby
-TreeView.configure do |config|
-  config.render_log_level = :info
-end
-```
-
-Valid symbolic values are:
-
-- `:debug`
-- `:info`
-- `:warn`
-- `:error`
-- `:fatal`
-- `:unknown`
-
-You can also pass the matching `Logger` constant. TreeView normalizes it back to the symbolic setting.
-
-```ruby
-TreeView.configure do |config|
-  config.render_log_level = Logger::INFO
-end
-```
-
-## When to use `nil`
-
-Set `render_log_level` to `nil` when you want Rails render logs to stay unchanged.
-
-```ruby
-TreeView.configure do |config|
-  config.render_log_level = nil
-end
-```
-
-This disables TreeView's `logger.silence(...)` wrapper and lets partial render entries appear with the host app's normal logging behavior.
-
-## Picking a level
-
-- Use `:warn` when TreeView render noise is not useful during normal development or operations.
-- Use `:info` or `:debug` when you want more visibility while checking row partial wiring or render flow.
-- Use `nil` when the host app already has its own log filtering rules and you want TreeView to stay out of that decision.
-
-## Responsibility boundary
-
-TreeView only decides whether to silence logs around its own helper-rendered partials.
-
-The host app still owns:
-
-- Rails logger configuration
-- log formatters and tagged logging
-- SQL and controller log verbosity
-- business-event logging
-- request tracing and instrumentation
-
-If the symptom is "I cannot see TreeView partial render lines" or "TreeView render lines are too noisy", start with this setting before changing the host app's broader logging policy.
+TreeView's responsibility is limited to lowering the log level around helper-rendered TreeView partials. Host applications still own global logger configuration, SQL and controller log verbosity, business-event logging, request tracing, and custom instrumentation.

--- a/docs/ja/render-log-silencing.md
+++ b/docs/ja/render-log-silencing.md
@@ -1,72 +1,9 @@
 # Render log silencing
 
-TreeView は、host app の log が `Rendered tree_view/...` で埋まりすぎないよう、helper 経由で描画する partial の log level を既定で下げます。
+このページは、古いリンクを壊さないための互換 alias です。
 
-この設定が効くのは `tree_view_rows` など TreeView helper を通る partial render だけです。host app 全体の logger policy、business log、controller log、SQL log、custom instrumentation を肩代わりするものではありません。
+現在の render log documentation は [render log level](render-log-level.md) にあります。
 
-## 既定挙動
+`TreeView.configuration.render_log_level`、指定できる値、既定の `:warn`、Rails 標準の partial render log をそのまま出すための `nil` は、現行ページを参照してください。
 
-- 既定値: `:warn`
-- 効果: logger が対応していれば、TreeView は helper-rendered partial を `Rails.logger.silence(...)` で囲って描画する
-- 適用範囲: TreeView helper 経由で描画される partial だけ
-
-TreeView はこの値を `TreeView.configuration.render_log_level` から読みます。
-
-## 設定方法
-
-global 設定は `TreeView.configure` で変更します。
-
-```ruby
-TreeView.configure do |config|
-  config.render_log_level = :info
-end
-```
-
-使える symbol は次のとおりです。
-
-- `:debug`
-- `:info`
-- `:warn`
-- `:error`
-- `:fatal`
-- `:unknown`
-
-対応する `Logger` 定数を渡しても構いません。TreeView 側で symbol に正規化します。
-
-```ruby
-TreeView.configure do |config|
-  config.render_log_level = Logger::INFO
-end
-```
-
-## `nil` を使う場面
-
-Rails の render log をそのまま残したい場合は `render_log_level` に `nil` を指定します。
-
-```ruby
-TreeView.configure do |config|
-  config.render_log_level = nil
-end
-```
-
-この設定では TreeView の `logger.silence(...)` wrapper を使わず、partial render の log も host app の通常設定どおりに出ます。
-
-## 設定値の選び方
-
-- 通常の開発や運用で TreeView partial の render log が多すぎるなら `:warn`
-- row partial の wiring や render flow を追いたいなら `:info` または `:debug`
-- host app 側で独自の log 制御をしており、TreeView に介入させたくないなら `nil`
-
-## 責務境界
-
-TreeView が決めるのは、自分の helper-rendered partial の周辺で log を silence するかどうかだけです。
-
-次は引き続き host app 側の責務です。
-
-- Rails logger 設定
-- formatter や tagged logging
-- SQL / controller log の粒度
-- business event の log
-- request tracing や instrumentation
-
-「TreeView partial の render log が見えない」「TreeView の render log だけ多い」と感じたら、host app 全体の logger policy を変える前に、まずこの設定を見直してください。
+TreeView が担当するのは、helper 経由で描画される TreeView partial の周辺だけ log level を下げることです。host app 全体の logger 設定、SQL / controller log、business-event logging、request tracing、custom instrumentation は host app 側の責務です。


### PR DESCRIPTION
## 対応内容

`docs/en|ja/troubleshooting.md` から参照されている旧名 `render-log-silencing.md` を、現行の `render-log-level.md` への互換 alias として整理します。

## 変更範囲

- `docs/en/render-log-silencing.md`
- `docs/ja/render-log-silencing.md`

## 判定分類

- `docs-stale`
- `docs-sync`

## 確認したこと

- current docs index は `render-log-level.md` を現行ページとして案内していること
- `render-log-silencing.md` は troubleshooting など古いリンクから到達しうるため、削除せず alias として残す方が安全なこと
- runtime code、API、CI、設定ファイルには触れていないこと

## リスク

- low
- docs-only の互換 alias 整理です。仕様や実装挙動は変更しません。