### PR TITLE
docs: persisted-state guide から mockup 導線を補う

### DIFF
--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -16,6 +16,8 @@ TreeView is responsible for:
 
 The host app remains responsible for storage ownership, authorization, save timing, controller actions, and UI wiring.
 
+For a static visual reference of the save/restore handoff, see [Persisted State boundary mockup](../mockups/persisted-state-boundary.html). The mockup shows representative before, changed, restored, save-failed, and retry cues without turning storage, save endpoints, authorization, or retry policy into gem-owned behavior.
+
 ## Generator
 
 Use the generator to create model and migration templates.

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -16,6 +16,8 @@ TreeView gem が担当するのは以下です。
 
 実際の保存先、owner model、認可、保存タイミング、controller action、UI更新はhost app側で実装します。
 
+保存・復元の受け渡しを静的な visual reference で確認したい場合は、[Persisted State boundary mockup](../mockups/persisted-state-boundary.html) を参照してください。この mockup は、保存前、変更後、復元後、保存失敗、retry の代表的な見え方を示しますが、storage、save endpoint、認可、retry policy を gem 側の責務として扱うものではありません。
+
 ## generator
 
 保存用modelとmigrationの雛形は generator で作成できます。


### PR DESCRIPTION
## 対応 Issue

Closes #722

## 変更内容

`docs/mockups/persisted-state-boundary.html` が current `main` に存在するため、Persisted State guide 側から visual reference へ辿れる導線を最小追加しました。

- `docs/en/persisted-state.md`
  - save / restore handoff の静的 visual reference として persisted-state boundary mockup へリンク
  - storage、save endpoint、authorization、retry policy は host app-owned のままと明記
- `docs/ja/persisted-state.md`
  - 英語版と同じ導線と責務境界を追加

## 判定分類

- `docs-sync`
- `docs-missing`

## 既存仕様への影響

- docs-only です。
- runtime API、StateStore、controller concern、generator、mockup HTML/CSS 本体、CI workflow は変更していません。
- mockup は current `main` 上の既存 asset を参照しており、未着地 feature の先書きではありません。

## 確認内容

- GitHub compare: `main...docs/722-persisted-state-mockup-link`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: `docs/en/persisted-state.md`, `docs/ja/persisted-state.md`
- CI run `#1027`: success
  - `changes`, `pr_specs`, `lint`: success
  - `javascript` / representative Rails lanes: docs-only skip path success
- local test / lint: 未実行
  - docs-only のリンク追加です。

## リスク

- low
- 主な確認観点は、リンク先 mockup が current main に存在し、guide 本文の責務境界と矛盾していないことです。