### PR TITLE
docs: Decision guide から toolbar と localized names へ辿れるようにする

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -15,6 +15,7 @@ For API details, see:
 - [Selection](selection.md)
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
+- [Localized names](localized-names.md)
 
 ## Row customization quick guide
 
@@ -27,6 +28,7 @@ Use the smallest TreeView extension point that matches the UI you are adding.
 | Inputs, selects, or inline editable labels | `row_partial` or `row_actions_partial` | Form object, validation, dirty state, persistence |
 | Level labels | `depth_label_builder` | Label wording and localization |
 | Badges, status pills, or marker-like labels | `badge_builder` | Status names, classes, and product semantics |
+| Locale-aware row labels, type badges, or tooltips | `TreeView::NodePresenter` plus LocalizedNames helpers | Locale files, final copy, and business wording |
 | Legacy/direct toggle-cell marker text | `marker_builder` when rendering toggle cells directly | Marker naming and classes |
 | Folder/file icons or type labels | `badge_builder`, `icon_builder`, or a cell in `row_partial` | Icon set, labels, and accessibility copy |
 | Current row highlighting or archived/disabled styling | `row_class_builder`, `row_data_builder`, and row-status docs | State rules and behavior |
@@ -134,6 +136,28 @@ icon_builder = ->(document) {
   document.folder? ? { text: "Folder", class: "is-folder" } : { text: "File", class: "is-file" }
 }
 ```
+
+## Localize row labels, badges, and tooltips
+
+Use [Localized names](localized-names.md) when row copy should follow the host app locale files instead of hard-coded strings. `TreeView::NodePresenter` can compose those helpers with row-specific values while leaving the final copy, translations, and business wording in the host app.
+
+```ruby
+presenter = TreeView::NodePresenter.define do
+  label { |item| item.respond_to?(:title) ? item.title : TreeView.model_name_for(item) }
+  tooltip { |item| TreeView.type_name_for(item) }
+  badge { |item| TreeView.attribute_name_for(item, :status) if item.respond_to?(:status) }
+end
+
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  presenter: presenter
+)
+```
+
+Use `TreeView.model_name_for` for model labels, `TreeView.attribute_name_for` for attribute labels, and `TreeView.type_name_for` for heterogeneous node type labels. TreeView only resolves display names; the host app decides which locale keys exist and where the labels appear in row partials, badges, titles, or tooltips.
 
 ## Highlight current, archived, disabled, or status rows
 
@@ -418,33 +442,3 @@ Look for these signals in the Rails log:
 - Repeated `Document Load` or `DocumentVersion Load` lines while rows render.
 - Many same-shaped queries that are not marked `CACHE`.
 - Derived helper calls from the row partial that repeatedly touch associations.
-
-Host-app mitigations include precomputing children as arrays, caching derived values used by the row partial, and temporarily reducing noisy development view logs while investigating database queries. Recursive partial logs are expected; repeated uncached queries are the problem.
-
-## Add row state classes
-
-```ruby
-render_state = TreeView::RenderState.new(
-  tree: tree,
-  root_items: tree.root_items,
-  row_partial: "documents/tree_columns",
-  ui_config: tree_ui,
-  row_class_builder: ->(document) {
-    ["document-row", ("is-archived" if document.archived?)]
-  }
-)
-```
-
-See [Row status](row-status.md) when the whole row should express disabled or readonly state.
-
-## Avoid node_key collisions
-
-For heterogeneous nodes in one tree, include the class name or another namespace.
-
-```ruby
-node_key_resolver = ->(node) {
-  TreeView.node_key(node.class.name, node.id)
-}
-```
-
-See [Node keys](node-keys.md) for details.

--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -442,3 +442,33 @@ Look for these signals in the Rails log:
 - Repeated `Document Load` or `DocumentVersion Load` lines while rows render.
 - Many same-shaped queries that are not marked `CACHE`.
 - Derived helper calls from the row partial that repeatedly touch associations.
+
+Host-app mitigations include precomputing children as arrays, caching derived values used by the row partial, and temporarily reducing noisy development view logs while investigating database queries. Recursive partial logs are expected; repeated uncached queries are the problem.
+
+## Add row state classes
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  row_class_builder: ->(document) {
+    ["document-row", ("is-archived" if document.archived?)]
+  }
+)
+```
+
+See [Row status](row-status.md) when the whole row should express disabled or readonly state.
+
+## Avoid node_key collisions
+
+For heterogeneous nodes in one tree, include the class name or another namespace.
+
+```ruby
+node_key_resolver = ->(node) {
+  TreeView.node_key(node.class.name, node.id)
+}
+```
+
+See [Node keys](node-keys.md) for details.

