### PR TITLE
design: transfer boundary states を drop mockup に追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -19,7 +19,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [keyboard-focus-states.html](keyboard-focus-states.html) | Focused keyboard reference showing static focus-visible samples for toggle links, native controls, toolbar actions, and row actions without promising a full keyboard model. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
-| [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus the host-app-owned move policy boundary. |
+| [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus transfer disabled / invalid payload boundary states. |
 | [persisted-state-boundary.html](persisted-state-boundary.html) | Focused persisted-state reference showing before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned. |
 | [turbo-frame-target.html](turbo-frame-target.html) | Focused Turbo Frame target boundary showing `data-turbo-frame` on TreeView toggle links beside the host-app-owned frame wrapper. |
 | [drag-interactive-controls.html](drag-interactive-controls.html) | Focused comparison for native interactive controls, `data-tree-view-interactive`, and `data-tree-view-ignore-drag` inside draggable rows. |
@@ -44,7 +44,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 7. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
 8. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
 9. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-10. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, and after drop cues without modeling host-app reorder rules or persistence.
+10. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
 11. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
 12. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
 13. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
@@ -93,7 +93,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 ## Drag/drop guidance
 
-- Use focused static mockups to compare coarse visual cues such as dragging, valid target, blocked target, and drop position.
+- Use focused static mockups to compare coarse visual cues such as dragging, valid target, blocked target, drop position, and invalid transfer boundaries.
 - Treat final move authorization, persistence, audit trails, and business copy as host-app responsibilities.
 
 ## Keyboard focus guidance

--- a/docs/mockups/drop-positions.html
+++ b/docs/mockups/drop-positions.html
@@ -97,6 +97,18 @@
   outline-offset: -2px;
 }
 
+.drop-position-row--disabled {
+  background: #f8fafc;
+  color: #64748b;
+  outline: 2px dashed #cbd5e1;
+  outline-offset: -2px;
+}
+
+.drop-position-row--disabled .tree-toggle,
+.drop-position-row--invalid .tree-toggle {
+  opacity: 0.78;
+}
+
 .drop-position-note-list {
   margin: 0;
   padding-left: 1.2rem;
@@ -110,6 +122,31 @@
 
 .drop-position-boundary p {
   margin: 0;
+}
+
+.drop-position-boundary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.drop-position-boundary-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid #dde4ec;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.drop-position-boundary-card h3,
+.drop-position-boundary-card p {
+  margin: 0;
+}
+
+.drop-position-boundary-card p {
+  color: #52606d;
+  font-size: 0.92rem;
 }
 
 @media (max-width: 680px) {
@@ -221,24 +258,58 @@
     </section>
 
     <section class="mock-section" aria-labelledby="boundary-heading">
-      <h2 id="boundary-heading">Disabled and responsibility boundary</h2>
+      <h2 id="boundary-heading">Transfer boundary states</h2>
       <div class="drop-position-boundary">
-        <p>TreeView can show a coarse target cue, but it does not decide whether a move is allowed for the host application's business rules.</p>
+        <p>These static states show how transfer guards and invalid events can be reviewed without making TreeView responsible for final move policy.</p>
         <ul class="drop-position-note-list">
-          <li>Use <code>data-tree-drop-position</code> for visual comparison of before, inside, and after positions.</li>
-          <li>Use disabled or invalid styling only as representative host-app policy output in this static reference.</li>
+          <li>Use <code>data-tree-transfer-disabled="true"</code> as a representative disabled target cue.</li>
+          <li>Use invalid styling to show the event boundary for malformed row payloads or transferred values.</li>
           <li>Keep final permission wording, persistence, audit trails, and reorder rules outside this mockup.</li>
         </ul>
       </div>
-      <table class="tree-view-table drop-position-table" data-controller="tree-view-transfer">
-        <thead><tr><th scope="col">tree</th><th scope="col">policy cue</th></tr></thead>
-        <tbody>
-          <tr class="tree-row drop-position-row drop-position-row--invalid" data-tree-node-key="folder:archive" data-tree-drop-position="inside" data-tree-drop-disabled-reason="Readonly target" aria-level="1" aria-disabled="true">
-            <td class="tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">blocked</span><span class="mock-node-title">Archived folder</span></span></span></td>
-            <td><span class="mock-status mock-status--error">host app rejects move</span></td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="drop-position-boundary-grid">
+        <article class="drop-position-boundary-card" aria-labelledby="transfer-disabled-heading">
+          <h3 id="transfer-disabled-heading">Transfer disabled target</h3>
+          <p>The row exposes a disabled transfer guard; authorization and exact explanation stay in the host app.</p>
+          <table class="tree-view-table drop-position-table" data-controller="tree-view-transfer">
+            <thead><tr><th scope="col">tree</th><th scope="col">boundary cue</th></tr></thead>
+            <tbody>
+              <tr class="tree-row drop-position-row drop-position-row--disabled" data-tree-node-key="folder:archive" data-tree-transfer-disabled="true" aria-level="1" aria-disabled="true">
+                <td class="tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">blocked</span><span class="mock-node-title">Archived folder</span></span></span></td>
+                <td><span class="mock-status">transfer disabled</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="drop-position-boundary-card" aria-labelledby="invalid-row-heading">
+          <h3 id="invalid-row-heading">Invalid row payload</h3>
+          <p>A malformed source row can be surfaced as an invalid transfer event without changing drop-position cues.</p>
+          <table class="tree-view-table drop-position-table" data-controller="tree-view-transfer">
+            <thead><tr><th scope="col">tree</th><th scope="col">boundary cue</th></tr></thead>
+            <tbody>
+              <tr class="tree-row drop-position-row drop-position-row--invalid" draggable="true" data-tree-node-key="task:missing-payload" aria-level="1">
+                <td class="tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">drag</span><span class="mock-node-title">Missing payload row</span></span></span></td>
+                <td><span class="mock-status mock-status--error">invalid row payload</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="drop-position-boundary-card" aria-labelledby="invalid-transfer-heading">
+          <h3 id="invalid-transfer-heading">Invalid transferred value</h3>
+          <p>When the transferred value cannot be read, show the failed boundary separately from host-app move failure.</p>
+          <table class="tree-view-table drop-position-table" data-controller="tree-view-transfer">
+            <thead><tr><th scope="col">tree</th><th scope="col">boundary cue</th></tr></thead>
+            <tbody>
+              <tr class="tree-row drop-position-row drop-position-row--invalid" data-tree-node-key="folder:planning" data-tree-drop-position="inside" aria-level="1">
+                <td class="tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">target</span><span class="mock-node-title">Planning folder</span></span></span></td>
+                <td><span class="mock-status mock-status--error">invalid transfer data</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+      </div>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## 対応Issue

- Closes #883

## 採用した方針

- `docs/mockups/drop-positions.html` の既存 before / inside / after cue comparison は保ったまま、同じ page 内に `Transfer boundary states` section を追加しました。
- 自動実行のためユーザー選択は待たず、Planner handoff に沿って「新規 page を増やさず、既存 focused page に section 分割で追加する」案を採用しました。
- runtime controller、public event payload、drop-position 判定、host-app move policy、authorization copy、persistence、audit trail には触れていません。

## 比較した案

- 案A: `drop-positions.html` 内に section を分けて追加する
  - 採用。既存の drag/drop review surface と同じ文脈で確認でき、README 更新も最小で済むため。
- 案B: 新規 focused mockup page を追加する
  - 不採用。今回の3状態は drop-position cue と近く、page を分けるほどの独立性はまだ低いため。
- 案C: `interaction-states.html` に追加する
  - 不採用。Planner handoff どおり broad page を主実装先にせず、drop-position comparison の focused page に閉じるため。

## 変更内容

- `docs/mockups/drop-positions.html`
  - transfer disabled target の静的状態を追加
  - invalid row payload の静的状態を追加
  - invalid transferred value の静的状態を追加
  - disabled / invalid boundary 用の軽量 CSS と responsive grid を追加
  - host-app-owned move policy / copy / persistence / audit trail の境界説明を更新
- `docs/mockups/README.md`
  - file table、recommended review flow、drag/drop guidance を、追加した boundary states に合わせて最小更新

## 変更した画面・コンポーネント

- `docs/mockups/drop-positions.html`
- `docs/mockups/README.md`

## 確認内容

- lint: 未実行（connector-only の static docs 変更）
- typecheck: 未実行（runtime code 変更なし）
- UI表示確認: HTML structure、section heading、table header、既存 `default-tree.css` 参照、boundary card grid の構成を確認
- レスポンシブ確認: `auto-fit` / `minmax(260px, 1fr)` と既存 narrow table fallback の範囲に閉じました
- アクセシビリティ確認: section / card heading の `aria-labelledby`、table headers、`aria-disabled` を追加し、mock-only invalid states は visual reference として説明文付きにしました

## スクリーンショット

<!-- connector-only 実行のため未添付 -->

## リスク

- low
- static mockup / README の更新のみです。runtime JavaScript、Rails helper、server-side move policy、authorization、event payload shape には触れていません。

## 補足

- compare: `main...design/883-transfer-boundary-mockup` は `ahead_by: 2` / `behind_by: 0` です。
- GitHub HTTPS clone/fetch は `CONNECT tunnel failed, response 403` で利用できなかったため、connector 経由で branch と差分を作成しました。