### PR TITLE
keyboard focus と lazy-loading handoff mockup を補強する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -113,6 +113,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
+| `docs/mockups/keyboard-focus-states.html` | Technical asset | No translation needed. |
 | `docs/mockups/lazy-loading-handoff.html` | Technical asset | No translation needed. |
 | `docs/mockups/drop-positions.html` | Technical asset | No translation needed. |
 | `docs/mockups/persisted-state-boundary.html` | Technical asset | No translation needed. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -16,6 +16,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [keyboard-focus-states.html](keyboard-focus-states.html) | Focused comparison for keyboard focus and focus-visible cues across toggle links, selection checkboxes, toolbar actions, and row actions. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
 | [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus the host-app-owned move policy boundary. |
 | [persisted-state-boundary.html](persisted-state-boundary.html) | Focused persisted-state reference showing before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned. |
@@ -39,20 +40,21 @@ They are **not** a complete Rails application and should not grow into host-app 
 4. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
 5. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 6. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-7. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-8. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
-9. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-10. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-11. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-12. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-13. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-14. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-15. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-16. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-17. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-18. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-19. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-20. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+7. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible keyboard focus cues across toggles, checkboxes, toolbar actions, and row actions without implying a full treegrid keyboard model.
+8. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+9. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
+10. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+11. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+12. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+13. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+14. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+15. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+16. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+17. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+18. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+19. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+20. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+21. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 
@@ -85,6 +87,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 - Use focused static mockups to compare coarse visual cues such as dragging, valid target, blocked target, and drop position.
 - Treat final move authorization, persistence, audit trails, and business copy as host-app responsibilities.
+
+## Keyboard focus guidance
+
+- Use static focus samples to compare visible cues without promising keyboard order, shortcut policy, roving tabindex, or full treegrid semantics.
+- Treat final focus order, route-level shortcuts, and host-app action semantics as host-app responsibilities.
 
 ## Review policy
 

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -17,7 +17,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [keyboard-focus-states.html](keyboard-focus-states.html) | Focused comparison for keyboard focus and focus-visible cues across toggle links, selection checkboxes, toolbar actions, and row actions. |
-| [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
+| [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing initial, loading-in-progress, loaded, and error/retry states across children container ownership and remote-state placeholder handoff boundaries. |
 | [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus the host-app-owned move policy boundary. |
 | [persisted-state-boundary.html](persisted-state-boundary.html) | Focused persisted-state reference showing before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned. |
 | [turbo-frame-target.html](turbo-frame-target.html) | Focused Turbo Frame target boundary showing `data-turbo-frame` on TreeView toggle links beside the host-app-owned frame wrapper. |
@@ -41,7 +41,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 5. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 6. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
 7. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible keyboard focus cues across toggles, checkboxes, toolbar actions, and row actions without implying a full treegrid keyboard model.
-8. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+8. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate initial, loading-in-progress, loaded, and error/retry remote-state handoff from the broader interaction-state page.
 9. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
 10. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
 11. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
@@ -87,6 +87,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 - Use focused static mockups to compare coarse visual cues such as dragging, valid target, blocked target, and drop position.
 - Treat final move authorization, persistence, audit trails, and business copy as host-app responsibilities.
+
+## Lazy-loading guidance
+
+- Use the focused handoff mockup when reviewers need to compare initial, loading-in-progress, loaded, and error/retry states without running a remote request.
+- Treat final spinner copy, request timing, authorization, retry policy, and Turbo response behavior as host-app responsibilities.
 
 ## Keyboard focus guidance
 

--- a/docs/mockups/keyboard-focus-states.html
+++ b/docs/mockups/keyboard-focus-states.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView keyboard focus states mockup</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.focus-state-page {
+  max-width: 1180px;
+}
+
+.focus-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.focus-summary__item {
+  border: 1px solid #d8e0ea;
+  border-radius: 8px;
+  background: #fff;
+  padding: 14px;
+}
+
+.focus-summary__item strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #102a43;
+}
+
+.focus-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.7fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.focus-demo-shell {
+  overflow-x: auto;
+  border: 1px solid #d8e0ea;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.focus-demo-shell .tree-view {
+  min-width: 760px;
+  margin: 0;
+}
+
+.focus-sample {
+  outline: 3px solid #2563eb;
+  outline-offset: 3px;
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.16);
+}
+
+.focus-sample--soft {
+  outline-color: #0f766e;
+  box-shadow: 0 0 0 6px rgba(15, 118, 110, 0.16);
+}
+
+.focus-note-list {
+  display: grid;
+  gap: 12px;
+}
+
+.focus-note {
+  border: 1px solid #d8e0ea;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 14px;
+}
+
+.focus-note h3,
+.focus-note p {
+  margin: 0;
+}
+
+.focus-note h3 {
+  margin-bottom: 0.4rem;
+  color: #102a43;
+}
+
+.focus-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.focus-toolbar a,
+.focus-toolbar button,
+.focus-row-action {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.2rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  color: #1d4ed8;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.focus-row-action {
+  min-height: 1.9rem;
+  padding: 0.3rem 0.55rem;
+}
+
+.focus-check {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (max-width: 760px) {
+  .focus-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .focus-demo-shell .tree-view {
+    min-width: 680px;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page focus-state-page">
+    <header class="mock-header">
+      <p class="mock-kicker">focused mockup</p>
+      <h1>Keyboard focus and focus-visible states</h1>
+      <p>
+        Static reference for checking TreeView's lightweight focus cue across representative controls.
+        The highlighted samples show visible focus styling only; focus order, shortcut keys, and full treegrid keyboard behavior remain host-app responsibilities.
+      </p>
+      <nav class="mock-page-nav" aria-label="Mockup navigation">
+        <a href="review-gallery.html">Back to gallery</a>
+        <a href="README.md">Mockup README</a>
+      </nav>
+      <div class="focus-summary" aria-label="Review summary">
+        <div class="focus-summary__item"><strong>Gem baseline</strong>Toggle links and shipped controls should expose a visible focus cue without changing row layout.</div>
+        <div class="focus-summary__item"><strong>Host-app boundary</strong>Final tab order, shortcut policy, and treegrid semantics are not promised by this mockup.</div>
+        <div class="focus-summary__item"><strong>Static artifact</strong>The blue and teal rings mark sample focus states so review does not depend on live keyboard interaction.</div>
+      </div>
+    </header>
+
+    <section class="mock-section focus-grid" aria-labelledby="focus-targets-heading">
+      <div>
+        <h2 id="focus-targets-heading">Representative focus targets</h2>
+        <div class="focus-toolbar" aria-label="Toolbar samples">
+          <button type="button" class="focus-sample">Expand current path</button>
+          <a href="#" class="focus-sample--soft">Open selected</a>
+          <button type="button" disabled>Collapse all</button>
+        </div>
+        <div class="focus-demo-shell">
+          <table class="tree-view" aria-label="Static focus target comparison">
+            <thead>
+              <tr>
+                <th scope="col">Node</th>
+                <th scope="col">Selection</th>
+                <th scope="col">State</th>
+                <th scope="col">Row action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row tree-row--expanded">
+                <td><a href="#" class="tree-toggle__action focus-sample" aria-expanded="true">Project docs</a></td>
+                <td><input class="focus-check" type="checkbox" aria-label="Select Project docs"></td>
+                <td><span class="tree-badge">Current path</span></td>
+                <td><button type="button" class="focus-row-action">Open</button></td>
+              </tr>
+              <tr class="tree-row tree-row--child">
+                <td><a href="#" class="tree-toggle__action" aria-expanded="false">API reference</a></td>
+                <td><input class="focus-check focus-sample--soft" type="checkbox" aria-label="Select API reference"></td>
+                <td><span class="tree-muted">Selectable checkbox focus</span></td>
+                <td><button type="button" class="focus-row-action">Open</button></td>
+              </tr>
+              <tr class="tree-row tree-row--leaf">
+                <td><span class="tree-leaf-label">Accessibility notes</span></td>
+                <td><input class="focus-check" type="checkbox" aria-label="Select Accessibility notes"></td>
+                <td><span class="tree-muted">Leaf row</span></td>
+                <td><button type="button" class="focus-row-action focus-sample">Preview</button></td>
+              </tr>
+              <tr class="tree-row tree-row--disabled">
+                <td><span class="tree-leaf-label">Archived rollout plan</span></td>
+                <td><input class="focus-check" type="checkbox" aria-label="Select Archived rollout plan" disabled></td>
+                <td><span class="tree-badge tree-badge--muted">Disabled</span></td>
+                <td><button type="button" class="focus-row-action" disabled>Open</button></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <aside class="focus-note-list" aria-label="Responsibility notes">
+        <div class="focus-note">
+          <h3>Toggle link cue</h3>
+          <p>The toggle action can show the same baseline ring as other links while keeping the table-first structure intact.</p>
+        </div>
+        <div class="focus-note">
+          <h3>Native controls</h3>
+          <p>Checkboxes and row buttons keep their native focusability. Host apps own any business-specific selection or action semantics.</p>
+        </div>
+        <div class="focus-note">
+          <h3>Not a keyboard model</h3>
+          <p>This page does not introduce roving tabindex, arrow-key navigation, or full WAI-ARIA treegrid behavior.</p>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/lazy-loading-handoff.html
+++ b/docs/mockups/lazy-loading-handoff.html
@@ -67,7 +67,7 @@
       <h1>TreeView lazy-loading handoff mock</h1>
       <p>
         Static reference for comparing the host-app-owned children container and remote-state placeholder that the lazy-loading guide describes.
-        It shows initial, loaded, and error/retry states without modeling fetch behavior, Turbo Stream responses, authorization, or cursor policy.
+        It shows initial, loading, loaded, and error/retry states without modeling fetch behavior, Turbo Stream responses, authorization, or cursor policy.
       </p>
     </header>
 
@@ -134,6 +134,51 @@
           <tr id="project_alpha_remote_state" class="tree-row tree-row--placeholder" data-tree-parent-key="project:alpha" data-tree-depth="1" aria-level="2">
             <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">state</span></span></span></td>
             <td colspan="3"><span class="mock-status mock-status--pending">remote-state placeholder is reserved</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="loading-heading">
+      <h2 id="loading-heading">Loading in progress</h2>
+      <table class="tree-view-table" data-controller="tree-view-state tree-view-remote-state">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">loading handoff</th>
+            <th scope="col">state</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="project_delta" class="tree-row is-loading" data-tree-node-key="project:delta" data-tree-depth="0" data-tree-expanded="true" data-tree-remote-state="loading" aria-level="1" aria-expanded="true" aria-busy="true">
+            <td class="btn-cell tree-toggle-cell" id="project_delta_button">
+              <span class="tree-toggle" aria-label="Remote branch loading">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true" aria-controls="project_delta_children project_delta_remote_state">loading</a>
+                  <span class="tree-toggle__level">loading</span>
+                </span>
+              </span>
+            </td>
+            <td>Project Delta</td>
+            <td>
+              <dl class="handoff-slot">
+                <dt>event boundary</dt>
+                <dd><code>tree-view:loading</code> marks the branch as in flight before host-app replacement arrives.</dd>
+                <dt>reserved targets</dt>
+                <dd>Children and remote-state slots stay visible so reviewers can see what gets replaced.</dd>
+              </dl>
+            </td>
+            <td><span class="mock-status mock-status--pending">loading</span></td>
+          </tr>
+          <tr id="project_delta_children" class="tree-row tree-row--placeholder" data-tree-parent-key="project:delta" data-tree-depth="1" aria-level="2">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">slot</span></span></span></td>
+            <td colspan="3">Children container remains host-app owned while the request is in progress.</td>
+          </tr>
+          <tr id="project_delta_remote_state" class="tree-row tree-row--placeholder" data-tree-parent-key="project:delta" data-tree-depth="1" aria-level="2">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">state</span></span></span></td>
+            <td colspan="3"><span class="mock-status mock-status--pending">Loading children...</span></td>
           </tr>
         </tbody>
       </table>
@@ -223,6 +268,7 @@
         <li>No real Turbo request, fetch controller, or retry implementation is included.</li>
         <li>No authorization, query policy, cursor policy, or host-app business label is modeled.</li>
         <li>The static rows only show which DOM region the host app is expected to replace or annotate.</li>
+        <li>The loading-in-progress sample is a visual handoff state, not a promise about spinner copy or request timing.</li>
       </ul>
     </section>
   </main>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -10,29 +10,38 @@
   max-width: 1320px;
 }
 
-.mock-gallery-return-nav {
+.mock-gallery-return-nav,
+.mock-gallery-review-path-links,
+.mock-gallery-links {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+.mock-gallery-return-nav {
   margin-top: 18px;
 }
 
-.mock-gallery-return-nav a {
+.mock-gallery-return-nav a,
+.mock-gallery-review-path-links a {
   display: inline-flex;
   align-items: center;
-  padding: 0.55rem 0.9rem;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.8rem;
   border: 1px solid #cbd5e1;
   border-radius: 999px;
   background: #fff;
-  color: #0f172a;
+  color: #1d4ed8;
   font-weight: 700;
   text-decoration: none;
 }
 
 .mock-gallery-return-nav a:hover,
-.mock-gallery-return-nav a:focus {
+.mock-gallery-return-nav a:focus,
+.mock-gallery-review-path-links a:hover,
+.mock-gallery-review-path-links a:focus {
   border-color: #1d4ed8;
-  color: #1d4ed8;
+  background: #eff6ff;
 }
 
 .mock-gallery-review-paths {
@@ -41,39 +50,16 @@
   margin-top: 18px;
   padding: 18px;
   border: 1px solid #d8e0ea;
-  border-radius: 12px;
+  border-radius: 8px;
   background: #f8fafc;
 }
 
 .mock-gallery-review-paths h2,
-.mock-gallery-review-paths p {
+.mock-gallery-review-paths p,
+.mock-gallery-card h2,
+.mock-gallery-card p,
+.mock-gallery-card ul {
   margin: 0;
-}
-
-.mock-gallery-review-path-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.mock-gallery-review-path-links a {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2.35rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 999px;
-  background: #fff;
-  color: #1d4ed8;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.mock-gallery-review-path-links a:hover,
-.mock-gallery-review-path-links a:focus {
-  border-color: #1d4ed8;
-  background: #eff6ff;
-  outline: 2px solid transparent;
 }
 
 .mock-gallery-grid {
@@ -87,15 +73,9 @@
   gap: 16px;
   background: #fff;
   border: 1px solid #dde4ec;
-  border-radius: 12px;
+  border-radius: 8px;
   box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
   padding: 20px;
-}
-
-.mock-gallery-card h2,
-.mock-gallery-card p,
-.mock-gallery-card ul {
-  margin: 0;
 }
 
 .mock-gallery-eyebrow {
@@ -116,12 +96,6 @@
   color: #334e68;
 }
 
-.mock-gallery-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
 .mock-gallery-links a {
   color: #1d4ed8;
   font-weight: 700;
@@ -134,9 +108,9 @@
 }
 
 .mock-gallery-preview {
-  min-height: 340px;
+  min-height: 320px;
   border: 1px solid #dde4ec;
-  border-radius: 12px;
+  border-radius: 8px;
   overflow: hidden;
   background: #f8fafc;
 }
@@ -144,7 +118,7 @@
 .mock-gallery-preview iframe {
   width: 100%;
   height: 100%;
-  min-height: 340px;
+  min-height: 320px;
   border: 0;
   background: #fff;
 }
@@ -173,7 +147,7 @@
 @media (max-width: 720px) {
   .mock-gallery-preview,
   .mock-gallery-preview iframe {
-    min-height: 280px;
+    min-height: 260px;
   }
 }
 </style>
@@ -198,7 +172,7 @@
       <ul>
         <li>Start here when a review needs quick side-by-side comparison across the baseline and focused mockup surfaces.</li>
         <li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li>
-        <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li>
+        <li>Treat final business copy, routes, permissions, keyboard policy, and actions as host-app responsibilities.</li>
       </ul>
       <nav class="mock-gallery-review-paths" aria-labelledby="gallery-review-paths-heading">
         <h2 id="gallery-review-paths-heading">Review paths</h2>
@@ -206,6 +180,7 @@
         <div class="mock-gallery-review-path-links">
           <a href="#gallery-default-heading">Baseline</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
+          <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
           <a href="#gallery-narrow-heading">Responsive and scale</a>
           <a href="#gallery-breadcrumb-heading">Navigation context</a>
           <a href="#gallery-path-builder-heading">Generated rows</a>
@@ -217,34 +192,37 @@
 
     <section class="mock-gallery-grid" aria-label="Mockup comparison gallery">
       <article class="mock-gallery-card" aria-labelledby="gallery-default-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Baseline structure</p><h2 id="gallery-default-heading">Default tree</h2><p>Inspect representative root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.</p><ul class="mock-gallery-points"><li>Expanded and collapsed hierarchy cues</li><li>Selection, badges, and status placement</li><li>Baseline row-actions column layout</li></ul><div class="mock-gallery-links"><a href="default-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Baseline structure</p><h2 id="gallery-default-heading">Default tree</h2><p>Inspect representative root, child, leaf, selected, collapsed, and disabled rows.</p><ul class="mock-gallery-points"><li>Expanded and collapsed hierarchy cues</li><li>Selection, badges, and status placement</li><li>Baseline row-actions column layout</li></ul><div class="mock-gallery-links"><a href="default-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-status-depth-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.</p><ul class="mock-gallery-points"><li>Normal, readonly, and disabled rows</li><li>Selection availability separated from row status</li><li>Depth-label meaning kept host-app owned</li></ul><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels.</p><ul class="mock-gallery-points"><li>Normal, readonly, and disabled rows</li><li>Selection availability separated from row status</li><li>Depth-label meaning kept host-app owned</li></ul><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-keyboard-focus-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused keyboard cue</p><h2 id="gallery-keyboard-focus-heading">Keyboard focus states</h2><p>Compare static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</p><ul class="mock-gallery-points"><li>Toggle link focus cue</li><li>Native checkbox and button focus samples</li><li>Host-app keyboard model boundary</li></ul><div class="mock-gallery-links"><a href="keyboard-focus-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="keyboard-focus-states.html" title="Keyboard focus states mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-lazy-handoff-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Compare the host-app-owned children container and remote-state placeholder across initial, loaded, and error/retry states.</p><ul class="mock-gallery-points"><li>Children container ownership</li><li>Remote-state slot handoff</li><li>Error/retry boundary without fetch behavior</li></ul><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Compare children container ownership and remote-state placeholder boundaries.</p><ul class="mock-gallery-points"><li>Children container ownership</li><li>Remote-state slot handoff</li><li>Error/retry boundary without fetch behavior</li></ul><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-persisted-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused persisted state</p><h2 id="gallery-persisted-heading">Persisted State boundary</h2><p>Compare expansion state before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned.</p><ul class="mock-gallery-points"><li><code>tree_instance_key</code> and expanded keys snapshot framing</li><li><code>tree-view-state:state-changed</code> event beside rendered rows</li><li>Save endpoint, authorization, error copy, and retry policy outside the gem</li></ul><div class="mock-gallery-links"><a href="persisted-state-boundary.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="persisted-state-boundary.html" title="Persisted State boundary mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused persisted state</p><h2 id="gallery-persisted-heading">Persisted State boundary</h2><p>Compare expansion state before, changed, restored, save-failed, and retry cues.</p><ul class="mock-gallery-points"><li><code>tree_instance_key</code> framing</li><li>Rendered rows beside state-changed event</li><li>Storage and retry policy outside the gem</li></ul><div class="mock-gallery-links"><a href="persisted-state-boundary.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="persisted-state-boundary.html" title="Persisted State boundary mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-drop-position-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused transfer cue</p><h2 id="gallery-drop-position-heading">Drop positions</h2><p>Compare before, inside, and after drop-position cues while keeping move permission, persistence, and final copy owned by the host app.</p><ul class="mock-gallery-points"><li>Leading and trailing insertion lines</li><li>Inside target row cue</li><li>Disabled target policy boundary</li></ul><div class="mock-gallery-links"><a href="drop-positions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drop-positions.html" title="Drop positions mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused transfer cue</p><h2 id="gallery-drop-position-heading">Drop positions</h2><p>Compare before, inside, and after drop-position cues.</p><ul class="mock-gallery-points"><li>Leading and trailing insertion lines</li><li>Inside target row cue</li><li>Disabled target policy boundary</li></ul><div class="mock-gallery-links"><a href="drop-positions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drop-positions.html" title="Drop positions mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-turbo-frame-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused Turbo boundary</p><h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2><p>Compare configured <code>data-turbo-frame</code> links beside a host-app-owned frame wrapper.</p><ul class="mock-gallery-points"><li>Link target attribute</li><li>Frame ownership boundary</li><li>No route or response behavior</li></ul><div class="mock-gallery-links"><a href="turbo-frame-target.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-drag-controls-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused interaction controls</p><h2 id="gallery-drag-controls-heading">Drag interactive controls</h2><p>Compare native controls, broad interactive markers, and drag-only ignore markers inside draggable rows.</p><ul class="mock-gallery-points"><li>Native controls remain interactive</li><li>Custom marker boundaries</li><li>Drag-only ignore behavior</li></ul><div class="mock-gallery-links"><a href="drag-interactive-controls.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused interaction controls</p><h2 id="gallery-drag-controls-heading">Drag interactive controls</h2><p>Compare native controls, broad interactive markers, and drag-only ignore markers.</p><ul class="mock-gallery-points"><li>Native controls remain interactive</li><li>Custom marker boundaries</li><li>Drag-only ignore behavior</li></ul><div class="mock-gallery-links"><a href="drag-interactive-controls.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-marker-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused marker policy</p><h2 id="gallery-marker-heading">Interactive marker behaviors</h2><p>Compare broad and narrow ignore markers for keyboard, row-click, and drag behavior.</p><ul class="mock-gallery-points"><li>Broad interactive marker</li><li>Keyboard and row-click boundaries</li><li>Drag-specific ignore marker</li></ul><div class="mock-gallery-links"><a href="interactive-marker-behaviors.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe></div>
@@ -256,19 +234,19 @@
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused path context</p><h2 id="gallery-breadcrumb-heading">Breadcrumb paths</h2><p>Compare breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</p><ul class="mock-gallery-points"><li>Path context outside rows</li><li>Current-row cue inside tree</li><li>Routes and overflow outside scope</li></ul><div class="mock-gallery-links"><a href="breadcrumb-paths.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="breadcrumb-paths.html" title="Breadcrumb paths mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused filtering modes</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Compare matched-only, ancestor-retaining, and descendant-retaining output without adding host-app search UI.</p><ul class="mock-gallery-points"><li>Matched-only output</li><li>Ancestor context</li><li>Descendant context</li></ul><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused filtering modes</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Compare matched-only, ancestor-retaining, and descendant-retaining output.</p><ul class="mock-gallery-points"><li>Matched-only output</li><li>Ancestor context</li><li>Descendant context</li></ul><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-path-builder-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused builder rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows while keeping file-manager behavior outside the gem contract.</p><ul class="mock-gallery-points"><li>Generated folder row cues</li><li>Record-backed rows</li><li>Host-app file actions outside scope</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused builder rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows.</p><ul class="mock-gallery-points"><li>Generated folder row cues</li><li>Record-backed rows</li><li>Host-app file actions outside scope</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-form-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Spacing and fallback</p><h2 id="gallery-empty-heading">Empty state</h2><p>Compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.</p><ul class="mock-gallery-points"><li>Reusable empty-row wrapper hook</li><li>Full-width message slot behavior</li><li>Difference from a populated row</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Spacing and fallback</p><h2 id="gallery-empty-heading">Empty state</h2><p>Compare no-root-items and no-results rows against a populated row.</p><ul class="mock-gallery-points"><li>Reusable empty-row wrapper hook</li><li>Full-width message slot behavior</li><li>Difference from a populated row</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
       </article>
     </section>
 
@@ -276,22 +254,10 @@
       <h2 id="comparison-cues-heading">Comparison cues</h2>
       <table class="mock-comparison-table"><thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead><tbody>
         <tr><td>Default tree</td><td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td><td>Host-app CRUD, queries, business labels, or authorization behavior.</td></tr>
-        <tr><td>Row status and depth labels</td><td>Row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
-        <tr><td>Resource table bridge</td><td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td><td>Saved table state, host-app queries, or business-specific row actions.</td></tr>
-        <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
+        <tr><td>Keyboard focus states</td><td>Static focus-visible cue comparison across toggle links, checkboxes, toolbar actions, and row actions.</td><td>Roving tabindex, arrow-key navigation, shortcut policy, or full treegrid semantics.</td></tr>
         <tr><td>Interaction states</td><td>Loading, retry, pagination, and general drag or drop status cues.</td><td>Real Turbo responses, route wiring, or persistence behavior.</td></tr>
-        <tr><td>Lazy-loading handoff</td><td>Children container ownership, remote-state placeholder handoff, and error/retry slot boundaries.</td><td>Real Turbo responses, fetch or retry controller behavior, authorization, or cursor policy.</td></tr>
-        <tr><td>Persisted State boundary</td><td>Expansion state before, changed, restored, save-failed, and retry cues.</td><td>Storage schema, save endpoint, authorization, retry policy, browser save helper, or final error copy.</td></tr>
-        <tr><td>Drop positions</td><td>Before, inside, and after transfer cues plus the disabled target policy boundary.</td><td>Move authorization, persistence, audit trails, route wiring, or final business copy.</td></tr>
-        <tr><td>Turbo Frame target</td><td>Configured <code>data-turbo-frame</code> link attributes beside the host-app-owned target frame.</td><td>Turbo Stream responses, Rails routes, controller actions, authorization, or frame placement policy.</td></tr>
-        <tr><td>Drag interactive controls</td><td>Plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers.</td><td>Drop targets, widget implementation details, permission rules, or business-specific drag affordances.</td></tr>
-        <tr><td>Interactive marker behaviors</td><td>The broad interactive marker against narrower keyboard, row-click, and drag behavior markers.</td><td>Host-app row-click implementation, widget internals, or broader keyboard and drag policy changes.</td></tr>
-        <tr><td>Windowed rendering</td><td>Visible-row slicing, current-row anchoring, and previous or next metadata framing.</td><td>Pagination controls, infinite scroll, query state, or data fetching behavior.</td></tr>
-        <tr><td>Breadcrumb paths</td><td>Breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</td><td>Route helpers, Turbo navigation, responsive overflow rules, and permission-aware labels.</td></tr>
-        <tr><td>Filtered tree modes</td><td>Matched-only, ancestor-retaining, and descendant-retaining output.</td><td>Search forms, highlighting, ranking, and authorization-aware filtering.</td></tr>
-        <tr><td>PathTreeBuilder rows</td><td>Generated folder row cues compared with record-backed rows and host-app-owned columns or actions.</td><td>File-manager routes, download behavior, record authorization, or public API changes.</td></tr>
-        <tr><td>Form-editing rows</td><td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td><td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td></tr>
-        <tr><td>Toolbar actions</td><td>Tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</td><td>Authorization, route names, current-path semantics, or action sequencing rules.</td></tr>
+        <tr><td>Navigation and scale references</td><td>Narrow layouts, breadcrumbs, windowed rendering, filtered modes, and generated rows.</td><td>Exact breakpoints, route helpers, query behavior, or data fetching policy.</td></tr>
+        <tr><td>Editing and controls</td><td>Toolbar actions, form-editing rows, native controls, and interactive marker boundaries.</td><td>Authorization, save workflows, widget internals, or broader keyboard and drag policy changes.</td></tr>
         <tr><td>Empty state</td><td>Spacing, wrapper hooks, and the full-width empty-row slot.</td><td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td></tr>
       </tbody></table>
     </section>


### PR DESCRIPTION
## Superseded

This PR has been superseded by #886.

Reason:

- Review follow-up requested separating #833 / lazy-loading handoff changes from #845.
- The old branch was stale and contained overlapping mockup changes.
- #886 was rebuilt from the latest `main` with only #845 keyboard focus mockup changes.

Replacement:

- #886
- head: `7b13b2be8212f67d82c4bea35ab65f15f6b0b6fb`
- compare: `main...design/845-keyboard-focus-mockup-refresh-v2` is `ahead_by: 1` / `behind_by: 0`