### PR TITLE
test: state-changed payload の JS guard を追加する

### DIFF
--- a/app/javascript/tree_view/state_controller.test.js
+++ b/app/javascript/tree_view/state_controller.test.js
@@ -1,0 +1,93 @@
+import { Application } from "@hotwired/stimulus"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { TreeViewStateController } from "./state_controller.js"
+
+function nextFrame() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function renderTree() {
+  document.body.innerHTML = `
+    <section
+      id="tree"
+      data-controller="tree-view-state"
+      data-tree-view-state-view-key-value="project-tree">
+      <div
+        id="project-1"
+        data-tree-view-state-target="node"
+        data-tree-view-state-node-key="project:1"
+        data-tree-view-state-expanded="true">
+        <button id="project-1-toggle" type="button">Toggle</button>
+      </div>
+      <div
+        id="project-2"
+        data-tree-view-state-target="node"
+        data-tree-view-state-node-key="project:2"
+        data-tree-view-state-expanded="false">
+        <button id="project-2-toggle" type="button">Toggle</button>
+      </div>
+      <div
+        id="missing-key"
+        data-tree-view-state-target="node"
+        data-tree-view-state-expanded="true">
+        <button id="missing-key-toggle" type="button">Toggle</button>
+      </div>
+    </section>
+  `
+
+  return document.getElementById("tree")
+}
+
+describe("TreeViewStateController state-changed details", () => {
+  let application
+
+  afterEach(() => {
+    if (application) application.stop()
+    application = null
+    document.body.innerHTML = ""
+  })
+
+  it("dispatches viewKey and expandedKeys when the controller connects", async () => {
+    const element = renderTree()
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-state:state-changed", eventSpy)
+
+    application = Application.start()
+    application.register("tree-view-state", TreeViewStateController)
+    await nextFrame()
+
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toEqual({
+      viewKey: "project-tree",
+      expandedKeys: ["project:1"]
+    })
+  })
+
+  it("updates expandedKeys when nodes collapse and refresh dispatches the current payload", async () => {
+    const element = renderTree()
+    application = Application.start()
+    application.register("tree-view-state", TreeViewStateController)
+    await nextFrame()
+
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-state")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-state:state-changed", eventSpy)
+
+    controller.markCollapsed({ target: document.getElementById("project-1-toggle") })
+
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toEqual({
+      viewKey: "project-tree",
+      expandedKeys: []
+    })
+
+    document.getElementById("project-2").dataset.treeViewStateExpanded = "true"
+    controller.refresh()
+
+    expect(eventSpy).toHaveBeenCalledTimes(2)
+    expect(eventSpy.mock.calls[1][0].detail).toEqual({
+      viewKey: "project-tree",
+      expandedKeys: ["project:2"]
+    })
+  })
+})


### PR DESCRIPTION
## 対応 Issue

Closes #729

## Issue ごとの完了内容

- #729
  - `TreeViewStateController` の `tree-view-state:state-changed` event detail を Vitest で固定しました。
  - connect 初回 dispatch で `viewKey` と expanded node の `expandedKeys` が含まれることを確認しました。
  - collapse 後と `refresh()` 後に、現在の expanded state が payload に反映される代表ケースを確認しました。

## 変更内容

- `app/javascript/tree_view/state_controller.test.js` を追加
- runtime JavaScript、event name、event detail shape、public export、docs は変更していません

## 改善カテゴリ

- test
- regression guard

## 既存仕様への影響

- 既存仕様への影響はありません。spec-only の追加です。
- `TreeViewStateController` の実装、keyboard navigation、persisted state save helper、manifest export には触れていません。

## 実施した確認内容

- GitHub compare: `main...quality/729-state-changed-payload-spec`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: `app/javascript/tree_view/state_controller.test.js`
- CI run `#983`: success on head `ac4eb317b715f31e869bf264838e86978c72dc46`
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success (`npm run test:js`)
  - representative Rails lanes: success
- local test: 未実行
  - この実行環境では GitHub HTTPS clone / fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で差分確認し、CI で検証しました。

## リスク評価

- low
- spec-only で、docs にある public event payload contract の代表挙動を固定するだけの変更です。

## 補足事項

- #723 の manifest / docs drift guard とはまとめず、controller dispatch behavior の test に閉じています。