### PR TITLE
docs: empty-state guidance を usage docs へつなぐ

### DIFF
--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -16,6 +16,16 @@ The usual flow is:
 
 TreeView renders the tree UI primitives. Host apps remain responsible for application-specific CRUD, authorization, persistence, server-side queries, Turbo Stream responses, and business actions.
 
+## Empty root and no-results rows
+
+When a screen has no root items or a filtered search returns no rows, keep the empty copy, CTA, permission messaging, and filter-reset behavior in the host app. Render the empty state in the table body at the same point where the screen would normally render `tree_view_rows(@render_state)`, then reuse TreeView's documented baseline hooks when the row should match the shared mockup:
+
+- `data-tree-view-empty-state="true"`
+- `.tree-view-empty-row__content`
+- `.tree-view-empty-row__message`
+
+For the focused visual reference and hook boundary, see [empty-state.html](../mockups/empty-state.html) and the [mockup empty-state guidance](../mockups/README.md#empty-state-guidance).
+
 ## Toggle modes
 
 Choose the toggle mode per tree instance. One host app can use different modes on different screens, or even render multiple trees with different modes on the same page.

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -14,6 +14,16 @@ language-specific docs 全体の入口と関連ガイドは [docs index](../READ
 
 TreeView gem はツリーUIの基盤を提供します。CRUD、認可、保存、server-side query、Turbo Stream response、業務固有actionはhost app側で実装します。
 
+## root items が空の場合 / no-results row
+
+root items が空の画面や、filter / search の結果が0件になった画面では、empty copy、CTA、permission messaging、filter reset behavior は host app 側で決めます。通常 `tree_view_rows(@render_state)` を置く table body の位置に empty state を描画し、共通 mockup と同じ見た目に寄せたい場合は TreeView の documented baseline hook を再利用してください。
+
+- `data-tree-view-empty-state="true"`
+- `.tree-view-empty-row__content`
+- `.tree-view-empty-row__message`
+
+focused visual reference と hook boundary は [empty-state.html](../mockups/empty-state.html) と [mockup empty-state guidance](../mockups/README.md#empty-state-guidance) を参照してください。
+
 ## toggle mode
 
 開閉方式はtree instanceごとに選びます。1つのhost app内で画面ごとに使い分けたり、同じpage内に異なるmodeのtreeを並べたりできます。


### PR DESCRIPTION
## 対応 Issue

Closes #809

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

`docs/mockups/empty-state.html` と `docs/mockups/README.md#empty-state-guidance` にある empty-state hook guidance へ、英日 usage docs から辿れる導線を追加しました。

- `docs/en/usage.md`
  - Basic flow の直後に empty root / no-results rows の短い節を追加
  - empty copy、CTA、permission messaging、filter reset behavior は host app responsibility と明記
  - `data-tree-view-empty-state="true"`、`.tree-view-empty-row__content`、`.tree-view-empty-row__message` と mockup へのリンクを追加
- `docs/ja/usage.md`
  - 英語版と同じ責務境界と hook 導線を同期

## 既存仕様への影響

- docs-only です。
- runtime helper、partials、CSS、mockup HTML 本体、empty-state helper / option の追加には触れていません。
- `docs/en|ja/troubleshooting.md` は、今回の論点が「基本的な描画導線」でありエラー診断ではないため変更していません。

## 確認内容

- `app/helpers/tree_view_helper/rendering.rb` と `app/views/tree_view/_tree_empty_row.html.erb` で current empty-row hook を確認
- `docs/mockups/README.md` の Empty-state guidance と矛盾しないことを確認
- GitHub compare: `main...docs/809-empty-state-usage-guidance`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: `docs/en/usage.md`, `docs/ja/usage.md`

## リスク

- low
- 既存 hook への docs 導線追加に閉じており、仕様判断やコード変更はありません。