### PR TITLE
docs mockup browser smoke を最新 main に載せ直す

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -60,7 +60,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 ## Automated smoke coverage
 
-- `npm run test:browser` opens representative mockup pages in Playwright and checks the review gallery, key local links, main headings, and sample regions.
+- `npm run test:browser` opens every HTML mockup listed in the Files table and checks the review gallery, local links, main headings, back-to-gallery links, representative sample regions, and the existing lazy-loading viewport overflow smoke.
 - The smoke coverage is intentionally narrow. It catches broken HTML, blank pages, missing review links, and missing representative regions without adding screenshot baselines or visual diff review.
 
 ## Copy and language policy

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test"
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
 const mockupsRoot = path.join(repoRoot, "docs/mockups")
+const mockupsReadmePath = path.join(mockupsRoot, "README.md")
 
 function mockupPath(file) {
   return path.join(mockupsRoot, file)
@@ -12,6 +13,12 @@ function mockupPath(file) {
 
 function mockupUrl(file) {
   return pathToFileURL(mockupPath(file)).toString()
+}
+
+function readmeMockupFiles() {
+  const readme = readFileSync(mockupsReadmePath, "utf8")
+  const matches = readme.matchAll(/\[[^\]]+\.html\]\(([^)]+\.html)\)/g)
+  return Array.from(new Set(Array.from(matches, (match) => match[1])))
 }
 
 async function openMockup(page, file) {
@@ -23,6 +30,109 @@ async function expectNoDocumentHorizontalOverflow(page) {
   const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
   expect(overflow).toBeLessThanOrEqual(1)
 }
+
+const focusedMockupSmokeTargets = [
+  {
+    file: "default-tree.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "resource-table-bridge.html",
+    sample: ".mock-bridge-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "narrow-sidebar-tree.html",
+    sample: ".mock-narrow-frame",
+    minimumCount: 2
+  },
+  {
+    file: "current-branch-sidebar.html",
+    sample: ".tree-row.is-selected[aria-current='page']",
+    minimumCount: 1
+  },
+  {
+    file: "row-status-depth-labels.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 3
+  },
+  {
+    file: "interaction-states.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 5
+  },
+  {
+    file: "keyboard-focus-states.html",
+    sample: ".focus-sample, .focus-sample--soft",
+    minimumCount: 5
+  },
+  {
+    file: "lazy-loading-handoff.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "drop-positions.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 3
+  },
+  {
+    file: "persisted-state-boundary.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "turbo-frame-target.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 3
+  },
+  {
+    file: "drag-interactive-controls.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "interactive-marker-behaviors.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "windowed-rendering.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "breadcrumb-paths.html",
+    sample: ".mock-breadcrumb-path",
+    minimumCount: 2
+  },
+  {
+    file: "filtered-tree-modes.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "path-tree-builder-rows.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "form-editing-rows.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "toolbar-actions.html",
+    sample: ".mock-toolbar-frame",
+    minimumCount: 3
+  },
+  {
+    file: "empty-state.html",
+    sample: "[data-tree-view-empty-state='true']",
+    minimumCount: 2
+  }
+]
 
 test.describe("docs mockup browser smoke", () => {
   test("review gallery loads representative navigation, previews, and local links", async ({ page }) => {
@@ -52,50 +162,20 @@ test.describe("docs mockup browser smoke", () => {
     expect(missingLinks).toEqual([])
   })
 
-  for (const mockup of [
-    {
-      file: "default-tree.html",
-      heading: "Default TreeView rendering mock",
-      section: "Standard table structure",
-      sample: ".tree-view-table tbody tr",
-      minimumCount: 4
-    },
-    {
-      file: "interaction-states.html",
-      heading: "TreeView interaction states mock",
-      section: "Lazy loading and retry states",
-      sample: ".tree-view-table tbody tr",
-      minimumCount: 5
-    },
-    {
-      file: "current-branch-sidebar.html",
-      heading: "Current branch sidebar mock",
-      section: "Current branch only expanded",
-      sample: ".tree-row.is-selected[aria-current='page']",
-      minimumCount: 1
-    },
-    {
-      file: "lazy-loading-handoff.html",
-      heading: "TreeView lazy-loading handoff mock",
-      section: "Loading in progress",
-      sample: "tr[aria-busy='true']",
-      minimumCount: 1
-    },
-    {
-      file: "empty-state.html",
-      heading: "TreeView empty state mock",
-      section: "No root items",
-      sample: "[data-tree-view-empty-state='true']",
-      minimumCount: 2
-    }
-  ]) {
-    test(`${mockup.file} exposes its main heading and representative sample region`, async ({ page }) => {
+  test("README mockup file list stays aligned with focused browser smoke targets", () => {
+    const expectedFiles = readmeMockupFiles().filter((file) => file !== "review-gallery.html").sort()
+    const coveredFiles = focusedMockupSmokeTargets.map((mockup) => mockup.file).sort()
+
+    expect(coveredFiles).toEqual(expectedFiles)
+  })
+
+  for (const mockup of focusedMockupSmokeTargets) {
+    test(`${mockup.file} exposes its main heading, return link, and representative sample region`, async ({ page }) => {
       await openMockup(page, mockup.file)
 
-      await expect(page.getByRole("heading", { name: mockup.heading, level: 1 })).toBeVisible()
-      await expect(page.getByRole("heading", { name: mockup.section })).toBeVisible()
+      await expect(page.locator("h1").first()).toBeVisible()
+      await expect(page.locator("a[href='review-gallery.html']").first()).toBeVisible()
       expect(await page.locator(mockup.sample).count()).toBeGreaterThanOrEqual(mockup.minimumCount)
-      await expect(page.getByRole("link", { name: "Back to review gallery" })).toHaveAttribute("href", "review-gallery.html")
     })
   }
 


### PR DESCRIPTION
docs mockup browser smoke coverage を current main の mockup set に合わせて再適用します。

## 対応 Issue

Closes #872

## 元PR

- Supersedes #874
- #874 は #873 / #886 以降の `main` から diverged し、`test/browser/docs_mockups_smoke.spec.js` が current main と重なったため、この PR では最新 `main` (`d176b4a3f6ee4a37eea68ed9f9e78dab957611dd`) から載せ直しています。

## 変更内容

- `docs/mockups/README.md` の automated smoke coverage 説明を、Files table 全体との照合と current lazy-loading viewport smoke を含む内容へ更新しました。
- `test/browser/docs_mockups_smoke.spec.js` に README の HTML mockup file list と focused smoke target list の一致 guard を追加しました。
- Files table 上の focused mockup 全件を representative smoke target に広げました。
- current main 側の lazy-loading viewport overflow smoke を維持しました。
- #886 で追加済みの `keyboard-focus-states.html` も smoke target に含めました。
- keyboard focus mockup は戻りリンク文言が他 mockup と違うため、link text ではなく `href="review-gallery.html"` の存在を確認する形にしています。

## 受け入れ条件との対応

- README Files table に載る focused mockup HTML が smoke target とずれた場合に検出できます。
- 各 focused mockup で main heading、gallery への戻り導線、代表 sample region を軽量に確認します。
- screenshot baseline、visual diff、mockup HTML/CSS redesign には広げていません。

## 変更範囲

- `docs/mockups/README.md`
- `test/browser/docs_mockups_smoke.spec.js`

runtime Ruby / JavaScript 実装、mockup HTML/CSS、Rails route、Turbo behavior、authorization、host-app policy には触れていません。

## 実施した確認

- GitHub compare: `main...fix/874-docs-mockups-smoke-main-refresh`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- local `npm run test:browser` は未実行です。この実行環境では repository checkout がないため、PR 作成後の GitHub Actions で確認します。

## リスク

- low
- test/docs-only の変更です。README 由来の file list と representative selector の同期を検出する guard で、runtime behavior には影響しません。

## 未対応・補足

- #874 の既存 PR branch は更新していません。履歴更新を避けるため、current main から replacement PR として作成しています。