### PR TITLE
docs: drag/drop event detail と position 境界を補う

### DIFF
--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -93,6 +93,29 @@ function onDrop(event) {
 }
 ```
 
+Host apps can also listen for the public transfer events dispatched by the `tree-view-transfer` controller instead of reading controller internals directly.
+
+```js
+document.addEventListener("tree-view-transfer:drop", (event) => {
+  const { sourcePayload, targetPayload, position } = event.detail
+  // Apply host-app authorization, ordering, persistence, and error handling here.
+})
+```
+
+The transfer controller exposes these reader-facing details:
+
+| Event | Main `event.detail` fields | Meaning |
+|---|---|---|
+| `tree-view-transfer:drag-start` | `sourcePayload`, `sourceRow` | A draggable TreeView row started a transfer and its payload was copied to `DataTransfer` when available. |
+| `tree-view-transfer:drag-over` | `targetPayload`, `targetRow`, `position` | The pointer is over a valid target row. TreeView reports the target payload and coarse drop position. |
+| `tree-view-transfer:drop` | `sourcePayload`, `targetPayload`, `position`, `targetRow` | A payload was dropped on a target row. Host apps decide whether the requested move is allowed and how to persist it. |
+| `tree-view-transfer:invalid-payload` | `value`, `row` | A target row's `data-tree-transfer-payload` could not be parsed as JSON. |
+| `tree-view-transfer:invalid-transfer` | `value` | The transferred JSON value from `DataTransfer` could not be parsed. |
+
+`position` is a TreeView-owned coarse cue for where the pointer sits inside the target row: the top third is `before`, the middle third is `inside`, and the bottom third is `after`. Treat it as input to host-app business rules, not as final authorization or persistence policy. For example, a host app may ignore `inside` for leaf-only trees, reject drops across projects, or translate `before` / `after` into an ordering update.
+
+For the full JavaScript event contract, see [JavaScript event contract](js-events.md#transfer-events).
+
 ## Responsibility boundary
 
 | Area | TreeView | Host app |
@@ -101,6 +124,8 @@ function onDrop(event) {
 | transfer data attributes | yes | consumes them |
 | dragstart helper | yes | wires action |
 | interactive-control drag-start guard | yes | marks custom widgets when needed |
+| transfer event detail | yes | listens and applies business behavior |
+| coarse drop position | reports `before`, `inside`, or `after` | decides whether the position is allowed and how to persist it |
 | drop target | no | yes |
 | reorder / move persistence | no | yes |
 | authorization | no | yes |

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -93,6 +93,29 @@ function onDrop(event) {
 }
 ```
 
+host appは controller 内部に直接依存せず、`tree-view-transfer` controller がdispatchする公開transfer eventをlistenできます。
+
+```js
+document.addEventListener("tree-view-transfer:drop", (event) => {
+  const { sourcePayload, targetPayload, position } = event.detail
+  // 認可、並び替え、保存、エラー表示などのhost app側処理をここで行う
+})
+```
+
+transfer controller が読者向けに公開する主なdetailは次のとおりです。
+
+| Event | Main `event.detail` fields | Meaning |
+|---|---|---|
+| `tree-view-transfer:drag-start` | `sourcePayload`, `sourceRow` | draggable な TreeView row のtransferが開始され、可能な場合はpayloadが `DataTransfer` にコピーされた。 |
+| `tree-view-transfer:drag-over` | `targetPayload`, `targetRow`, `position` | pointer がvalidなtarget row上にある。TreeView はtarget payloadと粗いdrop位置を返す。 |
+| `tree-view-transfer:drop` | `sourcePayload`, `targetPayload`, `position`, `targetRow` | payloadがtarget rowへdropされた。host app がそのmoveを許可するか、どう保存するかを決める。 |
+| `tree-view-transfer:invalid-payload` | `value`, `row` | target row の `data-tree-transfer-payload` をJSONとしてparseできなかった。 |
+| `tree-view-transfer:invalid-transfer` | `value` | `DataTransfer` から取得したJSON値をparseできなかった。 |
+
+`position` は、target row内でpointerがどこにあるかを示すTreeView側の粗いcueです。上 1/3 は `before`、中央 1/3 は `inside`、下 1/3 は `after` になります。これはhost appの業務ルールへの入力として扱い、最終的な許可・保存方針として扱わないでください。たとえば、leaf-only treeでは `inside` を無視したり、projectをまたぐdropを拒否したり、`before` / `after` を並び順更新へ変換したりできます。
+
+JavaScript event contract全体は [JavaScript event contract](js-events.md#transfer-events) を参照してください。
+
 ## 責務範囲
 
 | Area | TreeView | Host app |
@@ -101,6 +124,8 @@ function onDrop(event) {
 | transfer data attributes | yes | consumes them |
 | dragstart helper | yes | wires action |
 | interactive-control drag-start guard | yes | marks custom widgets when needed |
+| transfer event detail | yes | listens and applies business behavior |
+| coarse drop position | `before`, `inside`, `after` を返す | そのpositionを許可するか、どう保存するかを決める |
 | drop target | no | yes |
 | reorder / move persistence | no | yes |
 | authorization | no | yes |


### PR DESCRIPTION
## 対応 Issue

Closes #751

## 分類

- `code-ahead-of-docs`
- current `TreeViewTransferController` と `docs/en|ja/js-events.md` にある transfer event contract に対して、drag-and-drop guide 側の説明が薄かったため、docs 追従として扱いました。

## 変更内容

- `docs/en/drag-and-drop.md`
  - `tree-view-transfer:*` event の主要 `event.detail` fields を追加
  - `before` / `inside` / `after` の drop position boundary を追記
  - TreeView が coarse cue を返し、最終可否・保存は host app 側責務であることを明記
  - `js-events.md#transfer-events` への導線を追加
- `docs/ja/drag-and-drop.md`
  - 上記と同じ内容を日本語 guide に反映

## 変更しない範囲

- runtime JavaScript
- event name / detail key
- controller tests
- mockup HTML/CSS
- public API manifest

## 確認内容

- GitHub compare: `main...docs/751-drag-drop-event-detail`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: `docs/en/drag-and-drop.md`, `docs/ja/drag-and-drop.md`
- 実装確認: `app/javascript/tree_view/transfer_controller.js` の dispatch detail と `docs/en|ja/js-events.md` の Transfer events を照合
- local test: 未実行（docs-only の connector 経由更新）

## リスク

- low
- 既存 event contract の説明追従に閉じており、実装・仕様・mockup には触れていません。