### PR TITLE
keyboard focus states mockup を最新 main から作り直す

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -114,6 +114,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/narrow-sidebar-tree.html` | Technical asset | No translation needed. |
 | `docs/mockups/current-branch-sidebar.html` | Technical asset | No translation needed. |
 | `docs/mockups/interaction-states.html` | Technical asset | No translation needed. |
+| `docs/mockups/keyboard-focus-states.html` | Technical asset | No translation needed. |
 | `docs/mockups/lazy-loading-handoff.html` | Technical asset | No translation needed. |
 | `docs/mockups/drop-positions.html` | Technical asset | No translation needed. |
 | `docs/mockups/persisted-state-boundary.html` | Technical asset | No translation needed. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -17,6 +17,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [current-branch-sidebar.html](current-branch-sidebar.html) | Current branch sidebar reference showing current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues without host-app navigation policy. |
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [keyboard-focus-states.html](keyboard-focus-states.html) | Focused keyboard reference showing static focus-visible samples for toggle links, native controls, toolbar actions, and row actions without promising a full keyboard model. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
 | [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus the host-app-owned move policy boundary. |
 | [persisted-state-boundary.html](persisted-state-boundary.html) | Focused persisted-state reference showing before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned. |
@@ -41,20 +42,21 @@ They are **not** a complete Rails application and should not grow into host-app 
 5. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
 6. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 7. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-8. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-9. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
-10. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-11. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-12. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-13. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-14. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-15. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-16. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-17. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-18. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-19. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-20. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-21. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+8. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
+9. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+10. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
+11. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+12. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+13. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+14. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+15. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+16. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+17. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+18. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+19. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+20. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+21. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+22. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 
@@ -93,6 +95,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 - Use focused static mockups to compare coarse visual cues such as dragging, valid target, blocked target, and drop position.
 - Treat final move authorization, persistence, audit trails, and business copy as host-app responsibilities.
+
+## Keyboard focus guidance
+
+- Use `keyboard-focus-states.html` to review static focus-visible cues across representative focus targets.
+- Keep tab order, shortcut keys, roving tabindex, and full treegrid keyboard behavior in the host app or a separate implementation issue.
 
 ## Review policy
 

--- a/docs/mockups/keyboard-focus-states.html
+++ b/docs/mockups/keyboard-focus-states.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView keyboard focus states mockup</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.focus-state-page {
+  max-width: 1180px;
+}
+
+.focus-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.focus-summary__item {
+  border: 1px solid #d8e0ea;
+  border-radius: 8px;
+  background: #fff;
+  padding: 14px;
+}
+
+.focus-summary__item strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #102a43;
+}
+
+.focus-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.7fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.focus-demo-shell {
+  overflow-x: auto;
+  border: 1px solid #d8e0ea;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.focus-demo-shell .tree-view {
+  min-width: 760px;
+  margin: 0;
+}
+
+.focus-sample {
+  outline: 3px solid #2563eb;
+  outline-offset: 3px;
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.16);
+}
+
+.focus-sample--soft {
+  outline-color: #0f766e;
+  box-shadow: 0 0 0 6px rgba(15, 118, 110, 0.16);
+}
+
+.focus-note-list {
+  display: grid;
+  gap: 12px;
+}
+
+.focus-note {
+  border: 1px solid #d8e0ea;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 14px;
+}
+
+.focus-note h3,
+.focus-note p {
+  margin: 0;
+}
+
+.focus-note h3 {
+  margin-bottom: 0.4rem;
+  color: #102a43;
+}
+
+.focus-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.focus-toolbar a,
+.focus-toolbar button,
+.focus-row-action {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.2rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  color: #1d4ed8;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.focus-row-action {
+  min-height: 1.9rem;
+  padding: 0.3rem 0.55rem;
+}
+
+.focus-check {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (max-width: 760px) {
+  .focus-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .focus-demo-shell .tree-view {
+    min-width: 680px;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page focus-state-page">
+    <header class="mock-header">
+      <p class="mock-kicker">focused mockup</p>
+      <h1>Keyboard focus and focus-visible states</h1>
+      <p>
+        Static reference for checking TreeView's lightweight focus cue across representative controls.
+        The highlighted samples show visible focus styling only; focus order, shortcut keys, and full treegrid keyboard behavior remain host-app responsibilities.
+      </p>
+      <nav class="mock-page-nav" aria-label="Mockup navigation">
+        <a href="review-gallery.html">Back to gallery</a>
+        <a href="README.md">Mockup README</a>
+      </nav>
+      <div class="focus-summary" aria-label="Review summary">
+        <div class="focus-summary__item"><strong>Gem baseline</strong>Toggle links and shipped controls should expose a visible focus cue without changing row layout.</div>
+        <div class="focus-summary__item"><strong>Host-app boundary</strong>Final tab order, shortcut policy, and treegrid semantics are not promised by this mockup.</div>
+        <div class="focus-summary__item"><strong>Static artifact</strong>The blue and teal rings mark sample focus states so review does not depend on live keyboard interaction.</div>
+      </div>
+    </header>
+
+    <section class="mock-section focus-grid" aria-labelledby="focus-targets-heading">
+      <div>
+        <h2 id="focus-targets-heading">Representative focus targets</h2>
+        <div class="focus-toolbar" aria-label="Toolbar samples">
+          <button type="button" class="focus-sample">Expand current path</button>
+          <a href="#" class="focus-sample--soft">Open selected</a>
+          <button type="button" disabled>Collapse all</button>
+        </div>
+        <div class="focus-demo-shell">
+          <table class="tree-view" aria-label="Static focus target comparison">
+            <thead>
+              <tr>
+                <th scope="col">Node</th>
+                <th scope="col">Selection</th>
+                <th scope="col">State</th>
+                <th scope="col">Row action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row tree-row--expanded">
+                <td><a href="#" class="tree-toggle__action focus-sample" aria-expanded="true">Project docs</a></td>
+                <td><input class="focus-check" type="checkbox" aria-label="Select Project docs"></td>
+                <td><span class="tree-badge">Current path</span></td>
+                <td><button type="button" class="focus-row-action">Open</button></td>
+              </tr>
+              <tr class="tree-row tree-row--child">
+                <td><a href="#" class="tree-toggle__action" aria-expanded="false">API reference</a></td>
+                <td><input class="focus-check focus-sample--soft" type="checkbox" aria-label="Select API reference"></td>
+                <td><span class="tree-muted">Selectable checkbox focus</span></td>
+                <td><button type="button" class="focus-row-action">Open</button></td>
+              </tr>
+              <tr class="tree-row tree-row--leaf">
+                <td><span class="tree-leaf-label">Accessibility notes</span></td>
+                <td><input class="focus-check" type="checkbox" aria-label="Select Accessibility notes"></td>
+                <td><span class="tree-muted">Leaf row</span></td>
+                <td><button type="button" class="focus-row-action focus-sample">Preview</button></td>
+              </tr>
+              <tr class="tree-row tree-row--disabled">
+                <td><span class="tree-leaf-label">Archived rollout plan</span></td>
+                <td><input class="focus-check" type="checkbox" aria-label="Select Archived rollout plan" disabled></td>
+                <td><span class="tree-badge tree-badge--muted">Disabled</span></td>
+                <td><button type="button" class="focus-row-action" disabled>Open</button></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <aside class="focus-note-list" aria-label="Responsibility notes">
+        <div class="focus-note">
+          <h3>Toggle link cue</h3>
+          <p>The toggle action can show the same baseline ring as other links while keeping the table-first structure intact.</p>
+        </div>
+        <div class="focus-note">
+          <h3>Native controls</h3>
+          <p>Checkboxes and row buttons keep their native focusability. Host apps own any business-specific selection or action semantics.</p>
+        </div>
+        <div class="focus-note">
+          <h3>Not a keyboard model</h3>
+          <p>This page does not introduce roving tabindex, arrow-key navigation, or full WAI-ARIA treegrid behavior.</p>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -206,6 +206,7 @@
         <div class="mock-gallery-review-path-links">
           <a href="#gallery-default-heading">Baseline</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
+          <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
           <a href="#gallery-narrow-heading">Responsive and scale</a>
           <a href="#gallery-current-branch-heading">Current branch</a>
           <a href="#gallery-breadcrumb-heading">Navigation context</a>
@@ -234,6 +235,9 @@
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-keyboard-focus-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused keyboard cue</p><h2 id="gallery-keyboard-focus-heading">Keyboard focus states</h2><p>Compare static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</p><ul class="mock-gallery-points"><li>Toggle link focus cue</li><li>Native checkbox and button focus samples</li><li>Host-app keyboard model boundary</li></ul><div class="mock-gallery-links"><a href="keyboard-focus-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="keyboard-focus-states.html" title="Keyboard focus states mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-lazy-handoff-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Compare the host-app-owned children container and remote-state placeholder across initial, loaded, and error/retry states.</p><ul class="mock-gallery-points"><li>Children container ownership</li><li>Remote-state slot handoff</li><li>Error/retry boundary without fetch behavior</li></ul><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div>
@@ -285,6 +289,7 @@
         <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
         <tr><td>Current branch sidebar</td><td>Current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues.</td><td>Route selection, permission-aware labels, final sidebar ordering, or host-app navigation policy.</td></tr>
         <tr><td>Interaction states</td><td>Loading, retry, pagination, and general drag or drop status cues.</td><td>Real Turbo responses, route wiring, or persistence behavior.</td></tr>
+        <tr><td>Keyboard focus states</td><td>Static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</td><td>Tab order, shortcut policy, roving tabindex, arrow-key navigation, or full treegrid behavior.</td></tr>
         <tr><td>Lazy-loading handoff</td><td>Children container ownership, remote-state placeholder handoff, and error/retry slot boundaries.</td><td>Real Turbo responses, fetch or retry controller behavior, authorization, or cursor policy.</td></tr>
         <tr><td>Persisted State boundary</td><td>Expansion state before, changed, restored, save-failed, and retry cues.</td><td>Storage schema, save endpoint, authorization, retry policy, browser save helper, or final error copy.</td></tr>
         <tr><td>Drop positions</td><td>Before, inside, and after transfer cues plus the disabled target policy boundary.</td><td>Move authorization, persistence, audit trails, route wiring, or final business copy.</td></tr>


### PR DESCRIPTION
## 対応Issue

- Closes #845

## 採用した方針

- PR #853 の review follow-up として、最新 `main` から #845 の keyboard focus / focus-visible mockup だけを作り直しました。
- 自動実行のため、最も低リスクな「runtime には触れず、static mockup と mockup index / gallery 導線だけを補強する」案を採用しました。
- #833 / lazy-loading handoff 相当の変更は、既に merged 済みの #873 に任せ、このPRには含めていません。

## 比較した案

- 案A: PR #853 の既存ブランチに追加コミットする
  - stale branch / merge conflict と #833 重複差分が残るため不採用です。
- 案B: 最新 `main` から #845 の差分だけを作り直す
  - 今回採用。`behind_by: 0` で、changed files は keyboard focus mockup とその導線だけです。
- 案C: shipped CSS / runtime keyboard behavior まで変更する
  - roving tabindex、treegrid semantics、shortcut policy の設計判断に踏み込むため不採用です。

## 変更内容

- `docs/mockups/keyboard-focus-states.html` を追加し、toggle link、selection checkbox、row action、toolbar action の sample focus cue を並べました。
- `docs/mockups/README.md` に keyboard focus mockup の Files 行、review flow、responsibility guidance を追加しました。
- `docs/mockups/review-gallery.html` に Keyboard focus の review path、card、comparison cue を追加しました。
- `docs/i18n-audit.md` の technical assets table に新規 mockup を登録しました。

## 変更した画面・コンポーネント

- `docs/mockups/keyboard-focus-states.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `docs/i18n-audit.md`

