### PR TITLE
design: lazy-loading handoff mock の loading 状態と viewport smoke を追加する

### DIFF
--- a/docs/mockups/lazy-loading-handoff.html
+++ b/docs/mockups/lazy-loading-handoff.html
@@ -58,6 +58,10 @@
   margin: 0;
   padding-left: 1.2rem;
 }
+
+.mock-section {
+  overflow-x: auto;
+}
 </style>
 </head>
 <body>
@@ -67,7 +71,7 @@
       <h1>TreeView lazy-loading handoff mock</h1>
       <p>
         Static reference for comparing the host-app-owned children container and remote-state placeholder that the lazy-loading guide describes.
-        It shows initial, loaded, and error/retry states without modeling fetch behavior, Turbo Stream responses, authorization, or cursor policy.
+        It shows initial, loading-in-progress, loaded, and error/retry states without modeling fetch behavior, Turbo Stream responses, authorization, or cursor policy.
       </p>
     </header>
 
@@ -134,6 +138,51 @@
           <tr id="project_alpha_remote_state" class="tree-row tree-row--placeholder" data-tree-parent-key="project:alpha" data-tree-depth="1" aria-level="2">
             <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">state</span></span></span></td>
             <td colspan="3"><span class="mock-status mock-status--pending">remote-state placeholder is reserved</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="loading-heading">
+      <h2 id="loading-heading">Loading in progress</h2>
+      <table class="tree-view-table" data-controller="tree-view-state tree-view-remote-state">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">handoff slots</th>
+            <th scope="col">state</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="project_delta" class="tree-row is-loading" data-tree-node-key="project:delta" data-tree-depth="0" data-tree-expanded="true" data-tree-remote-state="loading" aria-level="1" aria-expanded="true" aria-busy="true">
+            <td class="btn-cell tree-toggle-cell" id="project_delta_button">
+              <span class="tree-toggle" aria-label="Remote branch loading">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true" aria-controls="project_delta_children project_delta_remote_state">loading</a>
+                  <span class="tree-toggle__level">remote</span>
+                </span>
+              </span>
+            </td>
+            <td>Project Delta</td>
+            <td>
+              <dl class="handoff-slot">
+                <dt>children container</dt>
+                <dd><code>project_delta_children</code> remains the host-app replacement target while the request is in flight.</dd>
+                <dt>remote-state slot</dt>
+                <dd><code>project_delta_remote_state</code> carries the loading cue after <code>tree-view:loading</code> is dispatched.</dd>
+              </dl>
+            </td>
+            <td><span class="mock-status mock-status--pending">loading</span></td>
+          </tr>
+          <tr id="project_delta_children" class="tree-row tree-row--placeholder" data-tree-parent-key="project:delta" data-tree-depth="1" aria-level="2">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">slot</span></span></span></td>
+            <td colspan="3">Children are not committed yet; the host app can keep the reserved row stable.</td>
+          </tr>
+          <tr id="project_delta_remote_state" class="tree-row tree-row--placeholder" data-tree-parent-key="project:delta" data-tree-depth="1" aria-level="2">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">loading</span></span></span></td>
+            <td colspan="3"><span class="mock-status mock-status--pending">Loading child rows...</span> Host app owns this copy and placement.</td>
           </tr>
         </tbody>
       </table>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -19,6 +19,11 @@ async function openMockup(page, file) {
   await expect(page.locator("main.mock-page")).toBeVisible()
 }
 
