### PR TITLE
test: package-root frozen object contract を固定する

### DIFF
--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -37,6 +37,18 @@ function assert(condition, message) {
   if (!condition) throw new Error(message)
 }
 
+function assertFrozenObject(value, name, { deep = false } = {}) {
+  assert(Object.isFrozen(value), `${name} export is not frozen`)
+
+  if (!deep) return
+
+  Object.entries(value).forEach(([key, item]) => {
+    if (item && typeof item === "object") {
+      assert(Object.isFrozen(item), `${name}.${key} export group is not frozen`)
+    }
+  })
+}
+
 const javascriptPackageManifest = loadJavascriptPackageManifest()
 const entrypointModule = await import(new URL("../app/javascript/tree_view/index.js", import.meta.url).href)
 
@@ -58,6 +70,7 @@ assert(
   JSON.stringify(entrypointModule.TreeViewControllerIdentifiers) === JSON.stringify(expectedIdentifiers),
   "TreeViewControllerIdentifiers export is out of sync"
 )
+assertFrozenObject(entrypointModule.TreeViewControllerIdentifiers, "TreeViewControllerIdentifiers")
 
 const expectedRegistrations = javascriptPackageManifest.controller_registrations.map(({ identifier, export: exportName }) => {
   assert(exportName in entrypointModule, `${exportName} export is missing`)
@@ -86,3 +99,5 @@ assert(
   JSON.stringify(entrypointModule.TreeViewEventNames) === JSON.stringify(expectedEventNames),
   "TreeViewEventNames export is out of sync"
 )
+assertFrozenObject(entrypointModule.TreeViewEventNames, "TreeViewEventNames", { deep: true })
+assertFrozenObject(entrypointModule.TreeViewTransferDropPositions, "TreeViewTransferDropPositions")


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #847

## Issue ごとの完了内容

- #847
  - `TreeViewEventNames` の top-level と nested event groups が frozen であることを entrypoint test で固定しました。
  - `TreeViewTransferDropPositions` と `TreeViewControllerIdentifiers` が frozen であることを同じ entrypoint test で固定しました。
  - 既存の named exports / controller registration / event name manifest sync check は維持しています。

## 変更内容

- `script/test_entrypoints.mjs` に frozen object assertion helper を追加
- public package-root object exports の readonly contract を `Object.isFrozen` で確認

## 改善カテゴリ

- test
- public API guard

## 既存仕様への影響

- 既存仕様への影響はありません。
- runtime controller behavior、event name values、object shape、manifest schema、TypeScript definitions には触れていません。
- 既存の `Object.freeze` 実装をテストで固定するだけです。

## 実施した確認内容

- GitHub compare: `main...quality/847-frozen-entrypoint-objects`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_entrypoints.mjs`)
- local `npm test` / `npm run test:js` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で確認します。

## リスク評価

- low
- test-only change で、公開 API の object immutability contract を既存実装に合わせて固定します。

## 補足事項

- JavaScript public API の rename / restructure、新規 export、Stimulus controller behavior、package build pipeline には広げていません。