### PR TITLE
Public API docs に hook inventory を追加する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -222,6 +222,18 @@ Host apps may rely on documented CSS classes, data attributes, and JavaScript ev
 
 `data-turbo-frame` emitted from configured Turbo toggle links is part of the documented host-app integration surface.
 
+Representative documented hooks are tracked where their feature behavior is explained:
+
+| Hook area | Representative hooks | Contract boundary |
+|---|---|---|
+| Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | TreeView-owned hooks documented in [Toolbar](toolbar.md). Use helper methods for supported actions and metadata instead of internal constants. |
+| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Stable host-element controller values documented in [Selection](selection.md). Row payloads and disabled decisions stay with `selection:` render-state builders. |
+| Lazy loading | `data-tree-remote-state`, remote placeholder IDs, lazy-loading lifecycle events | Stable placeholder and event hooks documented in [Lazy Loading](lazy-loading.md). Host apps still own request dispatch and response handling. |
+| Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | Reusable baseline hooks documented in the [mockup inventory](../mockups/README.md). They describe the shipped empty-state reference pattern, not every internal row class. |
+| Interaction markers | marker row classes and `data-*` hooks shown in focused mockups | Reference hooks documented through [mockups](../mockups/README.md) for review and adoption. Promote any hook to a machine-readable contract in `config/public_api_manifest.yml` only when it needs compatibility checks. |
+
+This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
+
 Undocumented CSS helper classes, data attributes, DOM structure details, and gem partial locals are implementation details.
 
 ## Breaking change criteria

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -222,6 +222,18 @@ host app が依存してよい browser-facing surface は、documented された
 
 設定済みの Turbo toggle link から出力される `data-turbo-frame` は documented host-app integration surface です。
 
+代表的な documented hook は、それぞれの feature behavior を説明している場所で追跡します。
+
+| hook area | 代表 hook | contract boundary |
+|---|---|---|
+| Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | [Toolbar](toolbar.md) で説明している TreeView-owned hook です。supported action や metadata は internal constant ではなく helper method から取得してください。 |
+| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | [Selection](selection.md) で説明している stable host-element controller value です。row payload や disabled 判定は `selection:` render-state builder 側に残ります。 |
+| Lazy loading | `data-tree-remote-state`, remote placeholder ID, lazy-loading lifecycle events | [Lazy Loading](lazy-loading.md) で説明している stable placeholder / event hook です。request dispatch と response handling は引き続き host app 側の責務です。 |
+| Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | [mockup inventory](../mockups/README.md) で説明している reusable baseline hook です。shipped empty-state reference pattern を示すもので、すべての internal row class を公開するものではありません。 |
+| Interaction markers | focused mockup に出てくる marker row classes / `data-*` hooks | review / adoption 用の reference hook として [mockups](../mockups/README.md) で説明します。compatibility check が必要な hook だけを `config/public_api_manifest.yml` の machine-readable contract へ昇格してください。 |
+
+この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
+
 undocumented な CSS helper class、data attribute、DOM 構造詳細、gem partial 内部 locals は内部実装です。
 
 ## Breaking change criteria


### PR DESCRIPTION
## 対応 Issue

Closes #769

## 変更内容

- `docs/en/public-api.md` の `CSS and DOM surface` に documented CSS / data hook inventory を追加しました。
- `docs/ja/public-api.md` に同等の inventory を追加しました。
- toolbar、selection、lazy-loading、empty state、interaction markers の代表 hook と参照先を整理しました。
- `config/public_api_manifest.yml` に載せる machine-readable contract と docs-only inventory の境界を明記しました。

## 判定分類

- `docs-missing` / `docs-sync`
- 既存 public API docs は policy を説明していましたが、代表 hook の所在が分散していたため、docs-only で導線を補完しました。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`

runtime markup、controller behavior、CSS visual design、public API manifest、compatibility spec には触れていません。

## 確認内容

- Issue #769 と Planner handoff の対象範囲を確認しました。
- GitHub compare: `main...docs/769-public-api-hook-inventory`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 2
- 追加した Markdown table のリンク先が既存 docs / mockups path と一致することを確認しました。
- local docs lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch / diff を作成しています。

## リスク

- low
- 代表 hook + 参照先 + contract 境界に絞り、TreeView の全 CSS class / data attribute を一括公開する表現にはしていません。