### PR TITLE
feat: StateStore に保存済み展開状態の clear API を追加する

### DIFF
--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -111,6 +111,19 @@ persisted_state = store.save!(
 )
 ```
 
+Clear saved expansion state for the same owner and tree instance key:
+
+```ruby
+persisted_state = store.clear!(
+  owner: current_user,
+  tree_instance_key: "documents:index"
+)
+```
+
+`clear!` deletes the matching persisted-state record when one exists. When no record exists, it still returns a `TreeView::PersistedState` for the requested key with empty `expanded_keys`, matching the empty-state behavior of `find`.
+
+TreeView only provides the store API. The host app still owns the reset route, authorization, confirmation UI, retry behavior, and response shape.
+
 ## Minimal controller concern
 
 If your host app wants to keep the save endpoint small, include `TreeView::PersistedStateController` in the controller and let it bridge the raw request values to `StateStore#save!`.

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -111,6 +111,19 @@ persisted_state = store.save!(
 )
 ```
 
+同じ owner と tree instance key の保存済み開閉状態をクリアする例:
+
+```ruby
+persisted_state = store.clear!(
+  owner: current_user,
+  tree_instance_key: "documents:index"
+)
+```
+
+`clear!` は一致する persisted-state record があれば削除します。record が存在しない場合も例外にせず、指定した key と空の `expanded_keys` を持つ `TreeView::PersistedState` を返します。これは `find` の empty-state behavior と同じ扱いです。
+
+TreeView が提供するのは store API までです。reset route、認可、確認 UI、retry、response shape は引き続き host app 側が持ちます。
+
 ## 最小 controller concern
 
 保存 endpoint を小さく保ちたい host app では、controller に `TreeView::PersistedStateController` を include して、raw request values から `StateStore#save!` への橋渡しだけ gem 側へ寄せられます。

--- a/lib/tree_view/state_store.rb
+++ b/lib/tree_view/state_store.rb
@@ -18,6 +18,12 @@ module TreeView
       PersistedState.new(tree_instance_key: tree_instance_key, expanded_keys: record.expanded_keys)
     end
 
+    def clear!(owner:, tree_instance_key:)
+      record = model.find_by(owner: owner, tree_instance_key: tree_instance_key)
+      record&.destroy!
+      PersistedState.new(tree_instance_key: tree_instance_key, expanded_keys: [])
+    end
+
     private
 
     attr_reader :model

--- a/spec/lib/tree_view/state_store_spec.rb
+++ b/spec/lib/tree_view/state_store_spec.rb
@@ -4,6 +4,11 @@ DummyRecord = Struct.new(:owner, :tree_instance_key, :expanded_keys) do
   def save!
     true
   end
+
+  def destroy!
+    DummyModel.record = nil
+    true
+  end
 end
 
 class DummyModel
@@ -55,5 +60,27 @@ RSpec.describe TreeView::StateStore do
     expect(DummyModel.record.expanded_keys).to eq(["node-1"])
     expect(state.tree_instance_key).to eq("documents")
     expect(state.expanded_keys).to eq(["node-1"])
+  end
+
+  it "clears an existing record and returns an empty persisted state" do
+    DummyModel.record = DummyRecord.new(:user, "documents", ["node-1"])
+    store = described_class.new(model: DummyModel)
+
+    state = store.clear!(owner: :user, tree_instance_key: "documents")
+
+    expect(DummyModel.record).to be_nil
+    expect(state).to be_a(TreeView::PersistedState)
+    expect(state.tree_instance_key).to eq("documents")
+    expect(state.expanded_keys).to eq([])
+    expect(store.find(owner: :user, tree_instance_key: "documents").expanded_keys).to eq([])
+  end
+
+  it "treats clearing a missing record as idempotent" do
+    store = described_class.new(model: DummyModel)
+
+    state = store.clear!(owner: :user, tree_instance_key: "documents")
+
+    expect(state.tree_instance_key).to eq("documents")
+    expect(state.expanded_keys).to eq([])
   end
 end


### PR DESCRIPTION
StateStore から owner / tree instance key 単位で保存済み展開状態を忘れられるようにします。

## 対応 Issue

Closes #732

## 変更内容

- `TreeView::StateStore#clear!(owner:, tree_instance_key:)` を追加しました。
- 対象 record がある場合は `destroy!` で削除し、空の `TreeView::PersistedState` を返します。
- 対象 record がない場合も idempotent に空の `TreeView::PersistedState` を返します。
- `spec/lib/tree_view/state_store_spec.rb` に既存 record / missing record の clear 観点を追加しました。
- `docs/en/persisted-state.md` / `docs/ja/persisted-state.md` に `clear!` の使用例と責務境界を最小追記しました。

## 受け入れ条件との対応

- owner + `tree_instance_key` 単位で保存済み expansion state を削除できます。
- record が無い場合も例外にせず、対象 key + empty `expanded_keys` の state を返します。
- clear 後の `find(owner:, tree_instance_key:)` は empty persisted state を返す想定を spec で固定しました。
- docs では、TreeView は store API まで、route / authorization / confirmation UI / retry / response shape は host app 側、という境界を英日で揃えました。

## 変更範囲

- `lib/tree_view/state_store.rb`
- `spec/lib/tree_view/state_store_spec.rb`
- `docs/en/persisted-state.md`
- `docs/ja/persisted-state.md`

DB schema、controller / route / authorization、browser helper、retry UI、reset button design、confirm dialog、JavaScript event payload は変更していません。

## 実施した確認

- GitHub compare: `main...feature/732-state-store-clear`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- local test / lint: 未実行
  - この実行環境では GitHub HTTPS clone / fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で差分を作成・確認しています。

## リスク

- medium
- public server-side API の additive change です。既存 `find` / `save!` の挙動、DB schema、controller concern、browser event contract には触れていません。

## 未対応・補足

- `PersistedStateController` に clear helper は追加していません。Planner 指示どおり、controller concern への拡張は別 Issue 範囲です。
- host app の reset route / authorization / UI design は非目標として扱っています。