### PR TITLE
docs: Rails 7.1 の PR matrix 方針を明文化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Pull requests run representative edge and current Rails lanes; Rails 7.1 stays in the main-branch full matrix.
         include:
           - rails: "7.0"
             gemfile: gemfiles/rails_7_0.gemfile

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -38,6 +38,8 @@ For the Rails version matrix:
 ```bash
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle install
@@ -87,6 +89,8 @@ Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-
 - Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - JavaScript entrypoint, unit, and browser smoke tests through `npm run test:js`
 
+The pull-request Rails lanes intentionally skip Rails 7.1 to keep PR feedback focused on representative lower, current, and next-major coverage; the `main` push full Rails matrix is the final compatibility gate that includes Rails 7.1.
+
 Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile.md`, `CHANGELOG.md`, and `AGENTS.md` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
 
 A green check suite does not by itself mean a pull request is ready to merge after `main` has moved. When a branch is `diverged`, check mergeability, changed files, risk, and how far the branch is behind. Prefer refreshing the branch and observing fresh CI when GitHub reports `mergeable: false`, when the branch is far behind, or when the pull request touches workflow definitions, public API, specs, or shared docs inventory. For small docs-only changes that are only a little behind, it is enough to confirm the changed files still apply cleanly, mergeability is true, and the named checks remain green.
@@ -94,7 +98,7 @@ A green check suite does not by itself mean a pull request is ready to merge aft
 Pushes to `main` also run the broader compatibility and release checks:
 
 - Ruby version matrix
-- Full Rails version matrix
+- Full Rails version matrix, including Rails 7.1
 - gem package verification
 
 ## Change checklist

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -38,6 +38,8 @@ Rails version matrixを確認する場合:
 ```bash
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake
 BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle install
@@ -87,6 +89,8 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
 - JavaScript entrypoint、unit、browser smoke tests: `npm run test:js`
 
+Pull Request の Rails lanes では、lower / current / next-major の代表範囲に絞るため Rails 7.1 は意図的に含めていません。Rails 7.1 は `main` push の full Rails matrix で確認する最終互換ゲートです。
+
 `README.md`、`docs/**`、`Product Profile.md`、`CHANGELOG.md`、`AGENTS.md` だけに触れる docs-only Pull Request では、`lint` と `pr_specs` はそのまま残しつつ、representative Rails job と JavaScript job を short-circuit します。branch protection のため、check 名はそのまま維持します。`.github/workflows/**` も変更する Pull Request ではこの shortcut を使わず、通常の PR lanes を確認します。
 
 `main` が進んで branch が `diverged` になった後は、green checks だけでは merge ready と判断しません。`mergeable`、changed files、risk、behind の大きさを確認します。GitHub が `mergeable: false` を返す場合、behind が大きい場合、または workflow 定義、public API、spec、shared docs inventory に触れる Pull Request では、branch refresh 後に fresh CI を観測することを優先します。小さく少しだけ behind している docs-only 変更では、changed files が clean に適用でき、`mergeable` が true で、同じ check 名が green のままなら、過度に重い refresh を必須にしなくてかまいません。
@@ -94,7 +98,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 `main` へのpushでは、より広い互換性確認とrelease向けのchecksも実行します。
 
 - Ruby version matrix
-- full Rails version matrix
+- full Rails version matrix（Rails 7.1 を含む）
 - gem package verification
 
 ## 変更時の確認ポイント


### PR DESCRIPTION
## 対応 Issue

Closes #778

## Issue ごとの完了内容

- #778
  - Rails 7.1 を PR representative matrix に追加せず、`main` push の full Rails matrix で確認する方針を明文化しました。
  - `.github/workflows/ci.yml` と `docs/en|ja/development.md` の説明を揃えました。
  - local matrix command 例には Rails 7.1 を含め、PR representative と full matrix の違いが読めるようにしました。

## 変更内容

- `.github/workflows/ci.yml`
  - `pr_rails_matrix` の matrix 直前に、PR は代表 Rails lanes、Rails 7.1 は main branch full matrix で確認する旨の短い comment を追加
- `docs/en/development.md`
  - Rails matrix command 例に Rails 7.1 を追加
  - CI policy に PR representative lanes と main push full matrix の責務分担を追記
- `docs/ja/development.md`
  - 英語版と同じ方針説明を追加

## 改善カテゴリ

- CI policy documentation
- docs-sync
- workflow maintainability

## 既存仕様への影響

- CI の実行対象、job name、matrix の実体、branch protection 前提は変更していません。
- Rails 7.1 を PR matrix に追加せず、既存の lightweight representative policy を説明するだけです。
- runtime code、public API、DB、認可、状態遷移、外部サービス契約への影響はありません。

## 実施した確認内容

- GitHub compare: `main...quality/778-rails-71-ci-policy`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- PR metadata: `mergeable: true`
- CI run `#1055`: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
- local test / lint: 未実行
  - この実行環境では GitHub HTTPS clone / fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で差分を作成しています。

## リスク評価

- medium
- workflow file に触るため CI 観測が必要です。ただし job 定義や matrix 実体は変えず、コメントと docs の方針明文化に限定しています。

## 補足事項

- docs-only shortcut、JavaScript job、package-lock / npm install policy、Ruby version matrix、高速化 redesign には広げていません。