### PR TITLE
RenderWindow に before / after row count metadata を追加する

### DIFF
--- a/docs/en/windowed-rendering.md
+++ b/docs/en/windowed-rendering.md
@@ -43,8 +43,12 @@ Main metadata:
 | `offset` | Start offset. |
 | `limit` | Maximum number of rows. |
 | `total_count` | Visible row count before windowing. |
+| `before_count` | Visible row count before the current window. |
+| `after_count` | Visible row count after the current window. |
 | `has_previous?` | Whether a previous window exists. |
 | `has_next?` | Whether a next window exists. |
+
+Use `before_count` and `after_count` for lightweight summaries such as "showing 51-100 of 238" or "138 rows after this window". They describe the already-computed visible rows only; pagination controls, URL state, data fetching, and any server-side paging policy remain host-app responsibilities.
 
 ## Visual reference
 

--- a/docs/ja/windowed-rendering.md
+++ b/docs/ja/windowed-rendering.md
@@ -43,8 +43,12 @@ window = tree_view_window(@render_state, offset: 0, limit: 50)
 | `offset` | 開始位置。 |
 | `limit` | 最大件数。 |
 | `total_count` | window適用前のvisible row数。 |
+| `before_count` | 現在のwindowより前にあるvisible row数。 |
+| `after_count` | 現在のwindowより後ろに残るvisible row数。 |
 | `has_previous?` | 前のwindowが存在するか。 |
 | `has_next?` | 次のwindowが存在するか。 |
+
+`before_count` / `after_count` は、「51-100 / 238件を表示中」や「このwindowの後ろに138件」のような軽いsummaryに使えます。これらは計算済みのvisible rowsだけを説明するmetadataです。pagination controls、URL state、data fetching、server-side paging policy は引き続き host app 側の責務です。
 
 ## Visual reference
 

--- a/lib/tree_view/render_window.rb
+++ b/lib/tree_view/render_window.rb
@@ -24,6 +24,14 @@ module TreeView
       visible_rows.length
     end
 
+    def before_count
+      [offset, total_count].min
+    end
+
+    def after_count
+      [total_count - [offset + rows.length, total_count].min, 0].max
+    end
+
     def start_index
       return total_count if total_count.zero?
 

--- a/spec/lib/tree_view/render_window_spec.rb
+++ b/spec/lib/tree_view/render_window_spec.rb
@@ -10,10 +10,28 @@ RSpec.describe TreeView::RenderWindow do
 
     expect(window.to_a).to eq([3, 4, 5])
     expect(window.total_count).to eq(10)
+    expect(window.before_count).to eq(2)
+    expect(window.after_count).to eq(5)
     expect(window.start_index).to eq(2)
     expect(window.end_index).to eq(5)
     expect(window.previous_offset).to eq(0)
     expect(window.next_offset).to eq(5)
+  end
+
+  it "reports counts before and after edge windows" do
+    empty = described_class.new([], offset: 0, limit: 4)
+    first = described_class.new(rows, offset: 0, limit: 4)
+    middle = described_class.new(rows, offset: 4, limit: 4)
+    last = described_class.new(rows, offset: 8, limit: 4)
+
+    expect(empty.before_count).to eq(0)
+    expect(empty.after_count).to eq(0)
+    expect(first.before_count).to eq(0)
+    expect(first.after_count).to eq(6)
+    expect(middle.before_count).to eq(4)
+    expect(middle.after_count).to eq(2)
+    expect(last.before_count).to eq(8)
+    expect(last.after_count).to eq(0)
   end
 
   it "reports previous and next availability" do
@@ -35,6 +53,8 @@ RSpec.describe TreeView::RenderWindow do
     expect(window).to be_empty
     expect(window.to_a).to eq([])
     expect(window.total_count).to eq(10)
+    expect(window.before_count).to eq(10)
+    expect(window.after_count).to eq(0)
     expect(window.start_index).to eq(10)
     expect(window.end_index).to eq(0)
     expect(window.next_offset).to be_nil


### PR DESCRIPTION
`TreeView::RenderWindow` から window 前後の visible row 数を直接読めるようにします。

## 対応 Issue

Closes #828

## 変更内容

- `TreeView::RenderWindow#before_count` / `#after_count` を追加
- RenderWindow spec に window 前後の件数 metadata の代表ケースを追加
- `docs/en/windowed-rendering.md` / `docs/ja/windowed-rendering.md` に metadata guidance を追加

## 受け入れ条件との対応

- `before_count` は window の前に存在する visible row 数を返します。
- `after_count` は window の後ろに残る visible row 数を返します。
- total 0、offset 0、中間 window、末尾 window、offset が total_count を超えるケースを spec で固定しました。
- 既存の `rows`、`start_index`、`end_index`、`next_offset`、`previous_offset`、`next?`、`previous?` は変更していません。
- docs は lightweight summary 用 metadata として説明し、host app の pagination / URL state / data fetching 責務を TreeView 側へ広げていません。
- `remaining_count` は Planner handoff の通り追加していません。

## 変更範囲

- `lib/tree_view/render_window.rb`
- `spec/lib/tree_view/render_window_spec.rb`
- `docs/en/windowed-rendering.md`
- `docs/ja/windowed-rendering.md`

`tree_view_rows` の markup、helper signature、server-side pagination、infinite scroll、public API manifest schema には触れていません。

## 実施した確認

- GitHub compare: `main...feature/828-render-window-row-counts`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- PR metadata
  - head: `b38c47d4b4f7153ad87610e2ab1a65f2c851bcd7`
  - `mergeable: true`
- CI run `#1080`: success
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success
  - `pr_rails_matrix (7.0, gemfiles/rails_7_0.gemfile, 3.2)`: success
  - `pr_rails_matrix (7.2, gemfiles/rails_7_2.gemfile, 3.2)`: success
  - `pr_rails_matrix (8.0, gemfiles/rails_8_0.gemfile, 3.3)`: success
  - full `rails_matrix` / `ruby_matrix` / `gem_package`: skipped by workflow policy for this PR shape
- local test / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch / diff / CI を確認しています。

## リスク

- medium
- public API の additive method 追加です。Planner handoff に従い、名前は `before_count` / `after_count` に絞っています。

## 未対応・補足

- `remaining_count` は追加していません。
- host app paging strategy、server-side pagination、infinite scroll、virtual scroll は非目標のままです。