### PR TITLE
docs: Unreleased changelog の docs/test 項目を同期する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ Breaking changes and required migration notes should be called out explicitly in
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
+- Added `TreeView::Diagnostics.run` documentation in Japanese and English for aggregate pre-render validation results.
+- Added FAQ guidance for keyboard behavior and `treegrid` responsibility boundaries in Japanese and English.
+- Added a host-app extension hook reverse lookup table in Japanese and English.
+- Added toolbar disabled-action troubleshooting guidance in Japanese and English.
+- Added transfer disabled / invalid boundary states to the drop-position mockup and updated the mockup review guidance.
 
 ### Tests
 
@@ -73,6 +78,8 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added Ruby and JavaScript specs for client-side toggle mode, mode builders, public API exports, and browser-local descendant visibility updates.
 - Added specs for RenderState internal configuration objects and the consolidated diagnostics entrypoint.
 - Added JavaScript public event contract specs for selection, remote state, and transfer events.
+- Added package-root frozen object contract coverage for public JavaScript object exports.
+- Added browser smoke coverage for representative docs mockup pages and the review gallery.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue

Closes #912

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の Unreleased / Documentation に、current `main` に入っている docs-only 追従項目を追加しました。
  - `TreeView::Diagnostics.run` docs
  - keyboard / `treegrid` FAQ boundary
  - host-app extension hook reverse lookup
  - toolbar disabled-action troubleshooting
  - transfer boundary states mockup
- Unreleased / Tests に、current `main` に入っている test guardrail 項目を追加しました。
  - package-root frozen object contract coverage
  - docs mockup browser smoke coverage

## 根拠

- `CHANGELOG.md` は Unreleased の `Documentation` / `Tests` を持ち、release 前に public-facing docs / test guardrail を整理する前提です。
- 直近で merge 済みの docs/test PR は current `main` に入っていますが、Unreleased の棚卸しから一部抜けていました。
- 未マージの open PR（例: #855, #908, #909 など）の内容は先取りしていません。merge 後に必要なら別途 Unreleased へ追記する対象です。

## 変更範囲

- `CHANGELOG.md`

runtime code、public API manifest、release tag、version bump、migration docs には触れていません。

## 確認

- GitHub compare: `main...docs/912-changelog-unreleased-sweep`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- docs-only changelog 更新のため local test / lint は未実行です。

## リスク

- low
- current `main` に入っている docs/test 変更の release-note 棚卸しに限定しています。未マージ PR の public API / export 追加は changelog 本文に先書きしていません。