### PR TITLE
docs: diverged PR の再同期判断を development docs に残す

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -89,6 +89,8 @@ Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-
 
 Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile.md`, `CHANGELOG.md`, and `AGENTS.md` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails and JavaScript jobs while preserving the same check names for branch protection. Pull requests that also touch `.github/workflows/**` do not use this shortcut and still run the normal PR lanes.
 
+A green CI run belongs to the exact head SHA that produced it. If `main` moves after that run and the pull request becomes diverged, recheck mergeability and the changed-file set before treating the result as merge-ready. Refresh the branch and rerun CI when `mergeable` is false, when workflow files changed, when public API or shared specs changed, or when shared docs inventories such as mockup galleries and i18n audits may conflict. Small docs-only PRs with no overlapping files can usually be refreshed with a narrow docs-only update and the same named checks.
+
 Pushes to `main` also run the broader compatibility and release checks:
 
 - Ruby version matrix
@@ -140,6 +142,7 @@ Pushes to `main` also run the broader compatibility and release checks:
 - Keep functional changes small.
 - Larger docs-only inventory or split PRs are acceptable.
 - PR CI must pass before merge.
+- Treat CI status, mergeability, and `main...branch` divergence together; a green stale head is not enough when the PR is no longer mergeable.
 - Docs-only PRs may short-circuit the representative Rails and JavaScript jobs, but merge still waits for the named checks to stay green.
 - PRs that change workflow definitions should be observed on a fresh head SHA before merge.
 - Full compatibility and package verification is confirmed on `main` before release decisions.

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -89,6 +89,8 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 
 `README.md`、`docs/**`、`Product Profile.md`、`CHANGELOG.md`、`AGENTS.md` だけに触れる docs-only Pull Request では、`lint` と `pr_specs` はそのまま残しつつ、representative Rails job と JavaScript job を short-circuit します。branch protection のため、check 名はそのまま維持します。`.github/workflows/**` も変更する Pull Request ではこの shortcut を使わず、通常の PR lanes を確認します。
 
+Green CI は、その run を作った exact head SHA に対する結果です。その後 `main` が進んで Pull Request が diverged になった場合は、merge-ready と扱う前に mergeability と changed files を確認してください。`mergeable` が false の場合、workflow files を変更している場合、public API や shared specs を変更している場合、mockup gallery や i18n audit のような shared docs inventory が衝突しうる場合は、branch refresh 後に CI を取り直します。重なりのない小さな docs-only PR なら、狭い docs-only update で refresh し、同じ check 名が green になることを確認すれば十分です。
+
 `main` へのpushでは、より広い互換性確認とrelease向けのchecksも実行します。
 
 - Ruby version matrix
@@ -140,6 +142,7 @@ Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScrip
 - 小さな機能変更は小さなPRにする
 - docs-onlyで単純な分割や棚卸しは大きめのPRでもよい
 - merge前にPR CIを通す
+- CI status、mergeability、`main...branch` の divergence を合わせて確認する。PR がすでに mergeable でない場合、green だった古い head だけでは十分ではない
 - docs-only PR では representative Rails / JavaScript job を short-circuit できるが、merge は同じ check 名が green のままで待つ
 - workflow 定義を変えるPRは、merge前に fresh な head SHA で Checks を観測する
 - release判定前に `main` でfull compatibility / package verificationを確認する


### PR DESCRIPTION
## 対応 Issue

Closes #800

## 判定分類

- `docs-sync`
- `docs-missing`

## 変更内容

CI が green でも `main` が進んで PR が diverged になった場合の再同期判断を、英日 development docs に最小追記しました。

- `docs/en/development.md`
  - CI 方針に、green CI は exact head SHA の結果であることを追記
  - `mergeable: false`、workflow / public API / shared specs / shared docs inventory 変更時は branch refresh 後に CI を取り直す判断を追加
  - branch / PR policy に CI status、mergeability、`main...branch` divergence を合わせて見る旨を追加
- `docs/ja/development.md`
  - 英語版と同じ判断基準を同期

## 既存仕様への影響

- docs-only です。
- GitHub settings、branch protection、CI workflow 実体、required check names、PR branch 更新 script は変更していません。
- 既存 open PR の branch refresh はこの PR では行っていません。

## 確認内容

- GitHub compare: `main...docs/800-diverged-pr-development-docs`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: docs 2 files
- local test / lint: 未実行
  - docs-only 変更です。

## リスク

- low
- 運用判断の明文化のみで、CI behavior は変更していません。