### PR TITLE
test: transfer drop positions と manifest の同期を固定する

### DIFF
--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -100,4 +100,10 @@ assert(
   "TreeViewEventNames export is out of sync"
 )
 assertFrozenObject(entrypointModule.TreeViewEventNames, "TreeViewEventNames", { deep: true })
+
+const expectedTransferDropPositions = javascriptPackageManifest.transfer_drop_positions
+assert(
+  JSON.stringify(entrypointModule.TreeViewTransferDropPositions) === JSON.stringify(expectedTransferDropPositions),
+  "TreeViewTransferDropPositions export is out of sync"
+)
 assertFrozenObject(entrypointModule.TreeViewTransferDropPositions, "TreeViewTransferDropPositions")


### PR DESCRIPTION
## 対応 Issue

Closes #925

## Issue ごとの完了内容

- #925
  - `script/test_entrypoints.mjs` で `TreeViewTransferDropPositions` と `config/public_api_manifest.yml` の `javascript_package_root.transfer_drop_positions` を比較する assertion を追加しました。
  - 既存の frozen object guard は維持しました。

## 変更内容

- entrypoint smoke の public API manifest 同期対象に transfer drop positions を追加しました。
- transfer controller、drop position の値、event name、controller registration、manifest schema は変更していません。

## 改善カテゴリ

- test
- public API drift guard

## 既存仕様への影響

- runtime behavior への影響はありません。
- `before` / `inside` / `after` の公開値は変更していません。

## 実施した確認内容

- GitHub compare: `main...quality/925-transfer-positions-manifest`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_entrypoints.mjs`)
- local `npm run test:entrypoints` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で確認します。

## リスク評価

- low
- 既存 smoke test の assertion 追加のみで、公開値や runtime code には触れていません。

## 補足事項

- docs relative link check (#926) や transfer controller behavior spec (#750) には広げていません。