### PR TITLE
current branch sidebar mockup を追加する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -112,6 +112,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/resource-table-bridge.html` | Technical asset | No translation needed. |
 | `docs/mockups/toolbar-actions.html` | Technical asset | No translation needed. |
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
+| `docs/mockups/current-branch-sidebar.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
 | `docs/mockups/lazy-loading-handoff.html` | Technical asset | No translation needed. |
 | `docs/mockups/drop-positions.html` | Technical asset | No translation needed. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -14,6 +14,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
+| [current-branch-sidebar.html](current-branch-sidebar.html) | Current branch sidebar reference showing current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues without host-app navigation policy. |
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
@@ -36,23 +37,24 @@ They are **not** a complete Rails application and should not grow into host-app 
 1. Start with [review-gallery.html](review-gallery.html) when you want a quick side-by-side pass across the current mockup set, or use its review-path links to jump directly to a state family.
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [narrow-sidebar-tree.html](narrow-sidebar-tree.html) when review needs a focused pass on 22rem or 18rem frames where hierarchy cues stay visible while secondary metadata wraps below the primary label.
-4. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
-5. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-6. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-7. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-8. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
-9. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-10. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-11. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-12. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-13. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-14. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-15. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-16. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-17. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-18. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-19. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-20. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+4. Use [current-branch-sidebar.html](current-branch-sidebar.html) when review needs to isolate `current_item:` / `current_key:` plus `auto_expand_ancestors: true` as a visual reference for the current row, ancestor path, and collapsed siblings.
+5. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
+6. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
+7. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+8. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+9. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
+10. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+11. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+12. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+13. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+14. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+15. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+16. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+17. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+18. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+19. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+20. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+21. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 
@@ -70,6 +72,12 @@ They are **not** a complete Rails application and should not grow into host-app 
 - Keep the toggle control, the primary node label, and the current or selected cue visible in the first scan line.
 - Move owner, status, badges, and less-frequent actions into stacked metadata or a compact action surface before hiding hierarchy cues.
 - Treat exact truncation, action menus, and responsive breakpoints as host-app responsibilities. These mockups are reference layouts, not a shipped responsive design system.
+
+## Current-branch guidance
+
+- Use the current-branch sidebar mockup to review the visual result of expanding only the ancestors of the current item.
+- Keep sibling branches collapsed unless the host app has a product reason to expose them by default.
+- Treat route selection, sidebar ordering, permission-aware labels, and final navigation behavior as host-app responsibilities.
 
 ## Empty-state guidance
 

