### PR TITLE
design: toolbar の長いラベル確認 mockup を追加する

### DIFF
--- a/docs/mockups/toolbar-actions.html
+++ b/docs/mockups/toolbar-actions.html
@@ -27,6 +27,10 @@
   background: #fff;
 }
 
+.mock-toolbar-frame--narrow {
+  max-width: 380px;
+}
+
 .mock-toolbar {
   display: flex;
   flex-wrap: wrap;
@@ -41,6 +45,7 @@
 .mock-toolbar__copy {
   display: grid;
   gap: 2px;
+  min-width: 0;
 }
 
 .mock-toolbar__eyebrow {
@@ -70,6 +75,7 @@
   align-items: center;
   gap: 8px;
   min-height: 2.4rem;
+  min-width: 0;
   padding: 0.45rem 0.9rem;
   border: 1px solid #cbd5e1;
   border-radius: 999px;
@@ -79,8 +85,14 @@
   text-decoration: none;
 }
 
+.mock-toolbar-button__label {
+  min-width: 0;
+  white-space: normal;
+}
+
 .mock-toolbar-button__icon {
   display: inline-flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   inline-size: 1.2rem;
@@ -163,6 +175,7 @@
 
 .mock-toolbar-node__caret {
   display: inline-flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   inline-size: 1.8rem;
@@ -228,6 +241,10 @@
     justify-content: center;
   }
 
+  .mock-toolbar-frame--narrow {
+    max-width: none;
+  }
+
   .mock-toolbar-node {
     grid-template-columns: 1fr;
   }
@@ -241,7 +258,7 @@
       <h1>Toolbar action states mock</h1>
       <p>
         Static reference for tree-wide expand, collapse, and current-path-preserving actions. This page keeps the review surface focused on
-        enabled, disabled, and current-state cues without bringing in host-app routes, authorization, or business wording.
+        enabled, disabled, current-state, and long-label cues without bringing in host-app routes, authorization, or business wording.
       </p>
     </header>
 
@@ -255,7 +272,7 @@
         <div>
           <h2 id="toolbar-overview-heading">Representative toolbar states</h2>
           <p class="mock-toolbar-note">
-            The mock keeps copy short and product-neutral. Final labels, routing, and permission messaging remain host-app responsibilities.
+            The mock keeps copy short and product-neutral for baseline states. Final labels, routing, and permission messaging remain host-app responsibilities.
           </p>
         </div>
 
@@ -268,15 +285,15 @@
             <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
               <a class="mock-toolbar-button" href="#" data-mock-state="expand-enabled">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
-                <span>Expand all</span>
+                <span class="mock-toolbar-button__label">Expand all</span>
               </a>
               <a class="mock-toolbar-button" href="#" data-mock-state="collapse-enabled">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
-                <span>Collapse all</span>
+                <span class="mock-toolbar-button__label">Collapse all</span>
               </a>
               <a class="mock-toolbar-button" href="#" data-mock-state="current-path-enabled">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
-                <span>Collapse to current path</span>
+                <span class="mock-toolbar-button__label">Collapse to current path</span>
               </a>
             </div>
           </div>
@@ -332,15 +349,15 @@
             <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
               <button class="mock-toolbar-button" type="button" aria-disabled="true">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
-                <span>Expand all</span>
+                <span class="mock-toolbar-button__label">Expand all</span>
               </button>
               <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="collapse-current">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
-                <span>Collapse all</span>
+                <span class="mock-toolbar-button__label">Collapse all</span>
               </a>
               <a class="mock-toolbar-button" href="#" data-mock-state="current-path-available">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
-                <span>Collapse to current path</span>
+                <span class="mock-toolbar-button__label">Collapse to current path</span>
               </a>
             </div>
           </div>
@@ -383,15 +400,15 @@
             <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
               <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="expand-current">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
-                <span>Expand all</span>
+                <span class="mock-toolbar-button__label">Expand all</span>
               </a>
               <button class="mock-toolbar-button" type="button" aria-disabled="true">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
-                <span>Collapse all</span>
+                <span class="mock-toolbar-button__label">Collapse all</span>
               </button>
               <button class="mock-toolbar-button" type="button" aria-disabled="true">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
-                <span>Collapse to current path</span>
+                <span class="mock-toolbar-button__label">Collapse to current path</span>
               </button>
             </div>
           </div>
@@ -434,15 +451,15 @@
             <div class="mock-toolbar__actions" aria-label="Tree-wide actions">
               <a class="mock-toolbar-button" href="#" data-mock-state="expand-from-current-path">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
-                <span>Expand all</span>
+                <span class="mock-toolbar-button__label">Expand all</span>
               </a>
               <a class="mock-toolbar-button" href="#" data-mock-state="collapse-from-current-path">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
-                <span>Collapse all</span>
+                <span class="mock-toolbar-button__label">Collapse all</span>
               </a>
               <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="current-path-current">
                 <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
-                <span>Collapse to current path</span>
+                <span class="mock-toolbar-button__label">Collapse to current path</span>
               </a>
             </div>
           </div>
@@ -491,6 +508,66 @@
       </div>
     </section>
 
+    <section class="mock-section mock-toolbar-grid" aria-labelledby="toolbar-label-heading">
+      <div>
+        <h2 id="toolbar-label-heading">Long and localized labels</h2>
+        <p class="mock-toolbar-note">
+          This narrow-width reference intentionally uses localized and longer labels so reviewers can check wrapping, disabled cues, and the current state without choosing final host-app wording.
+        </p>
+      </div>
+
+      <div class="mock-toolbar-frame mock-toolbar-frame--narrow">
+        <div class="mock-toolbar">
+          <div class="mock-toolbar__copy">
+            <p class="mock-toolbar__eyebrow">Localized narrow</p>
+            <p class="mock-toolbar__title">Labels wrap inside a compact toolbar</p>
+          </div>
+          <div class="mock-toolbar__actions" aria-label="Localized tree-wide actions">
+            <a class="mock-toolbar-button" href="#" data-mock-state="localized-expand-enabled">
+              <span class="mock-toolbar-button__icon" aria-hidden="true">+</span>
+              <span class="mock-toolbar-button__label">すべての部署とチームを展開</span>
+            </a>
+            <button class="mock-toolbar-button" type="button" aria-disabled="true">
+              <span class="mock-toolbar-button__icon" aria-hidden="true">-</span>
+              <span class="mock-toolbar-button__label">全階層を折りたたむ</span>
+            </button>
+            <a class="mock-toolbar-button mock-toolbar-button--current" href="#" data-mock-state="localized-current-path-current">
+              <span class="mock-toolbar-button__icon" aria-hidden="true">=</span>
+              <span class="mock-toolbar-button__label">現在の申請ルートだけを表示</span>
+            </a>
+          </div>
+        </div>
+        <div class="mock-toolbar-preview" aria-label="Localized narrow toolbar preview">
+          <div class="mock-toolbar-node is-expanded">
+            <div class="mock-toolbar-node__tree">
+              <span class="mock-toolbar-node__caret" aria-hidden="true">-</span>
+              <div>
+                <strong>Head Office</strong>
+                <div class="mock-toolbar-node__meta">
+                  <span class="mock-toolbar-pill">ancestor path</span>
+                  <span class="mock-toolbar-pill">localized labels</span>
+                </div>
+              </div>
+            </div>
+            <span class="mock-toolbar-pill">expanded</span>
+          </div>
+          <div class="mock-toolbar-node is-collapsed">
+            <div class="mock-toolbar-node__tree">
+              <span class="mock-toolbar-node__caret" aria-hidden="true">+</span>
+              <div>
+                <strong>Regional Operations</strong>
+                <div class="mock-toolbar-node__meta">
+                  <span class="mock-toolbar-pill">sibling branch</span>
+                  <span class="mock-toolbar-pill">copy wraps</span>
+                </div>
+              </div>
+            </div>
+            <span class="mock-toolbar-pill">collapsed</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="mock-section" aria-labelledby="toolbar-cues-heading">
       <h2 id="toolbar-cues-heading">State cues to review</h2>
       <table class="mock-toolbar-table">
@@ -521,6 +598,11 @@
             <td>Current path preserved</td>
             <td>The current-path action reads as the active state while ancestors stay open and sibling branches collapse away.</td>
             <td>The semantics of choosing the current path or how the host app stores that state.</td>
+          </tr>
+          <tr>
+            <td>Long or localized labels</td>
+            <td>A compact toolbar can wrap longer labels while preserving icon alignment, disabled styling, and current-state emphasis.</td>
+            <td>Final translations, product-specific action names, exact truncation rules, or host-app breakpoints.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## 対応Issue

- Closes #897

## 採用した方針

- 既存 `docs/mockups/toolbar-actions.html` に、長い / localized ラベルを確認する narrow-width section を追加しました。
- 自動実行のためユーザー選択は待たず、既存ページへ小さく追加する案を採用しました。新規 mockup page や helper runtime 変更よりも低リスクで、既存の review-gallery / README 導線をそのまま使えるためです。
- toolbar helper API、I18n lookup、host app route / authorization、product-specific copy には触れていません。

## 比較した案

- 案A: `toolbar-actions.html` に section を追加する
  - 採用。既存の enabled / disabled / current state と同じ文脈で、長いラベル時の wrapping と cue を確認できるため。
- 案B: dedicated mockup page を新規追加する
  - 不採用。今回の確認対象は toolbar actions の一 variant で、単独ページ化すると導線更新の割に差分が広がるため。
- 案C: README / gallery の説明だけ更新する
  - 不採用。実際の narrow-width 表示状態を確認できず、Issue の主目的である visual reference にならないため。

## 変更内容

- `docs/mockups/toolbar-actions.html`
  - 長い / localized ラベル用の narrow-width section を追加
  - label span と icon の sizing を調整し、長い copy が wrap しても icon / current / disabled cue が読めるようにしました
  - state cues table に long/localized labels の確認観点を追加
  - baseline states は同じページ内に維持し、host-app-owned copy / breakpoint / route policy は範囲外として明記

## 変更した画面・コンポーネント

- `docs/mockups/toolbar-actions.html`

## 確認内容

- lint: 未実行（connector-only の static HTML 変更）
- typecheck: 未実行（runtime code 変更なし）
- UI表示確認: HTML structure、section heading、localized label section、state cue table の構成を connector 上で確認
- レスポンシブ確認: narrow section は `max-width: 380px` と既存 mobile fallback に閉じ、exact breakpoint は host-app responsibility として扱いました
- アクセシビリティ確認: section heading の `aria-labelledby`、toolbar action group の `aria-label`、disabled button の `aria-disabled` を確認

## スクリーンショット

<!-- connector-only 実行のため未添付 -->

## リスク

- low
- static mockup HTML の更新のみです。runtime JavaScript、Rails helper、I18n lookup、routes、authorization、host app copy には触れていません。

## 補足

- compare: `main...design/897-toolbar-long-label-mockup` は `ahead_by: 1` / `behind_by: 0` です。
- GitHub HTTPS clone/fetch は `CONNECT tunnel failed, response 403` で利用できなかったため、connector 経由で branch と差分を作成しました。