### PR TITLE
gem package contents check に Rails integration files の代表検証を追加する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -59,7 +59,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, verifies the gem can be built, confirms release-facing files are packaged, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The main-push `gem_package` CI job additionally runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem so JavaScript, CSS, and importmap entrypoints remain packaged. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
+`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, verifies the gem can be built, confirms release-facing files are packaged, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The main-push `gem_package` CI job additionally runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem so representative Rails helper, view partial, locale, docs, JavaScript, CSS, and importmap files remain packaged. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
 
 Pull request CI checks:
 
@@ -73,7 +73,7 @@ Main-push CI checks:
 - Ruby version matrix
 - Rails version matrix
 - JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
-- Gem package verification, including JavaScript, CSS, and importmap file contents
+- Gem package verification, including representative Rails helper, view partial, locale, docs, JavaScript, CSS, and importmap file contents
 
 PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes compatibility matrices, JavaScript coverage, and package verification.
 
@@ -134,12 +134,16 @@ Before release:
 - Confirm packaged files include:
   - `lib/**/*`
   - Rails helpers, views, stylesheets, JavaScript, and importmap files
+  - `app/helpers/tree_view_helper.rb`
+  - `app/views/tree_view/_tree_row.html.erb`
   - `app/javascript/tree_view/index.js`
   - `app/assets/stylesheets/tree_view.scss`
   - `config/importmap.tree_view.rb`
+  - `config/locales/tree_view.toolbar.en.yml`
   - `README.md`
   - `CHANGELOG.md`
   - `docs/**/*`
+  - `docs/en/release.md`
   - `LICENSE*`
 
 ## Repository

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -59,7 +59,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。main-push の `gem_package` CI job では、built gem に JavaScript / CSS / importmap entrypoint が残っていることを `ruby script/check_gem_package_contents.rb tree_view-*.gem` でも確認します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
+`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。main-push の `gem_package` CI job では、built gem に Rails helper / view partial / locale / docs / JavaScript / CSS / importmap の代表ファイルが残っていることを `ruby script/check_gem_package_contents.rb tree_view-*.gem` でも確認します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
 
 Pull Request CI の確認項目:
 
@@ -73,7 +73,7 @@ Pull Request CI の確認項目:
 - Ruby version matrix
 - Rails version matrix
 - `package-lock.json` が `package.json` と同期するまでの間は、`npm install` と `npm run test:js` による JavaScript tests
-- JavaScript / CSS / importmap file contents を含む Gem package verification
+- Rails helper / view partial / locale / docs / JavaScript / CSS / importmap の代表ファイルを含む Gem package verification
 
 merge前にPR CIを通します。互換性matrix、JavaScript coverage、package verificationを含むため、release判定にはより広い `main` CIを使います。
 
@@ -134,12 +134,16 @@ release前に確認すること:
 - packaged filesに以下が含まれることを確認する
   - `lib/**/*`
   - Rails helpers, views, stylesheets, JavaScript, importmap files
+  - `app/helpers/tree_view_helper.rb`
+  - `app/views/tree_view/_tree_row.html.erb`
   - `app/javascript/tree_view/index.js`
   - `app/assets/stylesheets/tree_view.scss`
   - `config/importmap.tree_view.rb`
+  - `config/locales/tree_view.toolbar.en.yml`
   - `README.md`
   - `CHANGELOG.md`
   - `docs/**/*`
+  - `docs/en/release.md`
   - `LICENSE*`
 
 ## Repository

--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -4,9 +4,13 @@
 require "rubygems/package"
 
 REQUIRED_PACKAGED_PATHS = %w[
-  app/javascript/tree_view/index.js
+  app/helpers/tree_view_helper.rb
+  app/views/tree_view/_tree_row.html.erb
   app/assets/stylesheets/tree_view.scss
+  app/javascript/tree_view/index.js
   config/importmap.tree_view.rb
+  config/locales/tree_view.toolbar.en.yml
+  docs/en/release.md
 ].freeze
 
 root = File.expand_path("..", __dir__)


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #901

## Issue ごとの完了内容

- #901
  - `script/check_gem_package_contents.rb` の必須代表ファイルを、既存の JavaScript / CSS / importmap から Rails helper / view partial / locale / docs まで広げました。
  - 日英 release docs の `gem_package` CI / release checklist の説明を、実際の検証範囲と同期しました。

## 変更内容

- `REQUIRED_PACKAGED_PATHS` に以下の代表ファイルを追加しました。
  - `app/helpers/tree_view_helper.rb`
  - `app/views/tree_view/_tree_row.html.erb`
  - `config/locales/tree_view.toolbar.en.yml`
  - `docs/en/release.md`
- `docs/en/release.md` / `docs/ja/release.md` の package verification 説明と packaged files list を更新しました。

## 改善カテゴリ

- test / CI guard
- release docs sync
- package verification

## 既存仕様への影響

- runtime code、public API、UI、DB schema、authorization、external service contract は変更していません。
- built gem の検証対象を増やすだけで、packaging policy 自体は既存 gemspec / release docs に合わせています。

## 実施した確認内容

- GitHub compare: `main...quality/901-package-content-representatives`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- connector 経由で以下を確認しました。
  - `tree_view.gemspec` が helpers / views / assets / JavaScript / importmap / locales / docs を package files に含めていること
  - `app/views/tree_view/_tree_row.html.erb` と `config/locales/tree_view.toolbar.en.yml` が current main に存在すること
- local `gem build tree_view.gemspec` / `ruby script/check_gem_package_contents.rb tree_view-*.gem` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク評価

- low
- main-push の package verification が、release docs に書かれている Rails integration files / docs の抜けをより早く検出する変更です。

## 補足事項

- docs 全ファイル列挙や release automation redesign には広げていません。
- PR 作成後の GitHub Actions で lint / specs / JavaScript / representative Rails lanes の状態を確認します。