--- a/docs/mockups/current-branch-sidebar.html
+++ b/docs/mockups/current-branch-sidebar.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Current branch sidebar TreeView mock</title>
+<link rel="stylesheet" href="default-tree.css">
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Current branch sidebar mock</h1>
+      <p>
+        Static HTML for reviewing an initial sidebar state where the current row and its ancestors are expanded,
+        while sibling branches stay collapsed. The mock keeps route policy, Turbo navigation, and product-specific sidebar behavior outside the gem.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="branch-sidebar-heading">
+      <h2 id="branch-sidebar-heading">Current branch only expanded</h2>
+      <p class="mock-narrow-note">
+        The current page sits under Workspace / Docs / API. Those ancestors are open so the path is scannable,
+        while adjacent Products, Guides, and Examples branches remain collapsed.
+      </p>
+      <div class="mock-narrow-frame">
+        <p class="mock-narrow-caption">Representative frame width: 22rem</p>
+        <table class="tree-view-table tree-view-table--narrow" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+          <thead>
+            <tr>
+              <th scope="col">tree</th>
+              <th scope="col">navigation item</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="sidebar_workspace" class="tree-row is-expanded" data-tree-node-key="workspace" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="sidebar_workspace_button">
+                <span class="tree-toggle" aria-label="Workspace ancestor expanded">
+                  <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                  <span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a><span class="tree-toggle__level">root</span></span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary"><span class="mock-node-title">Workspace</span><span class="tree-node-badge tree-node-badge--info">ancestor</span></div>
+                  <div class="mock-node-secondary">Top-level section kept open for the current path.</div>
+                </div>
+              </td>
+            </tr>
+            <tr id="sidebar_products" class="tree-row is-collapsed" data-tree-node-key="products" data-tree-parent-key="workspace" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="sidebar_products_button">
+                <span class="tree-toggle" aria-label="Collapsed sibling branch">
+                  <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                  <span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a><span class="tree-toggle__level">child</span><span class="tree-toggle__hidden-count" title="Hidden descendants">6</span></span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary"><span class="mock-node-title">Products</span><span class="mock-status mock-status--pending">sibling</span></div>
+                  <div class="mock-node-secondary">Collapsed because it is outside the current branch.</div>
+                </div>
+              </td>
+            </tr>
+            <tr id="sidebar_docs" class="tree-row is-expanded" data-tree-node-key="docs" data-tree-parent-key="workspace" data-tree-depth="1" data-tree-expanded="true" aria-level="2" aria-expanded="true" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="sidebar_docs_button">
+                <span class="tree-toggle" aria-label="Docs ancestor expanded">
+                  <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                  <span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a><span class="tree-toggle__level">child</span></span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary"><span class="mock-node-title">Docs</span><span class="tree-node-badge tree-node-badge--info">ancestor</span></div>
+                  <div class="mock-node-secondary">Open because it contains the current page.</div>
+                </div>
+              </td>
+            </tr>
+            <tr id="sidebar_guides" class="tree-row is-collapsed" data-tree-node-key="guides" data-tree-parent-key="docs" data-tree-depth="2" data-tree-expanded="false" aria-level="3" aria-expanded="false" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="sidebar_guides_button">
+                <span class="tree-toggle" aria-label="Collapsed sibling under current ancestor">
+                  <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                  <span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a><span class="tree-toggle__level">branch</span><span class="tree-toggle__hidden-count" title="Hidden descendants">4</span></span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary"><span class="mock-node-title">Guides</span><span class="mock-status mock-status--pending">sibling</span></div>
+                  <div class="mock-node-secondary">Sibling branch stays collapsed.</div>
+                </div>
+              </td>
+            </tr>
+            <tr id="sidebar_api" class="tree-row is-expanded" data-tree-node-key="api" data-tree-parent-key="docs" data-tree-depth="2" data-tree-expanded="true" aria-level="3" aria-expanded="true" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="sidebar_api_button">
+                <span class="tree-toggle" aria-label="API ancestor expanded">
+                  <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                  <span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a><span class="tree-toggle__level">branch</span></span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary"><span class="mock-node-title">API</span><span class="tree-node-badge tree-node-badge--info">ancestor</span></div>
+                  <div class="mock-node-secondary">Last expanded ancestor before the current row.</div>
+                </div>
+              </td>
+            </tr>
+            <tr id="sidebar_controller_helpers" class="tree-row is-selected is-leaf" data-tree-node-key="controller-helpers" data-tree-parent-key="api" data-tree-depth="3" aria-level="4" aria-selected="true" aria-current="page">
+              <td class="btn-cell tree-toggle-cell" id="sidebar_controller_helpers_button">
+                <span class="tree-toggle" aria-label="Current leaf row">
+                  <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                  <span class="tree-toggle__control"><span class="tree-toggle__level">leaf</span></span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary"><span class="mock-node-title">Controller helpers</span><span class="mock-status mock-status--active">current</span></div>
+                  <div class="mock-node-secondary">Rendered with <code>aria-current="page"</code> and selected row color.</div>
+                </div>
+              </td>
+            </tr>
+            <tr id="sidebar_examples" class="tree-row is-collapsed" data-tree-node-key="examples" data-tree-parent-key="api" data-tree-depth="3" data-tree-expanded="false" aria-level="4" aria-expanded="false" aria-selected="false">
+              <td class="btn-cell tree-toggle-cell" id="sidebar_examples_button">
+                <span class="tree-toggle" aria-label="Collapsed sibling near current row">
+                  <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                  <span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a><span class="tree-toggle__level">branch</span><span class="tree-toggle__hidden-count" title="Hidden descendants">3</span></span>
+                </span>
+              </td>
+              <td>
+                <div class="mock-node-stack">
+                  <div class="mock-node-primary"><span class="mock-node-title">Examples</span><span class="mock-status mock-status--pending">sibling</span></div>
+                  <div class="mock-node-secondary">Nearby sibling branch remains collapsed.</div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="branch-rules-heading">
+      <h2 id="branch-rules-heading">Review cues</h2>
+      <ul>
+        <li>Expanded rows should communicate the current path, not a full sidebar product policy.</li>
+        <li>Collapsed sibling branches should keep toggle, depth, and hidden-count cues visible without exposing their children.</li>
+        <li>Current-row copy, routes, permissions, and final sidebar behavior remain host-app responsibilities.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -207,6 +207,7 @@
           <a href="#gallery-default-heading">Baseline</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
           <a href="#gallery-narrow-heading">Responsive and scale</a>
