### PR TITLE
feat: transfer drop position 名を public export にする

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -39,6 +39,12 @@ export const TreeViewEventNames = Object.freeze({
   })
 })
 
+export const TreeViewTransferDropPositions = Object.freeze({
+  before: "before",
+  inside: "inside",
+  after: "after"
+})
+
 export const TreeViewControllerIdentifiers = Object.freeze({
   state: "tree-view-state",
   client: "tree-view-client",

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -77,12 +77,17 @@ javascript_package_root:
   named_exports:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
+    - TreeViewTransferDropPositions
     - TreeViewStateController
     - TreeViewClientController
     - TreeViewSelectionController
     - TreeViewTransferController
     - TreeViewRemoteStateController
     - TreeViewEventNames
+  transfer_drop_positions:
+    before: before
+    inside: inside
+    after: after
   controller_registrations:
     - key: state
       identifier: tree-view-state

--- a/docs/en/transfer-drop-positions.md
+++ b/docs/en/transfer-drop-positions.md
@@ -1,0 +1,21 @@
+# Transfer Drop Positions
+
+`TreeViewTransferDropPositions` is the package-root public export for the documented transfer drop position names.
+
+```js
+import { TreeViewTransferDropPositions } from "tree_view"
+
+if (event.detail.position === TreeViewTransferDropPositions.inside) {
+  // Handle an inside drop target in the host app.
+}
+```
+
+The object is intentionally narrow:
+
+- `before` maps to `"before"`
+- `inside` maps to `"inside"`
+- `after` maps to `"after"`
+
+Use these values when handling `tree-view-transfer:drag-over` or `tree-view-transfer:drop` events and you want to avoid copying raw position strings in host-app code or tests.
+
+This export only names the values carried by `event.detail.position`. It does not add a reorder policy, persistence helper, authorization decision, or drag/drop calculation hook. TreeView still emits the same event names and detail keys, and host apps still own whether a drop is allowed and how a move is saved.

--- a/docs/ja/transfer-drop-positions.md
+++ b/docs/ja/transfer-drop-positions.md
@@ -1,0 +1,21 @@
+# Transfer Drop Positions
+
+`TreeViewTransferDropPositions` は、documented な transfer drop position 名を参照するための package-root public export です。
+
+```js
+import { TreeViewTransferDropPositions } from "tree_view"
+
+if (event.detail.position === TreeViewTransferDropPositions.inside) {
+  // host app 側で inside drop target を扱います。
+}
+```
+
+この object は intentionally narrow です。
+
+- `before` は `"before"` を返します
+- `inside` は `"inside"` を返します
+- `after` は `"after"` を返します
+
+`tree-view-transfer:drag-over` または `tree-view-transfer:drop` を扱う host app code / test で、raw string を写経せずに `event.detail.position` を比較したい場合に使ってください。
+
+この export は `event.detail.position` に入る値の名前だけを表します。reorder policy、persistence helper、authorization decision、drag/drop calculation hook は追加しません。TreeView が emit する event name と detail key は変わらず、drop を許可するか、move をどう保存するかは host app 側の責務です。

--- a/spec/javascript/tree_view_transfer_drop_positions_spec.rb
+++ b/spec/javascript/tree_view_transfer_drop_positions_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "TreeView transfer drop position export" do
+  let(:manifest) do
+    YAML.safe_load_file(File.expand_path("../../config/public_api_manifest.yml", __dir__))
+  end
+
+  let(:entrypoint_source) do
+    File.read(File.expand_path("../../app/javascript/tree_view/index.js", __dir__))
+  end
+
+  it "keeps the package-root transfer drop position export aligned with the manifest" do
+    positions = manifest.fetch("javascript_package_root").fetch("transfer_drop_positions")
+
+    expect(manifest.fetch("javascript_package_root").fetch("named_exports")).to include("TreeViewTransferDropPositions")
+    expect(positions).to eq({"before" => "before", "inside" => "inside", "after" => "after"})
+    expect(entrypoint_source).to include("export const TreeViewTransferDropPositions = Object.freeze({")
+
+    positions.each do |key, value|
+      expect(entrypoint_source).to include("#{key}: \"#{value}\"")
+    end
+  end
+end


### PR DESCRIPTION
transfer drop position 名を package-root から参照できる public export として追加します。

## 対応 Issue

Closes #753

## 変更内容

- `tree_view/index.js` に `TreeViewTransferDropPositions` を追加しました。
  - `before: "before"`
  - `inside: "inside"`
  - `after: "after"`
- `config/public_api_manifest.yml` に named export と position values を追加しました。
- `spec/javascript/tree_view_transfer_drop_positions_spec.rb` を追加し、manifest と entrypoint source の同期を確認します。
- `docs/en/transfer-drop-positions.md` / `docs/ja/transfer-drop-positions.md` を追加し、この export が `event.detail.position` の値だけを表す narrow constant であることを明記しました。

## 受け入れ条件との対応

- `TreeViewTransferDropPositions.before` / `.inside` / `.after` から documented position 名を参照できます。
- `TreeViewEventNames` / `TreeViewControllerIdentifiers` と同じ package-root public surface として manifest に載せました。
- `dropPosition` の計算、event name、detail key は変更していません。
- reorder / move persistence helper、host-app drop policy、CSS/data hook export には広げていません。

## 変更範囲

- `app/javascript/tree_view/index.js`
- `config/public_api_manifest.yml`
- `spec/javascript/tree_view_transfer_drop_positions_spec.rb`
- `docs/en/transfer-drop-positions.md`
- `docs/ja/transfer-drop-positions.md`

## 実施した確認

- GitHub compare: `main...feature/753-transfer-drop-positions-export`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 5 files
- CI run `#985`: success on head `045a28683146130a8747b30acf4216a8d67e32ab`
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success (`npm run test:js`)
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0 representative lanes: success
  - `gem_package` / full `rails_matrix` / `ruby_matrix`: skipped by workflow conditions
- PR metadata: `mergeable: true`
- local test / lint: 未実行
  - この実行環境では GitHub HTTPS clone / fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で差分を作成し CI で確認しました。

## リスク

- medium
- public JavaScript surface の additive export です。manifest / spec / docs を同時に更新し、既存 transfer behavior には触れていません。

## 未対応・補足

- `TreeViewTransferController#dropPosition` の計算変更はしていません。
- event detail の `position` key や value rename はしていません。
- DnD reorder helper、host-app persistence、browser E2E には広げていません。
