### PR TITLE
design: PathTreeBuilder rows mockup を追加する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -23,7 +23,7 @@ Use this table when you need a quick answer to "which user-facing pages must sta
 Japanese remains the more complete canonical prose source when English wording lags, but the pages below are the current cross-language planning baseline promised by `docs/en/README.md`, `docs/ja/README.md`, and `docs/README.md`.
 
 | Docs lane | Current coverage status | Priority | Maintenance expectation |
-|---|---|---|---|
+|---|---|---|
 | `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` | Published entry points for cross-language navigation and language-status guidance | High | Update in the same docs lane whenever reading order, docs map, or language-status promises change |
 | `docs/en/installation.md`, `docs/ja/installation.md` | Published in both trees | High | Keep setup, asset, importmap, and first-run instructions aligned before release-facing docs changes land |
 | `docs/en/minimal-usage.md`, `docs/ja/minimal-usage.md` | Published in both trees | High | Keep the first working host-app example aligned with installation and usage docs |
@@ -119,6 +119,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/windowed-rendering.html` | Technical asset | No translation needed. |
 | `docs/mockups/breadcrumb-paths.html` | Technical asset | No translation needed. |
 | `docs/mockups/filtered-tree-modes.html` | Technical asset | No translation needed. |
+| `docs/mockups/path-tree-builder-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/form-editing-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
 | `docs/mockups/row-status-depth-labels.html` | Technical asset | No translation needed. |

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -23,7 +23,7 @@ Use this table when you need a quick answer to "which user-facing pages must sta
 Japanese remains the more complete canonical prose source when English wording lags, but the pages below are the current cross-language planning baseline promised by `docs/en/README.md`, `docs/ja/README.md`, and `docs/README.md`.
 
 | Docs lane | Current coverage status | Priority | Maintenance expectation |
-|---|---|---|
+|---|---|---|---|
 | `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` | Published entry points for cross-language navigation and language-status guidance | High | Update in the same docs lane whenever reading order, docs map, or language-status promises change |
 | `docs/en/installation.md`, `docs/ja/installation.md` | Published in both trees | High | Keep setup, asset, importmap, and first-run instructions aligned before release-facing docs changes land |
 | `docs/en/minimal-usage.md`, `docs/ja/minimal-usage.md` | Published in both trees | High | Keep the first working host-app example aligned with installation and usage docs |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -22,6 +22,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
 | [breadcrumb-paths.html](breadcrumb-paths.html) | Focused comparison for breadcrumb-path context beside the tree's own current-row cue, without modeling host-app routes or Turbo navigation. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
+| [path-tree-builder-rows.html](path-tree-builder-rows.html) | Focused PathTreeBuilder comparison for generated folder rows versus record-backed rows, keeping host-app columns/actions outside the gem contract. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all, collapse-all, and collapse-to-current-path toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
@@ -41,10 +42,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 10. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
 11. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
 12. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-13. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-14. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-15. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-16. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+13. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+14. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+15. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+16. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+17. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Copy and language policy
 
@@ -62,6 +64,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 - Use `data-tree-view-empty-state="true"` together with `.tree-view-empty-row__content` and `.tree-view-empty-row__message` as the reusable baseline hook.
 - Keep final empty copy, CTA, permission messaging, and filter-reset behavior in the host app.
+
+## PathTreeBuilder guidance
+
+- Keep generated folder rows visually distinct from record-backed rows, but avoid business-specific folder permission wording.
+- Treat record columns, file actions, download affordances, and final file-manager behavior as host-app responsibilities.
 
 ## Review policy
 

