### PR TITLE
docs: StateStore#clear! を API reference に反映する

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -347,7 +347,7 @@ Client-side mode renders collapsed descendants inside the render scope into the 
 
 ## TreeView::PersistedState / StateStore
 
-APIs for saving and restoring expansion state through the generated host app model.
+APIs for saving, restoring, and clearing expansion state through the generated host app model.
 
 ```ruby
 store = TreeView::StateStore.new(model: TreeViewState)
@@ -362,7 +362,14 @@ store.save!(
   tree_instance_key: "documents:index",
   expanded_keys: expanded_keys
 )
+
+store.clear!(
+  owner: current_user,
+  tree_instance_key: "documents:index"
+)
 ```
+
+`clear!` deletes the matching saved expansion-state record when one exists. When no record exists, it still returns an empty `TreeView::PersistedState` for the requested owner and `tree_instance_key`. See [Persisted State](persisted-state.md#statestore) for reset-route and authorization responsibilities.
 
 ## Helpers
 
@@ -439,5 +446,6 @@ Main controllers:
 - [Error hierarchy](errors.md)
 - [Render log level](render-log-level.md)
 - [Node keys](node-keys.md)
+- [Persisted State](persisted-state.md)
 - [Tree diagnostics](tree-diagnostics.md)
 - [Public API policy](public-api.md)

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -347,7 +347,7 @@ client-side mode では、render scope 内の collapsed descendants を初期 HT
 
 ## TreeView::PersistedState / StateStore
 
-生成された host app model 経由で開閉状態を保存・復元するための API です。
+生成された host app model 経由で開閉状態を保存・復元・クリアするための API です。
 
 ```ruby
 store = TreeView::StateStore.new(model: TreeViewState)
@@ -362,7 +362,14 @@ store.save!(
   tree_instance_key: "documents:index",
   expanded_keys: expanded_keys
 )
+
+store.clear!(
+  owner: current_user,
+  tree_instance_key: "documents:index"
+)
 ```
+
+`clear!` は一致する保存済み展開状態 record があれば削除します。record が存在しない場合も、指定した owner と `tree_instance_key` の空の `TreeView::PersistedState` を返します。reset route と authorization の責務は [Persisted State](persisted-state.md#statestore) を参照してください。
 
 ## Helpers
 
@@ -439,5 +446,6 @@ registerTreeViewControllers(application)
 - [Error hierarchy](errors.md)
 - [render log level](render-log-level.md)
 - [Node keys](node-keys.md)
+- [Persisted State](persisted-state.md)
 - [Tree diagnostics](tree-diagnostics.md)
 - [Public API policy](public-api.md)


### PR DESCRIPTION
## 対応 Issue

Closes #788

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/api.md` / `docs/ja/api.md` の `TreeView::PersistedState / StateStore` section に `StateStore#clear!` を追加しました。
- API reference の説明を保存・復元だけでなく clear も含む表現に更新しました。
- `clear!` が matching record を削除し、record がない場合も empty `TreeView::PersistedState` を返すことを persisted-state guide と同じ責務境界で補足しました。
- Related docs から `persisted-state.md` へ辿れる導線を追加しました。

## 根拠

- PR #784 で `TreeView::StateStore#clear!` が merge 済みです。
- `docs/en/persisted-state.md` / `docs/ja/persisted-state.md` は `clear!` の使い方と reset route / authorization が host app responsibility であることを既に説明しています。
- 既存 API reference は `find` / `save!` のみで、landed public server-side API の `clear!` が見つけにくい状態でした。

## 変更範囲

- `docs/en/api.md`
- `docs/ja/api.md`

runtime code、public API manifest、StateStore behavior、spec、persisted-state guide 本文、controller concern、reset UI / route / authorization は変更していません。

## 確認

- GitHub compare: `main...docs/788-state-store-clear-api`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only
- local test / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後の CI を確認します。

## リスク

- low
- landed API を API reference に追従するだけで、仕様判断や実装変更は含みません。