### PR TITLE
selection data hook を package root export として公開する

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -53,6 +53,13 @@ export const TreeViewControllerIdentifiers = Object.freeze({
   remoteState: "tree-view-remote-state"
 })
 
+export const TreeViewSelectionDataHooks = Object.freeze({
+  hiddenInputNameValue: "data-tree-view-selection-hidden-input-name-value",
+  maxCountValue: "data-tree-view-selection-max-count-value",
+  cascadeValue: "data-tree-view-selection-cascade-value",
+  indeterminateValue: "data-tree-view-selection-indeterminate-value"
+})
+
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
   application.register("tree-view-client", TreeViewClientController)

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -81,6 +81,7 @@ javascript_package_root:
   named_exports:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
+    - TreeViewSelectionDataHooks
     - TreeViewTransferDropPositions
     - TreeViewStateController
     - TreeViewClientController
@@ -88,6 +89,11 @@ javascript_package_root:
     - TreeViewTransferController
     - TreeViewRemoteStateController
     - TreeViewEventNames
+  selection_data_hooks:
+    hidden_input_name_value: data-tree-view-selection-hidden-input-name-value
+    max_count_value: data-tree-view-selection-max-count-value
+    cascade_value: data-tree-view-selection-cascade-value
+    indeterminate_value: data-tree-view-selection-indeterminate-value
   transfer_drop_positions:
     before: before
     inside: inside

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -167,6 +167,7 @@ Stable enough for host apps to use:
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
 - `TreeViewControllerIdentifiers`
+- `TreeViewSelectionDataHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -180,6 +181,7 @@ Stable enough for host apps to use:
 
 `TreeViewEventNames` exposes the documented event names as a machine-readable package-root export. Use it when wiring host-app listeners and you want to avoid hand-copying event-name strings such as `TreeViewEventNames.selection.change` or `TreeViewEventNames.transfer.drop`.
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
+`TreeViewSelectionDataHooks` exposes the documented `tree-view-selection` host-element value attribute names as a machine-readable object. Use it when JavaScript needs to author or query those host-owned attributes without hand-copying strings such as `TreeViewSelectionDataHooks.hiddenInputNameValue`.
 
 Within `TreeViewEventNames`, lazy-loading request lifecycle names live under `hostLifecycle`:
 
@@ -198,6 +200,13 @@ Documented keys on `TreeViewControllerIdentifiers`:
 - `transfer`
 - `remoteState`
 
+Documented keys on `TreeViewSelectionDataHooks`:
+
+- `hiddenInputNameValue`
+- `maxCountValue`
+- `cascadeValue`
+- `indeterminateValue`
+
 The `tree-view-selection` controller's documented host-element value attributes are also part of the stable host-app wiring surface:
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -205,9 +214,9 @@ The `tree-view-selection` controller's documented host-element value attributes 
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
+Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
-The machine-readable source of truth for the package-root JavaScript exports and bundled controller identifiers lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, and selection data hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 
 Internal by default:
 
@@ -227,12 +236,12 @@ Representative documented hooks are tracked where their feature behavior is expl
 | Hook area | Representative hooks | Contract boundary |
 |---|---|---|
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | TreeView-owned hooks documented in [Toolbar](toolbar.md). Use helper methods for supported actions and metadata instead of internal constants. |
-| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Stable host-element controller values documented in [Selection](selection.md). Row payloads and disabled decisions stay with `selection:` render-state builders. |
+| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Stable host-element controller values documented in [Selection](selection.md) and mirrored by `TreeViewSelectionDataHooks`. Generated hidden input marker and source-id attributes remain TreeView-managed implementation details. |
 | Lazy loading | `data-tree-remote-state`, remote placeholder IDs, lazy-loading lifecycle events | Stable placeholder and event hooks documented in [Lazy Loading](lazy-loading.md). Host apps still own request dispatch and response handling. |
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | Reusable baseline hooks documented in the [mockup inventory](../mockups/README.md). They describe the shipped empty-state reference pattern, not every internal row class. |
 | Interaction markers | marker row classes and `data-*` hooks shown in focused mockups | Reference hooks documented through [mockups](../mockups/README.md) for review and adoption. Promote any hook to a machine-readable contract in `config/public_api_manifest.yml` only when it needs compatibility checks. |
 
-This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
+This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, selection data hooks, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
 
 Undocumented CSS helper classes, data attributes, DOM structure details, and gem partial locals are implementation details.
 

--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -132,10 +132,19 @@ When the tree sits inside a normal HTML form, the same controller can mirror che
 
 With `data-tree-view-selection-hidden-input-name-value`, TreeView writes one hidden input per valid checked payload and keeps those inputs in sync on connect, change, submit, and manual refresh.
 
+If your host app already imports the package root, use `TreeViewSelectionDataHooks.hiddenInputNameValue` when you need to reference the host-authored attribute name from JavaScript without hand-copying the raw string.
+
+```js
+import { TreeViewSelectionDataHooks } from "tree_view"
+
+const hiddenInputNameAttribute = TreeViewSelectionDataHooks.hiddenInputNameValue
+```
+
 - The hidden input `name` stays host-app controlled.
 - Values are written as JSON strings, so `TreeView.parse_selection_params(params[:selected_nodes])` keeps working.
 - Disabled checkboxes and invalid JSON payloads are skipped, matching the existing event payload behavior.
 - If the tree is not inside a form, TreeView keeps dispatching selection events and does not create hidden inputs.
+- Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks.
 
 ## Selection max count
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -167,6 +167,7 @@ host app が使ってよい入口:
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
 - `TreeViewControllerIdentifiers`
+- `TreeViewSelectionDataHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -180,6 +181,7 @@ host app が使ってよい入口:
 
 `TreeViewEventNames` は documented event names を machine-readable に参照するための package-root export です。host app 側で listener を配線するとき、`TreeViewEventNames.selection.change` や `TreeViewEventNames.transfer.drop` のように使うことで event name string の写経を避けられます。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
