### PR TITLE
design: multi-tree selection form mockup を追加する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -127,6 +127,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/path-tree-builder-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/form-editing-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/selection-max-count.html` | Technical asset | No translation needed. |
+| `docs/mockups/selection-multi-tree-form.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
 | `docs/mockups/row-status-depth-labels.html` | Technical asset | No translation needed. |
 | `docs/mockups/toggle-icon-states.html` | Technical asset | No translation needed. |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -31,6 +31,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [path-tree-builder-rows.html](path-tree-builder-rows.html) | Focused PathTreeBuilder comparison for generated folder rows versus record-backed rows, keeping host-app columns/actions outside the gem contract. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [selection-max-count.html](selection-max-count.html) | Focused selection max-count reference showing below-limit, limit-reached, and limit-exceeded feedback while keeping final action copy host-app owned. |
+| [selection-multi-tree-form.html](selection-multi-tree-form.html) | Focused multi-tree selection form reference showing source-specific selected counts, submit summary, empty state, and generated hidden input boundary. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all, collapse-all, and collapse-to-current-path toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
@@ -58,9 +59,10 @@ They are **not** a complete Rails application and should not grow into host-app 
 19. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
 20. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
 21. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-22. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-23. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-24. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+22. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
+23. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+24. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+25. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -214,6 +214,7 @@
           <a href="#gallery-path-builder-heading">Generated rows</a>
           <a href="#gallery-form-heading">Editing and controls</a>
           <a href="#gallery-selection-limit-heading">Selection limits</a>
+          <a href="#gallery-selection-form-heading">Selection form</a>
           <a href="#gallery-empty-heading">Empty and fallback states</a>
         </div>
       </nav>
@@ -280,6 +281,9 @@
       <article class="mock-gallery-card" aria-labelledby="gallery-selection-limit-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Attempted checkbox restored after limit-exceeded</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div>
       </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-selection-form-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Compare multiple TreeView selection groups inside one host-app form while keeping source-specific hidden input sync internal.</p><ul class="mock-gallery-points"><li>Selection counts grouped by source</li><li>Generated hidden input source boundary</li><li>Submit summary owned by the host app</li></ul><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div>
+      </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
       </article>
@@ -311,6 +315,7 @@
         <tr><td>PathTreeBuilder rows</td><td>Generated folder row cues compared with record-backed rows and host-app-owned columns or actions.</td><td>File-manager routes, download behavior, record authorization, or public API changes.</td></tr>
         <tr><td>Form-editing rows</td><td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td><td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td></tr>
         <tr><td>Selection max-count</td><td>Below-limit, limit-reached, and limit-exceeded feedback placement around checkbox selection.</td><td>Runtime controller changes, final bulk-action copy, authorization, server validation, or submit behavior.</td></tr>
+        <tr><td>Multi-tree selection form</td><td>Multiple TreeView selection groups inside one host-app form, grouped counts, and source-specific hidden input sync.</td><td>Params parsing, authorization, final bulk action behavior, and business-specific submit copy.</td></tr>
         <tr><td>Toolbar actions</td><td>Tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</td><td>Authorization, route names, current-path semantics, or action sequencing rules.</td></tr>
         <tr><td>Empty state</td><td>Spacing, wrapper hooks, and the full-width empty-row slot.</td><td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td></tr>
       </tbody></table>

