### PR TITLE
remote-state retry で loading change event を dispatch する

### DIFF
--- a/app/javascript/tree_view/event_contract.test.js
+++ b/app/javascript/tree_view/event_contract.test.js
@@ -132,6 +132,13 @@ describe("TreeView JavaScript public event contract", () => {
       childrenUrl: "/projects/1/children",
       nodeKey: "project:1"
     })
+    expect(changeSpy.mock.calls[1][0].detail).toMatchObject({
+      row,
+      state: "loading",
+      childrenUrl: "/projects/1/children",
+      nodeKey: "project:1"
+    })
+    expect(row.dataset.remoteState).toBe("loading")
     expect(retrySpy.mock.calls[0][0].detail).toMatchObject({
       row,
       childrenUrl: "/projects/1/children",

--- a/app/javascript/tree_view/remote_state_controller.js
+++ b/app/javascript/tree_view/remote_state_controller.js
@@ -18,12 +18,11 @@ export class TreeViewRemoteStateController extends Controller {
     if (!row) return
 
     row.dataset.remoteState = "loading"
+    this.dispatch("change", {
+      detail: this.remoteStateDetail(row, "loading")
+    })
     this.dispatch("retry", {
-      detail: {
-        row,
-        childrenUrl: row.dataset.treeChildrenUrl || null,
-        nodeKey: row.dataset.treeViewStateNodeKey || null
-      }
+      detail: this.remoteStateDetail(row)
     })
   }
 
@@ -35,13 +34,20 @@ export class TreeViewRemoteStateController extends Controller {
     if (options.loaded) row.dataset.treeLoaded = "true"
 
     this.dispatch("change", {
-      detail: {
-        row,
-        state,
-        childrenUrl: row.dataset.treeChildrenUrl || null,
-        nodeKey: row.dataset.treeViewStateNodeKey || null
-      }
+      detail: this.remoteStateDetail(row, state)
     })
+  }
+
+  remoteStateDetail(row, state = null) {
+    const detail = {
+      row,
+      childrenUrl: row.dataset.treeChildrenUrl || null,
+      nodeKey: row.dataset.treeViewStateNodeKey || null
+    }
+
+    if (state) detail.state = state
+
+    return detail
   }
 
   rowFromEvent(event) {

--- a/app/javascript/tree_view/remote_state_controller.js
+++ b/app/javascript/tree_view/remote_state_controller.js
@@ -19,10 +19,19 @@ export class TreeViewRemoteStateController extends Controller {
 
     row.dataset.remoteState = "loading"
     this.dispatch("change", {
-      detail: this.remoteStateDetail(row, "loading")
+      detail: {
+        row,
+        state: "loading",
+        childrenUrl: row.dataset.treeChildrenUrl || null,
+        nodeKey: row.dataset.treeViewStateNodeKey || null
+      }
     })
     this.dispatch("retry", {
-      detail: this.remoteStateDetail(row)
+      detail: {
+        row,
+        childrenUrl: row.dataset.treeChildrenUrl || null,
+        nodeKey: row.dataset.treeViewStateNodeKey || null
+      }
     })
   }
 
@@ -34,20 +43,13 @@ export class TreeViewRemoteStateController extends Controller {
     if (options.loaded) row.dataset.treeLoaded = "true"
 
     this.dispatch("change", {
-      detail: this.remoteStateDetail(row, state)
+      detail: {
+        row,
+        state,
+        childrenUrl: row.dataset.treeChildrenUrl || null,
+        nodeKey: row.dataset.treeViewStateNodeKey || null
+      }
     })
-  }
-
-  remoteStateDetail(row, state = null) {
-    const detail = {
-      row,
-      childrenUrl: row.dataset.treeChildrenUrl || null,
-      nodeKey: row.dataset.treeViewStateNodeKey || null
-    }
-
-    if (state) detail.state = state
-
-    return detail
   }
 
   rowFromEvent(event) {

--- a/docs/en/js-events.md
+++ b/docs/en/js-events.md
@@ -64,7 +64,7 @@ Dispatched when a checkbox value cannot be parsed as JSON.
 
 ### `tree-view-remote-state:change`
 
-Dispatched when a row is marked `loading`, `loaded`, or `error`.
+Dispatched when a row is marked `loading`, `loaded`, or `error`. A retry action also marks the row `loading` and dispatches this event before the retry event.
 
 `event.detail` contains:
 

--- a/docs/ja/js-events.md
+++ b/docs/ja/js-events.md
@@ -64,7 +64,7 @@ checkbox value をJSON parseできないときに発火します。
 
 ### `tree-view-remote-state:change`
 
-row が `loading`, `loaded`, `error` に変更されたときに発火します。
+row が `loading`, `loaded`, `error` に変更されたときに発火します。retry action も row を `loading` に戻し、retry event の前にこの event を発火します。
 
 `event.detail` は次を含みます。
 


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #875

## Issue ごとの完了内容

- #875
  - `retry` action が row を `data-remote-state="loading"` に戻すとき、`tree-view-remote-state:change` も dispatch するようにしました。
  - `change` detail は既存 loading path と同じ `row` / `state: "loading"` / `childrenUrl` / `nodeKey` に揃えました。
  - 既存の `tree-view-remote-state:retry` event と detail は維持しました。
  - public event contract spec と英日 docs を最小同期しました。

## 変更内容

- `app/javascript/tree_view/remote_state_controller.js`
  - `retry` 時に loading の `change` event を dispatch してから既存 `retry` event を dispatch
  - source-level public API compatibility guard が detail keys を検出できるよう、controller dispatch source に `row` / `state` / `childrenUrl` / `nodeKey` を明示
- `app/javascript/tree_view/event_contract.test.js`
  - retry 後に loading change event と retry event の両方を確認
- `docs/en/js-events.md` / `docs/ja/js-events.md`
  - retry action でも loading change event が出ることを補足

## 改善カテゴリ

- test
- behavior contract guard
- docs sync

## 既存仕様への影響

- event name / public detail key の rename はありません。
- lazy-loading fetch controller、Turbo response、host-app retry policy、mockup、remote-state lifecycle 全体には触れていません。
- retry 時の `retry` event は維持し、docs / manifest が示していた loading state change contract に controller を合わせる変更です。

## 実施した確認

- GitHub compare: `main...quality/875-remote-state-retry-change-event`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 4
- GitHub Actions `CI #1132`: success
- local `npm test` / `npm run check:js` は未実行です。
  - この実行環境から GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク評価

- medium
- public browser event の発火回数が retry 時に1つ増えます。ただし既存 docs が説明していた loading state change contract と整合させる方向で、event rename や detail key 変更はありません。

## 補足事項

- #876 の docs-only lane とは混ぜていません。
- 初回 CI run `#1131` は helper-based detail generation が既存 compatibility guard と合わず失敗しました。最終差分では detail keys を controller source に明示し、`#1132` で green になっています。