### PR TITLE
ResourceTableRenderState と table preference 境界を smoke する

### DIFF
--- a/docs/en/resource-table-bridge.md
+++ b/docs/en/resource-table-bridge.md
@@ -52,6 +52,18 @@ This keeps the responsibilities separate:
 
 For host apps that use both a regular table and a tree-table, start here to decide what TreeView owns, then read the table preferences layer docs for column state, widths, presets, export metadata, and preference UI. Keep TreeView responsible for row hierarchy, visible row order, expansion state, and rendering hooks; keep the table layer responsible for table-wide column and preference state.
 
+### Ownership boundary
+
+When combining TreeView with a table preferences layer, keep the persisted state split by purpose:
+
+| Owner | Owns | Does not own |
+| --- | --- | --- |
+| TreeView | row hierarchy, visible row order, expansion state, selection state, lazy-loading hooks, render hooks | column visibility, column order, column width, filters, sorts, presets |
+| Table preferences layer | column key, visibility, order, width, filter, sort, preset state | node keys, row identity, expansion state, selection state |
+| Host app | query execution, authorization, preload policy, business actions, partial overrides | hidden cross-gem state coupling |
+
+Treat node keys and row DOM ids as TreeView identity. Treat `data-rails-table-preferences-column-key` as table-column identity. They may appear in the same row markup, but they should not be reused for each other.
+
 For a focused visual reference that compares shared hierarchy rows across fuller and narrower visible-column sets without adding host-app table logic, see [resource-table-bridge.html](../mockups/resource-table-bridge.html).
 
 ## When to use it

--- a/docs/ja/resource-table-bridge.md
+++ b/docs/ja/resource-table-bridge.md
@@ -52,6 +52,18 @@ render_state = TreeView::ResourceTableRenderState.call(
 
 通常 table と tree-table の両方を使う host app では、まずこのページで TreeView が担当する範囲を決め、column state、width、preset、export metadata、preference UI の詳細は table preferences layer 側の docs を確認してください。TreeView には row hierarchy、visible row order、expansion state、rendering hook を任せ、table layer には table 全体の column / preference state を任せると、責務が重複しにくくなります。
 
+### 責務境界
+
+TreeView と table preferences layer を組み合わせる場合は、永続化する state を目的別に分けてください。
+
+| 担当 | 担当するもの | 担当しないもの |
+| --- | --- | --- |
+| TreeView | row hierarchy、visible row order、expansion state、selection state、lazy-loading hook、render hook | column visibility、column order、column width、filter、sort、preset |
+| table preferences layer | column key、visibility、order、width、filter、sort、preset state | node key、row identity、expansion state、selection state |
+| host app | query execution、authorization、preload policy、business action、partial差し替え | gem間で暗黙に共有する hidden state |
+
+node key と row DOM id は TreeView 側の identity として扱います。`data-rails-table-preferences-column-key` は table column 側の identity です。同じ row markup の中に出てきても、互いの代用として使わないでください。
+
 shared hierarchy rows と、より多い visible column / より少ない visible column の比較を host app 側の table logic なしで見たい場合は [resource-table-bridge.html](../mockups/resource-table-bridge.html) を参照してください。
 
 ## 使うべき場面

--- a/spec/integration/resource_table_render_state_integration_spec.rb
+++ b/spec/integration/resource_table_render_state_integration_spec.rb
@@ -43,6 +43,31 @@ RSpec.describe "Resource table render state integration" do
     expect(rendered).to include("active")
   end
 
+  it "keeps node identity separate from table column keys" do
+    render_state = TreeView::ResourceTableRenderState.call(
+      records: [root],
+      context: Object.new,
+      table_key: "projects_tree",
+      parent_id_method: :parent_item_id,
+      table_state: {
+        "visible_columns" => [
+          {"key" => "name"},
+          {"key" => "status"}
+        ]
+      }
+    )
+
+    rendered = build_view.tree_view_rows(render_state)
+
+    expect(rendered).to include('id="projects_tree_1"')
+    expect(rendered).to include('data-tree-view-resource-table-row="true"')
+    expect(rendered).to include('data-rails-table-preferences-table-key="projects_tree"')
+    expect(rendered).to include('data-rails-table-preferences-column-key="name"')
+    expect(rendered).to include('data-rails-table-preferences-column-key="status"')
+    expect(rendered).not_to include('data-rails-table-preferences-column-key="projects_tree_1"')
+    expect(rendered).not_to include('data-rails-table-preferences-column-key="1"')
+  end
+
   it "falls back to columns when table_state has no visible columns" do
     render_state = TreeView::ResourceTableRenderState.call(
       records: nodes,


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #927

## Issue ごとの完了内容

- #927
  - `ResourceTableRenderState` の existing integration spec に、node / row identity と table column key が混同されない representative smoke を追加しました。
  - `docs/en/resource-table-bridge.md` / `docs/ja/resource-table-bridge.md` に TreeView / table preferences layer / host app の責務境界を明記しました。
  - `rails_table_preferences` への runtime dependency や docs-portal 実画面変更は追加していません。

## 変更内容

- `spec/integration/resource_table_render_state_integration_spec.rb`
  - `table_key` / row DOM id / `data-rails-table-preferences-column-key` が別責務として出力されることを確認
- `docs/en/resource-table-bridge.md`
- `docs/ja/resource-table-bridge.md`
  - ownership boundary table を追加
  - node key / row DOM id と column key を互いの代用にしない guidance を追加

## 改善カテゴリ

- test
- docs-sync
- cross-gem boundary documentation

## 既存仕様への影響はないこと

- runtime API、`ResourceTableRenderState` の public signature、`table_state` shape、row partial behavior は変更していません。
- `rails_table_preferences` を dependency として追加していません。
- host app query / authorization / preload / business action には触れていません。

## 実施した確認内容

- GitHub compare: `main...quality/927-resource-table-boundary-smoke`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- local test は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の CI を確認します。

## リスク評価

- medium
- 変更は docs + existing integration spec に限定しています。複数 repo 採用判断に関係する境界整理ですが、runtime behavior は変更していません。

## 補足事項

- docs-portal 実装や Rails Table Preferences 連携実装には広げていません。