### PR TITLE
test: remote-state placeholder helper の state contract を固定する

### DIFF
--- a/spec/helpers/tree_remote_state_placeholder_attributes_spec.rb
+++ b/spec/helpers/tree_remote_state_placeholder_attributes_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "tree_remote_state_placeholder_attributes" do
+  def test_node(id)
+    Struct.new(:id, keyword_init: true).new(id: id)
+  end
+
+  def helper_with_ui
+    helper_class = Class.new do
+      include TreeViewHelper
+
+      attr_accessor :tree_ui
+    end
+
+    helper_class.new.tap do |helper|
+      helper.tree_ui = TreeView::UiConfig.new(
+        node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+        button_dom_id_builder: ->(item_or_id) { "node_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+        show_button_dom_id_builder: ->(item_or_id) { "node_show_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
+      )
+    end
+  end
+
+  it "keeps the no-state placeholder id contract" do
+    helper = helper_with_ui
+    item = test_node(1)
+
+    expect(helper.tree_remote_state_placeholder_attributes(item)).to eq({id: "node_1_remote_state"})
+  end
+
+  it "keeps documented loaded and error states as data attributes" do
+    helper = helper_with_ui
+    item = test_node(1)
+
+    expect(helper.tree_remote_state_placeholder_attributes(item, state: "loaded")).to eq({
+      id: "node_1_remote_state",
+      data: {tree_remote_state: "loaded"}
+    })
+    expect(helper.tree_remote_state_placeholder_attributes(item, state: :error)).to eq({
+      id: "node_1_remote_state",
+      data: {tree_remote_state: "error"}
+    })
+  end
+
+  it "passes host-app state values through with string coercion instead of validation" do
+    helper = helper_with_ui
+    item = test_node(1)
+
+    expect(helper.tree_remote_state_placeholder_attributes(item, state: :loading)).to eq({
+      id: "node_1_remote_state",
+      data: {tree_remote_state: "loading"}
+    })
+    expect(helper.tree_remote_state_placeholder_attributes(item, state: "retry")).to eq({
+      id: "node_1_remote_state",
+      data: {tree_remote_state: "retry"}
+    })
+  end
+end


### PR DESCRIPTION
## 対応 Issue

Closes #767

## Issue ごとの完了内容

- #767
  - `tree_remote_state_placeholder_attributes` の no-state contract を専用 helper spec で確認しました。
  - docs で使われている `state: "loaded"` と `state: :error` の代表挙動を確認しました。
  - helper が state value を validation せず `to_s` で data attribute に載せる current behavior を `:loading` / `"retry"` の代表 case で固定しました。

## 変更内容

- `spec/helpers/tree_remote_state_placeholder_attributes_spec.rb` を追加
  - public helper surface に近い小さな helper class を使い、stable DOM id と `data-tree-remote-state` 相当の Rails data hash を検証

## 改善カテゴリ

- test
- public helper compatibility guard

## 既存仕様への影響

- runtime implementation、public helper signature、remote-state controller behavior、Turbo response pattern、fetch / retry implementation、docs 本文は変更していません。
- 既存挙動を spec で固定するだけの変更です。

## 実施した確認内容

- GitHub compare: `main...quality/767-remote-state-placeholder-contract`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 spec file
- PR metadata: `mergeable: true`
- CI run `#1053`: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
- local test / lint: 未実行
  - この実行環境では GitHub HTTPS clone / fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で source diff を確認しています。

## リスク評価

- low
- spec-only の public helper contract guard です。

## 補足事項

- helper 本体はすでに `state.to_s` behavior を持っているため、docs 追記ではなく spec で current contract を固定する形に留めました。