### PR TITLE
GraphAdapter の children_resolver 戻り値境界を spec で固定する

### DIFF
--- a/spec/lib/tree_view/graph_adapter_spec.rb
+++ b/spec/lib/tree_view/graph_adapter_spec.rb
@@ -12,6 +12,39 @@ RSpec.describe TreeView::GraphAdapter do
     expect(adapter.node_key_for(root)).to eq(["GraphAdapterNode", 1])
   end
 
+  it "normalizes a nil children result to an empty array" do
+    root = GraphAdapterNode.new(1, nil)
+    adapter = described_class.new(roots: [root], children_resolver: ->(node) { node.children })
+
+    expect(adapter.children_for(root)).to eq([])
+  end
+
+  it "wraps a single child object in an array" do
+    child = GraphAdapterNode.new(2, [])
+    root = GraphAdapterNode.new(1, child)
+    adapter = described_class.new(roots: [root], children_resolver: ->(node) { node.children })
+
+    expect(adapter.children_for(root)).to eq([child])
+  end
+
+  it "preserves array-like enumerable children results" do
+    first_child = GraphAdapterNode.new(2, [])
+    second_child = GraphAdapterNode.new(3, [])
+    relation_like_children = Class.new do
+      def initialize(children)
+        @children = children
+      end
+
+      def to_a
+        @children
+      end
+    end.new([first_child, second_child])
+    root = GraphAdapterNode.new(1, relation_like_children)
+    adapter = described_class.new(roots: [root], children_resolver: ->(node) { node.children })
+
+    expect(adapter.children_for(root)).to eq([first_child, second_child])
+  end
+
   it "prefers node_key_resolver when provided" do
     node = GraphAdapterNode.new(1, [])
     adapter = described_class.new(

--- a/spec/lib/tree_view/graph_adapter_spec.rb
+++ b/spec/lib/tree_view/graph_adapter_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 GraphAdapterNode = Struct.new(:id, :children)
+GraphAdapterSingleChild = Struct.new(:id)
 
 RSpec.describe TreeView::GraphAdapter do
   it "provides roots, children, and node_key" do
@@ -20,7 +21,7 @@ RSpec.describe TreeView::GraphAdapter do
   end
 
   it "wraps a single child object in an array" do
-    child = GraphAdapterNode.new(2, [])
+    child = GraphAdapterSingleChild.new(2)
     root = GraphAdapterNode.new(1, child)
     adapter = described_class.new(roots: [root], children_resolver: ->(node) { node.children })
 

--- a/spec/lib/tree_view/graph_adapter_spec.rb
+++ b/spec/lib/tree_view/graph_adapter_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 GraphAdapterNode = Struct.new(:id, :children)
-GraphAdapterSingleChild = Struct.new(:id)
+GraphAdapterSingleChild = Class.new do
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+end
 
 RSpec.describe TreeView::GraphAdapter do
   it "provides roots, children, and node_key" do


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #858

## Issue ごとの完了内容

- #858
  - `GraphAdapter#children_for` が `children_resolver` の戻り値を `Array(...)` で正規化する current behavior を spec で固定しました。
  - `nil` は空配列、単一 child object は1要素配列、relation 風の `to_a` を持つ object は配列として扱う代表ケースを追加しました。
  - 既存の array children / node key behavior は維持しています。

## 変更内容

- `spec/lib/tree_view/graph_adapter_spec.rb`
  - children resolver の境界値 spec を追加

## 改善カテゴリ

- test
- public behavior guard
- small internal contract clarification

## 既存仕様への影響

- runtime code、public API、Tree construction、ActiveRecord query guidance は変更していません。
- 現行実装の `Array(@children_resolver.call(node))` による正規化を regression guard として固定するだけです。

## 実施した確認

- GitHub compare: `main...quality/858-graph-adapter-boundary-spec`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local RSpec は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で spec / lint を確認します。

## リスク評価

- low
- spec-only 変更で、既存挙動を変えません。

## 補足事項

- validation 追加や `GraphAdapter` redesign、performance guidance 改稿には広げていません。