--- a/docs/en/decision-guide.md
+++ b/docs/en/decision-guide.md
@@ -15,6 +15,7 @@ Use render controls first when the data is already available. Use lazy loading o
 |---|---|---|---|
 | Render a simple static tree | `TreeView::Tree`, `TreeView::RenderState`, `tree_view_rows` | `records:`, `parent_id_method:`, `row_partial:`, `UiConfigBuilder#build_static` | Best first implementation when all nodes are already available and no remote expand/collapse is needed. |
 | Add Turbo expand/collapse | `TreeView::UiConfigBuilder#build_turbo` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | `build` remains a backward-compatible alias. Host app routes and Turbo Stream actions own the response. |
+| Add tree-wide expand/collapse toolbar actions | [Toolbar helper](toolbar.md) | `tree_view_toolbar`, `tree_view_toolbar_actions`, `tree_view_toolbar_action_metadata`, `toggle_all_path_builder` | Use when the screen needs Expand all, Collapse all, or Collapse all except current path controls. TreeView supplies action metadata and toggle-all state values; the host app owns placement, labels, authorization copy, routes, and Turbo responses. |
 | Add browser-local expand/collapse without Turbo endpoints | `TreeView::UiConfigBuilder#build_client_side` | `initial_state`, `initial_expansion:`, `render_scope:` | Good for small to medium trees where all rows in the render scope can be included in the initial HTML. |
 | Keep the first render small | `TreeView::RenderState` | `max_initial_depth`, `initial_expansion:`, `render_scope:` | These are render controls. They reduce initial HTML volume, not database query volume by themselves. |
 | Limit which descendants can be rendered | `render_scope:` | `max_depth`, `max_leaf_distance` | Use when a page should never render beyond a chosen depth or distance from matched leaves. |
