### PR TITLE
RenderState grouped options の API docs を manifest と同期する

### DIFF
--- a/docs/en/api-overview.md
+++ b/docs/en/api-overview.md
@@ -178,6 +178,7 @@ window.has_next?
 | `toggle_scope:` | Depth and leaf-distance limits passed to toggle path builders. |
 | `selection:` | Checkbox selection behavior and payload options. |
 | `lazy_loading:` | Remote children state and scope options. |
+| `row_status:` | Row disabled, readonly, and disabled-reason builder options. |
 
 Flat keyword options take precedence when both forms are provided.
 

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -291,6 +291,9 @@ The exact machine-readable grouped-option contract for `TreeView::RenderState` l
 | `initial_expansion:` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | Equivalent flat keyword options still take priority when both forms are supplied. |
 | `render_scope:` | `max_depth`, `max_leaf_distance` | Use these grouped keys for the same render-depth and leaf-distance controls documented for `TreeView::RenderState`. |
 | `toggle_scope:` | `max_depth_from_root`, `max_leaf_distance` | Use these grouped keys for the same toggle-depth and toggle leaf-distance controls documented for `TreeView::RenderState`. |
+| `selection:` | `enabled`, `visibility`, `payload_builder`, `checkbox_name`, `disabled_builder`, `disabled_reason_builder`, `selected_keys`, `cascade`, `indeterminate`, `max_count` | Mirrors the documented `TreeView::RenderState::SelectionConfig` keys. See [Selection](selection.md) for behavior and host-app responsibilities. |
+| `lazy_loading:` | `enabled`, `loaded_keys`, `scope` | Mirrors the documented lazy-loading row-state hooks and optional host-app scope passthrough. See [Lazy Loading](lazy-loading.md). |
+| `row_status:` | `row_disabled_builder`, `row_readonly_builder`, `row_disabled_reason_builder` | Mirrors the documented row disabled / readonly state hooks and disabled-reason surface. |
 
 ## TreeView::UiConfig / UiConfigBuilder
 

--- a/docs/ja/api-overview.md
+++ b/docs/ja/api-overview.md
@@ -178,6 +178,7 @@ window.has_next?
 | `toggle_scope:` | 開閉path builderへ渡すdepth / leaf距離の制限。 |
 | `selection:` | checkbox selectionの挙動とpayload設定。 |
 | `lazy_loading:` | remote children読み込みの状態とscope設定。 |
+| `row_status:` | row disabled、readonly、disabled reason builder の設定。 |
 
 個別keyword optionとgrouped optionを同時に指定した場合は、後方互換性のため個別keyword optionが優先されます。
 

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -291,6 +291,9 @@ render_state = TreeView::RenderState.new(
 | `initial_expansion:` | `default`, `max_depth`, `expanded_keys`, `collapsed_keys`, `current_item`, `current_key`, `auto_expand_ancestors` | 個別 keyword option と両方書いた場合でも、優先されるのは個別 keyword option です。 |
 | `render_scope:` | `max_depth`, `max_leaf_distance` | `TreeView::RenderState` で documented されている render-depth / leaf-distance control と同じ契約です。 |
 | `toggle_scope:` | `max_depth_from_root`, `max_leaf_distance` | `TreeView::RenderState` で documented されている toggle-depth / toggle leaf-distance control と同じ契約です。 |
+| `selection:` | `enabled`, `visibility`, `payload_builder`, `checkbox_name`, `disabled_builder`, `disabled_reason_builder`, `selected_keys`, `cascade`, `indeterminate`, `max_count` | documented された `TreeView::RenderState::SelectionConfig` key と対応します。挙動と host app の責務は [Selection](selection.md) を参照してください。 |
+| `lazy_loading:` | `enabled`, `loaded_keys`, `scope` | lazy-loading row-state hook と任意の host-app scope passthrough に対応します。詳細は [Lazy Loading](lazy-loading.md) を参照してください。 |
+| `row_status:` | `row_disabled_builder`, `row_readonly_builder`, `row_disabled_reason_builder` | row disabled / readonly state hook と disabled reason surface に対応します。 |
 
 ## TreeView::UiConfig / UiConfigBuilder
 


### PR DESCRIPTION
## 対応 Issue

Closes #831

## 変更内容

- `docs/en/api.md` / `docs/ja/api.md` の `Documented grouped option keys` 表を `config/public_api_manifest.yml` の 6 group に同期しました。
- `selection:` / `lazy_loading:` / `row_status:` を API reference 本体から探せるようにしました。
- `docs/en/api-overview.md` / `docs/ja/api-overview.md` の RenderState option groups に `row_status:` を追加しました。

## 判定分類

- `docs-stale` / `docs-sync`
- `config/public_api_manifest.yml` と `docs/en|ja/public-api.md` では 6 group が整理済みでしたが、API reference 本体の grouped option table が 3 group のままだったため、docs-only で追従しました。

## 変更範囲

- `docs/en/api.md`
- `docs/ja/api.md`
- `docs/en/api-overview.md`
- `docs/ja/api-overview.md`

production code、public API manifest、compatibility spec、RenderState behavior には触れていません。

## 確認内容

- Issue #831 と review comment を確認しました。
- `config/public_api_manifest.yml` の `grouped_option_keys` が `initial_expansion` / `render_scope` / `toggle_scope` / `selection` / `lazy_loading` / `row_status` を持つことを確認しました。
- `docs/en|ja/public-api.md` の grouped option table と同じ key set になるように API reference を同期しました。
- GitHub compare: `main...docs/831-api-overview-row-status-main-current`
  - changed files: 4
  - docs-only
- local test / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch/raw 取得が 403 で失敗するため、GitHub connector 経由で branch / file update / compare を確認しています。

## リスク

- low
- manifest / compatibility spec にある既存 public contract の docs 追従に限定し、仕様追加や実装変更には広げていません。