--- a/docs/mockups/path-tree-builder-rows.html
+++ b/docs/mockups/path-tree-builder-rows.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PathTreeBuilder row mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.path-builder-page { max-width: 1180px; }
+.path-builder-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin: 0; }
+.path-builder-summary__item { display: grid; gap: 0.35rem; padding: 0.9rem 1rem; border: 1px solid #dde4ec; border-radius: 10px; background: #f8fafc; }
+.path-builder-summary__term { color: #52606d; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.path-builder-summary__description { margin: 0; color: #102a43; font-weight: 700; }
+.path-builder-grid { display: grid; grid-template-columns: minmax(0, 1.5fr) minmax(18rem, 0.85fr); gap: 18px; align-items: start; }
+.path-builder-note { margin: 0; color: #52606d; }
+.path-builder-callout { display: grid; gap: 0.55rem; padding: 1rem; border: 1px solid #cbd5e1; border-radius: 10px; background: #f8fafc; }
+.path-builder-callout h3, .path-builder-callout p { margin: 0; }
+.path-builder-code { display: block; overflow-x: auto; padding: 0.8rem; border-radius: 8px; background: #0f172a; color: #e2e8f0; font-size: 0.82rem; line-height: 1.45; }
+.path-builder-table-wrap { overflow-x: auto; }
+.path-builder-row-kind { display: inline-flex; align-items: center; justify-content: center; min-width: 4.75rem; padding: 0.12rem 0.5rem; border-radius: 999px; background: #edf2f7; color: #334e68; font-size: 0.78rem; font-weight: 800; }
+.path-builder-row-kind--folder { background: #e0f2fe; color: #075985; }
+.path-builder-row-kind--record { background: #ecfdf5; color: #166534; }
+.path-builder-record-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.path-builder-record-actions button { border: 1px solid #cbd5e1; border-radius: 8px; background: #fff; padding: 0.35rem 0.6rem; }
+.path-builder-record-actions button[aria-disabled="true"] { color: #9aa5b1; background: #f1f5f9; }
+.path-builder-columns { width: 100%; border-collapse: collapse; }
+.path-builder-columns th, .path-builder-columns td { border-bottom: 1px solid #e4e7eb; padding: 0.7rem 0.75rem; text-align: left; vertical-align: top; }
+.path-builder-columns th { background: #f1f5f9; color: #334e68; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; }
+@media (max-width: 860px) { .path-builder-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+  <main class="mock-page path-builder-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>PathTreeBuilder row mock</h1>
+      <p>
+        Focused static reference for comparing generated folder rows with record-backed rows from <code>PathTreeBuilder</code>.
+        This mock stays inside visual review: folder cues are generic TreeView output, while record columns and actions remain host-app owned.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="path-builder-summary-heading">
+      <h2 id="path-builder-summary-heading">Responsibility boundary</h2>
+      <dl class="path-builder-summary">
+        <div class="path-builder-summary__item">
+          <dt class="path-builder-summary__term">Generated folder row</dt>
+          <dd class="path-builder-summary__description">TreeView provides the hierarchy row, folder marker, toggle affordance, depth cue, and child count.</dd>
+        </div>
+        <div class="path-builder-summary__item">
+          <dt class="path-builder-summary__term">Record row</dt>
+          <dd class="path-builder-summary__description">The host app owns visible record columns, status labels, and business actions attached to the terminal path item.</dd>
+        </div>
+        <div class="path-builder-summary__item">
+          <dt class="path-builder-summary__term">Outside this mock</dt>
+          <dd class="path-builder-summary__description">Routes, downloads, authorization copy, and final file-manager behavior stay outside the gem mockup.</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="mock-section path-builder-grid" aria-labelledby="path-builder-table-heading">
+      <div>
+        <h2 id="path-builder-table-heading">Generated folders and records in one tree</h2>
+        <p class="path-builder-note">The same table shows folder nodes that exist only because of a path segment and record nodes that come from application data.</p>
+        <div class="path-builder-table-wrap">
+          <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+            <thead>
+              <tr>
+                <th scope="col">kind</th><th scope="col">tree</th><th scope="col">name</th><th scope="col">owner</th><th scope="col">status</th><th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="path_folder_policies" class="tree-row is-expanded" data-tree-node-key="folder:policies" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true" aria-selected="false">
+                <td><span class="path-builder-row-kind path-builder-row-kind--folder">folder</span></td>
+                <td class="btn-cell tree-toggle-cell" id="path_folder_policies_button">
+                  <span class="tree-toggle" aria-label="Policies folder expanded"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a><span class="tree-toggle__level">root</span></span></span>
+                  <span class="tree-node-marker" title="Generated folder node">generated</span><span class="tree-depth-label">L0</span><span class="tree-node-badge" title="Visible child count">2</span>
+                </td>
+                <td><strong>Policies</strong></td><td><span class="mock-status mock-status--pending">TreeView</span></td><td><span class="mock-status">folder cue</span></td><td class="tree-row-actions">-</td>
+              </tr>
+              <tr id="path_record_handbook" class="tree-row is-leaf" data-tree-node-key="record:handbook" data-tree-parent-key="folder:policies" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-selected="false">
+                <td><span class="path-builder-row-kind path-builder-row-kind--record">record</span></td>
+                <td class="btn-cell tree-toggle-cell" id="path_record_handbook_button">
+                  <span class="tree-toggle" aria-label="Employee handbook record"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">child</span></span></span>
+                  <span class="tree-node-marker" title="Record node">record</span><span class="tree-depth-label">L1</span>
+                </td>
+                <td><strong>Employee handbook.pdf</strong></td><td>People Ops</td><td><span class="mock-status mock-status--active">published</span></td><td class="tree-row-actions"><span class="path-builder-record-actions"><button type="button">Open</button><button type="button">Details</button></span></td>
+              </tr>
+              <tr id="path_folder_archive" class="tree-row is-collapsed" data-tree-node-key="folder:archive" data-tree-parent-key="folder:policies" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false" aria-selected="false">
+                <td><span class="path-builder-row-kind path-builder-row-kind--folder">folder</span></td>
+                <td class="btn-cell tree-toggle-cell" id="path_folder_archive_button">
+                  <span class="tree-toggle" aria-label="Archive folder collapsed"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a><span class="tree-toggle__level">child</span><span class="tree-toggle__hidden-count" title="Hidden descendants">4</span></span></span>
+                  <span class="tree-node-marker" title="Generated folder node">generated</span><span class="tree-depth-label">L1</span><span class="tree-node-badge tree-node-badge--warning" title="Hidden record count">4 records</span>
+                </td>
+                <td><strong>Archive</strong></td><td><span class="mock-status mock-status--pending">TreeView</span></td><td><span class="mock-status mock-status--archived">collapsed</span></td><td class="tree-row-actions">-</td>
+              </tr>
+              <tr id="path_record_q1" class="tree-row is-leaf is-selected" data-tree-node-key="record:q1" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="false" aria-level="1" aria-selected="true" aria-current="page">
+                <td><span class="path-builder-row-kind path-builder-row-kind--record">record</span></td>
+                <td class="btn-cell tree-toggle-cell" id="path_record_q1_button">
+                  <span class="tree-toggle" aria-label="Standalone record row"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">root</span></span></span>
+                  <span class="tree-node-marker" title="Record node">record</span><span class="tree-depth-label">L0</span><span class="tree-node-badge tree-node-badge--info" title="Current record">current</span>
+                </td>
+                <td><strong>Q1 roadmap.xlsx</strong></td><td>Product</td><td><span class="mock-status mock-status--active">ready</span></td><td class="tree-row-actions"><span class="path-builder-record-actions"><button type="button">Open</button><button type="button" aria-disabled="true">Download</button></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <aside class="path-builder-callout" aria-labelledby="path-builder-shape-heading">
+        <h3 id="path-builder-shape-heading">Mocked public shape</h3>
+        <p>The row examples mirror the docs-level split between generated folder nodes and record nodes, without defining final host-app actions.</p>
+        <code class="path-builder-code">FolderNode
+  key: folder:policies
+  record: nil
+  generated: true
+
+RecordNode
+  key: record:handbook
+  record: Document
+  generated: false</code>
+      </aside>
+    </section>
+
+    <section class="mock-section" aria-labelledby="path-builder-notes-heading">
+      <h2 id="path-builder-notes-heading">What this mock covers</h2>
+      <ul>
+        <li>Generated folder row markers, toggle affordance, depth label, and hidden-count cue</li>
+        <li>Record row markers beside host-app-owned columns and action buttons</li>
+        <li>A current record row that keeps TreeView current cue separate from business status</li>
+        <li>The boundary between generic folder output and final file-manager behavior</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -144,7 +144,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, row status and depth-label boundaries, narrow layouts, interaction states, Turbo Frame target boundaries, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
+        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, row status and depth-label boundaries, narrow layouts, interaction states, Turbo Frame target boundaries, drag-safe control markers, behavior-specific interactive marker boundaries, windowed rendering cues, breadcrumb path context, filtered-tree mode differences, PathTreeBuilder folder-versus-record rows, editing-oriented row layouts, empty-state spacing, table-bridge column sharing, and toolbar state cues in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -163,383 +163,71 @@
 
     <section class="mock-gallery-grid" aria-label="Mockup comparison gallery">
       <article class="mock-gallery-card" aria-labelledby="gallery-default-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Baseline structure</p>
-          <h2 id="gallery-default-heading">Default tree</h2>
-          <p>
-            Use this surface to inspect representative root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Expanded and collapsed hierarchy cues</li>
-            <li>Selection, badges, and status placement</li>
-            <li>Baseline row-actions column layout</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="default-tree.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Baseline structure</p><h2 id="gallery-default-heading">Default tree</h2><p>Use this surface to inspect representative root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.</p><ul class="mock-gallery-points"><li>Expanded and collapsed hierarchy cues</li><li>Selection, badges, and status placement</li><li>Baseline row-actions column layout</li></ul><div class="mock-gallery-links"><a href="default-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-status-depth-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused status cues</p>
-          <h2 id="gallery-status-depth-heading">Row status and depth labels</h2>
-          <p>
-            Use this surface to compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Normal, readonly, and disabled representative rows</li>
-            <li>Selection availability separated from row-wide status</li>
-            <li>Depth-label meaning kept host-app owned</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="row-status-depth-labels.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Use this surface to compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.</p><ul class="mock-gallery-points"><li>Normal, readonly, and disabled representative rows</li><li>Selection availability separated from row-wide status</li><li>Depth-label meaning kept host-app owned</li></ul><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused integration</p>
-          <h2 id="gallery-bridge-heading">Resource table bridge</h2>
-          <p>
-            Use this surface when review needs tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Shared desktop and compact column sets</li>
-            <li>Hierarchy readability in the first data column</li>
-            <li>Clear table-versus-tree responsibility boundary</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="resource-table-bridge.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Use this surface when review needs tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree responsibility boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Responsive reference</p>
-          <h2 id="gallery-narrow-heading">Narrow sidebar</h2>
-          <p>
-            Use this surface to compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>22rem and 18rem representative frames</li>
-            <li>Current, archived, and loading cues in compressed rows</li>
-            <li>Compact action treatment without hiding the tree path</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="narrow-sidebar-tree.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Use this surface to compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues in compressed rows</li><li>Compact action treatment without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">State transitions</p>
-          <h2 id="gallery-interaction-heading">Interaction states</h2>
-          <p>
-            Use this surface to review lazy loading, retry, pagination, and drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Loaded, loading, and error or retry rows</li>
-            <li>Children pagination placeholder rows</li>
-            <li>Dragging, valid drop, and blocked drop states</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="interaction-states.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Use this surface to review lazy loading, retry, pagination, and drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and error or retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-turbo-frame-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused Turbo boundary</p>
-          <h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2>
-          <p>
-            Use this surface to compare the configured <code>data-turbo-frame</code> toggle-link attribute against the host-app-owned frame wrapper and response boundary.
-          </p>
-          <ul class="mock-gallery-points">
-            <li><code>&lt;turbo-frame id="documents_tree"&gt;</code> wrapper as host-app markup</li>
-            <li>Expand and collapse links targeting <code>documents_tree</code></li>
-            <li>Route, authorization, and Turbo response kept outside the mockup</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="turbo-frame-target.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused Turbo boundary</p><h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2><p>Use this surface to compare the configured <code>data-turbo-frame</code> toggle-link attribute against the host-app-owned frame wrapper and response boundary.</p><ul class="mock-gallery-points"><li><code>&lt;turbo-frame id="documents_tree"&gt;</code> wrapper as host-app markup</li><li>Expand and collapse links targeting <code>documents_tree</code></li><li>Route, authorization, and Turbo response kept outside the mockup</li></ul><div class="mock-gallery-links"><a href="turbo-frame-target.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-drag-controls-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused drag guards</p>
-          <h2 id="gallery-drag-controls-heading">Drag interactive controls</h2>
-          <p>
-            Use this surface to compare plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers inside the same tree layout.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Native input, link, and button drag-start guard</li>
-            <li><code>data-tree-view-interactive</code> for custom widgets</li>
-            <li><code>data-tree-view-ignore-drag</code> for narrower drag-safe controls</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="drag-interactive-controls.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused drag guards</p><h2 id="gallery-drag-controls-heading">Drag interactive controls</h2><p>Use this surface to compare plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers inside the same tree layout.</p><ul class="mock-gallery-points"><li>Native input, link, and button drag-start guard</li><li><code>data-tree-view-interactive</code> for custom widgets</li><li><code>data-tree-view-ignore-drag</code> for narrower drag-safe controls</li></ul><div class="mock-gallery-links"><a href="drag-interactive-controls.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-marker-behavior-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused behavior markers</p>
-          <h2 id="gallery-marker-behavior-heading">Interactive marker behaviors</h2>
-          <p>
-            Use this surface to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers without expanding into host-app wiring.
-          </p>
-          <ul class="mock-gallery-points">
-            <li><code>data-tree-view-interactive</code> as the broad opt-out</li>
-            <li><code>data-tree-view-ignore-keyboard</code> for key handling only</li>
-            <li><code>data-tree-view-ignore-row-click</code> and <code>data-tree-view-ignore-drag</code> as narrower boundaries</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="interactive-marker-behaviors.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused behavior markers</p><h2 id="gallery-marker-behavior-heading">Interactive marker behaviors</h2><p>Use this surface to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers without expanding into host-app wiring.</p><ul class="mock-gallery-points"><li><code>data-tree-view-interactive</code> as the broad opt-out</li><li><code>data-tree-view-ignore-keyboard</code> for key handling only</li><li><code>data-tree-view-ignore-row-click</code> and <code>data-tree-view-ignore-drag</code> as narrower boundaries</li></ul><div class="mock-gallery-links"><a href="interactive-marker-behaviors.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-windowed-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused rendering</p>
-          <h2 id="gallery-windowed-heading">Windowed rendering</h2>
-          <p>
-            Use this surface to compare visible-row slices, current-row anchoring, and previous or next availability without introducing host-app paging controls or loading behavior.
-          </p>
-          <ul class="mock-gallery-points">
-            <li><code>offset</code> and <code>limit</code> window slices</li>
-            <li>Current-row anchoring inside the rendered window</li>
-            <li>Boundary between TreeView metadata and host-app paging UI</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="windowed-rendering.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="windowed-rendering.html" title="Windowed rendering mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused rendering</p><h2 id="gallery-windowed-heading">Windowed rendering</h2><p>Use this surface to compare visible-row slices, current-row anchoring, and previous or next availability without introducing host-app paging controls or loading behavior.</p><ul class="mock-gallery-points"><li><code>offset</code> and <code>limit</code> window slices</li><li>Current-row anchoring inside the rendered window</li><li>Boundary between TreeView metadata and host-app paging UI</li></ul><div class="mock-gallery-links"><a href="windowed-rendering.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="windowed-rendering.html" title="Windowed rendering mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-breadcrumb-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused navigation context</p>
-          <h2 id="gallery-breadcrumb-heading">Breadcrumb paths</h2>
-          <p>
-            Use this surface to compare breadcrumb-path context against the tree's own current-row cue without turning the mockup into a route-design or Turbo-navigation review.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Shallow and deep representative paths</li>
-            <li>Current item at the end of the breadcrumb chain</li>
-            <li>Role split between path context and row-local hierarchy cues</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="breadcrumb-paths.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="breadcrumb-paths.html" title="Breadcrumb paths mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused navigation context</p><h2 id="gallery-breadcrumb-heading">Breadcrumb paths</h2><p>Use this surface to compare breadcrumb-path context against the tree's own current-row cue without turning the mockup into a route-design or Turbo-navigation review.</p><ul class="mock-gallery-points"><li>Shallow and deep representative paths</li><li>Current item at the end of the breadcrumb chain</li><li>Role split between path context and row-local hierarchy cues</li></ul><div class="mock-gallery-links"><a href="breadcrumb-paths.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="breadcrumb-paths.html" title="Breadcrumb paths mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused filtering</p>
-          <h2 id="gallery-filtered-heading">Filtered tree modes</h2>
-          <p>
-            Use this surface to compare how `filtered_tree_for` keeps only matches, matches with ancestors, or matches with descendants without adding host-app search UI.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Matched-only versus ancestor or descendant context</li>
-            <li>Representative mode framing without highlighting</li>
-            <li>Clear boundary between TreeView output and host-app search behavior</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="filtered-tree-modes.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused filtering</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Use this surface to compare how `filtered_tree_for` keeps only matches, matches with ancestors, or matches with descendants without adding host-app search UI.</p><ul class="mock-gallery-points"><li>Matched-only versus ancestor or descendant context</li><li>Representative mode framing without highlighting</li><li>Clear boundary between TreeView output and host-app search behavior</li></ul><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div>
       </article>
-
+      <article class="mock-gallery-card" aria-labelledby="gallery-path-builder-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused path builder</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Use this surface to compare generated folder rows against record-backed rows without turning the reference into a file-manager application.</p><ul class="mock-gallery-points"><li>Generated folder cue, depth, toggle, and hidden-count placement</li><li>Record rows beside host-app-owned columns and actions</li><li>Boundary between public node shape and final business behavior</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div>
+      </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-editing-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused editing</p>
-          <h2 id="gallery-editing-heading">Form-editing rows</h2>
-          <p>
-            Use this surface to compare bulk edit rows, per-row edit placement, and the boundary between TreeView row selection and host-app business form controls.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Selection checkbox versus business checkbox roles</li>
-            <li>Editable text, select, and textarea cells inside rows</li>
-            <li>Per-row action placement without modeling save behavior</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="form-editing-rows.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing</p><h2 id="gallery-editing-heading">Form-editing rows</h2><p>Use this surface to compare bulk edit rows, per-row edit placement, and the boundary between TreeView row selection and host-app business form controls.</p><ul class="mock-gallery-points"><li>Selection checkbox versus business checkbox roles</li><li>Editable text, select, and textarea cells inside rows</li><li>Per-row action placement without modeling save behavior</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Focused controls</p>
-          <h2 id="gallery-toolbar-heading">Toolbar actions</h2>
-          <p>
-            Use this surface to compare tree-wide expand, collapse, and collapse-to-current-path affordances, including enabled, current, and disabled states, without adding real routes or authorization copy.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Mixed-tree all-actions state</li>
-            <li>All-expanded and all-collapsed variants</li>
-            <li>Current-path-preserving cue beside full collapse</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="toolbar-actions.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Use this surface to compare tree-wide expand, collapse, and collapse-to-current-path affordances, including enabled, current, and disabled states, without adding real routes or authorization copy.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue beside full collapse</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
       </article>
-
       <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading">
-        <div class="mock-gallery-copy">
-          <p class="mock-gallery-eyebrow">Spacing and fallback</p>
-          <h2 id="gallery-empty-heading">Empty state</h2>
-          <p>
-            Use this surface to compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.
-          </p>
-          <ul class="mock-gallery-points">
-            <li>Reusable empty-row wrapper hook</li>
-            <li>Full-width message slot behavior</li>
-            <li>Difference from a populated row with controls</li>
-          </ul>
-          <div class="mock-gallery-links">
-            <a href="empty-state.html">Open full mockup</a>
-          </div>
-        </div>
-        <div class="mock-gallery-preview">
-          <iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe>
-        </div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Spacing and fallback</p><h2 id="gallery-empty-heading">Empty state</h2><p>Use this surface to compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.</p><ul class="mock-gallery-points"><li>Reusable empty-row wrapper hook</li><li>Full-width message slot behavior</li><li>Difference from a populated row with controls</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
       </article>
     </section>
 
     <section class="mock-section" aria-labelledby="comparison-cues-heading">
       <h2 id="comparison-cues-heading">Comparison cues</h2>
-      <table class="mock-comparison-table">
-        <thead>
-          <tr>
-            <th scope="col">Surface</th>
-            <th scope="col">Best for</th>
-            <th scope="col">Keep outside scope</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Default tree</td>
-            <td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td>
-            <td>Host-app CRUD, queries, business labels, or authorization behavior.</td>
-          </tr>
-          <tr>
-            <td>Row status and depth labels</td>
-            <td>Comparing row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.</td>
-            <td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td>
-          </tr>
-          <tr>
-            <td>Resource table bridge</td>
-            <td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td>
-            <td>Saved table state, host-app queries, or business-specific row actions.</td>
-          </tr>
-          <tr>
-            <td>Narrow sidebar</td>
-            <td>Hierarchy readability when width shrinks and metadata needs to wrap.</td>
-            <td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td>
-          </tr>
-          <tr>
-            <td>Interaction states</td>
-            <td>Loading, retry, pagination, and drag or drop status cues.</td>
-            <td>Real Turbo responses, route wiring, or persistence behavior.</td>
-          </tr>
-          <tr>
-            <td>Turbo Frame target</td>
-            <td>Configured <code>data-turbo-frame</code> link attributes beside the host-app-owned target frame.</td>
-            <td>Turbo Stream responses, Rails routes, controller actions, authorization, or frame placement policy.</td>
-          </tr>
-          <tr>
-            <td>Drag interactive controls</td>
-            <td>Comparing plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers.</td>
-            <td>Drop targets, widget implementation details, permission rules, or business-specific drag affordances.</td>
-          </tr>
-          <tr>
-            <td>Interactive marker behaviors</td>
-            <td>Comparing the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.</td>
-            <td>Host-app row-click implementation, widget internals, or broader keyboard and drag policy changes.</td>
-          </tr>
-          <tr>
-            <td>Windowed rendering</td>
-            <td>Visible-row slicing, current-row anchoring, and previous or next metadata framing.</td>
-            <td>Pagination controls, infinite scroll, query state, or data fetching behavior.</td>
-          </tr>
-          <tr>
-            <td>Breadcrumb paths</td>
-            <td>Comparing breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</td>
-            <td>Route helpers, Turbo navigation, responsive overflow rules, and permission-aware labels.</td>
-          </tr>
-          <tr>
-            <td>Filtered tree modes</td>
-            <td>Comparing matched-only, ancestor-retaining, and descendant-retaining output.</td>
-            <td>Search forms, highlighting, ranking, and authorization-aware filtering.</td>
-          </tr>
-          <tr>
-            <td>Form-editing rows</td>
-            <td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td>
-            <td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td>
-          </tr>
-          <tr>
-            <td>Toolbar actions</td>
-            <td>Tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</td>
-            <td>Authorization, route names, current-path semantics, or action sequencing rules.</td>
-          </tr>
-          <tr>
-            <td>Empty state</td>
-            <td>Spacing, wrapper hooks, and the full-width empty-row slot.</td>
-            <td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td>
-          </tr>
-        </tbody>
-      </table>
+      <table class="mock-comparison-table"><thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead><tbody>
+        <tr><td>Default tree</td><td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td><td>Host-app CRUD, queries, business labels, or authorization behavior.</td></tr>
+        <tr><td>Row status and depth labels</td><td>Comparing row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
+        <tr><td>Resource table bridge</td><td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td><td>Saved table state, host-app queries, or business-specific row actions.</td></tr>
+        <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
+        <tr><td>Interaction states</td><td>Loading, retry, pagination, and drag or drop status cues.</td><td>Real Turbo responses, route wiring, or persistence behavior.</td></tr>
+        <tr><td>Turbo Frame target</td><td>Configured <code>data-turbo-frame</code> link attributes beside the host-app-owned target frame.</td><td>Turbo Stream responses, Rails routes, controller actions, authorization, or frame placement policy.</td></tr>
+        <tr><td>Drag interactive controls</td><td>Comparing plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers.</td><td>Drop targets, widget implementation details, permission rules, or business-specific drag affordances.</td></tr>
+        <tr><td>Interactive marker behaviors</td><td>Comparing the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.</td><td>Host-app row-click implementation, widget internals, or broader keyboard and drag policy changes.</td></tr>
+        <tr><td>Windowed rendering</td><td>Visible-row slicing, current-row anchoring, and previous or next metadata framing.</td><td>Pagination controls, infinite scroll, query state, or data fetching behavior.</td></tr>
+        <tr><td>Breadcrumb paths</td><td>Comparing breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</td><td>Route helpers, Turbo navigation, responsive overflow rules, and permission-aware labels.</td></tr>
+        <tr><td>Filtered tree modes</td><td>Comparing matched-only, ancestor-retaining, and descendant-retaining output.</td><td>Search forms, highlighting, ranking, and authorization-aware filtering.</td></tr>
+        <tr><td>PathTreeBuilder rows</td><td>Generated folder row cues compared with record-backed rows and host-app-owned columns or actions.</td><td>File-manager routes, download behavior, record authorization, or public API changes.</td></tr>
+        <tr><td>Form-editing rows</td><td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td><td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td></tr>
+        <tr><td>Toolbar actions</td><td>Tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</td><td>Authorization, route names, current-path semantics, or action sequencing rules.</td></tr>
+        <tr><td>Empty state</td><td>Spacing, wrapper hooks, and the full-width empty-row slot.</td><td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td></tr>
+      </tbody></table>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## 対応Issue

- Closes #739

## 採用した方針

- スケジュール実行のため、Planner handoff に沿って最も低リスクな static mockup 追加案を採用しました。
- `PathTreeBuilder` の generated folder row と record-backed row を 1 画面で比較できる focused reference を追加し、runtime implementation や public API、host-app route / authorization / download behavior には触れていません。

## 比較した案

- 案A: 既存 `default-tree.html` に PathTreeBuilder の行を少し足す。変更は小さい一方、baseline mockup の主題が広がるため不採用。
- 案B: 新規 `path-tree-builder-rows.html` を追加し、README と review gallery から辿れるようにする。#739 の受け入れ条件に直接効き、実装コードに触れないため採用。
- 案C: PathTreeBuilder docs 本文も同時に再整理する。#740 / #742 と重複しやすく scope が広がるため不採用。

## 変更内容

- `docs/mockups/path-tree-builder-rows.html` を追加
  - generated folder row と record-backed row の representative state を同じ table で比較
  - folder row は TreeView-owned cue、record row は host-app-owned columns / actions として見えるように整理
  - public shape の簡易 callout を追加
- `docs/mockups/README.md` に mockup 一覧、review flow、PathTreeBuilder guidance を追加
- `docs/mockups/review-gallery.html` に gallery card、iframe preview、comparison cue を追加
- `docs/i18n-audit.md` の technical assets inventory に新規 mockup を追加
- review follow-up で `docs/i18n-audit.md` の page-level coverage table separator を 4 列へ戻しました

## 変更した画面・コンポーネント

- `docs/mockups/path-tree-builder-rows.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `docs/i18n-audit.md`

## 確認内容

- CI: `CI #984` success on head `cf49670c00e390a6aa8150cb6f67dcbe33ce5226`
- lint: CI #984 `lint` success
- spec: CI #984 `pr_specs` success
- JavaScript: CI #984 docs-only skip path success
- Rails compatibility: CI #984 Rails 7.0 / 7.2 / 8.0 docs-only skip path success
- typecheck: 該当なし
- UI表示確認: connector 経由で HTML 構造、リンク先、iframe src を確認
- レスポンシブ確認: 新規 mockup は既存 shared CSS と page-local media query で narrow layout を 1 column に落とす構成
- アクセシビリティ確認: table header scope、return nav aria-label、representative row の aria-level / aria-expanded / aria-current を維持
- GitHub compare: `main...design/739-path-tree-builder-rows` は `ahead_by: 5` / `behind_by: 1`
- PR metadata: `mergeable: true`

## スクリーンショット

未取得。connector 経由の static HTML 更新で、この実行環境ではブラウザレンダリング確認ができていません。

## リスク

- low
- static mockup と index / gallery / inventory wiring に閉じています。`lib/tree_view/path_tree_builder.rb`、runtime JS、Rails routes/controllers、authorization、host-app action behavior は変更していません。

## 補足

- 初回 CI #978 は `pr_specs` の mockup inventory 追従漏れで failure。`docs/i18n-audit.md` を追従し、CI #980 で success を確認しました。
- review follow-up で Markdown table separator の破損を修正し、CI #984 success を確認しました。
- #749 merge 後の `main` に対して compare は `behind_by: 1` のままですが、behind commit は `app/javascript/tree_view/remote_state_controller.test.js` の spec-only 変更で、この PR の docs 差分とはファイル競合していません。PR metadata は `mergeable: true` です。
- #740 docs lane、#741 spec lane、#742 public API lane とは混ぜていません。