+`TreeViewSelectionDataHooks` は、documented な `tree-view-selection` host-element value attribute 名を machine-readable な object として公開します。JavaScript から host-owned attribute を authoring / query するとき、`TreeViewSelectionDataHooks.hiddenInputNameValue` のように使うことで raw string の写経を避けられます。
 
 `TreeViewEventNames` のうち、lazy-loading の request lifecycle 名は `hostLifecycle` にまとめています。
 
@@ -198,6 +200,13 @@ host app が使ってよい入口:
 - `transfer`
 - `remoteState`
 
+`TreeViewSelectionDataHooks` の documented key:
+
+- `hiddenInputNameValue`
+- `maxCountValue`
+- `cascadeValue`
+- `indeterminateValue`
+
 `tree-view-selection` controller の documented host-element value attribute も、stable な host-app wiring surface の一部です。
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -205,9 +214,9 @@ host app が使ってよい入口:
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
+これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する属性であり、host app が authoring する public hook ではありません。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
-package-root の JavaScript export と bundled controller identifier の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+package-root の JavaScript export、bundled controller identifier、selection data hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 
 内部扱い:
 
@@ -227,12 +236,12 @@ host app が依存してよい browser-facing surface は、documented された
 | hook area | 代表 hook | contract boundary |
 |---|---|---|
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | [Toolbar](toolbar.md) で説明している TreeView-owned hook です。supported action や metadata は internal constant ではなく helper method から取得してください。 |
-| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | [Selection](selection.md) で説明している stable host-element controller value です。row payload や disabled 判定は `selection:` render-state builder 側に残ります。 |
+| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | [Selection](selection.md) で説明している stable host-element controller value で、`TreeViewSelectionDataHooks` からも参照できます。generated hidden input marker と source-id attribute は TreeView-managed な実装詳細です。 |
 | Lazy loading | `data-tree-remote-state`, remote placeholder ID, lazy-loading lifecycle events | [Lazy Loading](lazy-loading.md) で説明している stable placeholder / event hook です。request dispatch と response handling は引き続き host app 側の責務です。 |
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | [mockup inventory](../mockups/README.md) で説明している reusable baseline hook です。shipped empty-state reference pattern を示すもので、すべての internal row class を公開するものではありません。 |
 | Interaction markers | focused mockup に出てくる marker row classes / `data-*` hooks | review / adoption 用の reference hook として [mockups](../mockups/README.md) で説明します。compatibility check が必要な hook だけを `config/public_api_manifest.yml` の machine-readable contract へ昇格してください。 |
 
