### PR TITLE
docs: Rails 8.0 の development matrix command を追加する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -40,6 +40,8 @@ BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake
 ```
 
 ## Public API compatibility specs

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -40,6 +40,8 @@ BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake
 ```
 
 ## Public API compatibility specs


### PR DESCRIPTION
## 対応 Issue

Closes #757

## 分類

- `docs-stale`
- `docs/en|ja/development.md` の Rails version matrix command example が、current CI policy にある `gemfiles/rails_8_0.gemfile` をまだ含んでいなかったため、docs 追従として扱いました。

## 変更内容

- `docs/en/development.md`
  - Rails version matrix command example に Rails 8.0 lane を追加
- `docs/ja/development.md`
  - 同じ command example に Rails 8.0 lane を追加

## 変更しない範囲

- `.github/workflows/**`
- Gemfile / `gemfiles/**`
- runtime code
- Rails support policy
- release checklist 全体

## 確認内容

- `.github/workflows/ci.yml` の PR representative Rails compatibility matrix に `gemfiles/rails_8_0.gemfile` が含まれることを確認
- `gemfiles/rails_8_0.gemfile` が存在することを確認
- GitHub compare: `main...docs/757-rails-8-development-matrix-latest`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: `docs/en/development.md`, `docs/ja/development.md`
- CI run `#990`: success on head `7716c03da1b43db6763b5282166b2efbd60feb03`
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: docs-only skip path success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: docs-only skip path success
- PR metadata: `mergeable: true`
- local test: 未実行（docs-only の connector 経由更新）

## リスク

- low
- 既存 CI policy にある Rails 8.0 laneを maintainer command example に反映するだけで、workflow や support policy は変更していません。