## 確認内容

- lint
  - 未実行です。PR作成後の GitHub Actions で確認します。
- typecheck
  - runtime / Ruby / JavaScript code は変更していません。
- UI表示確認
  - connector-only 実行のためブラウザ実表示は未確認です。
  - source 上で `review-gallery.html` と `README.md` から `keyboard-focus-states.html` に辿れることを確認しました。
- レスポンシブ確認
  - `keyboard-focus-states.html` は `auto-fit` と `@media (max-width: 760px)` で narrow viewport は 1 column へ落ちる構成です。
  - ブラウザ実表示は未確認です。
- アクセシビリティ確認
  - representative `aria-label` / `aria-expanded` を置き、full treegrid / roving tabindex / shortcut policy は非目標として明記しています。
- GitHub compare
  - `main...design/845-keyboard-focus-mockup-refresh-v2`: `ahead_by: 1` / `behind_by: 0`
  - changed files: 4

## スクリーンショット

<!-- UI変更がある場合は添付 -->

未添付です。connector-only 実行でブラウザ表示確認まではできていません。

## リスク

- low
- mockup/docs-only の変更です。Rails helper、Stimulus controller、runtime ARIA behavior、public API、lazy-loading fetch / Turbo behavior には触れていません。

## 補足

- PR #853 の review comment に対応する replacement PR です。
- #833 相当の lazy-loading handoff 変更はこのPRから分離済みです。