+async function expectNoDocumentHorizontalOverflow(page) {
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+  expect(overflow).toBeLessThanOrEqual(1)
+}
+
 test.describe("docs mockup browser smoke", () => {
   test("review gallery loads representative navigation, previews, and local links", async ({ page }) => {
     await openMockup(page, "review-gallery.html")
@@ -70,6 +75,13 @@ test.describe("docs mockup browser smoke", () => {
       minimumCount: 1
     },
     {
+      file: "lazy-loading-handoff.html",
+      heading: "TreeView lazy-loading handoff mock",
+      section: "Loading in progress",
+      sample: "tr[aria-busy='true']",
+      minimumCount: 1
+    },
+    {
       file: "empty-state.html",
       heading: "TreeView empty state mock",
       section: "No root items",
@@ -84,6 +96,21 @@ test.describe("docs mockup browser smoke", () => {
       await expect(page.getByRole("heading", { name: mockup.section })).toBeVisible()
       expect(await page.locator(mockup.sample).count()).toBeGreaterThanOrEqual(mockup.minimumCount)
       await expect(page.getByRole("link", { name: "Back to review gallery" })).toHaveAttribute("href", "review-gallery.html")
+    })
+  }
+
+  for (const viewport of [
+    { name: "desktop", width: 1280, height: 900 },
+    { name: "narrow", width: 390, height: 900 }
+  ]) {
+    test(`lazy-loading-handoff.html keeps loading state readable at ${viewport.name} width`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+      await openMockup(page, "lazy-loading-handoff.html")
+
+      await expect(page.getByRole("heading", { name: "Loading in progress" })).toBeVisible()
+      await expect(page.locator("#project_delta[aria-busy='true']")).toBeVisible()
+      await expect(page.getByText("Loading child rows...")).toBeVisible()
+      await expectNoDocumentHorizontalOverflow(page)
     })
   }
 })


### PR DESCRIPTION
## 対応Issue

- Closes #833

## 採用した方針

- 自動実行かつ review follow-up のため、#861 への `review:changes-requested` に合わせて、最新 `main` から replacement branch を作り直しました。
- Planner の方針に沿い、runtime には触れず `lazy-loading-handoff.html` に loading-in-progress の代表状態を追加する案を維持しています。
- reviewer 指摘の desktop / narrow width visual check については、手元環境で Playwright browser binary の取得が 403 で失敗したため、CI 上の browser smoke で確認する形に変更しました。
- narrow width で document 全体に横スクロールが漏れないよう、mockup page 内の section に `overflow-x: auto` を足し、wide table は section 内で収める方針にしています。

## 比較した案

- 案A: #861 に追加コメントだけ返す
  - 実装変更は最小ですが、visual check 未取得という reviewer 指摘に対する検証証跡が残りません。
- 案B: #861 に直接追加 commit する
  - 途中まで実施しましたが、main が進んで branch が stale になったため、reviewability を優先して破棄しました。
- 案C: 最新 main から replacement PR を作り、loading state と browser smoke を載せ直す
  - 今回採用。`behind_by: 0` の状態で、#833 の範囲内に差分を閉じられます。

## 変更内容

- `docs/mockups/lazy-loading-handoff.html`
  - 冒頭説明に loading-in-progress を追加
  - `Loading in progress` セクションを追加
  - loading 中の parent row、children container placeholder、remote-state placeholder を追加
  - static marker として `aria-busy="true"` / `data-tree-remote-state="loading"` を追加
  - narrow width で table overflow が document へ漏れないよう、mock section に `overflow-x: auto` を追加
- `test/browser/docs_mockups_smoke.spec.js`
  - lazy-loading handoff mock を representative sample 対象に追加
  - desktop 1280px / narrow 390px で loading heading、busy row、loading copy、document horizontal overflow を確認する browser smoke を追加
  - main に入った current-branch sidebar smoke は保持しています

## 変更した画面・コンポーネント

- `docs/mockups/lazy-loading-handoff.html`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- lint
  - 未確認。PR 作成後の GitHub Actions で確認します。
- typecheck
  - runtime Ruby / JavaScript 実装は変更していません。
- UI表示確認
  - CI browser smoke で loading 状態の表示を確認する test を追加しました。
- レスポンシブ確認
  - CI browser smoke で desktop 1280px / narrow 390px の document horizontal overflow を確認します。
- アクセシビリティ確認
  - section heading の `aria-labelledby`、table header、static loading marker の `aria-busy="true"` を追加しています。
- GitHub compare
  - `main...design/833-lazy-loading-progress-mock-v4`: `ahead_by: 2` / `behind_by: 0`

## スクリーンショット

<!-- UI変更がある場合は添付 -->

未添付です。手元環境では Playwright browser binary の取得が `Domain forbidden` / 403 で失敗しました。代わりに CI browser smoke に desktop / narrow width の確認を追加しています。

## リスク

- low
- static HTML mockup と browser smoke のみです。fetch 実装、Turbo behavior、retry policy、authorization、host app business copy には触れていません。

## 補足

- Supersedes #861。#861 は stale branch になったため、この PR に載せ直します。