### PR TITLE
docs/mockups の代表ページを browser smoke で確認する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -54,6 +54,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 19. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
 20. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
+## Automated smoke coverage
+
+- `npm run test:browser` opens representative mockup pages in Playwright and checks the review gallery, key local links, main headings, and sample regions.
+- The smoke coverage is intentionally narrow. It catches broken HTML, blank pages, missing review links, and missing representative regions without adding screenshot baselines or visual diff review.
+
 ## Copy and language policy
 
 - Mockups use short, product-neutral English copy so reviewers can compare layout and state cues without language changes becoming visual noise.

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test"
+import { existsSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const mockupsRoot = path.join(repoRoot, "docs/mockups")
+
+function mockupPath(file) {
+  return path.join(mockupsRoot, file)
+}
+
+function mockupUrl(file) {
+  return pathToFileURL(mockupPath(file)).toString()
+}
+
+async function openMockup(page, file) {
+  await page.goto(mockupUrl(file))
+  await expect(page.locator("main.mock-page")).toBeVisible()
+}
+
+test.describe("docs mockup browser smoke", () => {
+  test("review gallery loads representative navigation, previews, and local links", async ({ page }) => {
+    await openMockup(page, "review-gallery.html")
+
+    await expect(page.getByRole("heading", { name: "TreeView mockup review gallery", level: 1 })).toBeVisible()
+    await expect(page.getByRole("navigation", { name: "Documentation entry points" })).toBeVisible()
+    await expect(page.getByRole("navigation", { name: "Mockup comparison gallery" })).toBeHidden({ timeout: 1 }).catch(() => {})
+    await expect(page.getByRole("link", { name: "Baseline" })).toHaveAttribute("href", "#gallery-default-heading")
+    await expect(page.getByRole("link", { name: "Interaction states" })).toHaveAttribute("href", "#gallery-interaction-heading")
+    await expect(page.frameLocator("iframe[title='Default tree mock preview']").getByRole("heading", { name: "Default TreeView rendering mock", level: 1 })).toBeVisible()
+
+    const linkedFiles = await page.locator("a[href]").evaluateAll((anchors) =>
+      Array.from(new Set(
+        anchors
+          .map((anchor) => anchor.getAttribute("href"))
+          .filter((href) => href && !href.startsWith("#"))
+      ))
+    )
+    const missingLinks = linkedFiles.filter((href) => !existsSync(path.resolve(mockupsRoot, href)))
+
+    expect(linkedFiles).toContain("default-tree.html")
+    expect(linkedFiles).toContain("interaction-states.html")
+    expect(linkedFiles).toContain("empty-state.html")
+    expect(missingLinks).toEqual([])
+  })
+
+  for (const mockup of [
+    {
+      file: "default-tree.html",
+      heading: "Default TreeView rendering mock",
+      section: "Standard table structure",
+      sample: ".tree-view-table tbody tr",
+      minimumCount: 4
+    },
+    {
+      file: "interaction-states.html",
+      heading: "TreeView interaction states mock",
+      section: "Lazy loading and retry states",
+      sample: ".tree-view-table tbody tr",
+      minimumCount: 5
+    },
+    {
+      file: "empty-state.html",
+      heading: "TreeView empty state mock",
+      section: "No root items",
+      sample: "[data-tree-view-empty-state='true']",
+      minimumCount: 2
+    }
+  ]) {
+    test(`${mockup.file} exposes its main heading and representative sample region`, async ({ page }) => {
+      await openMockup(page, mockup.file)
+
+      await expect(page.getByRole("heading", { name: mockup.heading, level: 1 })).toBeVisible()
+      await expect(page.getByRole("heading", { name: mockup.section })).toBeVisible()
+      await expect(page.locator(mockup.sample)).toHaveCount(mockup.minimumCount)
+      await expect(page.getByRole("link", { name: "Back to review gallery" })).toHaveAttribute("href", "review-gallery.html")
+    })
+  }
+})

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -25,7 +25,6 @@ test.describe("docs mockup browser smoke", () => {
 
     await expect(page.getByRole("heading", { name: "TreeView mockup review gallery", level: 1 })).toBeVisible()
     await expect(page.getByRole("navigation", { name: "Documentation entry points" })).toBeVisible()
-    await expect(page.getByRole("navigation", { name: "Mockup comparison gallery" })).toBeHidden({ timeout: 1 }).catch(() => {})
     await expect(page.getByRole("link", { name: "Baseline" })).toHaveAttribute("href", "#gallery-default-heading")
     await expect(page.getByRole("link", { name: "Interaction states" })).toHaveAttribute("href", "#gallery-interaction-heading")
     await expect(page.frameLocator("iframe[title='Default tree mock preview']").getByRole("heading", { name: "Default TreeView rendering mock", level: 1 })).toBeVisible()
@@ -73,7 +72,7 @@ test.describe("docs mockup browser smoke", () => {
 
       await expect(page.getByRole("heading", { name: mockup.heading, level: 1 })).toBeVisible()
       await expect(page.getByRole("heading", { name: mockup.section })).toBeVisible()
-      await expect(page.locator(mockup.sample)).toHaveCount(mockup.minimumCount)
+      expect(await page.locator(mockup.sample).count()).toBeGreaterThanOrEqual(mockup.minimumCount)
       await expect(page.getByRole("link", { name: "Back to review gallery" })).toHaveAttribute("href", "review-gallery.html")
     })
   }


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #717

## Issue ごとの完了内容

- #717
  - `docs/mockups/review-gallery.html` を Playwright smoke で開き、主要 heading、documentation nav、review-path link、default-tree iframe preview を確認するようにしました。
  - review gallery 内の local link が実ファイルへ解決できることを確認し、`default-tree.html` / `interaction-states.html` / `empty-state.html` の代表リンクを guard しました。
  - `default-tree.html`、`interaction-states.html`、`empty-state.html` を file URL で開き、main heading、代表 section、sample region、gallery への return link を確認するようにしました。
  - `docs/mockups/README.md` に `npm run test:browser` でこの smoke coverage が走ることと、visual regression には広げない境界を追記しました。

## 変更内容

- `test/browser/docs_mockups_smoke.spec.js` を追加
- `docs/mockups/README.md` に Automated smoke coverage を追記

## 改善カテゴリ

- test
- docs
- browser smoke

## 既存仕様への影響

- 既存仕様への影響はありません。
- runtime code、Rails helper、Stimulus controller、CSS、mockup HTML/CSS の見た目、API、DB、認可には触れていません。
- screenshot baseline や full visual regression には広げていません。

## 実施した確認

- GitHub compare: `main...quality/717-docs-mockup-browser-smoke`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 2
- local `npm run test:browser` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch / diff を作成しています。
  - PR 作成後の GitHub Actions で `javascript` job の Playwright 実行を確認します。

## リスク評価

- low
- test/docs-only の guard 追加で、公開挙動や配布物の runtime surface は変更していません。

## 補足事項

- 全 mockup page の網羅、スクリーンショット差分、visual redesign、Rails runtime behavior の検証には広げていません。