### PR TITLE
toolbar action contract を public API manifest に固定する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -43,6 +43,18 @@ helper_methods:
   - tree_view_toolbar_supported_actions
   - tree_view_toolbar_actions
   - tree_view_toolbar_action_metadata
+toolbar_actions:
+  supported_actions:
+    - expand_all
+    - collapse_all
+    - collapse_all_except_current_path
+  states:
+    expand_all: expanded
+    collapse_all: collapsed
+    collapse_all_except_current_path: current_path
+  data_hooks:
+    action: data-tree-view-toolbar-action
+    disabled: data-tree-view-toolbar-disabled
 grouped_option_keys:
   initial_expansion:
     - default

--- a/docs/en/toolbar.md
+++ b/docs/en/toolbar.md
@@ -45,6 +45,12 @@ Supported actions:
 
 `collapse_all_except_current_path` is a host-app contract. TreeView only emits the toolbar action and state value.
 
+## Machine-readable contract
+
+The toolbar action surface is also tracked in `config/public_api_manifest.yml` under `toolbar_actions`. That manifest lists the supported action names, their `toggle_all_path` states, and the documented data hooks `data-tree-view-toolbar-action` and `data-tree-view-toolbar-disabled`.
+
+Host apps should prefer `tree_view_toolbar_supported_actions`, `tree_view_toolbar_actions`, or `tree_view_toolbar_action_metadata` when building custom toolbar markup. The manifest exists for compatibility checks and integration audits; internal constants remain implementation details.
+
 ## Visual reference
 
 For a static comparison of expand-all, collapse-all, and current-path-preserving toolbar states, see [toolbar-actions.html](../mockups/toolbar-actions.html).

--- a/docs/ja/toolbar.md
+++ b/docs/ja/toolbar.md
@@ -45,6 +45,12 @@ tree_ui = TreeView::UiConfigBuilder.new(
 
 `collapse_all_except_current_path` はhost appとのcontractです。TreeViewはtoolbar actionとstate値を出すだけです。
 
+## machine-readable contract
+
+toolbar action surface は `config/public_api_manifest.yml` の `toolbar_actions` でも管理します。この manifest には supported action names、対応する `toggle_all_path` state、documented data hooks の `data-tree-view-toolbar-action` / `data-tree-view-toolbar-disabled` を載せます。
+
+host app が独自 toolbar markup を組み立てる場合は、raw string を手書きするより `tree_view_toolbar_supported_actions`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` を使ってください。manifest は compatibility check と integration audit のための source of truth であり、internal constants は引き続き implementation detail です。
+
 ## Visual reference
 
 expand-all、collapse-all、current path を残す toolbar state を静的に見比べたい場合は [toolbar-actions.html](../mockups/toolbar-actions.html) を参照してください。

--- a/spec/public_api_toolbar_contract_spec.rb
+++ b/spec/public_api_toolbar_contract_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_view"
+require "action_view/helpers"
+require "yaml"
+
+RSpec.describe "Toolbar public API contract" do
+  let(:manifest) do
+    YAML.safe_load_file(File.expand_path("../config/public_api_manifest.yml", __dir__)).fetch("toolbar_actions")
+  end
+  let(:helper_class) do
+    Class.new do
+      include ActionView::Context
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::UrlHelper
+      include ActionView::Helpers::OutputSafetyHelper
+      include ActionView::Helpers::FormTagHelper
+      include TreeViewHelper
+    end
+  end
+  let(:helper) { helper_class.new }
+  let(:ui_config) do
+    TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" },
+      toggle_all_path_builder: ->(state) { "/tree?state=#{state}" }
+    )
+  end
+  let(:render_state) { instance_double(TreeView::RenderState, ui_config: ui_config) }
+
+  it "keeps supported toolbar actions aligned with the manifest" do
+    expect(helper.tree_view_toolbar_supported_actions.map(&:to_s)).to eq(manifest.fetch("supported_actions"))
+  end
+
+  it "keeps toolbar action states and data hooks aligned with the manifest" do
+    manifest.fetch("supported_actions").each do |action_name|
+      metadata = helper.tree_view_toolbar_action_metadata(render_state, action_name)
+
+      expect(metadata.fetch(:action).to_s).to eq(action_name)
+      expect(metadata.fetch(:state).to_s).to eq(manifest.fetch("states").fetch(action_name))
+      expect(metadata.fetch(:data).fetch(:tree_view_toolbar_action).to_s).to eq(action_name)
+      expect(metadata.fetch(:data)).not_to have_key(:tree_view_toolbar_disabled)
+    end
+  end
+
+  it "keeps disabled toolbar metadata aligned with the manifest data hooks" do
+    static_ui_config = TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" }
+    )
+    static_render_state = instance_double(TreeView::RenderState, ui_config: static_ui_config)
+
+    metadata = helper.tree_view_toolbar_action_metadata(static_render_state, :expand_all)
+
+    expect(manifest.fetch("data_hooks")).to eq(
+      "action" => "data-tree-view-toolbar-action",
+      "disabled" => "data-tree-view-toolbar-disabled"
+    )
+    expect(metadata.fetch(:data)).to include(
+      tree_view_toolbar_action: :expand_all,
+      tree_view_toolbar_disabled: true
+    )
+  end
+end


### PR DESCRIPTION
toolbar action の action / state / data hook を machine-readable public surface として固定します。

## 対応 Issue

Closes #922

## 変更内容

- `config/public_api_manifest.yml` に `toolbar_actions` contract を追加しました。
  - supported actions: `expand_all`, `collapse_all`, `collapse_all_except_current_path`
  - state mapping: `expanded`, `collapsed`, `current_path`
  - documented data hooks: `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled`
- 新規 `spec/public_api_toolbar_contract_spec.rb` で manifest と `tree_view_toolbar_supported_actions` / `tree_view_toolbar_action_metadata` の整合を固定しました。
- `docs/en/toolbar.md` / `docs/ja/toolbar.md` に、manifest は compatibility / audit の source of truth であり、host app は helper 経由で custom toolbar を組む方針を追記しました。

## 受け入れ条件との対応

- manifest から toolbar actions / states / data hooks を読めるようにしました。
- supported actions と helper metadata の action / state / data が manifest と一致することを spec で確認します。
- docs では raw string 直書きより helper 経由利用を推奨し、internal constants は public constant に昇格していません。
- toolbar rendering、supported actions、path generation、labels は変更していません。

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_api_toolbar_contract_spec.rb`
- `docs/en/toolbar.md`
- `docs/ja/toolbar.md`

JavaScript controller、analytics API、authorization-aware policy、toolbar rendering / CSS / mockup は変更していません。

## 実施した確認

- GitHub compare: `main...feature/922-toolbar-public-contract-v2`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- local `bundle exec rspec spec/public_api_compatibility_spec.rb spec/helpers/tree_view_toolbar_helper_spec.rb spec/public_api_toolbar_contract_spec.rb` は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク

- medium
- manifest に toolbar action contract を追加するため、今後の変更で compatibility surface として扱われる範囲が増えます。今回は既存 helper / docs で実質公開済みの action metadata に限定しています。

## 未対応・補足

- `docs/en/public-api.md` / `docs/ja/public-api.md` には既に toolbar helper、actions、data hooks、internal constants boundary の説明があるため、このPRでは toolbar docs へ machine-readable contract の追記に留めました。
- 最初に作った `feature/922-toolbar-public-contract` は作業中に main が進んだためPR化せず、最新 main から `feature/922-toolbar-public-contract-v2` を作り直しています。