### PR TITLE
feature: RenderWindow に before/after count metadata を追加する

### DIFF
--- a/docs/en/windowed-rendering.md
+++ b/docs/en/windowed-rendering.md
@@ -43,8 +43,14 @@ Main metadata:
 | `offset` | Start offset. |
 | `limit` | Maximum number of rows. |
 | `total_count` | Visible row count before windowing. |
+| `before_count` | Number of visible rows before the current window. |
+| `after_count` | Number of visible rows after the current window. |
 | `has_previous?` | Whether a previous window exists. |
 | `has_next?` | Whether a next window exists. |
+
+`before_count` and `after_count` are summary metadata. Use them when the host app wants to show labels such as "20 rows before this window" or "35 rows remaining after this window" without recalculating those counts from `offset`, `limit`, and `total_count`.
+
+They never return negative values. If the requested offset is beyond the visible row count, `before_count` is capped at `total_count` and `after_count` is `0`.
 
 ## Visual reference
 

--- a/docs/ja/windowed-rendering.md
+++ b/docs/ja/windowed-rendering.md
@@ -43,8 +43,14 @@ window = tree_view_window(@render_state, offset: 0, limit: 50)
 | `offset` | 開始位置。 |
 | `limit` | 最大件数。 |
 | `total_count` | window適用前のvisible row数。 |
+| `before_count` | 現在のwindowより前にあるvisible row数。 |
+| `after_count` | 現在のwindowより後ろに残るvisible row数。 |
 | `has_previous?` | 前のwindowが存在するか。 |
 | `has_next?` | 次のwindowが存在するか。 |
+
+`before_count` / `after_count` は summary 用metadataです。host app が「このwindowの前に20件ある」「このwindowの後ろに35件残っている」のような表示を作るとき、`offset` / `limit` / `total_count` から毎回再計算せずに利用できます。
+
+どちらも負の値は返しません。指定されたoffsetがvisible row数を超える場合、`before_count` は `total_count` で止まり、`after_count` は `0` になります。
 
 ## Visual reference
 

--- a/lib/tree_view/render_window.rb
+++ b/lib/tree_view/render_window.rb
@@ -24,6 +24,14 @@ module TreeView
       visible_rows.length
     end
 
+    def before_count
+      [offset, total_count].min
+    end
+
+    def after_count
+      [total_count - [offset + rows.length, total_count].min, 0].max
+    end
+
     def start_index
       return total_count if total_count.zero?
 

--- a/spec/lib/tree_view/render_window_spec.rb
+++ b/spec/lib/tree_view/render_window_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe TreeView::RenderWindow do
 
     expect(window.to_a).to eq([3, 4, 5])
     expect(window.total_count).to eq(10)
+    expect(window.before_count).to eq(2)
+    expect(window.after_count).to eq(5)
     expect(window.start_index).to eq(2)
     expect(window.end_index).to eq(5)
     expect(window.previous_offset).to eq(0)
@@ -29,12 +31,33 @@ RSpec.describe TreeView::RenderWindow do
     expect(last).not_to be_next
   end
 
+  it "reports non-negative before and after counts" do
+    empty = described_class.new([], offset: 0, limit: 5)
+    first = described_class.new(rows, offset: 0, limit: 4)
+    middle = described_class.new(rows, offset: 4, limit: 4)
+    last = described_class.new(rows, offset: 8, limit: 4)
+    beyond = described_class.new(rows, offset: 20, limit: 5)
+
+    expect(empty.before_count).to eq(0)
+    expect(empty.after_count).to eq(0)
+    expect(first.before_count).to eq(0)
+    expect(first.after_count).to eq(6)
+    expect(middle.before_count).to eq(4)
+    expect(middle.after_count).to eq(2)
+    expect(last.before_count).to eq(8)
+    expect(last.after_count).to eq(0)
+    expect(beyond.before_count).to eq(10)
+    expect(beyond.after_count).to eq(0)
+  end
+
   it "handles offsets beyond the visible rows" do
     window = described_class.new(rows, offset: 20, limit: 5)
 
     expect(window).to be_empty
     expect(window.to_a).to eq([])
     expect(window.total_count).to eq(10)
+    expect(window.before_count).to eq(10)
+    expect(window.after_count).to eq(0)
     expect(window.start_index).to eq(10)
     expect(window.end_index).to eq(0)
     expect(window.next_offset).to be_nil


### PR DESCRIPTION
RenderWindow の window summary 用 metadata として `before_count` / `after_count` を追加します。

## 対応 Issue

Closes #828

## 変更内容

- `TreeView::RenderWindow` に `before_count` / `after_count` を追加
- empty / first / middle / last / offset beyond total の代表ケースを spec で固定
- `docs/en/windowed-rendering.md` / `docs/ja/windowed-rendering.md` に summary metadata と non-negative boundary を追記

## 受け入れ条件との対応

- `before_count` は現在の window より前に存在する visible row 数を返します。
- `after_count` は現在の window より後ろに残る visible row 数を返します。
- total 0、offset 0、middle、末尾、offset >= total_count で non-negative な値になることを spec に追加しました。
- 既存の `rows` / `start_index` / `end_index` / `next_offset` / `previous_offset` / `next?` / `previous?` は変更していません。
- docs は host app の pagination / URL state / data fetching responsibility を TreeView 側へ広げない書き方にしています。

## 変更範囲

- `lib/tree_view/render_window.rb`
- `spec/lib/tree_view/render_window_spec.rb`
- `docs/en/windowed-rendering.md`
- `docs/ja/windowed-rendering.md`

`tree_view_rows` の markup、helper signature、server-side pagination、infinite scroll、public API manifest schema には触れていません。

## 実施した確認

- GitHub compare: `main...feature/828-render-window-counts`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- CI run `#1112`: success
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success
  - `pr_rails_matrix (7.0)`: success
  - `pr_rails_matrix (7.2)`: success
  - `pr_rails_matrix (8.0)`: success
  - full `gem_package` / `ruby_matrix` / `rails_matrix`: workflow policy により skipped
- PR metadata: `mergeable: true`
- local `bundle exec rspec spec/lib/tree_view/render_window_spec.rb` は未実行です。
  - この実行環境には Ruby がありません。
  - GitHub HTTPS clone/fetch は `CONNECT tunnel failed, response 403` で失敗しました。

## リスク

- medium
- additive public API 追加です。Planner handoff に従い、名前は `before_count` / `after_count` に絞り、曖昧な `remaining_count` は追加していません。

## 未対応・補足

- host app paging strategy、URL query state、data fetching、virtual scroll は非目標のままです。