### PR TITLE
Troubleshooting に GraphAdapter performance 診断導線を追加する

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -46,6 +46,30 @@ Read next:
 - [Accessibility Semantics](accessibility-semantics.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## Tree rendering triggers repeated queries or high ActiveRecord time
+
+Treat this as a host-app data loading and row partial problem first. TreeView can traverse the tree and render rows, but it does not choose eager-loading, authorization, caching, or derived-value strategies for application records.
+
+Check these signals in the Rails log while rendering the tree.
+
+- `ActiveRecord:` time is high compared with `Views:` time.
+- Similar `Document Load`, `DocumentVersion Load`, or application-specific query lines repeat while rows render.
+- Repeated queries are not marked `CACHE`.
+- The row partial calls helpers or associations that perform database work for every row.
+
+Then move the expensive work out of the render loop.
+
+- Materialize parent records before building the tree.
+- Return arrays, not lazy ActiveRecord relations, from `GraphAdapter` `children_resolver` callbacks.
+- Cache child collections by parent id in the host app.
+- Precompute authorization, version, or display metadata before the row partial renders.
+
+Read next:
+
+- [Cookbook: GraphAdapter and ActiveRecord performance](cookbook.md#graphadapter-and-activerecord-performance)
+- [Rendering Boundaries](rendering-boundaries.md)
+- [Tree diagnostics](tree-diagnostics.md)
+
 ## CSS or JavaScript integration does not seem to apply
 
 Start with installation wiring.

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -46,6 +46,30 @@ TreeView は row wrapper と共通 tree UI cell を担当し、`row_partial` の
 - [Accessibility Semantics](accessibility-semantics.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## tree rendering 中に query が繰り返される / ActiveRecord time が大きい
+
+まず host app 側の data loading と row partial の問題として切り分けます。TreeView は tree traversal と row rendering を担いますが、application record の eager loading、authorization、caching、derived value の作り方は決めません。
+
+tree を描画しているときの Rails log で次を確認します。
+
+- `Views:` に比べて `ActiveRecord:` が大きい。
+- row render 中に `Document Load`、`DocumentVersion Load`、または host app 固有の query が同じ形で繰り返される。
+- 繰り返し出る query が `CACHE` になっていない。
+- row partial から呼ぶ helper や association access が row ごとに DB work を発生させている。
+
+高コストな処理は render loop の外へ移してください。
+
+- tree 構築前に親 record を確定する。
+- `GraphAdapter` の `children_resolver` から lazy な ActiveRecord relation ではなく配列を返す。
+- parent id ごとの children cache を host app 側で作る。
+- authorization、version、表示用 metadata は row partial の描画前に事前計算する。
+
+次に読む文書:
+
+- [Cookbook: GraphAdapter と ActiveRecord の性能](cookbook.md#graphadapter-と-activerecord-の性能)
+- [Rendering Boundaries](rendering-boundaries.md)
+- [Tree diagnostics](tree-diagnostics.md)
+
 ## CSS や JavaScript の統合が効いていないように見える
 
 まず導入 wiring を確認してください。


### PR DESCRIPTION
## 概要

Issue #838 の docs-only 対応です。

Troubleshooting から、tree rendering 中の repeated query / high `ActiveRecord:` time / row partial query symptom を起点に Cookbook の GraphAdapter / ActiveRecord performance guidance へ辿れる導線を日英で追加しました。

## 変更内容

- `docs/en/troubleshooting.md`
  - repeated queries / high ActiveRecord time の症状別セクションを追加
  - Cookbook / Rendering Boundaries / Tree diagnostics への read-next を追加
- `docs/ja/troubleshooting.md`
  - 英語版と同等の診断導線を追加

## 判定分類

- `docs-stale`
- `docs-sync`

## 確認観点

- `docs/en|ja/cookbook.md` の GraphAdapter performance guidance と矛盾していないこと
- TreeView が query optimization を自動で担う説明にせず、host app owned query / caching / authorization / derived value boundary を保っていること
- production code、GraphAdapter behavior、CI workflow には触れていないこと

Closes #838