### PR TITLE
PR CI で package-sensitive 変更の gem verification を走らせる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      package_sensitive: ${{ steps.detect.outputs.package_sensitive }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -20,6 +21,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "package_sensitive=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -32,6 +34,7 @@ jobs:
           fi
 
           docs_only=true
+          package_sensitive=false
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             # Root maintainer prose docs linked from the docs indexes are still docs-only changes.
@@ -39,7 +42,12 @@ jobs:
               README.md|docs/*|Product\ Profile.md|CHANGELOG.md|AGENTS.md) ;;
               *)
                 docs_only=false
-                break
+                ;;
+            esac
+
+            case "$file" in
+              tree_view.gemspec|script/check_gem_package_contents.rb|.github/workflows/ci.yml|config/importmap.tree_view.rb|lib/*|lib/**|app/helpers/*|app/helpers/**|app/views/*|app/views/**|app/assets/*|app/assets/**|app/javascript/*|app/javascript/**|config/locales/*|config/locales/**)
+                package_sensitive=true
                 ;;
             esac
           done <<EOF
@@ -47,6 +55,7 @@ jobs:
           EOF
 
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "package_sensitive=$package_sensitive" >> "$GITHUB_OUTPUT"
 
   lint:
     runs-on: ubuntu-latest
@@ -169,7 +178,8 @@ jobs:
         run: npm run test:js
 
   gem_package:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && needs.changes.outputs.package_sensitive == 'true'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -67,6 +67,9 @@ Pull request CI checks:
 - Ruby specs through `bundle exec rspec`
 - Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
 - JavaScript tests through `npm install`, Playwright browser setup, and `npm run test:js`
+- Gem package verification when the PR touches package-sensitive paths
+
+Package-sensitive PR paths include `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb` and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Prose-only docs PRs keep the lighter docs-only behavior unless they also touch one of those package-sensitive paths.
 
 Main-push CI checks:
 
@@ -75,7 +78,7 @@ Main-push CI checks:
 - JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
 - Gem package verification, including representative Rails helper, view partial, locale, docs, JavaScript, CSS, and importmap file contents
 
-PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes compatibility matrices, JavaScript coverage, and package verification.
+PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes full compatibility matrices, JavaScript coverage, and unconditional package verification.
 
 ## Documentation
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -67,6 +67,9 @@ Pull Request CI の確認項目:
 - Ruby specs: `bundle exec rspec`
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
 - JavaScript tests: `npm install`、Playwright browser setup、`npm run test:js`
+- package-sensitive path を触るPRでの Gem package verification
+
+package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb` と `config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。prose-only docs PR は、その package-sensitive path も触らない限り、従来どおり軽い docs-only 挙動を維持します。
 
 `main` push CI の確認項目:
 
@@ -75,7 +78,7 @@ Pull Request CI の確認項目:
 - `package-lock.json` が `package.json` と同期するまでの間は、`npm install` と `npm run test:js` による JavaScript tests
 - Rails helper / view partial / locale / docs / JavaScript / CSS / importmap の代表ファイルを含む Gem package verification
 
-merge前にPR CIを通します。互換性matrix、JavaScript coverage、package verificationを含むため、release判定にはより広い `main` CIを使います。
+merge前にPR CIを通します。release判定には、full compatibility matrices、JavaScript coverage、unconditional package verificationを含む、より広い `main` CIを使います。
 
 ## ドキュメント
 


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #920

## Issue ごとの完了内容

- #920
  - `changes` job に `package_sensitive` output を追加しました。
  - PR が package-sensitive path を触る場合に `gem_package` job を実行するようにしました。
  - main push の `gem_package` は従来どおり実行します。
  - 英日 release docs に PR package verification の path 条件と実行内容を同期しました。

## 変更内容

- `.github/workflows/ci.yml`
  - changed files detection で `docs_only` と独立して `package_sensitive` を判定
  - package-sensitive path:
    - `tree_view.gemspec`
    - `script/check_gem_package_contents.rb`
    - `.github/workflows/ci.yml`
    - `lib/**`
    - `app/helpers/**`, `app/views/**`, `app/assets/**`, `app/javascript/**`
    - `config/importmap.tree_view.rb`, `config/locales/**`
  - `gem_package` job を main push または package-sensitive PR で実行
- `docs/en/release.md` / `docs/ja/release.md`
  - PR CI の package verification 条件と実行コマンドを同期
  - release 判断では main CI の unconditional package verification を使うことを維持

## 改善カテゴリ

- CI
- build / release guard
- docs sync

## 既存仕様への影響はないこと

- runtime code、public API、Rails/Ruby matrix、package contents required list は変更していません。
- main-push full CI は弱めていません。
- docs-only shortcut 全体は撤廃していません。

## 実施した確認内容

- GitHub compare: `main...quality/920-pr-package-verification`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- local workflow execution / test は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で `gem_package` がこの PR では実行対象になることを確認します。

## リスク評価

- medium
- CI 条件変更のため、path 判定の漏れや不要実行のリスクがあります。変更は package-sensitive 判定と release docs sync に限定しています。

## 補足事項

- #915 / PR #919 の required package path 追加とは混ぜていません。
- package contents required list や RubyGems publish automation には触れていません。