### PR TITLE
row status builder option を public API manifest で固定する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -73,6 +73,10 @@ grouped_option_keys:
     - enabled
     - loaded_keys
     - scope
+  row_status:
+    - row_disabled_builder
+    - row_readonly_builder
+    - row_disabled_reason_builder
 javascript_package_root:
   named_exports:
     - registerTreeViewControllers

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "Public API compatibility" do
     ui_config = instance_double(TreeView::UiConfig)
     row_disabled_builder = ->(item) { item == :disabled }
     row_readonly_builder = ->(item) { item == :readonly }
-    row_disabled_reason_builder = ->(item) { item == :disabled ? "archived" : nil }
+    row_disabled_reason_builder = ->(item) { (item == :disabled) ? "archived" : nil }
 
     state = TreeView::RenderState.new(
       tree: tree,

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -92,11 +92,17 @@ RSpec.describe "Public API compatibility" do
     end
   end
 
+  def dom_id_suffix(item_or_id)
+    return item_or_id.id if item_or_id.respond_to?(:id)
+
+    item_or_id
+  end
+
   def public_ui_config
     TreeView::UiConfig.new(
-      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      button_dom_id_builder: ->(item_or_id) { "node_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      show_button_dom_id_builder: ->(item_or_id) { "node_show_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
+      node_dom_id_builder: ->(item_or_id) { "node_#{dom_id_suffix(item_or_id)}" },
+      button_dom_id_builder: ->(item_or_id) { "node_button_#{dom_id_suffix(item_or_id)}" },
+      show_button_dom_id_builder: ->(item_or_id) { "node_show_button_#{dom_id_suffix(item_or_id)}" }
     )
   end
 

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -17,7 +17,8 @@ RENDER_STATE_GROUPED_OPTION_KEY_RESOLVERS = {
   "render_scope" => -> { TreeView::RenderState::VALID_RENDER_SCOPE_KEYS.map(&:to_s) },
   "toggle_scope" => -> { TreeView::RenderState::VALID_TOGGLE_SCOPE_KEYS.map(&:to_s) },
   "selection" => -> { TreeView::RenderState::SelectionConfig::VALID_KEYS.map(&:to_s) },
-  "lazy_loading" => -> { %w[enabled loaded_keys scope] }
+  "lazy_loading" => -> { %w[enabled loaded_keys scope] },
+  "row_status" => -> { %w[row_disabled_builder row_readonly_builder row_disabled_reason_builder] }
 }.freeze
 
 RSpec.describe "Public API compatibility" do
@@ -153,6 +154,9 @@ RSpec.describe "Public API compatibility" do
   it "keeps representative grouped option behavior available" do
     tree = instance_double(TreeView::Tree)
     ui_config = instance_double(TreeView::UiConfig)
+    row_disabled_builder = ->(item) { item == :disabled }
+    row_readonly_builder = ->(item) { item == :readonly }
+    row_disabled_reason_builder = ->(item) { item == :disabled ? "archived" : nil }
 
     state = TreeView::RenderState.new(
       tree: tree,
@@ -188,7 +192,10 @@ RSpec.describe "Public API compatibility" do
         enabled: true,
         loaded_keys: ["node:1"],
         scope: "children"
-      }
+      },
+      row_disabled_builder: row_disabled_builder,
+      row_readonly_builder: row_readonly_builder,
+      row_disabled_reason_builder: row_disabled_reason_builder
     )
 
     expect(state.initial_state).to eq(:collapsed)
@@ -211,6 +218,9 @@ RSpec.describe "Public API compatibility" do
     expect(state.lazy_loading_enabled?).to eq(true)
     expect(state.lazy_loading_loaded_keys).to eq(["node:1"])
     expect(state.lazy_loading_scope).to eq("children")
+    expect(state.row_disabled_builder).to eq(row_disabled_builder)
+    expect(state.row_readonly_builder).to eq(row_readonly_builder)
+    expect(state.row_disabled_reason_builder).to eq(row_disabled_reason_builder)
   end
 
   it "keeps documented helper method names available through TreeViewHelper" do


### PR DESCRIPTION
## 対応 Issue

Closes #794

## Issue ごとの完了内容

- #794
  - `row_disabled_builder` / `row_readonly_builder` / `row_disabled_reason_builder` を public API manifest に追加しました。
  - public API compatibility spec が manifest の row status key と実際の RenderState reader surface を確認するようにしました。
  - runtime behavior 変更には広げていません。

## 変更内容

- `config/public_api_manifest.yml`
  - `grouped_option_keys.row_status` に current row status builder option を追加
- `spec/public_api_compatibility_spec.rb`
  - manifest の row status key を固定
  - representative RenderState construction で row status builder reader が維持されることを確認

## 改善カテゴリ

- test
- public API drift guard
- small maintenance

## 既存仕様への影響

- runtime behavior、helper behavior、CSS、docs wording、DB schema、認可、JavaScript event contract は変更していません。
- unified `row_status_builder` の追加や row status API redesign には広げていません。

## 確認内容

- GitHub compare: `main...quality/794-row-status-manifest`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- local RSpec / lint: 未実行
  - この実行環境には Ruby がなく、GitHub HTTPS clone / fetch も `CONNECT tunnel failed, response 403` で失敗しました。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- risk: low
- manifest と compatibility spec の drift guard に閉じています。

## 補足事項

- #793 は docs wording の同期、#794 は manifest/spec 側の再発防止なので、PR は別にしています。