### PR TITLE
docs: demo application boundary の導線を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
 - [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure and interaction states. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
+- [English demo application boundary](en/demo-application-boundary.md): decide when to use static mockups versus a real Rails demo app, without adding private or unavailable demo links.
+- [日本語Demo application boundary](ja/demo-application-boundary.md): static mockup と real Rails demo app の役割分担、未公開 demo link を増やさない方針。
 - [English Turbo Frame option](en/turbo-frame.md): target TreeView Turbo toggle links at a host-app Turbo Frame without custom JavaScript.
 - [日本語Turbo Frame オプション](ja/turbo-frame.md): TreeView の Turbo toggle link を host app の Turbo Frame に向ける設定。
 - [English Persisted State](en/persisted-state.md): save and restore TreeView expansion state through host-app-owned storage.
@@ -37,6 +39,7 @@
 - [Public API](en/public-api.md) / [公開 API](ja/public-api.md): compatibility contract and the surfaces host apps may use directly.
 - [Migration guide](en/migration.md) / [移行ガイド](ja/migration.md): upgrade expectations, deprecations, and release-note reading order.
 - [Design policy](en/design-policy.md) / [設計思想と責務範囲](ja/design-policy.md): repository scope, responsibility boundaries, and non-goals.
+- [Demo application boundary](en/demo-application-boundary.md) / [Demo application boundary](ja/demo-application-boundary.md): handoff policy between static gem mockups and a future public Rails demo application.
 - [Development](en/development.md) / [開発・保守方針](ja/development.md): CI, local checks, documentation update workflow, and maintenance habits.
 - [Code quality](en/code-quality.md) / [コード品質](ja/code-quality.md): lint, tests, error message quality, and documentation quality policy.
 - [Release checklist](en/release.md) / [リリースチェックリスト](ja/release.md): release workflow, CI and package verification, and changelog expectations.

--- a/docs/en/demo-application-boundary.md
+++ b/docs/en/demo-application-boundary.md
@@ -1,0 +1,25 @@
+# Demo application boundary
+
+TreeView keeps reusable tree rendering primitives in this gem repository. End-to-end Rails application examples belong outside this repository so the gem docs do not grow into CRUD, authorization, seed data, or product-specific workflow documentation.
+
+## Static mockups vs. a real demo app
+
+Use the static [TreeView mockups](../mockups/README.md) when you need to review baseline DOM structure, CSS hooks, ARIA placement, and representative interaction states without running Rails.
+
+Use a real Rails demo application when you need examples that require routes, controllers, database records, authorization, Turbo responses, seed data, or complete host-app workflows.
+
+## Link policy
+
+Do not add a direct demo repository link from this gem's public docs until the demo repository is publicly available. Until then, keep public entry points focused on:
+
+- the static mockups for visual and DOM references
+- feature guides for reusable TreeView APIs and hooks
+- host-app responsibility boundaries for CRUD, authorization, routes, and business actions
+
+When a public demo repository is available, add a short link from the root README or docs index and keep the wording clear that the demo app is an example host application, not part of TreeView's gem contract.
+
+## Non-goals
+
+- Adding Rails controllers, routes, models, seed data, or authorization examples to this gem repository
+- Turning `docs/mockups/` into a playground application
+- Documenting application-specific file-manager behavior as TreeView behavior

--- a/docs/ja/demo-application-boundary.md
+++ b/docs/ja/demo-application-boundary.md
@@ -1,0 +1,25 @@
+# Demo application boundary
+
+TreeView は、再利用できる tree rendering primitives をこの gem repository に置きます。CRUD、authorization、seed data、product-specific workflow まで含む end-to-end の Rails application example は、この repository の外に置き、gem docs が host app 実装例として膨らみすぎないようにします。
+
+## Static mockup と real demo app の違い
+
+Rails を起動せずに baseline DOM structure、CSS hooks、ARIA placement、代表的な interaction state を確認したい場合は、static な [TreeView mockups](../mockups/README.md) を使います。
+
+routes、controllers、database records、authorization、Turbo responses、seed data、complete host-app workflow が必要な例は、real Rails demo application 側で扱います。
+
+## Link policy
+
+Demo repository が public になるまでは、この gem の public docs から demo repository へ直接 link しません。それまでは public entry point を次に限定します。
+
+- visual / DOM reference としての static mockups
+- 再利用できる TreeView API / hooks の feature guide
+- CRUD、authorization、routes、business actions に関する host-app responsibility boundary
+
+Public demo repository が利用できる状態になったら、root README または docs index から短い link を追加します。その場合も、demo app は example host application であり、TreeView gem contract そのものではないことを明確にします。
+
+## Non-goals
+
+- この gem repository に Rails controllers、routes、models、seed data、authorization examples を追加すること
+- `docs/mockups/` を playground application に変えること
+- application-specific file-manager behavior を TreeView behavior として文書化すること


### PR DESCRIPTION
## 対応 Issue

Closes #904

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/en/demo-application-boundary.md` を追加し、static mockups と real Rails demo app の責務境界を整理しました。
- `docs/ja/demo-application-boundary.md` を追加し、同じ方針を日本語 docs 側にも揃えました。
- `docs/README.md` から日英の boundary guide へ導線を追加しました。

## 根拠

- `docs/mockups/README.md` は、Rails routes / controllers / database records / authorization / Turbo responses が必要な例は static mockup ではなく playground / demo app に置く方針を既に持っています。
- `README.md` / Product Profile は TreeView が complete file-manager application ではなく、CRUD / authorization / business actions は host app responsibility だと説明しています。
- `matsuo-haruhito/tree_view-rails-demo` は現時点で public repository ではないため、public docs から直接 link は追加していません。

## 変更範囲

- `docs/README.md`
- `docs/en/demo-application-boundary.md`
- `docs/ja/demo-application-boundary.md`

runtime code、routes、controllers、models、mockup HTML/CSS、demo repository 本体には触れていません。

## 確認

- GitHub compare: `main...docs/904-demo-handoff-boundary`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- connector-only 実行のため local test / lint は未実行です。
- docs-only の新規 guide と docs index 導線追加に限定しています。

## リスク

- low
- 未公開 demo repository への broken link を作らず、既存の host-app responsibility boundary を docs として明文化するだけです。