### PR TITLE
docs: persisted state の manual owner include guidance を補う

### DIFF
--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -48,6 +48,32 @@ This still creates the same migration, model, and concern files. If `app/models/
 
 If the owner model file does not exist, the generator skips model injection and you can include the concern manually.
 
+### If owner injection is skipped
+
+When the generator reports that the owner model file does not exist, first confirm which model should own the saved tree state. Then add `include TreeViewStateOwner` to that existing model after the generated concern exists at `app/models/concerns/tree_view_state_owner.rb`.
+
+For a plain owner model, the manual include is the same line the generator would add:
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  include TreeViewStateOwner
+end
+```
+
+For a namespaced or module-wrapped owner, add the include inside the actual class that will be passed as the `owner:` to `TreeView::StateStore`:
+
+```ruby
+# app/models/admin/user.rb
+module Admin
+  class User < ApplicationRecord
+    include TreeViewStateOwner
+  end
+end
+```
+
+Manual include is the expected follow-up when the owner model is generated later, lives in a namespace, or uses a project-specific file layout that the generator did not update. Do not change the generated migration or `TreeViewState` model for this case; the host app only needs the owner class to include the concern before it calls `tree_view_state_for`, `save_tree_view_state!`, or passes the owner into `TreeView::StateStore`.
+
 ## Owner model
 
 Include the concern in the host app owner model.

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -48,6 +48,32 @@ bin/rails generate tree_view:state:install User
 
 owner model file が存在しない場合、model への注入は skip されます。その場合は concern を手動で include してください。
 
+### owner への注入が skip された場合
+
+owner model file が存在しないと表示された場合は、まず保存された tree state を所有する model を確認してください。そのうえで、生成済みの `app/models/concerns/tree_view_state_owner.rb` がある状態で、その model に `include TreeViewStateOwner` を追加します。
+
+通常の owner model では、手動で追加する行は generator が追加するものと同じです。
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  include TreeViewStateOwner
+end
+```
+
+namespace 付き、または `module` で囲まれた owner では、`TreeView::StateStore` の `owner:` に渡す実際の class の中に include します。
+
+```ruby
+# app/models/admin/user.rb
+module Admin
+  class User < ApplicationRecord
+    include TreeViewStateOwner
+  end
+end
+```
+
+owner model を後から作る場合、namespace 配下に置く場合、または project 固有の file layout により generator が更新しなかった場合は、手動 include が自然な follow-up です。このケースでは生成済み migration や `TreeViewState` model を変更する必要はありません。host app 側では、`tree_view_state_for`、`save_tree_view_state!`、または `TreeView::StateStore` へ owner を渡す前に、その owner class が concern を include していれば十分です。
+
 ## owner model
 
 host app側のowner modelに concern をincludeします。


### PR DESCRIPTION
## 対応 Issue

Closes #746

## 変更内容

- `docs/en/persisted-state.md` に、install generator が owner model injection を skip した後の manual include guidance を追加
- `docs/ja/persisted-state.md` に同等の案内を追加
- plain owner model と namespaced / module-wrapped owner model の最小例を追加
- generated migration / `TreeViewState` model は変更せず、owner class に `TreeViewStateOwner` を include すればよい責務境界を明記

## 判定分類

- `docs-missing`
- current generator は owner model file 不在時に `say_status :skip` して終了し、既存 docs は手動 include 可能とは書いていたものの、skip 後にどの class / file を確認して何を足すかの実務的な案内が不足していました。

## 確認内容

- 参照した source of truth:
  - `lib/generators/tree_view/state/install_generator.rb`
  - `spec/generators/tree_view/state/install_generator_spec.rb`
  - `docs/en/persisted-state.md`
  - `docs/ja/persisted-state.md`
- GitHub compare: `main...docs/746-persisted-state-manual-owner-include`
  - `ahead_by: 2`
  - `behind_by: 0`
  - 変更ファイルは `docs/en/persisted-state.md` / `docs/ja/persisted-state.md` の2ファイルのみ
- ローカル test: 未実行（docs-only かつ connector 経由の Markdown 更新のため）

## リスク

- low
- Markdown docs の追記に閉じています。generator implementation、migration、StateStore API、controller、route、authorization、runtime behavior、依存関係は変更していません。

## 非対象

- #745 の namespaced owner injection 方針決定や generator 実装変更
- persisted state schema の変更
- controller / route / authorization の設計
- full troubleshooting page の追加