### PR TITLE
docs: selection hidden input の source id 境界を明記する

### DIFF
--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -137,6 +137,8 @@ With `data-tree-view-selection-hidden-input-name-value`, TreeView writes one hid
 - Disabled checkboxes and invalid JSON payloads are skipped, matching the existing event payload behavior.
 - If the tree is not inside a form, TreeView keeps dispatching selection events and does not create hidden inputs.
 
+When one form contains multiple `tree-view-selection` controllers, TreeView tags each generated hidden input with `data-tree-view-selection-source-id` so one controller only removes and rewrites its own generated inputs. If the controller element already has `data-tree-view-selection-source-id`, TreeView reuses that value; otherwise it assigns a generated source id on connect. Use separate `data-tree-view-selection-hidden-input-name-value` names when the host app wants separate submitted params for each tree. Reuse a name only when the server-side action intentionally accepts one combined array.
+
 ## Selection max count
 
 Host apps can limit the number of checked boxes on the JavaScript controller.

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -137,6 +137,8 @@ tree が通常の HTML form の中にある場合、同じ controller で checke
 - disabled checkbox と不正な JSON payload は既存 event と同じく skip されます。
 - tree が form の外にある場合は、selection event だけを dispatch し、hidden input は生成しません。
 
+1つの form に複数の `tree-view-selection` controller がある場合、TreeView は生成した hidden input に `data-tree-view-selection-source-id` を付けます。これにより、各 controller は自分が生成した hidden input だけを削除・再生成します。controller element に `data-tree-view-selection-source-id` がすでにある場合はその値を使い、なければ connect 時に自動生成します。tree ごとに別々の params として受け取りたい場合は、`data-tree-view-selection-hidden-input-name-value` に別々の名前を指定してください。同じ名前を使うのは、server-side action が1つの配列としてまとめて受け取る設計のときに限ります。
+
 ## 最大選択数
 
 JavaScript controller側で、checked checkboxの最大数を制限できます。


### PR DESCRIPTION
## 対応 Issue

Closes #930

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/selection.md` / `docs/ja/selection.md` の hidden input sync section に、同じ form 内に複数 `tree-view-selection` controller がある場合の source id 境界を追記しました。
- generated hidden input に `data-tree-view-selection-source-id` が付くこと、controller element 側に明示済みならその値を使い、なければ自動生成されることを説明しました。
- hidden input `name` は host app が決めること、tree ごとに params を分けたい場合は別名にし、同名は server-side action が combined array を意図するときだけ使うことを補足しました。

## 根拠

- `app/javascript/tree_view/selection_controller.js` は `hiddenInputSourceId()` で controller ごとの source id を保持し、`removeSyncedHiddenInputs(form)` では同じ source id の generated hidden input だけを削除します。
- 既存 selection docs は hidden input sync、invalid / disabled payload skip、nearest form sync を説明していますが、複数 controller / source id 境界の説明が不足していました。

## 変更範囲

- `docs/en/selection.md`
- `docs/ja/selection.md`

runtime code、selection controller behavior、JS spec、multi-tree mockup、server-side params policy、authorization、business action behavior は変更していません。

## 確認

- GitHub compare: `main...docs/930-selection-source-id-boundary`
  - changed files: 2 docs-only
  - additions: 2
  - deletions: 0
- local test / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の CI を確認します。

## リスク

- low
- 実装済みの generated hidden input source id 境界を利用者 docs に追記するだけで、payload schema や runtime behavior は変更していません。