### PR TITLE
mockup review gallery に review path 導線を追加する

### DIFF
--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -35,6 +35,47 @@
   color: #1d4ed8;
 }
 
+.mock-gallery-review-paths {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+  padding: 18px;
+  border: 1px solid #d8e0ea;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.mock-gallery-review-paths h2,
+.mock-gallery-review-paths p {
+  margin: 0;
+}
+
+.mock-gallery-review-path-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.mock-gallery-review-path-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-gallery-review-path-links a:hover,
+.mock-gallery-review-path-links a:focus {
+  border-color: #1d4ed8;
+  background: #eff6ff;
+  outline: 2px solid transparent;
+}
+
 .mock-gallery-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -159,6 +200,19 @@
         <li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li>
         <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li>
       </ul>
+      <nav class="mock-gallery-review-paths" aria-labelledby="gallery-review-paths-heading">
+        <h2 id="gallery-review-paths-heading">Review paths</h2>
+        <p>Jump to the first card in a state family, then continue through nearby cards for related comparisons.</p>
+        <div class="mock-gallery-review-path-links">
+          <a href="#gallery-default-heading">Baseline</a>
+          <a href="#gallery-interaction-heading">Interaction states</a>
+          <a href="#gallery-narrow-heading">Responsive and scale</a>
+          <a href="#gallery-breadcrumb-heading">Navigation context</a>
+          <a href="#gallery-path-builder-heading">Generated rows</a>
+          <a href="#gallery-form-heading">Editing and controls</a>
+          <a href="#gallery-empty-heading">Empty and fallback states</a>
+        </div>
+      </nav>
     </section>
 
     <section class="mock-gallery-grid" aria-label="Mockup comparison gallery">


### PR DESCRIPTION
## 対応Issue

- Closes #826

## 採用した方針

- 静的 HTML/CSS のまま、`review-gallery.html` の冒頭に目的別ジャンプ導線を追加しました。
- 自動実行のためユーザー選択は待たず、既存 iframe card / comparison table を source of truth として保つ低リスク案を採用しました。
- gallery を JavaScript-heavy app にせず、カテゴリ移動だけを補うことで review speed を上げる方針です。

## 比較した案

- 案A: CSS/HTML のジャンプ導線を追加する
  - 採用。実装範囲が `review-gallery.html` だけで、既存 card と iframe preview を壊しにくい。
- 案B: JavaScript filter を追加する
  - 未採用。目的別の絞り込みは強いが、状態管理と hidden card の keyboard / screen-reader 境界が増える。
- 案C: README の recommended review flow を再構成する
  - 未採用。Issue の主対象が gallery であり、README 全体の導線整理へ広がりやすい。

## 変更内容

- `review-gallery.html` の usage section に `Review paths` ナビゲーションを追加
- Baseline / Interaction states / Responsive and scale / Navigation context / Generated rows / Editing and controls / Empty and fallback states へジャンプできる anchor link を追加
- mobile 幅でも chip が折り返す CSS を追加
- hover / focus 時に境界と背景が変わるようにし、keyboard navigation の見つけやすさを補強

## 変更した画面・コンポーネント

- `docs/mockups/review-gallery.html`

## 確認内容

- lint: 未実行（static HTML/CSS の 1 file change）
- typecheck: 対象外
- UI表示確認: diff で nav 追加箇所と既存 card anchor の対応を確認
- レスポンシブ確認: CSS が `flex-wrap` を使い、狭幅でも link chip が折り返すことを確認
- アクセシビリティ確認: `nav` + `aria-labelledby` と既存 heading id への anchor link に閉じていることを確認

## スクリーンショット

<!-- connector-only 実行のため未添付。静的 HTML/CSS の差分は PR diff で確認してください。 -->

## リスク

- low

## 補足

- individual focused mockup の内容、README の recommended review flow、Rails routes、host-app CRUD / authorization / business copy には触れていません。
