### PR TITLE
test: remote state の loaded / retry detail を固定する

### DIFF
--- a/app/javascript/tree_view/remote_state_controller.test.js
+++ b/app/javascript/tree_view/remote_state_controller.test.js
@@ -50,6 +50,26 @@ describe("TreeViewRemoteStateController remote state details", () => {
     })
   })
 
+  it("dispatches loaded details and marks the row as loaded", () => {
+    const element = document.querySelector("[data-controller='tree-view-remote-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-remote-state")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-remote-state:change", eventSpy)
+    const row = document.querySelector("#remote-row")
+
+    controller.loaded({ target: document.querySelector("#remote-button"), detail: {} })
+
+    expect(row.dataset.remoteState).toBe("loaded")
+    expect(row.dataset.treeLoaded).toBe("true")
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      row,
+      state: "loaded",
+      childrenUrl: "/projects/1/children",
+      nodeKey: "project:1"
+    })
+  })
+
   it("dispatches error details from an explicit detail row with null URL fallbacks", () => {
     const element = document.querySelector("[data-controller='tree-view-remote-state']")
     const controller = application.getControllerForElementAndIdentifier(element, "tree-view-remote-state")
@@ -67,6 +87,25 @@ describe("TreeViewRemoteStateController remote state details", () => {
       state: "error",
       childrenUrl: null,
       nodeKey: null
+    })
+  })
+
+  it("dispatches retry details and returns the row to loading state", () => {
+    const element = document.querySelector("[data-controller='tree-view-remote-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-remote-state")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-remote-state:retry", eventSpy)
+    const row = document.querySelector("#remote-row")
+    row.dataset.remoteState = "error"
+
+    controller.retry({ target: document.querySelector("#remote-button"), detail: {} })
+
+    expect(row.dataset.remoteState).toBe("loading")
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      row,
+      childrenUrl: "/projects/1/children",
+      nodeKey: "project:1"
     })
   })
 })


### PR DESCRIPTION
## 対応 Issue

Closes #744

## Issue ごとの完了内容

- #744
  - `TreeViewRemoteStateController#loaded` が `data-remote-state="loaded"` と `data-tree-loaded="true"` を更新することを JavaScript spec で固定しました。
  - `tree-view-remote-state:change` の `loaded` detail に `row` / `state` / `childrenUrl` / `nodeKey` が含まれることを確認しました。
  - `retry` が row を loading state に戻し、`tree-view-remote-state:retry` detail に `childrenUrl` / `nodeKey` を含めることを確認しました。

## 変更内容

- `app/javascript/tree_view/remote_state_controller.test.js` に loaded / retry の代表 spec を追加
- runtime code、lazy-loading fetch policy、Turbo response、public event name / detail key は変更していません

## 改善カテゴリ

- test
- regression guard

## 既存仕様への影響

- 既存仕様への影響はありません。spec-only の追加です。
- remote-state controller behavior、event contract、lazy-loading implementation は変更していません。

## 実施した確認内容

- GitHub compare: `main...quality/744-remote-state-loaded-retry-spec-current`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: `app/javascript/tree_view/remote_state_controller.test.js`
- local test: 未実行
  - この実行環境では GitHub HTTPS clone / fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で差分確認しています。

## リスク評価

- low
- spec-only で、既存の loaded / retry contract を固定するだけの変更です。

## 補足事項

- Playwright browser smoke や lazy-loading fetch integration には広げていません。