--- a/docs/mockups/selection-multi-tree-form.html
+++ b/docs/mockups/selection-multi-tree-form.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView multi-tree selection form mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-selection-page {
+  max-width: 1280px;
+}
+
+.mock-selection-layout {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-selection-frame {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  background: #fff;
+}
+
+.mock-selection-form-header,
+.mock-selection-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mock-selection-form-header__copy {
+  display: grid;
+  gap: 4px;
+}
+
+.mock-selection-form-header h2,
+.mock-selection-form-header p,
+.mock-selection-summary p {
+  margin: 0;
+}
+
+.mock-selection-note {
+  color: #52606d;
+}
+
+.mock-selection-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.mock-selection-group {
+  display: grid;
+  gap: 12px;
+  border: 1px solid #e4e7eb;
+  border-radius: 12px;
+  background: #f8fafc;
+  overflow: hidden;
+}
+
+.mock-selection-group__header {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: #fff;
+}
+
+.mock-selection-group__header h3,
+.mock-selection-group__header p {
+  margin: 0;
+}
+
+.mock-selection-group__body {
+  padding: 0 14px 14px;
+}
+
+.mock-selection-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-selection-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.8rem;
+  padding: 0.2rem 0.62rem;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.mock-selection-chip--empty {
+  background: #e9ecef;
+  color: #334155;
+}
+
+.mock-selection-chip--boundary {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.mock-selection-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-selection-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid #93c5fd;
+  border-radius: 999px;
+  background: #fff;
+  color: #1d4ed8;
+  font: inherit;
+  font-weight: 700;
+}
+
+.mock-selection-button--secondary {
+  border-color: #cbd5e1;
+  color: #334155;
+}
+
+.mock-selection-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: #102a43;
+}
+
+.mock-selection-choice input {
+  inline-size: 1rem;
+  block-size: 1rem;
+}
+
+.mock-selection-hidden-stack {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.mock-selection-hidden-stack h3,
+.mock-selection-hidden-stack p {
+  margin: 0;
+}
+
+.mock-selection-hidden-row {
+  display: grid;
+  gap: 4px;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #e4e7eb;
+  border-radius: 10px;
+  background: #fff;
+  color: #334155;
+  font-size: 0.88rem;
+}
+
+.mock-selection-code {
+  color: #0f172a;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
+.mock-selection-tree-wrap {
+  overflow-x: auto;
+}
+
+.mock-selection-tree-wrap .tree-view-table {
+  min-width: 520px;
+}
+
+@media (max-width: 720px) {
+  .mock-selection-frame {
+    padding: 14px;
+  }
+
+  .mock-selection-groups {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-selection-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView multi-tree selection form mock</h1>
+      <p>
+        Static reference for reviewing one host-app form that contains multiple TreeView selection groups.
+        TreeView owns checkbox selection state and generated hidden inputs. The host app owns group labels, submit summary, authorization, and the business action that consumes the submitted payload.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-selection-layout" aria-labelledby="multi-tree-form-heading">
+      <div class="mock-selection-frame">
+        <div class="mock-selection-form-header">
+          <div class="mock-selection-form-header__copy">
+            <h2 id="multi-tree-form-heading">Bulk review form with two selection sources</h2>
+            <p class="mock-selection-note">The form groups selected rows by source, while each TreeView instance keeps its own generated hidden input.</p>
+          </div>
+          <div class="mock-selection-chip-row" aria-label="Representative form state">
+            <span class="mock-selection-chip">3 total selected</span>
+            <span class="mock-selection-chip mock-selection-chip--boundary">hidden sync separated by source id</span>
+          </div>
+        </div>
+
+        <div class="mock-selection-groups">
+          <article class="mock-selection-group" aria-labelledby="policy-tree-heading">
+            <div class="mock-selection-group__header">
+              <h3 id="policy-tree-heading">Policy library</h3>
+              <p class="mock-selection-note">Two selected rows from the documents tree.</p>
+              <div class="mock-selection-chip-row">
+                <span class="mock-selection-chip">selected: 2</span>
+                <span class="mock-selection-chip mock-selection-chip--boundary">source: policies</span>
+              </div>
+            </div>
+            <div class="mock-selection-group__body mock-selection-tree-wrap">
+              <table class="tree-view-table">
+                <thead>
+                  <tr><th scope="col">tree</th><th scope="col">name</th><th scope="col">state</th></tr>
+                </thead>
+                <tbody>
+                  <tr class="tree-row is-expanded" aria-level="1" aria-expanded="true">
+                    <td class="tree-toggle-cell"><label class="mock-selection-choice"><input type="checkbox" checked> Select</label></td>
+                    <td>Operations handbook</td>
+                    <td><span class="status-badge is-success">Ready</span></td>
+                  </tr>
+                  <tr class="tree-row is-current" aria-level="2" aria-current="page">
+                    <td class="tree-toggle-cell"><label class="mock-selection-choice"><input type="checkbox" checked> Select</label></td>
+                    <td>Escalation matrix</td>
+                    <td><span class="status-badge is-warning">Needs review</span></td>
+                  </tr>
+                  <tr class="tree-row" aria-level="2">
+                    <td class="tree-toggle-cell"><label class="mock-selection-choice"><input type="checkbox"> Select</label></td>
+                    <td>Training checklist</td>
+                    <td><span class="status-badge">Draft</span></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+
+          <article class="mock-selection-group" aria-labelledby="asset-tree-heading">
+            <div class="mock-selection-group__header">
+              <h3 id="asset-tree-heading">Asset folders</h3>
+              <p class="mock-selection-note">One selected folder from a second TreeView instance in the same form.</p>
+              <div class="mock-selection-chip-row">
+                <span class="mock-selection-chip">selected: 1</span>
+                <span class="mock-selection-chip mock-selection-chip--boundary">source: assets</span>
+              </div>
+            </div>
+            <div class="mock-selection-group__body mock-selection-tree-wrap">
+              <table class="tree-view-table">
+                <thead>
+                  <tr><th scope="col">tree</th><th scope="col">folder</th><th scope="col">owner</th></tr>
+                </thead>
+                <tbody>
+                  <tr class="tree-row is-expanded" aria-level="1" aria-expanded="true">
+                    <td class="tree-toggle-cell"><label class="mock-selection-choice"><input type="checkbox"> Select</label></td>
+                    <td>Brand assets</td>
+                    <td>Design</td>
+                  </tr>
+                  <tr class="tree-row is-selected" aria-level="2">
+                    <td class="tree-toggle-cell"><label class="mock-selection-choice"><input type="checkbox" checked> Select</label></td>
+                    <td>Launch banners</td>
+                    <td>Marketing</td>
+                  </tr>
+                  <tr class="tree-row" aria-level="2">
+                    <td class="tree-toggle-cell"><label class="mock-selection-choice"><input type="checkbox"> Select</label></td>
+                    <td>Product screenshots</td>
+                    <td>Product</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </div>
+
+        <div class="mock-selection-summary" aria-label="Host app submit summary">
+          <p class="mock-selection-note">Host app summary: apply the bulk review action to 2 policy rows and 1 asset row.</p>
+          <div class="mock-selection-actions">
+            <button class="mock-selection-button" type="button">Apply review action</button>
+            <button class="mock-selection-button mock-selection-button--secondary" type="button">Clear visible selection</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="hidden-sync-heading">
+      <div class="mock-selection-hidden-stack">
+        <h2 id="hidden-sync-heading">Generated hidden input boundary</h2>
+        <p class="mock-selection-note">These rows are shown as a review aid only. In a real form, generated hidden inputs stay internal and the host app decides how much summary copy to expose.</p>
+        <div class="mock-selection-hidden-row">
+          <strong>Policy source</strong>
+          <span class="mock-selection-code">name="bulk_review[policy_ids]" data-tree-view-selection-source-id="policies" value='["policy-101","policy-122"]'</span>
+        </div>
+        <div class="mock-selection-hidden-row">
+          <strong>Asset source</strong>
+          <span class="mock-selection-code">name="bulk_review[asset_ids]" data-tree-view-selection-source-id="assets" value='["asset-folder-204"]'</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="empty-source-heading">
+      <h2 id="empty-source-heading">Empty source state</h2>
+      <p class="mock-selection-note">
+        When one TreeView group has no selected rows, keep the group visible if the host app needs the user to compare sources, but show the empty count instead of exposing an empty hidden payload.
+      </p>
+      <div class="mock-selection-chip-row">
+        <span class="mock-selection-chip mock-selection-chip--empty">archived folders: 0 selected</span>
+        <span class="mock-selection-chip mock-selection-chip--boundary">empty generated payload remains internal</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -138,6 +138,11 @@ const focusedMockupSmokeTargets = [
     minimumCount: 3
   },
   {
+    file: "selection-multi-tree-form.html",
+    sample: ".mock-selection-group",
+    minimumCount: 2
+  },
+  {
     file: "empty-state.html",
     sample: "[data-tree-view-empty-state='true']",
     minimumCount: 2
@@ -153,8 +158,10 @@ test.describe("docs mockup browser smoke", () => {
     await expect(page.getByRole("link", { name: "Baseline" })).toHaveAttribute("href", "#gallery-default-heading")
     await expect(page.getByRole("link", { name: "Interaction states" })).toHaveAttribute("href", "#gallery-interaction-heading")
     await expect(page.getByRole("link", { name: "Current branch" })).toHaveAttribute("href", "#gallery-current-branch-heading")
+    await expect(page.getByRole("link", { name: "Selection form" })).toHaveAttribute("href", "#gallery-selection-form-heading")
     await expect(page.frameLocator("iframe[title='Default tree mock preview']").getByRole("heading", { name: "Default TreeView rendering mock", level: 1 })).toBeVisible()
     await expect(page.frameLocator("iframe[title='Current branch sidebar mock preview']").getByRole("heading", { name: "Current branch sidebar mock", level: 1 })).toBeVisible()
+    await expect(page.frameLocator("iframe[title='Multi-tree selection form mock preview']").getByRole("heading", { name: "TreeView multi-tree selection form mock", level: 1 })).toBeVisible()
 
     const linkedFiles = await page.locator("a[href]").evaluateAll((anchors) =>
       Array.from(new Set(
@@ -168,6 +175,7 @@ test.describe("docs mockup browser smoke", () => {
     expect(linkedFiles).toContain("default-tree.html")
     expect(linkedFiles).toContain("interaction-states.html")
     expect(linkedFiles).toContain("current-branch-sidebar.html")
+    expect(linkedFiles).toContain("selection-multi-tree-form.html")
     expect(linkedFiles).toContain("empty-state.html")
     expect(missingLinks).toEqual([])
   })


### PR DESCRIPTION
## 対応Issue

- Closes #889

## 採用した方針

- dedicated mockup page `selection-multi-tree-form.html` を追加し、1つの host app form に複数 TreeView selection group がある状態を静的に確認できるようにしました。
- review follow-up として current `main` (`f1ab743dd4219c30e7428cca830d6981a54a8618`) へ載せ直し、`docs/mockups/review-gallery.html` の差分を追加カード / review path / comparison cue のみに最小化しました。
- JavaScript controller、Rails helper、server-side params handling、authorization、business action behavior には触れていません。

## 比較した案

- 案A: 既存 `form-editing-rows.html` に selection hidden input sync の section を追加する
  - 不採用。form editing と hidden input sync の論点が混ざり、レビュー対象がぼやけるため。
- 案B: dedicated focused mockup page を追加する
  - 採用。selection group label、selected count、submit summary、generated hidden input boundary を1ページで読みやすくできるため。
- 案C: runtime fixture / browser E2E を追加する
  - 不採用。Issue は design static mockup lane で、runtime behavior は既存 controller/spec の責務に残すため。

## 変更内容

- `docs/mockups/selection-multi-tree-form.html` を追加
  - policy tree / asset tree の2 selection source を並べて表示
  - source ごとの selected count と host-app submit summary を追加
  - generated hidden input は review aid として下部に分離し、通常 UI の主役にしない構成にしました
  - empty source state も短く追加
- `docs/mockups/README.md` に file table と review flow の入口を追加
- `docs/mockups/review-gallery.html` に review path / gallery card / iframe preview / comparison cue を追加
- `test/browser/docs_mockups_smoke.spec.js` に新規 mockup と gallery link の smoke coverage を追加
- `docs/i18n-audit.md` の technical assets table に新規 mockup を追加

## 変更した画面・コンポーネント

- `docs/mockups/selection-multi-tree-form.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `test/browser/docs_mockups_smoke.spec.js`
- `docs/i18n-audit.md`

## 受け入れ条件との対応

- multi-tree form / bulk action form の selection grouping を focused mockup として追加しました。
- selection group label、selected count、submit action、empty/selected state、generated hidden input boundary を同一ページで確認できます。
- README と review gallery の両方から辿れるようにしました。
- selection docs の hidden-input sync guidance と矛盾しないよう、params parsing / authorization / business action は host app responsibility として残しました。
- runtime JavaScript / Rails helper / server-side params handling は変更していません。

## 確認内容

- GitHub compare: `main...design/889-selection-multi-tree-mockup`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 5
  - `docs/mockups/review-gallery.html`: additions 5 / deletions 0
- GitHub Actions CI `#1239`: initial run failed because `docs/i18n-audit.md` technical assets table was missing the new mockup asset.
- GitHub Actions CI `#1240`: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `gem_package`: skipped
- local test / lint は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で branch を更新しています。

## リスク

- low
- static mockup / docs index / browser smoke target / technical asset inventory の追加のみです。runtime controller、public event contract、server-side params parsing、authorization、business action behavior には触れていません。

## 補足

- review follow-up 指摘の current main 載せ直しと `review-gallery.html` 差分最小化を反映しました。
