### PR TITLE
state install generator で namespaced owner へ concern を注入する

### DIFF
--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -48,11 +48,19 @@ bin/rails generate tree_view:state:install User
 
 This still creates the same migration, model, and concern files. If `app/models/user.rb` exists and does not already include `TreeViewStateOwner`, the generator adds the include line.
 
-If the owner model file does not exist, the generator skips model injection and you can include the concern manually.
+For a namespaced owner, pass the constant name. The generator resolves the conventional file path and can update both `class Admin::User < ApplicationRecord` and module-wrapped `module Admin; class User < ApplicationRecord` style definitions.
+
+```bash
+bin/rails generate tree_view:state:install Admin::User
+```
+
+If `app/models/admin/user.rb` exists and contains one of those representative class definitions, the generator adds the include line inside the owner class.
+
+If the owner model file does not exist, or the class definition is too custom for the generator to find safely, the generator skips model injection and you can include the concern manually.
 
 ### If owner injection is skipped
 
-When the generator reports that the owner model file does not exist, first confirm which model should own the saved tree state. Then add `include TreeViewStateOwner` to that existing model after the generated concern exists at `app/models/concerns/tree_view_state_owner.rb`.
+When the generator reports that the owner model file does not exist or the class definition was not found, first confirm which model should own the saved tree state. Then add `include TreeViewStateOwner` to that existing model after the generated concern exists at `app/models/concerns/tree_view_state_owner.rb`.
 
 For a plain owner model, the manual include is the same line the generator would add:
 
@@ -74,7 +82,7 @@ module Admin
 end
 ```
 
-Manual include is the expected follow-up when the owner model is generated later, lives in a namespace, or uses a project-specific file layout that the generator did not update. Do not change the generated migration or `TreeViewState` model for this case; the host app only needs the owner class to include the concern before it calls `tree_view_state_for`, `save_tree_view_state!`, or passes the owner into `TreeView::StateStore`.
+Manual include is the expected follow-up when the owner model is generated later or uses a project-specific file layout or class definition that the generator did not update. Do not change the generated migration or `TreeViewState` model for this case; the host app only needs the owner class to include the concern before it calls `tree_view_state_for`, `save_tree_view_state!`, or passes the owner into `TreeView::StateStore`.
 
 ## Owner model
 

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -48,11 +48,19 @@ bin/rails generate tree_view:state:install User
 
 この場合も、migration、model、concern は通常どおり生成されます。`app/models/user.rb` が存在し、まだ `TreeViewStateOwner` を include していなければ、generator が include 行を追加します。
 
-owner model file が存在しない場合、model への注入は skip されます。その場合は concern を手動で include してください。
+namespace 付き owner では constant 名を渡します。generator は慣例的な file path を解決し、`class Admin::User < ApplicationRecord` 形式と、`module Admin; class User < ApplicationRecord` のような module-wrapped 形式の代表例を更新できます。
+
+```bash
+bin/rails generate tree_view:state:install Admin::User
+```
+
+`app/models/admin/user.rb` が存在し、これらの代表的な class 定義がある場合、generator は owner class の中に include 行を追加します。
+
+owner model file が存在しない場合、または class 定義が project 固有で generator が安全に見つけられない場合、model への注入は skip されます。その場合は concern を手動で include してください。
 
 ### owner への注入が skip された場合
 
-owner model file が存在しないと表示された場合は、まず保存された tree state を所有する model を確認してください。そのうえで、生成済みの `app/models/concerns/tree_view_state_owner.rb` がある状態で、その model に `include TreeViewStateOwner` を追加します。
+owner model file が存在しない、または class 定義が見つからないと表示された場合は、まず保存された tree state を所有する model を確認してください。そのうえで、生成済みの `app/models/concerns/tree_view_state_owner.rb` がある状態で、その model に `include TreeViewStateOwner` を追加します。
 
 通常の owner model では、手動で追加する行は generator が追加するものと同じです。
 
@@ -74,7 +82,7 @@ module Admin
 end
 ```
 
-owner model を後から作る場合、namespace 配下に置く場合、または project 固有の file layout により generator が更新しなかった場合は、手動 include が自然な follow-up です。このケースでは生成済み migration や `TreeViewState` model を変更する必要はありません。host app 側では、`tree_view_state_for`、`save_tree_view_state!`、または `TreeView::StateStore` へ owner を渡す前に、その owner class が concern を include していれば十分です。
+owner model を後から作る場合、または project 固有の file layout / class definition により generator が更新しなかった場合は、手動 include が自然な follow-up です。このケースでは生成済み migration や `TreeViewState` model を変更する必要はありません。host app 側では、`tree_view_state_for`、`save_tree_view_state!`、または `TreeView::StateStore` へ owner を渡す前に、その owner class が concern を include していれば十分です。
 
 ## owner model
 

--- a/lib/generators/tree_view/state/install_generator.rb
+++ b/lib/generators/tree_view/state/install_generator.rb
@@ -29,11 +29,33 @@ module TreeView
           content = File.read(owner_file)
           return if content.include?("include TreeViewStateOwner")
 
