### PR TITLE
docs: StateStore#clear! を CHANGELOG に反映する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added `tree_view_toolbar(render_state)` for rendering tree-wide expand/collapse toolbar actions through `UiConfig#toggle_all_path`.
 - Added `TreeView::NodePresenter` as a thin adapter for node-level resolver hooks and `RenderState` row class/data/icon/badge builders.
 - Added owner model argument support to the persisted state install generator so `tree_view:state:install User` can include `TreeViewStateOwner` in an existing owner model.
+- Added `TreeView::StateStore#clear!` so host apps can clear saved expansion state for an owner and tree instance key.
 - Added `RenderState` current node ancestor expansion via `current_item` / `current_key` and `auto_expand_ancestors`.
 - Added `TreeView::PathTreeBuilder` for building generated folder nodes and record nodes from path-like record values.
 - Added `TreeView.configuration.render_log_level`, defaulting to `:warn`, so TreeView helper-rendered partial logs can be silenced without changing the host app's global Rails logger level.


### PR DESCRIPTION
## 対応 Issue

Closes #799

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`

## 変更内容

`TreeView::StateStore#clear!` は PR #784 で public server-side API として main に入り、`docs/en|ja/persisted-state.md` には使用例が反映済みでした。一方で release-facing summary である `CHANGELOG.md` の Unreleased / Added からは追えなかったため、公開 API 追加として 1 行追記しました。

## 確認内容

- PR #784 が merge 済みであることを確認
- `docs/en/persisted-state.md` が `store.clear!` の使い方と host app responsibility boundary を説明済みであることを確認
- `CHANGELOG.md` の `Unreleased` / `Added` に `StateStore#clear!` の public API addition が未掲載だったことを確認

## 範囲外

- `StateStore#clear!` の実装、spec、戻り値、例外設計は変更していません。
- API reference 本体の詳細追従は #788 の範囲として残し、この PR では release-facing summary に閉じています。
- `docs/en|ja/release.md` は public API 変更時に CHANGELOG を確認する方針が既にあり、個別 API 名の追記は不要と判断しました。

## リスク

- low
- docs-only / `CHANGELOG.md` 1 ファイルの追従です。