### PR TITLE
LocalizedNames docs の NodePresenter example を representative spec で固定する

### DIFF
--- a/spec/lib/tree_view/node_presenter_spec.rb
+++ b/spec/lib/tree_view/node_presenter_spec.rb
@@ -4,6 +4,47 @@ require "spec_helper"
 
 NodePresenterTestNode = Struct.new(:id, :name, :kind, keyword_init: true)
 
+class NodePresenterLocalizedModelName
+  def human(count: 1, default: nil)
+    I18n.t(
+      :node_presenter_localized_document,
+      scope: "activemodel.models",
+      count: count,
+      default: default
+    )
+  end
+end
+
+class NodePresenterLocalizedDocument
+  attr_reader :node_type, :status
+
+  def initialize(node_type:, status: nil)
+    @node_type = node_type
+    @status = status
+  end
+
+  def self.model_name
+    NodePresenterLocalizedModelName.new
+  end
+
+  def self.human_attribute_name(attribute_name, default: nil)
+    I18n.t(
+      attribute_name,
+      scope: "activemodel.attributes.node_presenter_localized_document",
+      default: default
+    )
+  end
+end
+
+class NodePresenterTitledDocument < NodePresenterLocalizedDocument
+  attr_reader :title
+
+  def initialize(title:, node_type:, status: nil)
+    super(node_type: node_type, status: status)
+    @title = title
+  end
+end
+
 RSpec.describe TreeView::NodePresenter do
   let(:node) { NodePresenterTestNode.new(id: 1, name: "Guide", kind: "document") }
 
@@ -43,6 +84,46 @@ RSpec.describe TreeView::NodePresenter do
     expect(presenter.row_data_builder.call(node)).to eq({node_kind: "document"})
     expect(presenter.badge_builder.call(node)).to eq("Guide")
     expect(presenter.icon_builder.call(node)).to eq("document")
+  end
+
+  it "composes localized names through presenter builders" do
+    I18n.backend.store_translations(
+      :en,
+      activemodel: {
+        models: {
+          node_presenter_localized_document: {
+            one: "Document"
+          }
+        },
+        attributes: {
+          node_presenter_localized_document: {
+            status: "Status"
+          }
+        }
+      },
+      tree_view: {
+        node_types: {
+          report: "Report"
+        }
+      }
+    )
+
+    presenter = described_class.define do
+      label { |item| item.respond_to?(:title) ? item.title : TreeView.model_name_for(item) }
+      tooltip { |item| TreeView.type_name_for(item) }
+      badge { |item| TreeView.attribute_name_for(item, :status) if item.respond_to?(:status) }
+    end
+    titled_document = NodePresenterTitledDocument.new(title: "Quarterly report", node_type: :report, status: :draft)
+    translated_document = NodePresenterLocalizedDocument.new(node_type: :report, status: :draft)
+    fallback_document = NodePresenterLocalizedDocument.new(node_type: :generated_folder)
+
+    expect(presenter.label_for(titled_document)).to eq("Quarterly report")
+    expect(presenter.label_for(translated_document)).to eq("Document")
+    expect(presenter.tooltip_for(translated_document)).to eq("Report")
+    expect(presenter.badge_for(translated_document)).to eq("Status")
+    expect(presenter.tooltip_for(fallback_document)).to eq("Generated folder")
+  ensure
+    I18n.reload!
   end
 
   it "allows immutable chaining through builder methods" do


### PR DESCRIPTION
## 対応 Issue

Closes #818

## Issue ごとの完了内容

- #818
  - `TreeView::NodePresenter.define` の `label` / `tooltip` / `badge` から `TreeView.model_name_for`、`TreeView.type_name_for`、`TreeView.attribute_name_for` を呼ぶ representative spec を追加しました。
  - I18n translation がある model name、node type、attribute label が presenter 経由でも解決されることを確認します。
  - docs example の `label` 分岐について、title あり item と title なし item の model name fallback の両方を固定しました。
  - 既存の `LocalizedNames` 単体 fallback spec とは責務を分け、呼び出し元である `NodePresenter` 側の composition だけを guard しています。

## 変更内容

- `spec/lib/tree_view/node_presenter_spec.rb` に presenter 用の小さな test fixture と spec を追加しました。
- docs の NodePresenter example と同じ形の builder composition を spec に置きました。
- `spec/lib/tree_view/localized_names_spec.rb` には変更を残していません。
- review follow-up として current `main` 起点の clean commit に refresh し、PR diff を spec 1 ファイルに戻しました。

## 受け入れ条件との対応

- `label` / `tooltip` / `badge` builder 経由で localized helper を呼ぶ representative case を追加しました。
- title あり item は item 側 title を返し、title なし item は `TreeView.model_name_for` fallback を通すことを確認します。
- translated node type と missing translation fallback を `TreeView.type_name_for` 経由で確認します。
- attribute label を `TreeView.attribute_name_for(item, :status)` 経由で確認します。
- runtime behavior、public API、docs 本文には触れていません。

## 変更範囲

- `spec/lib/tree_view/node_presenter_spec.rb`

## 実施した確認

- GitHub compare: `main...quality/818-localized-names-node-presenter-spec`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: `spec/lib/tree_view/node_presenter_spec.rb`
- PR metadata
  - head: `7d49f9717023012b588006bd0a596addb815f832`
  - `mergeable: true`
- CI run `#1072`: success
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success
  - `pr_rails_matrix (7.0, gemfiles/rails_7_0.gemfile, 3.2)`: success
  - `pr_rails_matrix (7.2, gemfiles/rails_7_2.gemfile, 3.2)`: success
  - `pr_rails_matrix (8.0, gemfiles/rails_8_0.gemfile, 3.3)`: success
  - full `rails_matrix` / `ruby_matrix` / `gem_package`: skipped by workflow policy for this PR shape
- local test / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch / diff / CI を確認しています。

## リスク評価

- low
- spec-only の regression guard です。

## 未対応・補足

- localized convenience / preset の新 API 追加、docs / cookbook 導線追加、visual mockup 追加には広げていません。