### PR TITLE
docs: Rails 8.0 の development matrix command を追加する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -40,6 +40,8 @@ BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake
 ```
 
 ## Public API compatibility specs

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -40,6 +40,8 @@ BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake
 ```
 
 ## Public API compatibility specs


### PR DESCRIPTION
Superseded by a fresh branch from current `main` because this PR was created while `main` moved and became `mergeable: false`.

Original scope: Closes #757

No merge intended for this PR.