### PR TITLE
lazy-loading retry の Troubleshooting 導線を補強する

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -123,11 +123,18 @@ Check these points.
 
 If the row shows loading or error state but never settles, inspect the host-app request/response lifecycle rather than the row partial first.
 
+When the host app listens for retry or remote-state events, also confirm the browser-side detail matches the row wiring.
+
+- `tree-view-remote-state:retry` carries `row`, `childrenUrl`, and `nodeKey` in `event.detail`.
+- `childrenUrl` comes from the row's `data-tree-children-url` attribute.
+- `nodeKey` comes from the row's `data-tree-view-state-node-key` attribute.
+- If either value is `null`, inspect the rendered row attributes before changing retry handling.
+
 Read next:
 
 - [Lazy Loading](lazy-loading.md)
 - [Children Pagination](children-pagination.md)
-- [JavaScript event contract](js-events.md)
+- [JavaScript event contract](js-events.md#tree-view-remote-stateretry)
 
 ## Selection payloads are missing or not what the host app expects
 

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -123,11 +123,18 @@ lazy loading は Turbo / server-driven 前提です。
 
 loading や error の見た目だけは出るのに完了しない場合は、row partial より先に host app の request / response lifecycle を確認してください。
 
+host app が retry event や remote-state event を購読している場合は、browser 側の detail と row wiring も確認します。
+
+- `tree-view-remote-state:retry` の `event.detail` には `row`、`childrenUrl`、`nodeKey` が入ります。
+- `childrenUrl` は row の `data-tree-children-url` から来ます。
+- `nodeKey` は row の `data-tree-view-state-node-key` から来ます。
+- どちらかが `null` の場合は、retry handler を直す前に描画済み row の data attribute を確認してください。
+
 次に読む文書:
 
 - [Lazy Loading](lazy-loading.md)
 - [Children Pagination](children-pagination.md)
-- [JavaScript event contract](js-events.md)
+- [JavaScript event contract](js-events.md#tree-view-remote-stateretry)
 
 ## selection payload が足りない / 想定と違う
 


### PR DESCRIPTION
## 対応 Issue

Closes #876

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/troubleshooting.md` の lazy-loading stuck section に、retry / remote-state event を購読している場合の確認観点を追加しました。
- `docs/ja/troubleshooting.md` に同じ確認観点を追加しました。
- `tree-view-remote-state:retry` の `event.detail` に含まれる `row` / `childrenUrl` / `nodeKey` と、`data-tree-children-url` / `data-tree-view-state-node-key` の対応を短く明記しました。
- 詳細は既存の `js-events.md#tree-view-remote-stateretry` へ委譲しています。

## 根拠

- `app/javascript/tree_view/remote_state_controller.js` は retry 時に row dataset から `childrenUrl` / `nodeKey` を取得し、無い場合は `null` を渡しています。
- `docs/en|ja/js-events.md` は remote-state retry event の public detail を既に文書化しています。
- 既存 Troubleshooting は lazy-loading stuck の入口を持っていますが、retry event detail と row data attribute の逆引き観点が不足していました。

## 変更範囲

- `docs/en/troubleshooting.md`
- `docs/ja/troubleshooting.md`

runtime controller、Turbo response、host-app endpoint、retry policy には触れていません。

## 確認

- GitHub compare で changed files が日英 Troubleshooting 2 ファイルだけであることを確認しました。
- connector-only 実行のためローカル test / lint は未実行です。PR 作成後の GitHub Actions を確認します。

## リスク

- low
- 既存 event contract と runtime detail を Troubleshooting から辿れるようにする docs-only 変更です。