@@ -29,6 +30,7 @@ Use render controls first when the data is already available. Use lazy loading o
 | Add editable fields inside rows | [Forms and editing rows](form-editing.md) and [Cookbook](cookbook.md#row-customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Objects | TreeView supports inline-editing layouts. The host app owns edit mode, validation, persistence, authorization, dirty-state handling, and Turbo workflows. |
 | Add row action buttons | [Cookbook](cookbook.md#row-customization-quick-guide) | `row_actions_partial` | Recommended slot for Edit, Show, Delete, Archive, and custom host-app actions. |
 | Customize level labels, badges, icons, or status visuals | [Cookbook](cookbook.md#row-customization-quick-guide) | `depth_label_builder`, `badge_builder`, `icon_builder`, `row_class_builder`, `row_data_builder` | TreeView provides rendering hooks; product-specific labels, statuses, and permissions stay in the host app. |
+| Localize row labels, badges, or tooltips with Rails I18n | [Localized names](localized-names.md) and [Cookbook](cookbook.md#localize-row-labels-badges-and-tooltips) | `TreeView.model_name_for`, `TreeView.attribute_name_for`, `TreeView.type_name_for`, `TreeView::NodePresenter` | Use when row visuals should follow host app locale files. TreeView resolves display names; the host app owns locale content, business wording, and where labels are rendered. |
 | Add drag-and-drop | Drag/drop row hooks | Drag attributes and row event payloads | TreeView exposes integration hooks. The host app validates and persists the move. |
 | Persist expansion state | `TreeView::PersistedState`, `TreeView::StateStore` | `rails g tree_view:state:install`, persisted state model | Use when users should return to the same expanded/collapsed tree state. |
 | Validate tree data and identifiers | Diagnostics APIs | node key, DOM ID, orphan, and cycle diagnostics | Use during integration, tests, or admin diagnostics before rendering invalid structures. |
@@ -44,6 +46,7 @@ flowchart TD
   C -->|No, no browser opening| D[Static rendering: Tree + RenderState + tree_view_rows]
   C -->|No, browser-local opening is enough| CL[Client-side rendering: UiConfigBuilder#build_client_side]
   C -->|Yes| E[Turbo rendering: UiConfigBuilder#build_turbo with show/hide path builders]
+  C -->|Yes, plus tree-wide controls| TB[Toolbar helper with toggle_all_path_builder]
   B -->|No, fetching everything is too expensive| F[Lazy Loading or Children Pagination]
   F --> G{Are child sets huge per parent?}
   G -->|Yes| H[Children Pagination in the host app, exposed through lazy-loading URLs]
@@ -64,6 +67,7 @@ flowchart TD
   P -->|Drag/drop| S[Drag/drop hooks plus host-app handlers]
   A --> Y{Need row visuals?}
   Y -->|Level labels, badges, icons, status| Z[Cookbook row customization hooks]
+  Y -->|Locale-aware labels or type names| LN[LocalizedNames helpers with NodePresenter]
   A --> T{Need confidence in input data?}
   T -->|Yes| U[Diagnostics APIs]
 ```
@@ -89,7 +93,7 @@ flowchart TD
 5. Use [GraphAdapter adapter mode](api-overview.md#adapter-mode) when the tree mixes different record classes or graph-like edges and cannot be represented cleanly by one parent-id column.
 6. Use `build_client_side` when the data is already available, initial HTML volume is acceptable, and Turbo endpoints would be unnecessary overhead.
 7. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
-8. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
+8. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Localized names](localized-names.md), [Toolbar helper](toolbar.md), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
 9. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
 
 ## Common combinations
@@ -106,8 +110,10 @@ flowchart TD
 | Bulk action page | Static or Turbo rendering + `selection:` + host-app form action |
 | Bulk edit page | Static or Turbo rendering + row partial form controls + host-app Form Object |
 | Per-row inline edit page | Display row partials + `row_actions_partial` + host-app edit action / Turbo response + editing row partial |
+| Tree-wide action toolbar | Turbo rendering + `toggle_all_path_builder` + `tree_view_toolbar` + host-app placement and authorization |
 | Row action menu | `row_actions_partial` + host-app routes, authorization, and action handlers |
 | Status-heavy tree table | `row_class_builder` + `badge_builder` + host-app status rules |
+| Localized row display | `TreeView::NodePresenter` + LocalizedNames helpers + host-app locale files |
 | Reorderable hierarchy | Static or Turbo rendering + drag/drop hooks + host-app move endpoint |
 
 ## Related docs
@@ -116,6 +122,9 @@ flowchart TD
 - [API overview: adapter mode](api-overview.md#adapter-mode)
 - [API reference](api.md)
 - [Cookbook: Row customization quick guide](cookbook.md#row-customization-quick-guide)
+- [Localized names](localized-names.md)
+- [Toolbar helper](toolbar.md)
+- [Toolbar actions mockup](../mockups/toolbar-actions.html)
 - [Render Scale](render-scale.md)
 - [Lazy Loading](lazy-loading.md)
 - [Children Pagination](children-pagination.md)

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -15,6 +15,7 @@ cookbook は、個別APIの詳細仕様ではなく、host appでよく使う構
 - [Selection](selection.md)
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
+- [Localized names](localized-names.md)
 
 ## 行customization quick guide
 
@@ -27,6 +28,7 @@ cookbook は、個別APIの詳細仕様ではなく、host appでよく使う構
 | input、select、inline編集label | `row_partial` または `row_actions_partial` | Form Object、validation、dirty state、保存 |
 | level label | `depth_label_builder` | label文言とlocalization |
 | badge、status pill、marker風label | `badge_builder` | status名、class、product semantics |
+| localeに沿ったrow label、type badge、tooltip | `TreeView::NodePresenter` と LocalizedNames helpers | locale file、最終copy、業務文言 |
 | legacy / direct toggle-cell marker text | toggle cellを直接描画する場合の `marker_builder` | marker名とclass |
 | folder/file iconやtype label | `badge_builder`、`icon_builder`、または `row_partial` 内のcell | icon set、label、accessibility文言 |
 | current row highlight、archived / disabled styling | `row_class_builder`、`row_data_builder`、Row status docs | 状態判定ruleとbehavior |
@@ -134,6 +136,28 @@ icon_builder = ->(document) {
   document.folder? ? { text: "Folder", class: "is-folder" } : { text: "File", class: "is-file" }
 }
 ```
+
+## row label、badge、tooltipをlocalizeする
+
+row copyをhard-coded stringではなくhost appのlocale fileに合わせたい場合は、[Localized names](localized-names.md) を使います。`TreeView::NodePresenter` と組み合わせると、rowごとの値を使いながら、最終copy、translation、業務文言はhost app側に残せます。
+
+```ruby
+presenter = TreeView::NodePresenter.define do
+  label { |item| item.respond_to?(:title) ? item.title : TreeView.model_name_for(item) }
+  tooltip { |item| TreeView.type_name_for(item) }
+  badge { |item| TreeView.attribute_name_for(item, :status) if item.respond_to?(:status) }
+end
+
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  presenter: presenter
+)
+```
+
+model label には `TreeView.model_name_for`、attribute label には `TreeView.attribute_name_for`、異種nodeのtype labelには `TreeView.type_name_for` を使います。TreeViewは表示名を解決するだけで、どのlocale keyを用意するか、row partial、badge、title、tooltipのどこに表示するかはhost appが決めます。
 
 ## current / archived / disabled / status rowを強調する
 
@@ -418,33 +442,3 @@ Rails log では次を見ます。
 - row render 中に `Document Load` や `DocumentVersion Load` が繰り返される。
 - `CACHE` ではない同形queryが大量に出る。
 - row partial から呼ぶ helper が association を繰り返し触っている。
-
-host app 側の対策は、children を配列で事前計算する、row partial で使う derived value をcacheする、DB query 調査中だけ development の view log ノイズを抑える、などです。recursive partial log は想定内で、問題は繰り返し発生する uncached query です。
-
-## 行に状態classを付ける
-
-```ruby
-render_state = TreeView::RenderState.new(
-  tree: tree,
-  root_items: tree.root_items,
-  row_partial: "documents/tree_columns",
-  ui_config: tree_ui,
-  row_class_builder: ->(document) {
-    ["document-row", ("is-archived" if document.archived?)]
-  }
-)
-```
-
-行全体のdisabled / readonly状態を表す場合は [Row status](row-status.md) も参照してください。
-
-## node_key衝突を避ける
-
-異種nodeを同じtreeで扱う場合は、class名などを含めます。
-
-```ruby
-node_key_resolver = ->(node) {
-  TreeView.node_key(node.class.name, node.id)
-}
-```
-
-詳細は [Node keys](node-keys.md) を参照してください。

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -442,3 +442,33 @@ Rails log では次を見ます。
 - row render 中に `Document Load` や `DocumentVersion Load` が繰り返される。
 - `CACHE` ではない同形queryが大量に出る。
 - row partial から呼ぶ helper が association を繰り返し触っている。
+
+host app 側の対策は、children を配列で事前計算する、row partial で使う derived value をcacheする、DB query 調査中だけ development の view log ノイズを抑える、などです。recursive partial log は想定内で、問題は繰り返し発生する uncached query です。
+
+## 行に状態classを付ける
+
+```ruby
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "documents/tree_columns",
+  ui_config: tree_ui,
+  row_class_builder: ->(document) {
+    ["document-row", ("is-archived" if document.archived?)]
+  }
+)
+```
+
+行全体のdisabled / readonly状態を表す場合は [Row status](row-status.md) も参照してください。
+
+## node_key衝突を避ける
+
+異種nodeを同じtreeで扱う場合は、class名などを含めます。
+
+```ruby
+node_key_resolver = ->(node) {
+  TreeView.node_key(node.class.name, node.id)
+}
+```
+
+詳細は [Node keys](node-keys.md) を参照してください。

--- a/docs/ja/decision-guide.md
+++ b/docs/ja/decision-guide.md
@@ -15,6 +15,7 @@ TreeViewのAPIは大きく分けると次の2種類です。
 |---|---|---|---|
 | 単純なstatic treeを描画したい | `TreeView::Tree`, `TreeView::RenderState`, `tree_view_rows` | `records:`, `parent_id_method:`, `row_partial:`, `UiConfigBuilder#build_static` | 全nodeが取得済みでremote expand/collapseが不要な場合の最初の実装です。 |
 | Turboでexpand/collapseしたい | `TreeView::UiConfigBuilder#build_turbo` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder` | `build` は後方互換aliasです。host appのroutesとTurbo Stream actionがresponseを担当します。 |
+| tree全体のexpand/collapse toolbar actionを追加したい | [Toolbar helper](toolbar.md) | `tree_view_toolbar`, `tree_view_toolbar_actions`, `tree_view_toolbar_action_metadata`, `toggle_all_path_builder` | Expand all、Collapse all、Collapse all except current path の操作を画面に置きたい場合に使います。TreeViewはaction metadataとtoggle-all state valueを提供し、placement、label、authorization copy、route、Turbo responseはhost appが担当します。 |
 | Turbo endpointなしでbrowser内だけで開閉したい | `TreeView::UiConfigBuilder#build_client_side` | `initial_state`, `initial_expansion:`, `render_scope:` | render scope内の全行を初期HTMLに含められる小〜中規模treeに向いています。 |
 | 初期描画を小さくしたい | `TreeView::RenderState` | `max_initial_depth`, `initial_expansion:`, `render_scope:` | これは描画制御です。初期HTML量は減りますが、それだけでdatabase query量が減るわけではありません。 |
 | 描画対象の子孫範囲を制限したい | `render_scope:` | `max_depth`, `max_leaf_distance` | ページ上で一定のdepthやmatched leavesからの距離を超えて描画したくない場合に使います。 |
@@ -29,6 +30,7 @@ TreeViewのAPIは大きく分けると次の2種類です。
 | 行内に編集fieldを置きたい | [Form と編集行](form-editing.md) と [Cookbook](cookbook.md#行customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Object | TreeViewはinline-editing layoutを支援します。edit mode、validation、persistence、authorization、dirty-state handling、Turbo workflowはhost appが担当します。 |
 | 行action buttonを追加したい | [Cookbook](cookbook.md#行customization-quick-guide) | `row_actions_partial` | Edit、Show、Delete、Archive、host app固有actionの推奨slotです。 |
 | level label、badge、icon、status visualをcustomizeしたい | [Cookbook](cookbook.md#行customization-quick-guide) | `depth_label_builder`, `badge_builder`, `icon_builder`, `row_class_builder`, `row_data_builder` | TreeViewは描画hookを提供します。product固有label、status、permissionはhost app側に残します。 |
+| Rails I18nに沿ったrow label、badge、tooltipを出したい | [Localized names](localized-names.md) と [Cookbook](cookbook.md#row-labelbadgetooltipをlocalizeする) | `TreeView.model_name_for`, `TreeView.attribute_name_for`, `TreeView.type_name_for`, `TreeView::NodePresenter` | row visualをhost appのlocale fileに合わせたい場合に使います。TreeViewは表示名を解決し、locale内容、業務文言、どこへ表示するかはhost appが担当します。 |
 | drag-and-dropを追加したい | Drag/drop row hooks | drag属性とrow event payload | TreeViewは連携hookを出します。移動のvalidationと永続化はhost appが担当します。 |
 | 開閉状態を保存したい | `TreeView::PersistedState`, `TreeView::StateStore` | `rails g tree_view:state:install`, persisted state model | ユーザが再訪したときに同じ開閉状態へ戻したい場合に使います。 |
 | tree dataや識別子を検証したい | Diagnostics APIs | node key、DOM ID、orphan、cycle diagnostics | integration時、test時、invalidな構造の描画前確認に使います。 |
@@ -44,6 +46,7 @@ flowchart TD
   C -->|いいえ、browser上で開かない| D[Static rendering: Tree + RenderState + tree_view_rows]
   C -->|いいえ、browser内開閉で十分| CL[Client-side rendering: UiConfigBuilder#build_client_side]
   C -->|はい| E[Turbo rendering: UiConfigBuilder#build_turbo と show/hide path builders]
+  C -->|はい、tree全体の操作も必要| TB[Toolbar helper と toggle_all_path_builder]
   B -->|いいえ、全取得が重い| F[Lazy Loading または Children Pagination]
   F --> G{親ごとの子要素数が非常に多い?}
   G -->|はい| H[host app側のChildren Paginationをlazy-loading URL経由で連携]
@@ -64,6 +67,7 @@ flowchart TD
   P -->|drag/drop| S[Drag/drop hooks と host-app handlers]
   A --> Y{row visualが必要?}
   Y -->|level label, badge, icon, status| Z[Cookbook row customization hooks]
+  Y -->|localeに沿ったlabelやtype名| LN[LocalizedNames helpers と NodePresenter]
   A --> T{input dataを検証したい?}
   T -->|はい| U[Diagnostics APIs]
 ```
@@ -89,7 +93,7 @@ flowchart TD
 5. 1つのparent id columnだけでは扱いにくい異種recordやgraph-like edgeがある場合は [GraphAdapter adapter mode](api-overview.md#adapter-mode) を使います。
 6. dataは取得済みで、初期HTML量を許容でき、Turbo endpointが過剰な場合は `build_client_side` を使います。
 7. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
-8. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
+8. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Localized names](localized-names.md)、[Toolbar helper](toolbar.md)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
 9. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
 
 ## よくある組み合わせ
@@ -106,8 +110,10 @@ flowchart TD
 | bulk action page | StaticまたはTurbo rendering + `selection:` + host-app form action |
 | bulk edit page | StaticまたはTurbo rendering + row partial form controls + host-app Form Object |
 | per-row inline edit page | 表示用row partial + `row_actions_partial` + host-app edit action / Turbo response + 編集用row partial |
+| tree全体のaction toolbar | Turbo rendering + `toggle_all_path_builder` + `tree_view_toolbar` + host-app placement / authorization |
 | row action menu | `row_actions_partial` + host-app route、authorization、action handler |
 | statusが多いtree table | `row_class_builder` + `badge_builder` + host-app status rules |
+| localized row display | `TreeView::NodePresenter` + LocalizedNames helpers + host-app locale files |
 | 並び替え可能な階層 | StaticまたはTurbo rendering + drag/drop hooks + host-app move endpoint |
 
 ## 関連docs
@@ -116,6 +122,9 @@ flowchart TD
 - [API概要: adapter mode](api-overview.md#adapter-mode)
 - [API仕様](api.md)
 - [Cookbook: 行customization quick guide](cookbook.md#行customization-quick-guide)
+- [Localized names](localized-names.md)
+- [Toolbar helper](toolbar.md)
+- [Toolbar actions mockup](../mockups/toolbar-actions.html)
 - [Render Scale](render-scale.md)
 - [Lazy Loading](lazy-loading.md)
 - [Children Pagination](children-pagination.md)


### PR DESCRIPTION
## 対応 Issue

Closes #816
Closes #921

## 判定分類

- `docs-stale`
- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/decision-guide.md` / `docs/ja/decision-guide.md` に、既存 public helper surface である toolbar action helper family への use-case 導線を追加しました。
  - `tree_view_toolbar`
  - `tree_view_toolbar_actions`
  - `tree_view_toolbar_action_metadata`
  - `toggle_all_path_builder`
- Decision guide から LocalizedNames と `TreeView::NodePresenter` の composition に辿れるようにしました。
- `docs/en/cookbook.md` / `docs/ja/cookbook.md` に、LocalizedNames helpers を `NodePresenter` と組み合わせる短い recipe を追加しました。

## 根拠

- #921 は、README / API docs / manifest では toolbar helper が public surface として見える一方、Decision guide から expand-all / collapse-all / current-path toolbar を選びにくい docs gap として整理されています。
- #816 は、LocalizedNames guide は存在するものの、Decision guide / Cookbook から Rails I18n に沿った row label / badge / tooltip の使いどころへ辿りにくい docs gap として Planner handoff 済みです。
- どちらも既存実装・既存 public docs への導線追加で完結し、runtime helper behavior や public API manifest の変更は不要です。

## 変更範囲

- `docs/en/decision-guide.md`
- `docs/ja/decision-guide.md`
- `docs/en/cookbook.md`
- `docs/ja/cookbook.md`

runtime code、public API manifest、mockup HTML/CSS、toolbar behavior、LocalizedNames / NodePresenter behavior は変更していません。

## 確認

- GitHub compare: `main...docs/816-921-decision-guide-entrypoints`
  - changed files: 4 docs-only
- local test / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の CI を確認します。

## リスク

- low
- 既存 docs への選び方・参照導線を追加するだけで、仕様や実装 contract は変更していません。

## 補足

- branch 作成中に `main` が #918 の API reference commit で進んだため、compare は `behind_by: 1` になる可能性があります。進んだ差分は `docs/en/api.md` / `docs/ja/api.md` で、今回の変更対象4ファイルとは重ならないことを確認しています。