### PR TITLE
gem package contents の entrypoint 同梱確認を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,5 +178,6 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - run: gem build tree_view.gemspec
+      - run: ruby script/check_gem_package_contents.rb tree_view-*.gem
       - run: gem install tree_view-*.gem
       - run: ruby -e "require 'tree_view'"

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -59,7 +59,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, verifies the gem can be built, confirms release-facing files are packaged, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. It skips tag alignment until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
+`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, verifies the gem can be built, confirms release-facing files are packaged, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The main-push `gem_package` CI job additionally runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem so JavaScript, CSS, and importmap entrypoints remain packaged. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
 
 Pull request CI checks:
 
@@ -73,7 +73,7 @@ Main-push CI checks:
 - Ruby version matrix
 - Rails version matrix
 - JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
-- Gem package verification
+- Gem package verification, including JavaScript, CSS, and importmap file contents
 
 PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes compatibility matrices, JavaScript coverage, and package verification.
 
@@ -129,10 +129,14 @@ Before release:
 
 - Confirm `TreeView::VERSION` matches the release version.
 - Run `gem build tree_view.gemspec`.
+- Run `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem.
 - Install the generated gem locally and confirm `require "tree_view"` works.
 - Confirm packaged files include:
   - `lib/**/*`
   - Rails helpers, views, stylesheets, JavaScript, and importmap files
+  - `app/javascript/tree_view/index.js`
+  - `app/assets/stylesheets/tree_view.scss`
+  - `config/importmap.tree_view.rb`
   - `README.md`
   - `CHANGELOG.md`
   - `docs/**/*`

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -59,7 +59,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
+`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。main-push の `gem_package` CI job では、built gem に JavaScript / CSS / importmap entrypoint が残っていることを `ruby script/check_gem_package_contents.rb tree_view-*.gem` でも確認します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
 
 Pull Request CI の確認項目:
 
@@ -73,7 +73,7 @@ Pull Request CI の確認項目:
 - Ruby version matrix
 - Rails version matrix
 - `package-lock.json` が `package.json` と同期するまでの間は、`npm install` と `npm run test:js` による JavaScript tests
-- Gem package verification
+- JavaScript / CSS / importmap file contents を含む Gem package verification
 
 merge前にPR CIを通します。互換性matrix、JavaScript coverage、package verificationを含むため、release判定にはより広い `main` CIを使います。
 
@@ -129,10 +129,14 @@ release前に確認すること:
 
 - `TreeView::VERSION` がrelease versionと一致することを確認する
 - `gem build tree_view.gemspec` を実行する
+- built gem に対して `ruby script/check_gem_package_contents.rb tree_view-*.gem` を実行する
 - 生成gemをローカルinstallして `require "tree_view"` を確認する
 - packaged filesに以下が含まれることを確認する
   - `lib/**/*`
   - Rails helpers, views, stylesheets, JavaScript, importmap files
+  - `app/javascript/tree_view/index.js`
+  - `app/assets/stylesheets/tree_view.scss`
+  - `config/importmap.tree_view.rb`
   - `README.md`
   - `CHANGELOG.md`
   - `docs/**/*`

--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rubygems/package"
+
+REQUIRED_PACKAGED_PATHS = %w[
+  app/javascript/tree_view/index.js
+  app/assets/stylesheets/tree_view.scss
+  config/importmap.tree_view.rb
+].freeze
+
+root = File.expand_path("..", __dir__)
+gem_path = ARGV.first || Dir[File.join(root, "tree_view-*.gem")].max_by { |path| File.mtime(path) }
+
+abort "No built gem found. Run `gem build tree_view.gemspec` first." unless gem_path
+
+files = Gem::Package.new(gem_path).spec.files
+missing = REQUIRED_PACKAGED_PATHS.reject { |path| files.include?(path) }
+
+if missing.empty?
+  puts "Gem package contents verified: #{File.basename(gem_path)}"
+else
+  warn "Gem package contents verification failed: #{File.basename(gem_path)}"
+  warn "Missing packaged files:"
+  missing.each { |path| warn "  - #{path}" }
+  abort "Gem package contents verification failed."
+end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #825

## Issue ごとの完了内容

- #825
  - built `.gem` の contents から `app/javascript/tree_view/index.js`、`app/assets/stylesheets/tree_view.scss`、`config/importmap.tree_view.rb` の同梱を確認する軽量 Ruby script を追加しました。
  - `gem_package` job で `gem build` 後、install / require check の前にこの contents check を実行するようにしました。
  - 日英 release checklist に、local / CI で package contents check が確認する代表 entrypoint を追記しました。

## 変更内容

- `script/check_gem_package_contents.rb` を追加
- `.github/workflows/ci.yml` の `gem_package` job に `ruby script/check_gem_package_contents.rb tree_view-*.gem` を追加
- `docs/en/release.md` / `docs/ja/release.md` に gem contents check と対象ファイルを追記

## 改善カテゴリ

- CI / build safety
- package verification
- docs

## 既存仕様への影響

- 既存仕様への影響はありません。
- runtime behavior、public API、JavaScript behavior、importmap strategy、gemspec packaging target は変更していません。
- PR CI job 名や branch protection 前提も変更していません。main-push の release gate だけを小さく強化しています。

## 実施した確認

- GitHub compare: `main...quality/825-gem-package-contents-check`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- local `gem build` / script / install / require / standardrb は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch / diff を作成しています。
- PR 作成後の GitHub Actions で PR CI を確認します。
  - この package contents check 自体は `main` push の `gem_package` job で走る設計です。

## リスク評価

- low
- `.gem` の spec file list を読む deterministic check の追加です。flaky / slow な browser や npm 処理は追加していません。

## 補足事項

- npm publishing、package root exports redesign、importmap strategy 変更、Rails install generator 追加、runtime public API 変更には広げていません。