### PR TITLE
package contents check で JS controller files も守る

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -8,6 +8,11 @@ REQUIRED_PACKAGED_PATHS = %w[
   app/views/tree_view/_tree_row.html.erb
   app/assets/stylesheets/tree_view.scss
   app/javascript/tree_view/index.js
+  app/javascript/tree_view/client_controller.js
+  app/javascript/tree_view/remote_state_controller.js
+  app/javascript/tree_view/selection_controller.js
+  app/javascript/tree_view/state_controller.js
+  app/javascript/tree_view/transfer_controller.js
   config/importmap.tree_view.rb
   config/locales/tree_view.toolbar.en.yml
   docs/en/release.md


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #915

## Issue ごとの完了内容

- #915
  - `script/check_gem_package_contents.rb` の required package path に、package root `app/javascript/tree_view/index.js` が import / export する controller files を追加しました。
  - `TreeViewClientController` / `TreeViewRemoteStateController` / `TreeViewSelectionController` / `TreeViewStateController` / `TreeViewTransferController` の import target files が built gem から欠落した場合に package contents check で検出できるようにしました。

## 変更内容

- `REQUIRED_PACKAGED_PATHS` に以下を追加しました。
  - `app/javascript/tree_view/client_controller.js`
  - `app/javascript/tree_view/remote_state_controller.js`
  - `app/javascript/tree_view/selection_controller.js`
  - `app/javascript/tree_view/state_controller.js`
  - `app/javascript/tree_view/transfer_controller.js`

## 改善カテゴリ

- build
- CI / release guard
- packaging quality

## 既存仕様への影響はないこと

- JavaScript export 名、controller behavior、public API manifest、gemspec include pattern は変更していません。
- built gem の verification list を current package root の依存 files に同期するだけです。

## 実施した確認内容

- GitHub compare: `main...quality/915-package-js-controller-guard`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local test / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の CI で package contents check を確認します。

## リスク評価

- low
- required path の追加のみで、runtime behavior や packaging include pattern には触れていません。

## 補足事項

- `script/test_entrypoints.mjs` や public API manifest の責務には広げず、built gem に files が入っていることの guard に限定しています。