### PR TITLE
docs: diverged PR の再同期判断を development docs に追加

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -89,6 +89,8 @@ Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-
 
 Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile.md`, `CHANGELOG.md`, and `AGENTS.md` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
 
+A green check suite does not by itself mean a pull request is ready to merge after `main` has moved. When a branch is `diverged`, check mergeability, changed files, risk, and how far the branch is behind. Prefer refreshing the branch and observing fresh CI when GitHub reports `mergeable: false`, when the branch is far behind, or when the pull request touches workflow definitions, public API, specs, or shared docs inventory. For small docs-only changes that are only a little behind, it is enough to confirm the changed files still apply cleanly, mergeability is true, and the named checks remain green.
+
 Pushes to `main` also run the broader compatibility and release checks:
 
 - Ruby version matrix
@@ -142,4 +144,5 @@ Pushes to `main` also run the broader compatibility and release checks:
 - PR CI must pass before merge.
 - Docs-only PRs may short-circuit the representative Rails and JavaScript jobs, but merge still waits for the named checks to stay green.
 - PRs that change workflow definitions should be observed on a fresh head SHA before merge.
+- If a PR is `diverged` from `main`, do not rely on old green CI alone; review mergeability, changed files, risk, and behind count before deciding whether to refresh.
 - Full compatibility and package verification is confirmed on `main` before release decisions.

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -89,6 +89,8 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 
 `README.md`、`docs/**`、`Product Profile.md`、`CHANGELOG.md`、`AGENTS.md` だけに触れる docs-only Pull Request では、`lint` と `pr_specs` はそのまま残しつつ、representative Rails job と JavaScript job を short-circuit します。branch protection のため、check 名はそのまま維持します。`.github/workflows/**` も変更する Pull Request ではこの shortcut を使わず、通常の PR lanes を確認します。
 
+`main` が進んで branch が `diverged` になった後は、green checks だけでは merge ready と判断しません。`mergeable`、changed files、risk、behind の大きさを確認します。GitHub が `mergeable: false` を返す場合、behind が大きい場合、または workflow 定義、public API、spec、shared docs inventory に触れる Pull Request では、branch refresh 後に fresh CI を観測することを優先します。小さく少しだけ behind している docs-only 変更では、changed files が clean に適用でき、`mergeable` が true で、同じ check 名が green のままなら、過度に重い refresh を必須にしなくてかまいません。
+
 `main` へのpushでは、より広い互換性確認とrelease向けのchecksも実行します。
 
 - Ruby version matrix
@@ -142,4 +144,5 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 - merge前にPR CIを通す
 - docs-only PR では representative Rails / JavaScript job を short-circuit できるが、merge は同じ check 名が green のままで待つ
 - workflow 定義を変えるPRは、merge前に fresh な head SHA で Checks を観測する
+- PR が `main` から `diverged` している場合は、古い green CI だけに頼らず、refresh するかを決める前に mergeability、changed files、risk、behind count を確認する
 - release判定前に `main` でfull compatibility / package verificationを確認する


### PR DESCRIPTION
## 対応 Issue

Closes #800

## Issue ごとの完了内容

- #800
  - green CI だけでは diverged PR の merge readiness を判断しない方針を英日 development docs に追記しました。
  - `mergeable`、changed files、risk、behind の大きさを見る判断軸を明記しました。
  - `mergeable: false`、workflow / public API / spec / shared docs inventory 変更、behind が大きい PR では branch refresh 後の fresh CI を優先する方針を入れました。
  - 小さく少しだけ behind している docs-only PR では、過度に重い refresh を必須にしない逃げ道も残しました。

## 変更内容

- `docs/en/development.md`
  - CI policy に diverged PR の確認方針を追加
  - Branch and PR policy に old green CI だけへ依存しない注意を追加
- `docs/ja/development.md`
  - 英語版と同じ判断基準を同期

## 改善カテゴリ

- docs
- CI / PR review guidance
- maintenance workflow clarity

## 既存仕様への影響

- runtime behavior、public API、DB schema、認可、状態遷移、外部サービス契約への影響はありません。
- GitHub settings、branch protection、CI workflow、PR branch 更新 script は変更していません。
- 既存 open PR の branch refresh 作業も行っていません。

## 実施した確認内容

- GitHub compare: `main...docs/800-diverged-pr-guidance`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 (`docs/en/development.md`, `docs/ja/development.md`)
- docs-only 変更のため local test / lint は未実行です。
- この実行環境では GitHub HTTPS clone / fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で source と compare を確認しました。

## リスク評価

- low
- development docs の運用方針追記だけに閉じています。軽い docs-only PR まで refresh 必須と読めないよう、低リスク docs-only の例外も併記しています。

## 補足事項

- 対象3リポジトリの open PR review follow-up も確認しました。CIコメントのみのPRは新規対応不要、`needs-human` や feature/design 範囲のPRは Quality Fixer の自動修正範囲外として扱いました。