-          updated = content.sub(/^class #{Regexp.escape(owner_model_name)}\b.*$/, "\\0\n  include TreeViewStateOwner")
+          updated = inject_owner_concern(content)
+          if updated == content
+            say_status :skip, "#{owner_path} class definition not found"
+            return
+          end
+
           File.write(owner_file, updated)
         end
 
         private
+
+        def inject_owner_concern(content)
+          owner_class_candidates.each do |class_name|
+            pattern = /^(\s*)class #{Regexp.escape(class_name)}\b.*$/
+            next unless content.match?(pattern)
+
+            return content.sub(pattern) do |line|
+              "#{line}\n#{Regexp.last_match(1)}  include TreeViewStateOwner"
+            end
+          end
+
+          content
+        end
+
+        def owner_class_candidates
+          [owner_model_name, owner_model_name.demodulize].uniq
+        end
 
         def migration_path
           "db/migrate/#{migration_number}_create_tree_view_states.rb"

--- a/spec/generators/tree_view/state/install_generator_spec.rb
+++ b/spec/generators/tree_view/state/install_generator_spec.rb
@@ -54,6 +54,34 @@ RSpec.describe TreeView::Generators::State::InstallGenerator do
     expect(File.read(user_model)).to include("class User < ApplicationRecord\n  include TreeViewStateOwner\nend")
   end
 
+  it "includes the owner concern in a namespaced class-line owner model" do
+    FileUtils.mkdir_p(File.join(destination_root, "app/models/admin"))
+    admin_user_model = File.join(destination_root, "app/models/admin/user.rb")
+    File.write(admin_user_model, <<~RUBY)
+      class Admin::User < ApplicationRecord
+      end
+    RUBY
+
+    run_generator("Admin::User")
+
+    expect(File.read(admin_user_model)).to include("class Admin::User < ApplicationRecord\n  include TreeViewStateOwner\nend")
+  end
+
+  it "includes the owner concern in a module-wrapped namespaced owner model" do
+    FileUtils.mkdir_p(File.join(destination_root, "app/models/admin"))
+    admin_user_model = File.join(destination_root, "app/models/admin/user.rb")
+    File.write(admin_user_model, <<~RUBY)
+      module Admin
+        class User < ApplicationRecord
+        end
+      end
+    RUBY
+
+    run_generator("Admin::User")
+
+    expect(File.read(admin_user_model)).to include("  class User < ApplicationRecord\n    include TreeViewStateOwner\n  end")
+  end
+
   it "does not duplicate the owner concern include" do
     FileUtils.mkdir_p(File.join(destination_root, "app/models"))
     user_model = File.join(destination_root, "app/models/user.rb")


### PR DESCRIPTION
state install generator が namespaced owner model の代表形式にも `TreeViewStateOwner` を注入できるようにします。

## 対応 Issue

Closes #745

## 変更内容

- `tree_view:state:install Admin::User` が `app/models/admin/user.rb` を対象にできる既存 path 解決を活かし、owner class の検出候補を namespaced constant と demodulized class name に広げました。
- `class Admin::User < ApplicationRecord` 形式と `module Admin; class User < ApplicationRecord` 形式で `include TreeViewStateOwner` が入る representative spec を追加しました。
- class 定義を安全に見つけられない場合は skip して手動 include に逃がすようにしました。
- 英日 persisted-state docs に、namespaced owner の自動注入対象と手動 include に戻す境界を同期しました。

## 受け入れ条件との対応

- namespaced owner file path は `owner_model_name.underscore` により `app/models/admin/user.rb` として扱います。
- class-line 形式と module-wrapped 形式の representative spec を追加しました。
- plain `User`、既存 include の重複回避、owner file 不在時 skip は維持しています。
- migration、`TreeViewState`、`TreeView::StateStore`、controller concern は変更していません。

## 変更範囲

- `lib/generators/tree_view/state/install_generator.rb`
- `spec/generators/tree_view/state/install_generator_spec.rb`
- `docs/en/persisted-state.md`
- `docs/ja/persisted-state.md`

DB schema / migration template、persisted state model、StateStore、controller concern、host app authorization policy には触れていません。

## 実施した確認

- GitHub compare: `main...feature/745-namespaced-state-owner-generator`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- local `bundle exec rspec spec/generators/tree_view/state/install_generator_spec.rb` は未実行です。
  - この実行環境には Ruby がありません。
  - GitHub HTTPS clone/fetch も `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch / diff を作成しています。
- PR 作成後の GitHub Actions で generator spec / lint / compatibility checks を確認します。

## リスク

- medium
- owner model file への自動書き換え対象を広げる変更です。代表的な namespaced class-line / module-wrapped 形式だけを spec で固定し、見つけられない class 定義は skip して manual include に逃がします。

## 未対応・補足

- Ruby parser 導入、generator 全体の rewrite、project-specific namespace convention の決め打ちはしていません。
- #746 の docs-only manual include guidance lane はこの PR に吸収していません。