### PR TITLE
root README に drag/drop と children pagination docs 導線を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Key documents:
 | Cookbook | [Cookbook](docs/en/cookbook.md) | [Cookbook](docs/ja/cookbook.md) |
 | Forms and editing rows | [Forms and editing rows](docs/en/form-editing.md) | [Form と編集行](docs/ja/form-editing.md) |
 | Resource table bridge | [Resource table bridge](docs/en/resource-table-bridge.md) | [Resource table bridge](docs/ja/resource-table-bridge.md) |
+| Drag and drop | [Drag and Drop](docs/en/drag-and-drop.md) | [Drag and Drop](docs/ja/drag-and-drop.md) |
+| Children pagination | [Children Pagination](docs/en/children-pagination.md) | [Children Pagination](docs/ja/children-pagination.md) |
 | Tree identity and diagnostics | [Node keys](docs/en/node-keys.md) and [Tree diagnostics](docs/en/tree-diagnostics.md) | [Node key 設計](docs/ja/node-keys.md) and [Tree diagnostics](docs/ja/tree-diagnostics.md) |
 | Rendering scale and boundaries | [Render Scale](docs/en/render-scale.md), [Rendering Boundaries](docs/en/rendering-boundaries.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #882

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- root `README.md` の Key documents table に `Drag and drop` 行を追加しました。
- root `README.md` の Key documents table に `Children pagination` 行を追加しました。
- 日英それぞれ `docs/en|ja/drag-and-drop.md` と `docs/en|ja/children-pagination.md` へ直接辿れるようにしました。

## 根拠

- root README の Features / responsibility boundary では drag/drop hooks と children pagination に触れています。
- `docs/en/README.md` / `docs/ja/README.md` には `Drag and Drop` と `Children Pagination` が user docs として掲載済みです。
- root README の Key documents table からだけ該当ページへの直接導線が抜けていました。

## 変更範囲

- `README.md`

runtime code、API reference 本文、mockup HTML/CSS、feature docs 本文には触れていません。

## 確認

- GitHub compare: `main...docs/882-root-readme-feature-links-current`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- connector-only 実行のため local test / lint は未実行です。docs-only の table link 追加に限定しています。

## リスク

- low
- 既存 docs entrypoint への導線追加だけで、仕様・挙動・公開 API の説明は変更していません。