+          <a href="#gallery-current-branch-heading">Current branch</a>
           <a href="#gallery-breadcrumb-heading">Navigation context</a>
           <a href="#gallery-path-builder-heading">Generated rows</a>
           <a href="#gallery-form-heading">Editing and controls</a>
@@ -227,6 +228,9 @@
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-current-branch-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused branch state</p><h2 id="gallery-current-branch-heading">Current branch sidebar</h2><p>Review a sidebar state where the current row and its ancestors are expanded while sibling branches stay collapsed.</p><ul class="mock-gallery-points"><li>Current row and ancestor path</li><li>Collapsed sibling branches</li><li>Host-app navigation policy outside scope</li></ul><div class="mock-gallery-links"><a href="current-branch-sidebar.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="current-branch-sidebar.html" title="Current branch sidebar mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
@@ -279,6 +283,7 @@
         <tr><td>Row status and depth labels</td><td>Row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
         <tr><td>Resource table bridge</td><td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td><td>Saved table state, host-app queries, or business-specific row actions.</td></tr>
         <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
+        <tr><td>Current branch sidebar</td><td>Current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues.</td><td>Route selection, permission-aware labels, final sidebar ordering, or host-app navigation policy.</td></tr>
         <tr><td>Interaction states</td><td>Loading, retry, pagination, and general drag or drop status cues.</td><td>Real Turbo responses, route wiring, or persistence behavior.</td></tr>
         <tr><td>Lazy-loading handoff</td><td>Children container ownership, remote-state placeholder handoff, and error/retry slot boundaries.</td><td>Real Turbo responses, fetch or retry controller behavior, authorization, or cursor policy.</td></tr>
         <tr><td>Persisted State boundary</td><td>Expansion state before, changed, restored, save-failed, and retry cues.</td><td>Storage schema, save endpoint, authorization, retry policy, browser save helper, or final error copy.</td></tr>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -27,7 +27,9 @@ test.describe("docs mockup browser smoke", () => {
     await expect(page.getByRole("navigation", { name: "Documentation entry points" })).toBeVisible()
     await expect(page.getByRole("link", { name: "Baseline" })).toHaveAttribute("href", "#gallery-default-heading")
     await expect(page.getByRole("link", { name: "Interaction states" })).toHaveAttribute("href", "#gallery-interaction-heading")
+    await expect(page.getByRole("link", { name: "Current branch" })).toHaveAttribute("href", "#gallery-current-branch-heading")
     await expect(page.frameLocator("iframe[title='Default tree mock preview']").getByRole("heading", { name: "Default TreeView rendering mock", level: 1 })).toBeVisible()
+    await expect(page.frameLocator("iframe[title='Current branch sidebar mock preview']").getByRole("heading", { name: "Current branch sidebar mock", level: 1 })).toBeVisible()
 
     const linkedFiles = await page.locator("a[href]").evaluateAll((anchors) =>
       Array.from(new Set(
@@ -40,6 +42,7 @@ test.describe("docs mockup browser smoke", () => {
 
     expect(linkedFiles).toContain("default-tree.html")
     expect(linkedFiles).toContain("interaction-states.html")
+    expect(linkedFiles).toContain("current-branch-sidebar.html")
     expect(linkedFiles).toContain("empty-state.html")
     expect(missingLinks).toEqual([])
   })
@@ -58,6 +61,13 @@ test.describe("docs mockup browser smoke", () => {
       section: "Lazy loading and retry states",
       sample: ".tree-view-table tbody tr",
       minimumCount: 5
+    },
+    {
+      file: "current-branch-sidebar.html",
+      heading: "Current branch sidebar mock",
+      section: "Current branch only expanded",
+      sample: ".tree-row.is-selected[aria-current='page']",
+      minimumCount: 1
     },
     {
       file: "empty-state.html",


### PR DESCRIPTION
## 対応Issue

- Closes #857

## 採用した方針

- 案B: 新規 sibling mockup page を追加し、既存の `narrow-sidebar-tree.html` とは役割を分ける方針を採用しました。
- 理由: Planner handoff の通り、既存 narrow mockup は幅の縮小時の読みやすさが主題です。#857 は current row / ancestor rows / collapsed sibling branches の関係を focused に見せる Issue なので、新規 `current-branch-sidebar.html` に分離するのが低リスクで review しやすいと判断しました。

## 比較した案

- 案A: `narrow-sidebar-tree.html` に current branch section を追加する
  - 変更量は少ない一方、narrow-width と current-branch 初期展開の論点が混ざります。
- 案B: 新規 sibling mockup page を追加する
  - 今回採用。既存 mockup の役割を保ち、current branch だけを単体で確認できます。
- 案C: cookbook 本文へ visual reference を大きく追記する
  - 実装 guidance と visual reference が近くなりますが、prose docs の rewrite が広がるため今回は見送りました。

## 変更内容

- `docs/mockups/current-branch-sidebar.html` を追加
  - current row、expanded ancestors、collapsed sibling branches、depth / toggle / hidden-count cue を静的HTMLで確認できるようにしました。
- `docs/mockups/README.md` に file table、review flow、current-branch guidance を追加
- `docs/mockups/review-gallery.html` に review path、preview card、comparison cue を追加
- `docs/i18n-audit.md` の technical asset inventory に追加
- browser smoke に gallery link / iframe / representative sample region の確認を追加

## 変更した画面・コンポーネント

- `docs/mockups/current-branch-sidebar.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `docs/i18n-audit.md`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- lint
  - 未実行です。connector-only 実行でローカル clone/fetch が `CONNECT tunnel failed, response 403` になりました。
- typecheck
  - runtime Ruby / JavaScript 実装は変更していません。
- UI表示確認
  - 静的HTML source、gallery iframe/link、heading、representative sample selector を差分上で確認しました。
- レスポンシブ確認
  - 既存 `tree-view-table--narrow` / `mock-narrow-frame` を再利用し、22rem frame に閉じています。ブラウザ実表示は未確認です。
- アクセシビリティ確認
  - representative `aria-level` / `aria-expanded` / `aria-selected` / `aria-current="page"` を配置しました。runtime expansion algorithm や focus behavior は変更していません。
- GitHub compare
  - `main...design/857-current-branch-sidebar-mockup-main-current`: `ahead_by: 1` / `behind_by: 0`

## スクリーンショット

<!-- UI変更がある場合は添付 -->

未添付です。connector-only 実行でブラウザ表示確認まではできていません。

## リスク

- low
- static mockup/docs/test-smoke のみの変更です。`auto_expand_ancestors:` の runtime 実装、Rails routes、Turbo navigation、host-app authorization、sidebar product policy には触れていません。

## 補足

- 作業途中で古い `main` から作った `design/857-current-branch-sidebar-mockup` は使わず、current `main` から `design/857-current-branch-sidebar-mockup-main-current` に載せ直しました。