### PR TITLE
docs: Product Profile の public API manifest 導線を同期する

### DIFF
--- a/Product Profile.md
+++ b/Product Profile.md
@@ -17,9 +17,10 @@ It packages tree traversal, render state, helpers, partials, CSS baseline, and J
 When implementation and docs drift, use this order:
 
 1. Current code in `lib/`, `app/helpers/`, `app/views/`, `app/assets/`, and `app/javascript/`
-2. Explicit decisions in the relevant issue and pull request
-3. Durable docs under `docs/`, especially the relevant guides in `docs/en/` and `docs/ja/`
-4. Entry-point summaries in `README.md`, `docs/README.md`, `AGENTS.md`, and this profile
+2. Machine-readable public API contracts in `config/public_api_manifest.yml` and the compatibility checks that read them
+3. Explicit decisions in the relevant issue and pull request
+4. Durable docs under `docs/`, especially the relevant guides in `docs/en/` and `docs/ja/`
+5. Entry-point summaries in `README.md`, `docs/README.md`, `AGENTS.md`, and this profile
 
 Treat `CHANGELOG.md` as a release-facing summary of shipped public changes, not as the primary source for current behavior.
 
@@ -28,6 +29,7 @@ Treat `CHANGELOG.md` as a release-facing summary of shipped public changes, not 
 - Tree traversal and structure helpers
 - Render state and row rendering helpers
 - Generic UI configuration builders and hooks
+- Public API compatibility manifests and checks for documented helpers, grouped options, and JavaScript entrypoints
 - Selection, lazy loading, windowed rendering, persisted state, and diagnostics
 - Bundled CSS baseline and JavaScript controller entrypoints that support those primitives
 - Documentation for public APIs and responsibility boundaries
@@ -58,6 +60,7 @@ Use these durable entry points together when you are checking scope, docs sync, 
 - `docs/en/README.md` or `docs/ja/README.md` for language-specific docs navigation
 - `docs/i18n-audit.md` for cross-language maintenance rules and docs update coverage
 - `docs/en/release.md` or `docs/ja/release.md` for release checklist, release consistency checks, and changelog expectations
+- `config/public_api_manifest.yml` for machine-readable public API contracts that specs and entrypoint smoke checks compare against current code
 - `CHANGELOG.md` for shipped public changes, compatibility notes, and notable docs additions
 
 ## Recommended first reads
@@ -70,5 +73,6 @@ For maintainers making changes, start in this order:
 4. `docs/en/README.md` or `docs/ja/README.md` for language-specific docs navigation
 5. `docs/en/design-policy.md` or `docs/ja/design-policy.md` for responsibility boundaries
 6. `docs/i18n-audit.md` when the task changes public docs or language coverage
-7. `docs/en/release.md` or `docs/ja/release.md` when the task affects release-facing docs, compatibility notes, or package verification workflow
-8. `CHANGELOG.md` when the task affects release-facing public behavior or compatibility notes
+7. `config/public_api_manifest.yml` when the task changes documented helper methods, grouped options, JavaScript entrypoints, controller identifiers, or event contracts
+8. `docs/en/release.md` or `docs/ja/release.md` when the task affects release-facing docs, compatibility notes, or package verification workflow
+9. `CHANGELOG.md` when the task affects release-facing public behavior or compatibility notes


### PR DESCRIPTION
## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `Product Profile.md` の source-of-truth order に `config/public_api_manifest.yml` と compatibility checks を追加しました。
- TreeView が owns する対象に public API compatibility manifests/checks を明記しました。
- maintainer companion docs と recommended first reads に、helper methods / grouped options / JavaScript entrypoints / controller identifiers / event contracts を変更するときの manifest 確認導線を追加しました。

## 根拠

- `AGENTS.md` は manifest 変更時に `docs/en|ja/public-api.md`、関連 docs、release docs、CHANGELOG を確認する運用を持っています。
- `docs/en/public-api.md` も `config/public_api_manifest.yml` を helper methods、JavaScript package-root exports、controller identifiers、RenderState grouped option keys の machine-readable source of truth として扱っています。
- 一方で `Product Profile.md` の source-of-truth / maintainer first-read guidance には manifest への導線がなく、public API contract 変更時の入口として少し古くなっていました。

## 変更範囲

- `Product Profile.md`

runtime code、public API manifest、spec、README、language docs、CHANGELOG は変更していません。

## 確認

- GitHub compare: `main...docs/product-profile-public-api-manifest`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- docs-only profile 更新のため local test / lint は未実行です。

## リスク

- low
- 既存の `AGENTS.md` / `docs/en/public-api.md` の運用と Product Profile の導線を同期するだけで、仕様や実装 contract は変更していません。

## 補足

- 元 PR #917 は branch refresh 中に一時的に差分なしとなったため closed されました。この PR は同じ docs-only 内容を current `main` から開き直した replacement PR です。