### PR TITLE
PathTreeBuilder の edge behavior を spec で固定する

### DIFF
--- a/spec/lib/tree_view/path_tree_builder_spec.rb
+++ b/spec/lib/tree_view/path_tree_builder_spec.rb
@@ -83,9 +83,45 @@ RSpec.describe TreeView::PathTreeBuilder do
     expect(builder.children_for(builder.root_items.first).map(&:label)).to eq(["Nested document"])
   end
 
+  it "uses custom separators and ignores blank path segments" do
+    document = PathTreeBuilderDocument.new(
+      id: 1,
+      source_relative_path: "docs :: guides ::  :: intro.md",
+      title: "Intro"
+    )
+
+    builder = described_class.new(
+      records: [document],
+      path_resolver: ->(record) { record.source_relative_path },
+      separator: "::"
+    )
+
+    docs = builder.nodes.find { |node| node.key == "folder:docs" }
+    guides = builder.nodes.find { |node| node.key == "folder:docs::guides" }
+    intro = builder.nodes.find { |node| node.key == "record:1" }
+
+    expect(docs.label).to eq("docs")
+    expect(docs.parent_key).to be_nil
+    expect(guides.label).to eq("guides")
+    expect(guides.parent_key).to eq("folder:docs")
+    expect(intro.label).to eq("intro.md")
+    expect(intro.path).to eq("docs::guides::intro.md")
+    expect(intro.parent_key).to eq("folder:docs::guides")
+  end
+
   it "raises a configuration error for invalid resolvers" do
     expect do
       described_class.new(records: [], path_resolver: :source_relative_path)
     end.to raise_error(TreeView::ConfigurationError, /path_resolver must respond to call/)
+  end
+
+  it "raises a configuration error for unsupported sort keys" do
+    expect do
+      described_class.new(
+        records: [],
+        path_resolver: ->(record) { record.source_relative_path },
+        sort: {folders_last: true}
+      )
+    end.to raise_error(TreeView::ConfigurationError, /sort contains unknown keys: folders_last/)
   end
 end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #741

## Issue ごとの完了内容

- #741
  - `PathTreeBuilder` の custom `separator:` 使用時に folder / record path が同じ separator で組み立てられることを spec で固定しました。
  - blank path segment が無視され、record が正しい parent folder 配下に置かれる代表ケースを追加しました。
  - unsupported sort key が `TreeView::ConfigurationError` になる代表ケースを追加しました。

## 変更内容

- `spec/lib/tree_view/path_tree_builder_spec.rb`
  - custom separator + blank segment handling の regression spec を追加
  - unknown sort key の configuration error spec を追加

## 改善カテゴリ

- test
- public behavior contract guard

## 既存仕様への影響

- 既存仕様への影響はありません。
- runtime code、public API、docs、rendering、JavaScript、DB、認可、外部サービス契約は変更していません。
- 既存 implementation / docs から読み取れる current behavior を spec で固定するだけです。

## 実施した確認

- GitHub compare: `main...quality/741-path-tree-builder-edges`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local RSpec は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
  - Ruby / bundle 実行環境をローカルに展開できませんでした。
- PR 作成後の GitHub Actions で RSpec / CI を確認します。

## リスク評価

- low
- spec-only 変更です。挙動変更はありません。

## 補足事項

- PathTreeBuilder redesign、property-based / fuzz spec、public helper 追加、docs / mockup 更新には広げていません。