### PR TITLE
lazy-loading guide に handoff mockup 導線を追加する

### DIFF
--- a/docs/en/lazy-loading.md
+++ b/docs/en/lazy-loading.md
@@ -143,6 +143,8 @@ When you render the host-app placeholder regions, TreeView can also generate the
 
 These helper names are part of the documented public helper surface. Host apps may depend on them directly when wiring placeholder regions or Turbo Stream replacements.
 
+For a static visual companion to this boundary, see [lazy-loading-handoff.html](../mockups/lazy-loading-handoff.html). The mockup isolates children container ownership, remote-state placeholder handoff, and error/retry slots without adding Rails routes, fetch behavior, or authorization policy.
+
 ## Turbo Stream response pattern
 
 Return only the subtree or placeholder region the host app owns. For example:

--- a/docs/ja/lazy-loading.md
+++ b/docs/ja/lazy-loading.md
@@ -143,6 +143,8 @@ host app側のplaceholder領域を描画するときは、TreeView helper で ch
 
 これらの helper 名も documented public helper surface の一部です。placeholder region や Turbo Stream replacement を組むとき、host app はこれらを直接使ってかまいません。
 
+この境界を静的に確認する visual companion として、[lazy-loading-handoff.html](../mockups/lazy-loading-handoff.html) も参照してください。この mockup は Rails routes、fetch behavior、authorization policy を追加せず、children container の所有、remote-state placeholder の handoff、error / retry slot の境界だけを切り出しています。
+
 ## Turbo Stream response pattern
 
 host appが所有するsubtreeやplaceholder領域だけを返します。


### PR DESCRIPTION
## 概要

Issue #668 の docs-only follow-up です。

`lazy-loading-handoff.html` が current `main` の mockup inventory に入ったため、日英の lazy-loading guide から placeholder region / remote-state handoff の focused mockup へ辿れる導線を追加しました。

## 変更内容

- `docs/en/lazy-loading.md`
  - host-app-owned placeholder region と remote-state element の説明直後に `lazy-loading-handoff.html` への visual companion link を追加
- `docs/ja/lazy-loading.md`
  - 英語版と同じ位置・同じ責務境界で日本語導線を追加

## 判定分類

- `docs-stale`
- `docs-sync`

## 確認観点

- current `docs/mockups/README.md` に `lazy-loading-handoff.html` が存在すること
- runtime lazy-loading behavior、Turbo/fetch contract、mockup HTML/CSS 本体には触れていないこと
- host app が routes / fetch behavior / authorization policy を持つ責務境界を変えていないこと

Closes #668