### PR TITLE
selection hidden input source 分離を spec で固定する

### DIFF
--- a/app/javascript/tree_view/selection_hidden_input_source.test.js
+++ b/app/javascript/tree_view/selection_hidden_input_source.test.js
@@ -1,0 +1,95 @@
+import { Application } from "@hotwired/stimulus"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { TreeViewSelectionController } from "./index.js"
+
+function nextFrame() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("TreeViewSelectionController hidden input source isolation", () => {
+  let application
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <form id="bulk-form">
+        <table
+          id="tree-a"
+          data-controller="tree-view-selection"
+          data-tree-view-selection-hidden-input-name-value="selected_nodes[]"
+        >
+          <tbody>
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  id="node-a"
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  value='{ "id": "a" }'
+                  checked
+                >
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table
+          id="tree-b"
+          data-controller="tree-view-selection"
+          data-tree-view-selection-hidden-input-name-value="selected_nodes[]"
+        >
+          <tbody>
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  id="node-b"
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  value='{ "id": "b" }'
+                  checked
+                >
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    `
+
+    application = Application.start()
+    application.register("tree-view-selection", TreeViewSelectionController)
+    await nextFrame()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  function generatedHiddenInputs() {
+    return Array.from(
+      document.querySelectorAll("input[data-tree-view-selection-generated-hidden-input='true']")
+    )
+  }
+
+  it("keeps generated hidden inputs scoped to the controller that created them", () => {
+    const treeA = document.querySelector("#tree-a")
+    const treeB = document.querySelector("#tree-b")
+    const controllerA = application.getControllerForElementAndIdentifier(treeA, "tree-view-selection")
+    const controllerB = application.getControllerForElementAndIdentifier(treeB, "tree-view-selection")
+    const initialInputs = generatedHiddenInputs()
+
+    expect(initialInputs).toHaveLength(2)
+    expect(initialInputs.map((input) => input.name)).toEqual(["selected_nodes[]", "selected_nodes[]"])
+    expect(initialInputs.map((input) => JSON.parse(input.value))).toEqual([{ id: "a" }, { id: "b" }])
+    expect(new Set(initialInputs.map((input) => input.dataset.treeViewSelectionSourceId)).size).toBe(2)
+
+    document.querySelector("#node-a").checked = false
+    controllerA.refresh()
+
+    const remainingInputs = generatedHiddenInputs()
+
+    expect(remainingInputs).toHaveLength(1)
+    expect(JSON.parse(remainingInputs[0].value)).toEqual({ id: "b" })
+    expect(remainingInputs[0].dataset.treeViewSelectionSourceId).toBe(treeB.dataset.treeViewSelectionSourceId)
+    expect(remainingInputs[0].dataset.treeViewSelectionSourceId).not.toBe(treeA.dataset.treeViewSelectionSourceId)
+    expect(controllerB.selectedPayloads()).toEqual([{ id: "b" }])
+  })
+})


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #887

## Issue ごとの完了内容

- #887
  - 同じ form 内に複数の `tree-view-selection` controller があり、同じ hidden input name を使う代表 fixture を追加しました。
  - 初回 connect で controller ごとに generated hidden input と source id が分かれることを確認しました。
  - controller A の `refresh()` が自分の generated hidden input だけを更新し、controller B の generated hidden input を削除しないことを確認しました。
  - hidden input の `name` / JSON `value` / `data-tree-view-selection-source-id` の contract を固定しました。

## 変更内容

- `app/javascript/tree_view/selection_hidden_input_source.test.js` を追加
- runtime JavaScript、public event detail、hidden input name/value contract、selection cascade/max-count behavior は変更していません。

## 改善カテゴリ

- test
- regression guard
- hidden input sync source isolation

## 既存仕様への影響

- 既存仕様への影響はありません。
- 実装変更なしの spec-only 変更です。
- 同一 form 内の複数 controller が互いの generated hidden input を消さない current behavior を固定するだけです。

## 実施した確認

- GitHub compare: `main...quality/887-selection-hidden-input-source`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local `npm test` / `npm run test:js` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で JavaScript / lint / Rails compatibility checks を確認します。

## リスク評価

- low
- test-only の変更です。runtime behavior、API契約、DB、認可、外部サービス契約には触れていません。

## 補足事項

- selection hidden input sync API の redesign、server-side parameter parsing、selection cascade / indeterminate / max-count policy には広げていません。