### PR TITLE
Decision guide に GraphAdapter の選び方を補う

### DIFF
--- a/docs/en/decision-guide.md
+++ b/docs/en/decision-guide.md
@@ -24,6 +24,7 @@ Use render controls first when the data is already available. Use lazy loading o
 | Add full virtual scrolling | Host-app JavaScript | Scroll observers, virtualization library, URL/window state | TreeView does not provide built-in DOM virtualization or infinite-scroll control. Combine it with render metadata only when useful. |
 | Show search results with ancestors | `path_tree_for` | `tree.path_tree_for(matches)` | Use when matched records need enough ancestors to preserve context from root to match. |
 | Show child-to-parent paths | `reverse_tree_for` | `tree.reverse_tree_for(items)` | Use when the primary display starts from children and expands toward parents. |
+| Render heterogeneous or graph-like nodes | [API overview: adapter mode](api-overview.md#adapter-mode) | `TreeView::GraphAdapter`, `TreeView::Tree.new(adapter:)`, `children_resolver`, `node_key_resolver` | Use when one tree mixes different record classes or derives children from graph-like edges instead of one parent-id column. TreeView traverses roots and children supplied by the host app; data model, authorization, cycle policy, and persistence stay in the host app. |
 | Add checkbox selection | `selection:` options plus host-element `tree-view-selection` wiring | `enabled`, `checkbox_name`, `selected_keys`, `disabled_builder`, `disabled_reason_builder`, `visibility`, `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Use grouped `selection:` options for row payload generation, disabled reasons, and checkbox visibility. Use the controller value attributes for hidden-input sync, client-side max-count limits, and rendered-row cascade / indeterminate behavior. TreeView renders selection state and values; the host app still owns the submitted business action. |
 | Add editable fields inside rows | [Forms and editing rows](form-editing.md) and [Cookbook](cookbook.md#row-customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Objects | TreeView supports inline-editing layouts. The host app owns edit mode, validation, persistence, authorization, dirty-state handling, and Turbo workflows. |
 | Add row action buttons | [Cookbook](cookbook.md#row-customization-quick-guide) | `row_actions_partial` | Recommended slot for Edit, Show, Delete, Archive, and custom host-app actions. |
@@ -55,6 +56,7 @@ flowchart TD
   A --> M{Is the tree derived from a subset?}
   M -->|Search matches need ancestors| N[path_tree_for]
   M -->|Children should point back to parents| O[reverse_tree_for]
+  M -->|Mixed node classes or graph-like edges| GA[GraphAdapter with host-app roots, children_resolver, and node_key_resolver]
   A --> P{Need interaction state?}
   P -->|Checkboxes| Q[selection: options]
   P -->|Editable fields or row actions| X[row_partial / row_actions_partial plus host-app workflows]
@@ -84,10 +86,11 @@ flowchart TD
 2. Add [API overview](api-overview.md) concepts only when the use case needs them.
 3. Use [Render Scale](render-scale.md) when HTML size or visible row count becomes the issue.
 4. Use [Lazy Loading](lazy-loading.md) and [Children Pagination](children-pagination.md) when query volume or child count is the issue; those pages include copyable host-app controller, Turbo Stream, cursor, and retry patterns.
-5. Use `build_client_side` when the data is already available, initial HTML volume is acceptable, and Turbo endpoints would be unnecessary overhead.
-6. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
-7. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
-8. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
+5. Use [GraphAdapter adapter mode](api-overview.md#adapter-mode) when the tree mixes different record classes or graph-like edges and cannot be represented cleanly by one parent-id column.
+6. Use `build_client_side` when the data is already available, initial HTML volume is acceptable, and Turbo endpoints would be unnecessary overhead.
+7. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
+8. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
+9. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
 
 ## Common combinations
 
@@ -96,6 +99,7 @@ flowchart TD
 | Small admin taxonomy | Static tree + `max_initial_depth` if needed |
 | Small docs sidebar with local opening | Client-side mode + `initial_state: :collapsed` + render scope as needed |
 | Large folder browser | Lazy Loading + Children Pagination + Persisted State |
+| Heterogeneous project workspace | GraphAdapter + stable `node_key_resolver` + host-app row partial / presenter |
 | Large scrolling browser | Host-app virtual scrolling + render/window metadata as needed |
 | Search page | `path_tree_for` + render scope around matches |
 | Breadcrumb-like reverse view | `reverse_tree_for` + custom row partial |
@@ -109,6 +113,7 @@ flowchart TD
 ## Related docs
 
 - [API overview](api-overview.md)
+- [API overview: adapter mode](api-overview.md#adapter-mode)
 - [API reference](api.md)
 - [Cookbook: Row customization quick guide](cookbook.md#row-customization-quick-guide)
 - [Render Scale](render-scale.md)

--- a/docs/ja/decision-guide.md
+++ b/docs/ja/decision-guide.md
@@ -24,6 +24,7 @@ TreeViewのAPIは大きく分けると次の2種類です。
 | full virtual scrollingを追加したい | host app JavaScript | scroll observer、virtualization library、URL/window state | TreeViewは組み込みのDOM仮想化やinfinite-scroll制御を提供しません。必要に応じてrender metadataと組み合わせます。 |
 | 検索結果をancestor付きで表示したい | `path_tree_for` | `tree.path_tree_for(matches)` | matchしたrecordをrootからの文脈付きで表示したい場合に使います。 |
 | childからparentへ辿る表示をしたい | `reverse_tree_for` | `tree.reverse_tree_for(items)` | 子側を起点にして親方向へ展開する表示に使います。 |
+| 異種node混在やgraph-like nodeを描画したい | [API概要: adapter mode](api-overview.md#adapter-mode) | `TreeView::GraphAdapter`, `TreeView::Tree.new(adapter:)`, `children_resolver`, `node_key_resolver` | 1つのparent id columnだけでは表しにくい、複数record class混在やgraph-like edge由来のtreeに使います。TreeViewはhost appが渡すrootとchildrenを辿ります。data model、authorization、cycle policy、保存はhost app側の責務です。 |
 | checkbox selectionを追加したい | `selection:` option と host element 上の `tree-view-selection` wiring | `enabled`, `checkbox_name`, `selected_keys`, `disabled_builder`, `disabled_reason_builder`, `visibility`, `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | row payload 生成、disabled reason、checkbox visibility は grouped `selection:` option 側で決めます。hidden input sync、client-side の最大選択数制限、描画済み row の cascade / indeterminate は controller value attribute 側で設定します。TreeViewはselection stateとvalueを描画しますが、送信後の業務 action は引き続き host app が担当します。 |
 | 行内に編集fieldを置きたい | [Form と編集行](form-editing.md) と [Cookbook](cookbook.md#行customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Object | TreeViewはinline-editing layoutを支援します。edit mode、validation、persistence、authorization、dirty-state handling、Turbo workflowはhost appが担当します。 |
 | 行action buttonを追加したい | [Cookbook](cookbook.md#行customization-quick-guide) | `row_actions_partial` | Edit、Show、Delete、Archive、host app固有actionの推奨slotです。 |
@@ -55,6 +56,7 @@ flowchart TD
   A --> M{subsetからtreeを作りたい?}
   M -->|検索matchにancestorが必要| N[path_tree_for]
   M -->|childからparentへ見せたい| O[reverse_tree_for]
+  M -->|異種node混在やgraph-like edge| GA[GraphAdapter と host-app roots / children_resolver / node_key_resolver]
   A --> P{interaction stateが必要?}
   P -->|checkbox| Q[selection: options]
   P -->|編集fieldや行action| X[row_partial / row_actions_partial と host-app workflow]
@@ -84,10 +86,11 @@ flowchart TD
 2. 必要になったuse caseに応じて [API概要](api-overview.md) の概念を足します。
 3. HTML量やvisible row数が問題になったら [Render Scale](render-scale.md) を使います。
 4. query量や子要素数が問題になったら [Lazy Loading](lazy-loading.md) と [Children Pagination](children-pagination.md) を使います。これらのページには、host app controller、Turbo Stream、cursor、retry patternのコピー可能な例があります。
-5. dataは取得済みで、初期HTML量を許容でき、Turbo endpointが過剰な場合は `build_client_side` を使います。
-6. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
-7. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
-8. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
+5. 1つのparent id columnだけでは扱いにくい異種recordやgraph-like edgeがある場合は [GraphAdapter adapter mode](api-overview.md#adapter-mode) を使います。
+6. dataは取得済みで、初期HTML量を許容でき、Turbo endpointが過剰な場合は `build_client_side` を使います。
+7. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
+8. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
+9. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
 
 ## よくある組み合わせ
 
@@ -96,6 +99,7 @@ flowchart TD
 | 小さな管理用taxonomy | Static tree + 必要に応じて `max_initial_depth` |
 | 小さなdocs sidebarのlocal開閉 | Client-side mode + `initial_state: :collapsed` + 必要に応じてrender scope |
 | 大きなfolder browser | Lazy Loading + Children Pagination + Persisted State |
+| 異種nodeを含むproject workspace | GraphAdapter + 安定した `node_key_resolver` + host-app row partial / presenter |
 | 大きなscrolling browser | host app virtual scrolling + 必要に応じてrender/window metadata |
 | 検索ページ | `path_tree_for` + match周辺のrender scope |
 | breadcrumb風のreverse view | `reverse_tree_for` + custom row partial |
@@ -109,6 +113,7 @@ flowchart TD
 ## 関連docs
 
 - [API概要](api-overview.md)
+- [API概要: adapter mode](api-overview.md#adapter-mode)
 - [API仕様](api.md)
 - [Cookbook: 行customization quick guide](cookbook.md#行customization-quick-guide)
 - [Render Scale](render-scale.md)


### PR DESCRIPTION
## 概要

Issue #812 の docs-only follow-up です。

`README.md` と `docs/en|ja/api-overview.md` では `GraphAdapter` が heterogeneous / graph-like nodes 向けの public API として案内されていますが、API 選択の入口である Decision guide からは選ぶ場面が薄かったため、日英の Decision guide に最小導線を追加しました。

## 変更内容

- `docs/en/decision-guide.md`
  - use-case table に `GraphAdapter` / adapter mode の選択肢を追加
  - flowchart、project stage、common combinations、related docs に adapter mode への導線を追加
- `docs/ja/decision-guide.md`
  - 英語版と同じ内容を日本語側にも同期

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`

## 確認観点

- current `lib/tree_view/graph_adapter.rb` と `docs/en|ja/api-overview.md` の adapter mode 説明に沿っていること
- Graph traversal / authorization / cycle handling / persistence の新仕様を追加していないこと
- runtime code、mockup、README 全体再構成には広げていないこと

Closes #812