### PR TITLE
TreeView::Diagnostics.run の docs entry point を追加する

### DIFF
--- a/docs/en/tree-diagnostics.md
+++ b/docs/en/tree-diagnostics.md
@@ -51,6 +51,29 @@ render_state.validate_unique_dom_ids!
 
 This gives host apps a concrete validation point before rendering invalid or surprising tree data.
 
+For an aggregate check, use `TreeView::Diagnostics.run` after building the tree and render state:
+
+```ruby
+result = TreeView::Diagnostics.run(
+  tree: tree,
+  render_state: render_state,
+  checks: %i[node_keys dom_ids orphans cycles],
+  raise_errors: false
+)
+
+unless result.success?
+  Rails.logger.warn(result.errors.map { |entry| entry[:message] })
+end
+
+result.warnings.each do |warning|
+  Rails.logger.info(warning[:message])
+end
+```
+
+`checks:` accepts the diagnostics you want to run. Omit it to run the default `node_keys`, `dom_ids`, `orphans`, and `cycles` checks, or pass a smaller list when a host-app test only needs part of the pre-render validation. Keep `raise_errors: false` when you want a `Result` object with `errors` and `warnings`; set `raise_errors: true` when a failing check should raise immediately.
+
+`Result#success?` only reflects collected errors. Orphan reports are warnings, so review `warnings` when filtered, imported, or permission-scoped data can leave records outside the rendered tree.
+
 ## Node key uniqueness
 
 Enable validation when building the tree to catch duplicate node keys early.

--- a/docs/ja/tree-diagnostics.md
+++ b/docs/ja/tree-diagnostics.md
@@ -51,6 +51,29 @@ render_state.validate_unique_dom_ids!
 
 これにより、host appは不正または意図しないtree dataを描画する前に、具体的なvalidation pointを持てます。
 
+複数の確認をまとめて実行したい場合は、treeとrender stateを作ったあとに `TreeView::Diagnostics.run` を使えます。
+
+```ruby
+result = TreeView::Diagnostics.run(
+  tree: tree,
+  render_state: render_state,
+  checks: %i[node_keys dom_ids orphans cycles],
+  raise_errors: false
+)
+
+unless result.success?
+  Rails.logger.warn(result.errors.map { |entry| entry[:message] })
+end
+
+result.warnings.each do |warning|
+  Rails.logger.info(warning[:message])
+end
+```
+
+`checks:` には実行したいdiagnosticsを指定できます。省略すると、defaultの `node_keys`、`dom_ids`、`orphans`、`cycles` が実行されます。host appのtestで一部だけ確認したい場合は、より小さいlistを渡してください。`raise_errors: false` のままなら `errors` と `warnings` を持つ `Result` が返り、`raise_errors: true` にすると失敗したcheckが即座に例外をraiseします。
+
+`Result#success?` は収集されたerrorsだけを見ます。orphan reportはwarningsとして返るため、filter、import、permission scopeによって描画対象外のrecordsが生じる可能性がある場合は `warnings` も確認してください。
+
 ## node key uniqueness
 
 node keyの重複を検出したい場合は、tree作成時にvalidationを有効にします。


### PR DESCRIPTION
## 対応 Issue

Closes #842

## 変更内容

- `docs/en/tree-diagnostics.md` に `TreeView::Diagnostics.run` の aggregate validation 例を追加しました。
- `docs/ja/tree-diagnostics.md` に同等の説明を追加しました。
- `checks:`、`raise_errors:`、`Result#success?`、`errors`、`warnings` の読み方を pre-render validation の文脈で最小限補足しました。

## 判定分類

- `docs-stale` / `docs-sync`
- 既存 public API (`TreeView::Diagnostics`) の説明追従漏れで、docs-only で完結します。

## 変更範囲

- `docs/en/tree-diagnostics.md`
- `docs/ja/tree-diagnostics.md`

production code、diagnostics behavior、public API manifest、result serialization、host app 固有の監視・管理画面例には触れていません。

## 確認内容

- `lib/tree_view/diagnostics.rb` で `run(tree:, render_state:, checks:, raise_errors:)`、`DEFAULT_CHECKS`、`Result#success?`、`errors` / `warnings` の挙動を確認しました。
- `config/public_api_manifest.yml` で `Diagnostics` が public constant に含まれることを確認しました。
- GitHub compare: `main...docs/842-diagnostics-run-entrypoint`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- local docs lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch / diff を作成しています。

## リスク

- low
- 既存 public API の説明追加のみです。個別 helper や `CycleDiagnostics` を置き換える表現にはしていません。