-この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
+この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、selection data hook、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
 
 undocumented な CSS helper class、data attribute、DOM 構造詳細、gem partial 内部 locals は内部実装です。
 

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -132,10 +132,19 @@ tree が通常の HTML form の中にある場合、同じ controller で checke
 
 `data-tree-view-selection-hidden-input-name-value` を指定すると、TreeView は valid な checked payload ごとに hidden input を 1 つずつ生成し、connect / change / submit / manual refresh に追従して同期します。
 
+host app が package root をすでに import している場合、JavaScript から host-authored attribute name を参照するときは `TreeViewSelectionDataHooks.hiddenInputNameValue` を使うと raw string の写経を避けられます。
+
+```js
+import { TreeViewSelectionDataHooks } from "tree_view"
+
+const hiddenInputNameAttribute = TreeViewSelectionDataHooks.hiddenInputNameValue
+```
+
 - hidden input の `name` は host app 側で決められます。
 - value は JSON 文字列で書き込まれるため、`TreeView.parse_selection_params(params[:selected_nodes])` をそのまま使えます。
 - disabled checkbox と不正な JSON payload は既存 event と同じく skip されます。
 - tree が form の外にある場合は、selection event だけを dispatch し、hidden input は生成しません。
+- generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する内部寄りの属性であり、host app が authoring する public hook ではありません。
 
 ## 最大選択数
 

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -72,6 +72,13 @@ assert(
 )
 assertFrozenObject(entrypointModule.TreeViewControllerIdentifiers, "TreeViewControllerIdentifiers")
 
+const expectedSelectionDataHooks = deepCamelizeKeys(javascriptPackageManifest.selection_data_hooks)
+assert(
+  JSON.stringify(entrypointModule.TreeViewSelectionDataHooks) === JSON.stringify(expectedSelectionDataHooks),
+  "TreeViewSelectionDataHooks export is out of sync"
+)
+assertFrozenObject(entrypointModule.TreeViewSelectionDataHooks, "TreeViewSelectionDataHooks")
+
 const expectedRegistrations = javascriptPackageManifest.controller_registrations.map(({ identifier, export: exportName }) => {
   assert(exportName in entrypointModule, `${exportName} export is missing`)
   return [identifier, entrypointModule[exportName]]


### PR DESCRIPTION
selection controller の host-element value attributes を machine-readable な package-root export として参照できるようにします。

## 対応 Issue

Closes #890

## 変更内容

- `TreeViewSelectionDataHooks` を `tree_view/index.js` から追加 export しました。
- 公開対象は host app が authoring する `tree-view-selection` value attributes に限定しています。
  - `hiddenInputNameValue`
  - `maxCountValue`
  - `cascadeValue`
  - `indeterminateValue`
- `config/public_api_manifest.yml` に selection data hook values を追加し、entrypoint smoke check で export 値と freeze を確認するようにしました。
- 英日 `public-api` / `selection` docs に利用方法と責務境界を追記しました。

## 受け入れ条件との対応

- package root から `TreeViewSelectionDataHooks` を import できるようにしました。
- manifest の `javascript_package_root.named_exports` と `selection_data_hooks` に新 export と値を同期しました。
- `script/test_entrypoints.mjs` で export の存在、manifest との一致、`Object.freeze` を確認します。
- docs では host element に置く stable value attributes を export で参照できることを説明しました。
- generated hidden input marker と source id は TreeView が生成・管理する内部寄り属性として扱い、今回の public export には含めていません。
- selection event names / event detail keys / hidden input sync behavior は変更していません。

## 変更範囲

- `app/javascript/tree_view/index.js`
- `config/public_api_manifest.yml`
- `script/test_entrypoints.mjs`
- `docs/en/public-api.md`
- `docs/en/selection.md`
- `docs/ja/public-api.md`
- `docs/ja/selection.md`

## 実施した確認

- GitHub compare: `main...feature/890-selection-data-hooks-export`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 7
- head: `d96f917732b3099ac2c4087c14db5cae54a9db7c`
- local `bundle exec rspec spec/public_api_compatibility_spec.rb` / `node script/test_entrypoints.mjs` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で entrypoint smoke / RSpec / lint / compatibility checks を確認します。

## リスク

- medium
- public JavaScript export と manifest contract の追加です。公開対象を既に documented な host-authored value attributes に限定し、generated marker / source-id 属性や hidden input sync behavior には広げていません。

## 未対応・補足

- generated hidden input marker / source id の public export 化は行っていません。
- transfer / remote-state / toolbar data hook export には広げていません。
- server-side selection params parser、form submission policy、authorization、business action は扱っていません。