### PR TITLE
test: remote state controller の loading/error payload を固定する

### DIFF
--- a/app/javascript/tree_view/remote_state_controller.test.js
+++ b/app/javascript/tree_view/remote_state_controller.test.js
@@ -1,0 +1,72 @@
+import { Application } from "@hotwired/stimulus"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TreeViewRemoteStateController } from "./index.js"
+
+function nextFrame() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("TreeViewRemoteStateController remote state details", () => {
+  let application
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <table data-controller="tree-view-remote-state">
+        <tbody>
+          <tr id="remote-row" data-tree-view-state-target="node" data-tree-view-state-node-key="project:1" data-tree-children-url="/projects/1/children">
+            <td><button id="remote-button" type="button">Load</button></td>
+          </tr>
+          <tr id="detail-row" data-tree-view-state-target="node"></tr>
+        </tbody>
+      </table>
+    `
+
+    application = Application.start()
+    application.register("tree-view-remote-state", TreeViewRemoteStateController)
+    await nextFrame()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  it("dispatches loading details from the nearest row target", () => {
+    const element = document.querySelector("[data-controller='tree-view-remote-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-remote-state")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-remote-state:change", eventSpy)
+    const row = document.querySelector("#remote-row")
+
+    controller.loading({ target: document.querySelector("#remote-button"), detail: {} })
+
+    expect(row.dataset.remoteState).toBe("loading")
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      row,
+      state: "loading",
+      childrenUrl: "/projects/1/children",
+      nodeKey: "project:1"
+    })
+  })
+
+  it("dispatches error details from an explicit detail row with null URL fallbacks", () => {
+    const element = document.querySelector("[data-controller='tree-view-remote-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-remote-state")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-remote-state:change", eventSpy)
+    const row = document.querySelector("#detail-row")
+
+    controller.error({ target: document.querySelector("#remote-button"), detail: { row } })
+
+    expect(row.dataset.remoteState).toBe("error")
+    expect(document.querySelector("#remote-row").dataset.remoteState).toBeUndefined()
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      row,
+      state: "error",
+      childrenUrl: null,
+      nodeKey: null
+    })
+  })
+})


### PR DESCRIPTION
## 対応 Issue

Closes #737

## Issue ごとの完了内容

- #737
  - `TreeViewRemoteStateController#loading` の `tree-view-remote-state:change` detail を JavaScript test で固定しました。
  - `TreeViewRemoteStateController#error` が `event.detail.row` を優先して使う代表ケースを追加しました。
  - `childrenUrl` / `nodeKey` が存在しない場合の `null` fallback も同じ代表ケースで確認しました。

## 変更内容

- `app/javascript/tree_view/remote_state_controller.test.js` を追加
  - nearest row target からの loading detail
  - explicit `detail.row` からの error detail

## 改善カテゴリ

- test
- JavaScript controller contract guard

## 既存仕様への影響

- runtime JavaScript は変更していません。
- event name、payload key、lazy-loading docs、public export、host-app retry policy には触れていません。

## 実施した確認内容

- GitHub compare: `main...quality/737-remote-state-js-contract`
  - `ahead_by: 1`
  - `behind_by: 0`
  - 変更ファイルは新規 JS test 1 file のみ
- ローカル実行: 未実行（この実行環境から GitHub clone / npm install ができないため）

## リスク評価

- low
- test-only の追加で、既存 controller behavior を固定する変更です。

## 補足事項

- CI 結果は PR 作成後に確認します。