### PR TITLE
docs: English README の language status を現状に合わせる

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -11,7 +11,7 @@ Documentation now lives in language-specific directories, and bilingual coverage
 - [Japanese documentation](../ja/README.md)
 - [Documentation i18n audit](../i18n-audit.md)
 
-Not every page has a complete English translation yet. English coverage is prioritized for entry points, installation, minimal usage, usage, and API overview first.
+Most user-facing, feature, release, and maintainer pages now exist in both language trees. When English detail lags behind Japanese wording, track that mismatch through the i18n audit rather than treating the English tree as entry-point-only coverage.
 
 ## For users
 


### PR DESCRIPTION
## 対応 Issue

Closes #777

## 変更内容

`docs/en/README.md` の Language status を、current docs tree と `docs/i18n-audit.md` の bilingual maintenance 方針に合わせました。

- 古い「English coverage は entry points / installation / minimal usage / usage / API overview 優先」という表現を削除
- 多くの user-facing / feature / release / maintainer docs が両 language tree に存在する現在の状態を反映
- English detail が Japanese wording に遅れる場合は i18n audit で追跡する、という運用に寄せる

## 改善カテゴリ

- docs-sync
- docs-stale

## 既存仕様への影響

- docs-only です。
- runtime code、public API、CI workflow、依存関係、docs map の構造は変更していません。
- `docs/ja/README.md` と `docs/i18n-audit.md` は current wording と整合していたため変更していません。

## 確認内容

- GitHub compare: `main...docs/777-en-readme-language-status`
  - changed files: 1 (`docs/en/README.md`)
  - `behind_by: 0`

## リスク

- low
- 主な確認観点は、Language status が current bilingual coverage と i18n audit の maintenance expectation と矛盾しないことです。