### PR TITLE
state-changed event detail を event contract spec で固定する

### DIFF
--- a/app/javascript/tree_view/event_contract.test.js
+++ b/app/javascript/tree_view/event_contract.test.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   TreeViewRemoteStateController,
   TreeViewSelectionController,
+  TreeViewStateController,
   TreeViewTransferController
 } from "./index.js"
 
@@ -15,6 +16,7 @@ describe("TreeView JavaScript public event contract", () => {
 
   beforeEach(() => {
     application = Application.start()
+    application.register("tree-view-state", TreeViewStateController)
     application.register("tree-view-selection", TreeViewSelectionController)
     application.register("tree-view-remote-state", TreeViewRemoteStateController)
     application.register("tree-view-transfer", TreeViewTransferController)
@@ -23,6 +25,48 @@ describe("TreeView JavaScript public event contract", () => {
   afterEach(() => {
     application.stop()
     document.body.innerHTML = ""
+  })
+
+  it("dispatches tree-view-state:state-changed with stable view and expansion detail", async () => {
+    document.body.innerHTML = `
+      <section id="root">
+        <table data-controller="tree-view-state" data-tree-view-state-view-key-value="projects">
+          <tbody>
+            <tr id="alpha" data-tree-view-state-target="node" data-tree-view-state-node-key="project:1" data-tree-view-state-expanded="true">
+              <td><button id="alpha-toggle">Project 1</button></td>
+            </tr>
+            <tr id="beta" data-tree-view-state-target="node" data-tree-view-state-node-key="project:2" data-tree-view-state-expanded="false">
+              <td><button id="beta-toggle">Project 2</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    `
+    const stateSpy = vi.fn()
+    document.querySelector("#root").addEventListener("tree-view-state:state-changed", stateSpy)
+    await nextFrame()
+
+    const initialEvent = stateSpy.mock.calls[0][0]
+    expect(initialEvent.bubbles).toBe(true)
+    expect(initialEvent.cancelable).toBe(true)
+    expect(initialEvent.detail).toEqual({
+      viewKey: "projects",
+      expandedKeys: ["project:1"]
+    })
+
+    const element = document.querySelector("[data-controller='tree-view-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-state")
+    controller.markCollapsed({ target: document.querySelector("#alpha-toggle") })
+    controller.markExpanded({ target: document.querySelector("#beta-toggle") })
+
+    expect(stateSpy.mock.calls.at(-2)[0].detail).toEqual({
+      viewKey: "projects",
+      expandedKeys: []
+    })
+    expect(stateSpy.mock.calls.at(-1)[0].detail).toEqual({
+      viewKey: "projects",
+      expandedKeys: ["project:2"]
+    })
   })
 
   it("dispatches tree-view-selection:change with stable selection detail", async () => {


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #864

## Issue ごとの完了内容

- #864
  - `app/javascript/tree_view/event_contract.test.js` に `tree-view-state:state-changed` の代表 spec を追加しました。
  - connect 時の初回 dispatch で `viewKey` / `expandedKeys` が含まれることを固定しました。
  - `markCollapsed` / `markExpanded` 後の snapshot 更新も同じ public detail shape で確認します。
  - event が bubble / cancelable であることを既存 event contract spec と同じ粒度で確認します。

## 変更内容

- `TreeViewStateController` を public event contract spec の Stimulus application に登録
- state controller の `state-changed` event detail guard を追加

## 改善カテゴリ

- test
- public event contract guard

## 既存仕様への影響

- 既存仕様への影響はありません。
- runtime code、event name、public API manifest、docs、persisted-state endpoint には触れていません。
- 既存実装が dispatch している event detail を spec で固定するだけです。

## 実施した確認

- GitHub compare: `main...quality/864-state-changed-event-contract`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local `npm test -- app/javascript/tree_view/event_contract.test.js` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で `pr_specs` / `lint` / `javascript` / compatibility checks を確認します。

## リスク評価

- low
- spec-only の public event contract guard で、runtime behavior は変更していません。

## 補足事項

- persisted-state save endpoint、debounce / dirty-state policy、keyboard navigation、Playwright / axe smoke には広げていません。