### PR TITLE
design: selection max-count mockup を latest main に載せ直す

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -23,7 +23,7 @@ Use this table when you need a quick answer to "which user-facing pages must sta
 Japanese remains the more complete canonical prose source when English wording lags, but the pages below are the current cross-language planning baseline promised by `docs/en/README.md`, `docs/ja/README.md`, and `docs/README.md`.
 
 | Docs lane | Current coverage status | Priority | Maintenance expectation |
-|---|---|---|---|
+|---|---|---|
 | `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` | Published entry points for cross-language navigation and language-status guidance | High | Update in the same docs lane whenever reading order, docs map, or language-status promises change |
 | `docs/en/installation.md`, `docs/ja/installation.md` | Published in both trees | High | Keep setup, asset, importmap, and first-run instructions aligned before release-facing docs changes land |
 | `docs/en/minimal-usage.md`, `docs/ja/minimal-usage.md` | Published in both trees | High | Keep the first working host-app example aligned with installation and usage docs |
@@ -126,6 +126,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/filtered-tree-modes.html` | Technical asset | No translation needed. |
 | `docs/mockups/path-tree-builder-rows.html` | Technical asset | No translation needed. |
 | `docs/mockups/form-editing-rows.html` | Technical asset | No translation needed. |
+| `docs/mockups/selection-max-count.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
 | `docs/mockups/row-status-depth-labels.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -23,7 +23,7 @@ Use this table when you need a quick answer to "which user-facing pages must sta
 Japanese remains the more complete canonical prose source when English wording lags, but the pages below are the current cross-language planning baseline promised by `docs/en/README.md`, `docs/ja/README.md`, and `docs/README.md`.
 
 | Docs lane | Current coverage status | Priority | Maintenance expectation |
-|---|---|---|
+|---|---|---|---|
 | `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` | Published entry points for cross-language navigation and language-status guidance | High | Update in the same docs lane whenever reading order, docs map, or language-status promises change |
 | `docs/en/installation.md`, `docs/ja/installation.md` | Published in both trees | High | Keep setup, asset, importmap, and first-run instructions aligned before release-facing docs changes land |
 | `docs/en/minimal-usage.md`, `docs/ja/minimal-usage.md` | Published in both trees | High | Keep the first working host-app example aligned with installation and usage docs |

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -29,6 +29,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [path-tree-builder-rows.html](path-tree-builder-rows.html) | Focused PathTreeBuilder comparison for generated folder rows versus record-backed rows, keeping host-app columns/actions outside the gem contract. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
+| [selection-max-count.html](selection-max-count.html) | Focused selection max-count reference showing below-limit, limit-reached, and limit-exceeded feedback while keeping final action copy host-app owned. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all, collapse-all, and collapse-to-current-path toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
@@ -54,9 +55,10 @@ They are **not** a complete Rails application and should not grow into host-app 
 17. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
 18. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
 19. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-20. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-21. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-22. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+20. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+21. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+22. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+23. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -212,6 +212,7 @@
           <a href="#gallery-breadcrumb-heading">Navigation context</a>
           <a href="#gallery-path-builder-heading">Generated rows</a>
           <a href="#gallery-form-heading">Editing and controls</a>
+          <a href="#gallery-selection-limit-heading">Selection limits</a>
           <a href="#gallery-empty-heading">Empty and fallback states</a>
         </div>
       </nav>
@@ -272,6 +273,9 @@
       <article class="mock-gallery-card" aria-labelledby="gallery-form-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div>
       </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-selection-limit-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Attempted checkbox restored after limit-exceeded</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div>
+      </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
       </article>
@@ -301,6 +305,7 @@
         <tr><td>Filtered tree modes</td><td>Matched-only, ancestor-retaining, and descendant-retaining output.</td><td>Search forms, highlighting, ranking, and authorization-aware filtering.</td></tr>
         <tr><td>PathTreeBuilder rows</td><td>Generated folder row cues compared with record-backed rows and host-app-owned columns or actions.</td><td>File-manager routes, download behavior, record authorization, or public API changes.</td></tr>
         <tr><td>Form-editing rows</td><td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td><td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td></tr>
+        <tr><td>Selection max-count</td><td>Below-limit, limit-reached, and limit-exceeded feedback placement around checkbox selection.</td><td>Runtime controller changes, final bulk-action copy, authorization, server validation, or submit behavior.</td></tr>
         <tr><td>Toolbar actions</td><td>Tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</td><td>Authorization, route names, current-path semantics, or action sequencing rules.</td></tr>
         <tr><td>Empty state</td><td>Spacing, wrapper hooks, and the full-width empty-row slot.</td><td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td></tr>
       </tbody></table>

--- a/docs/mockups/selection-max-count.html
+++ b/docs/mockups/selection-max-count.html
@@ -1,0 +1,514 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView selection max-count mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-limit-page {
+  max-width: 1280px;
+}
+
+.mock-limit-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-limit-state {
+  display: grid;
+  gap: 14px;
+}
+
+.mock-limit-state__header {
+  display: grid;
+  gap: 8px;
+}
+
+.mock-limit-eyebrow {
+  margin: 0;
+  color: #52606d;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mock-limit-note {
+  margin: 0;
+  color: #52606d;
+}
+
+.mock-limit-frame {
+  border: 1px solid #dde4ec;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.mock-limit-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e4e7eb;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.mock-limit-toolbar__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.mock-limit-toolbar__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mock-limit-toolbar__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mock-limit-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.16rem 0.58rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0f4c81;
+  font-size: 0.79rem;
+  font-weight: 700;
+}
+
+.mock-limit-chip--neutral {
+  background: #e9ecef;
+  color: #334155;
+}
+
+.mock-limit-chip--warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.mock-limit-chip--success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-limit-body {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+}
+
+.mock-limit-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid #d8e0ea;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.mock-limit-summary__copy {
+  display: grid;
+  gap: 4px;
+}
+
+.mock-limit-summary__title,
+.mock-limit-summary__meta {
+  margin: 0;
+}
+
+.mock-limit-summary__title {
+  color: #102a43;
+  font-weight: 700;
+}
+
+.mock-limit-summary__meta {
+  color: #52606d;
+  font-size: 0.92rem;
+}
+
+.mock-limit-count {
+  min-width: 4.8rem;
+  padding: 0.38rem 0.62rem;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-weight: 800;
+  text-align: center;
+}
+
+.mock-limit-count--reached {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.mock-limit-count--open {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.mock-limit-message {
+  margin: 0;
+  padding: 0.82rem 0.95rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #fff;
+  color: #334155;
+}
+
+.mock-limit-message--warning {
+  border-color: #f59e0b;
+  background: #fffbeb;
+  color: #78350f;
+}
+
+.mock-limit-table-wrap {
+  overflow-x: auto;
+}
+
+.mock-limit-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #102a43;
+}
+
+.mock-limit-choice input {
+  inline-size: 1rem;
+  block-size: 1rem;
+}
+
+.mock-limit-choice input:disabled + span {
+  color: #64748b;
+}
+
+.mock-limit-row-note {
+  display: block;
+  margin-top: 0.3rem;
+  color: #52606d;
+  font-size: 0.86rem;
+}
+
+.mock-limit-event {
+  display: grid;
+  gap: 8px;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid #fde68a;
+  border-radius: 12px;
+  background: #fffbeb;
+}
+
+.mock-limit-event code {
+  overflow-wrap: anywhere;
+}
+
+.mock-limit-boundary-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-limit-boundary-table th,
+.mock-limit-boundary-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-limit-boundary-table th {
+  background: #f8fafc;
+  color: #334e68;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .mock-limit-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .mock-limit-count {
+    justify-self: start;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page mock-limit-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView selection max-count mock</h1>
+      <p>
+        Static reference for comparing max-count and limit-exceeded feedback without turning the page into a real bulk action workflow.
+        TreeView owns checkbox state and public events. The host app owns final message text, action blocking, routing, and business policy.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-limit-grid" aria-labelledby="selection-limit-states-heading">
+      <div class="mock-limit-state">
+        <div class="mock-limit-state__header">
+          <p class="mock-limit-eyebrow">State A</p>
+          <h2 id="selection-limit-states-heading">Selected count below the limit</h2>
+          <p class="mock-limit-note">The count is visible, but the host app still decides what action the selection enables.</p>
+        </div>
+
+        <div class="mock-limit-frame">
+          <div class="mock-limit-toolbar">
+            <div class="mock-limit-toolbar__copy">
+              <p class="mock-limit-toolbar__title">Selection group: review candidates</p>
+            </div>
+            <div class="mock-limit-toolbar__meta" aria-label="Representative selection metadata">
+              <span class="mock-limit-chip mock-limit-chip--success">2 selected</span>
+              <span class="mock-limit-chip mock-limit-chip--neutral">max: 3</span>
+            </div>
+          </div>
+          <div class="mock-limit-body">
+            <div class="mock-limit-summary" aria-labelledby="below-limit-summary">
+              <div class="mock-limit-summary__copy">
+                <p id="below-limit-summary" class="mock-limit-summary__title">Additional rows can still be selected</p>
+                <p class="mock-limit-summary__meta">This area is host-app-owned copy listening to TreeView selection events.</p>
+              </div>
+              <span class="mock-limit-count mock-limit-count--open">2 / 3</span>
+            </div>
+            <div class="mock-limit-table-wrap">
+              <table class="tree-view-table">
+                <thead>
+                  <tr>
+                    <th scope="col">select</th>
+                    <th scope="col">tree row</th>
+                    <th scope="col">status</th>
+                    <th scope="col">note</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="tree-row is-expanded" aria-level="1" aria-expanded="true">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td class="tree-toggle-cell">
+                      <span class="tree-toggle" aria-label="Policy folder">
+                        <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                        <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span>
+                      </span>
+                    </td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>TreeView provides checkbox state; action copy is outside scope.</td>
+                  </tr>
+                  <tr class="tree-row" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td class="tree-toggle-cell">
+                      <span class="tree-toggle" aria-label="Child row">
+                        <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                        <span class="tree-toggle__control"><span class="tree-depth-label">child</span></span>
+                      </span>
+                    </td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>Selected count can update nearby host-app summary text.</td>
+                  </tr>
+                  <tr class="tree-row" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox"><span>Select</span></label></td>
+                    <td class="tree-toggle-cell">
+                      <span class="tree-toggle" aria-label="Available child row">
+                        <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                        <span class="tree-toggle__control"><span class="tree-depth-label">child</span></span>
+                      </span>
+                    </td>
+                    <td><span class="tree-badge tree-badge--muted">available</span></td>
+                    <td>Unchecked rows remain available while selected count is below max.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-limit-state">
+        <div class="mock-limit-state__header">
+          <p class="mock-limit-eyebrow">State B</p>
+          <h2>Limit reached</h2>
+          <p class="mock-limit-note">The page can show a gentle reached state without implying TreeView owns final business blocking.</p>
+        </div>
+
+        <div class="mock-limit-frame">
+          <div class="mock-limit-toolbar">
+            <div class="mock-limit-toolbar__copy">
+              <p class="mock-limit-toolbar__title">Selection group: review candidates</p>
+            </div>
+            <div class="mock-limit-toolbar__meta" aria-label="Representative limit metadata">
+              <span class="mock-limit-chip mock-limit-chip--warning">limit reached</span>
+              <span class="mock-limit-chip mock-limit-chip--neutral">max: 3</span>
+            </div>
+          </div>
+          <div class="mock-limit-body">
+            <div class="mock-limit-summary" aria-labelledby="limit-reached-summary">
+              <div class="mock-limit-summary__copy">
+                <p id="limit-reached-summary" class="mock-limit-summary__title">Maximum selection reached</p>
+                <p class="mock-limit-summary__meta">Keep the cue near the tree, but avoid product-specific action promises.</p>
+              </div>
+              <span class="mock-limit-count mock-limit-count--reached">3 / 3</span>
+            </div>
+            <p class="mock-limit-message">Host app message slot: deselect one row before choosing another.</p>
+            <div class="mock-limit-table-wrap">
+              <table class="tree-view-table">
+                <thead>
+                  <tr>
+                    <th scope="col">select</th>
+                    <th scope="col">tree row</th>
+                    <th scope="col">status</th>
+                    <th scope="col">note</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="tree-row is-selected" aria-level="1">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td>Policy library</td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>Selected rows remain editable by the host app only if the app chooses that pattern.</td>
+                  </tr>
+                  <tr class="tree-row is-selected" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td>Escalation matrix</td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>The max count is a TreeView guard, not a bulk action design.</td>
+                  </tr>
+                  <tr class="tree-row is-selected" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td>Training checklist</td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>The summary can announce the reached state in host-owned UI.</td>
+                  </tr>
+                  <tr class="tree-row" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox"><span>Select</span></label><span class="mock-limit-row-note">would exceed max</span></td>
+                    <td>Archive checklist</td>
+                    <td><span class="tree-badge tree-badge--muted">not selected</span></td>
+                    <td>Do not style this as a disabled permission state unless the host app owns that decision.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-limit-state">
+        <div class="mock-limit-state__header">
+          <p class="mock-limit-eyebrow">State C</p>
+          <h2>Limit-exceeded feedback</h2>
+          <p class="mock-limit-note">After an over-limit attempt, the attempted checkbox is shown returned to unchecked and the host app owns message placement.</p>
+        </div>
+
+        <div class="mock-limit-frame">
+          <div class="mock-limit-toolbar">
+            <div class="mock-limit-toolbar__copy">
+              <p class="mock-limit-toolbar__title">Selection group: review candidates</p>
+            </div>
+            <div class="mock-limit-toolbar__meta" aria-label="Representative exceeded metadata">
+              <span class="mock-limit-chip mock-limit-chip--warning">event: limit-exceeded</span>
+              <span class="mock-limit-chip mock-limit-chip--neutral">checkbox restored</span>
+            </div>
+          </div>
+          <div class="mock-limit-body">
+            <div class="mock-limit-summary" aria-labelledby="limit-exceeded-summary">
+              <div class="mock-limit-summary__copy">
+                <p id="limit-exceeded-summary" class="mock-limit-summary__title">Selection stayed at the maximum</p>
+                <p class="mock-limit-summary__meta">The attempted row is not selected after TreeView restores the checkbox.</p>
+              </div>
+              <span class="mock-limit-count mock-limit-count--reached">3 / 3</span>
+            </div>
+            <div class="mock-limit-event" role="status" aria-live="polite">
+              <strong>Host app feedback slot</strong>
+              <span>Show a neutral message here after <code>tree-view-selection:limit-exceeded</code>. Final wording and action blocking remain outside TreeView.</span>
+            </div>
+            <div class="mock-limit-table-wrap">
+              <table class="tree-view-table">
+                <thead>
+                  <tr>
+                    <th scope="col">select</th>
+                    <th scope="col">tree row</th>
+                    <th scope="col">status</th>
+                    <th scope="col">event cue</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="tree-row is-selected" aria-level="1">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td>Policy library</td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>Selected value remains in the payload.</td>
+                  </tr>
+                  <tr class="tree-row is-selected" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td>Escalation matrix</td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>Selected count remains stable.</td>
+                  </tr>
+                  <tr class="tree-row is-selected" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox" checked><span>Select</span></label></td>
+                    <td>Training checklist</td>
+                    <td><span class="tree-badge">selected</span></td>
+                    <td>Host app can keep action controls unchanged.</td>
+                  </tr>
+                  <tr class="tree-row" aria-level="2">
+                    <td><label class="mock-limit-choice"><input type="checkbox"><span>Select</span></label><span class="mock-limit-row-note">attempt was restored</span></td>
+                    <td>Archive checklist</td>
+                    <td><span class="tree-badge tree-badge--muted">not selected</span></td>
+                    <td><code>attemptedChecked: true</code>, final checkbox unchecked.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="selection-limit-boundary-heading">
+      <h2 id="selection-limit-boundary-heading">What this mock compares</h2>
+      <table class="mock-limit-boundary-table">
+        <thead>
+          <tr>
+            <th scope="col">Surface</th>
+            <th scope="col">Best for</th>
+            <th scope="col">Keep outside scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Selected count</td>
+            <td>Showing the current count and max near the tree in a product-neutral way.</td>
+            <td>Final localized copy, action availability, and bulk action policy.</td>
+          </tr>
+          <tr>
+            <td>Limit reached</td>
+            <td>Making the max-count state visible without turning every unchecked row into a permission problem.</td>
+            <td>Authorization, disabled business controls, and route-specific submit behavior.</td>
+          </tr>
+          <tr>
+            <td>Limit exceeded</td>
+            <td>Showing that TreeView restores the attempted checkbox and emits a public event.</td>
+            <td>Toast frameworks, modal dialogs, retry flows, or server-side validation policy.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #931
- Supersedes #937

## 判定分類

- `docs-sync`
- `docs-stale`

## 変更内容

- #937 の `review:changes-requested` に対応し、selection max-count mockup 差分を最新 `main` から切り直しました。
- `docs/mockups/selection-max-count.html` を追加し、below-limit / limit-reached / limit-exceeded の3状態を静的に比較できるようにしています。
- `docs/mockups/README.md` と `docs/mockups/review-gallery.html` に review flow / gallery 導線を追加しています。
- `docs/i18n-audit.md` の Technical assets に `selection-max-count.html` を追加しています。

## 根拠

- #937 は CI green 後に `main` から diverged し、Reviewer Agent から latest main 取り込み後の再 CI を求められていました。
- 旧 PR head `97ab3f5c3d2d29bbba7aa2da597093c901e2df03` の docs blob だけを最新 `main` `f6eaa5ad9c1c0c9c9c3694f8cd6bf1a223d23352` 上へ移植しています。
- runtime controller、public event contract、Rails helper、server-side params、authorization、business action behavior には触れていません。

## 確認

- GitHub compare: `main...design/931-selection-max-count-mockup-refresh`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 4
- connector-only の static docs/mockup 変更のため local lint / typecheck / browser render は未実行です。

## リスク

- low
- static mockup と docs index / maintenance checklist のみの更新です。仕様判断やコード変更は含みません。

## 補足

- #937 は最新 main 追従用の replacement PR としてこの PR に置き換えます。