### PR TITLE
docs: helper API reference を public manifest と同期する

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -371,11 +371,17 @@ store.save!(
 | `tree_view_rows(render_state, window: nil)` | Renders TreeView rows. |
 | `tree_view_window(render_state, offset:, limit:)` | Returns windowing metadata. |
 | `tree_node_dom_id(item_or_id, ui: @tree_ui)` | Builds a node DOM ID through the resolved `UiConfig`. |
+| `tree_children_container_dom_id(item_or_id, ui: @tree_ui)` | Builds the children container DOM ID used by lazy-loading placeholder regions and Turbo Stream replacements. |
+| `tree_remote_state_placeholder_dom_id(item_or_id, ui: @tree_ui)` | Builds the remote-state placeholder DOM ID for a lazy-loaded row. |
+| `tree_remote_state_placeholder_attributes(item_or_id, state: nil, ui: @tree_ui)` | Returns the documented data attributes for the remote-state placeholder element. |
 | `tree_selection_value(item, tree, builder = nil)` | Builds the JSON checkbox value from the default or custom selection payload builder. |
 | `tree_view_breadcrumb(tree, item, ...)` | Renders breadcrumbs. |
 | `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ...)` | Renders TreeView's bundled toolbar markup. |
+| `tree_view_toolbar_supported_actions` | Returns the documented toolbar action keys TreeView can validate and describe. |
 | `tree_view_toolbar_actions(render_state, actions: ..., labels: {})` | Returns toolbar action hashes so the host app can render its own markup. |
 | `tree_view_toolbar_action_metadata(render_state, action, label: nil)` | Returns metadata for one supported toolbar action. |
+
+Use the remote-state placeholder helpers with the lazy-loading placeholder and Turbo Stream patterns in [Lazy Loading](lazy-loading.md). Use the toolbar helper family with the supported action and metadata boundary in [Toolbar helper](toolbar.md).
 
 The public helper compatibility contract follows the documented helper-method set in `config/public_api_manifest.yml`. Internal helper plumbing used by bundled partials is intentionally omitted from this table.
 

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -371,11 +371,17 @@ store.save!(
 | `tree_view_rows(render_state, window: nil)` | TreeView rows を描画する。 |
 | `tree_view_window(render_state, offset:, limit:)` | windowing metadata を返す。 |
 | `tree_node_dom_id(item_or_id, ui: @tree_ui)` | 解決された `UiConfig` を通して node DOM ID を組み立てる。 |
+| `tree_children_container_dom_id(item_or_id, ui: @tree_ui)` | lazy-loading placeholder region と Turbo Stream replacement で使う children container DOM ID を組み立てる。 |
+| `tree_remote_state_placeholder_dom_id(item_or_id, ui: @tree_ui)` | lazy-loaded row 用の remote-state placeholder DOM ID を組み立てる。 |
+| `tree_remote_state_placeholder_attributes(item_or_id, state: nil, ui: @tree_ui)` | remote-state placeholder element 用の documented data 属性を返す。 |
 | `tree_selection_value(item, tree, builder = nil)` | default または custom の selection payload builder から checkbox value 用 JSON を作る。 |
 | `tree_view_breadcrumb(tree, item, ...)` | breadcrumb を描画する。 |
 | `tree_view_toolbar(render_state, actions: ..., labels: ..., class_name: ..., button_class_name: ...)` | TreeView bundled toolbar の markup を描画する。 |
+| `tree_view_toolbar_supported_actions` | TreeView が validate / describe できる documented toolbar action key を返す。 |
 | `tree_view_toolbar_actions(render_state, actions: ..., labels: {})` | host app が独自 markup を組み立てるための toolbar action hash を返す。 |
 | `tree_view_toolbar_action_metadata(render_state, action, label: nil)` | 1 つの supported toolbar action 用 metadata を返す。 |
+
+remote-state placeholder helpers は [Lazy Loading](lazy-loading.md) の placeholder / Turbo Stream pattern と合わせて使います。toolbar helper family は [Toolbar helper](toolbar.md) の supported action と metadata boundary を参照してください。
 
 public helper の compatibility contract は `config/public_api_manifest.yml` に documented された helper-method set に従います。bundled partial の内部 plumbing 用 helper は、この表から意図的に外しています。
 


### PR DESCRIPTION
## 対応 Issue

Closes #822

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/api.md` / `docs/ja/api.md` の Helpers table に、`config/public_api_manifest.yml` の public helper method set から抜けていた helper を追加しました。
  - `tree_children_container_dom_id`
  - `tree_remote_state_placeholder_dom_id`
  - `tree_remote_state_placeholder_attributes`
  - `tree_view_toolbar_supported_actions`
- remote-state placeholder helpers は lazy-loading guide、toolbar helper family は toolbar guide へ委譲する導線を追加しました。

## 根拠

- Issue #822 / Planner handoff は、runtime helper や manifest schema を変えず、API reference から public helper set を見つけられるようにする docs-only lane として整理されています。
- `config/public_api_manifest.yml` の `helper_methods` には上記 helpers が含まれています。
- `docs/en|ja/lazy-loading.md` と `docs/en|ja/toolbar.md` には詳細な使い方が既にあるため、API reference では一覧性とリンクに留めています。

## 変更範囲

- `docs/en/api.md`
- `docs/ja/api.md`

helper implementation、`config/public_api_manifest.yml`、toolbar behavior、lazy-loading / remote-state controller behavior は変更していません。

## 確認

- GitHub compare: `main...docs/822-helper-api-reference`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- docs-only 更新のため local test / lint は未実行です。

## リスク

- low
- 既存 manifest と既存 guide への参照導線を API reference に同期するだけで、runtime contract は変更していません。