### PR TITLE
selection / transfer controller の境界 spec を追加する

### DIFF
--- a/app/javascript/tree_view/selection_transfer_contract.test.js
+++ b/app/javascript/tree_view/selection_transfer_contract.test.js
@@ -1,0 +1,245 @@
+import { Application } from "@hotwired/stimulus"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TreeViewSelectionController, TreeViewTransferController } from "./index.js"
+
+function nextFrame() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("TreeViewSelectionController integration contracts", () => {
+  let application
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <form id="selection-form">
+        <table
+          data-controller="tree-view-selection"
+          data-tree-view-selection-cascade-value="true"
+          data-tree-view-selection-indeterminate-value="true"
+          data-tree-view-selection-max-count-value="2"
+          data-tree-view-selection-hidden-input-name-value="selected_projects[]"
+        >
+          <tbody>
+            <tr data-tree-depth="0">
+              <td><input class="tree-selection-checkbox" type="checkbox" value='{"key":"project:1"}'></td>
+            </tr>
+            <tr data-tree-depth="1">
+              <td><input class="tree-selection-checkbox" type="checkbox" value='{"key":"project:2"}'></td>
+            </tr>
+            <tr data-tree-depth="1">
+              <td><input class="tree-selection-checkbox" type="checkbox" value='{"key":"project:3"}' disabled></td>
+            </tr>
+            <tr data-tree-depth="0">
+              <td><input class="tree-selection-checkbox" type="checkbox" value='{"key":"project:4"}'></td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    `
+
+    application = Application.start()
+    application.register("tree-view-selection", TreeViewSelectionController)
+    await nextFrame()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  it("syncs hidden inputs and dispatches selected payload detail", () => {
+    const element = document.querySelector("[data-controller='tree-view-selection']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-selection")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-selection:change", eventSpy)
+    const [parent] = document.querySelectorAll(".tree-selection-checkbox")
+
+    parent.checked = true
+    controller.toggle({ target: parent })
+
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      selectedCount: 2,
+      selectedValues: ['{"key":"project:1"}', '{"key":"project:2"}'],
+      selectedPayloads: [{ key: "project:1" }, { key: "project:2" }]
+    })
+
+    const hiddenInputs = Array.from(
+      document.querySelectorAll("#selection-form input[type='hidden'][name='selected_projects[]']")
+    )
+    expect(hiddenInputs.map((input) => JSON.parse(input.value))).toEqual([
+      { key: "project:1" },
+      { key: "project:2" }
+    ])
+    expect(new Set(hiddenInputs.map((input) => input.dataset.treeViewSelectionSourceId)).size).toBe(1)
+  })
+
+  it("restores the attempted checkbox and reports max-count boundary detail", () => {
+    const element = document.querySelector("[data-controller='tree-view-selection']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-selection")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-selection:limit-exceeded", eventSpy)
+    const checkboxes = document.querySelectorAll(".tree-selection-checkbox:not(:disabled)")
+
+    checkboxes[0].checked = true
+    checkboxes[1].checked = true
+    checkboxes[2].checked = true
+    controller.toggle({ target: checkboxes[2] })
+
+    expect(checkboxes[2].checked).toBe(false)
+    expect(checkboxes[2].indeterminate).toBe(false)
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      maxCount: 2,
+      attemptedCount: 3,
+      attemptedChecked: true,
+      checkbox: checkboxes[2]
+    })
+  })
+
+  it("dispatches invalid-payload detail for malformed checkbox values", () => {
+    const element = document.querySelector("[data-controller='tree-view-selection']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-selection")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-selection:invalid-payload", eventSpy)
+    const [checkbox] = document.querySelectorAll(".tree-selection-checkbox")
+
+    checkbox.checked = true
+    checkbox.value = "not-json"
+
+    expect(controller.selectedPayloads()).toEqual([])
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      value: "not-json",
+      checkbox
+    })
+  })
+})
+
+describe("TreeViewTransferController integration contracts", () => {
+  let application
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <table data-controller="tree-view-transfer">
+        <tbody>
+          <tr id="source-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:1"}'>
+            <td><button class="action-button" type="button">Edit</button></td>
+          </tr>
+          <tr id="target-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:2"}'></tr>
+          <tr id="disabled-row" data-tree-depth="0" data-tree-transfer-disabled="true" data-tree-transfer-payload='{"key":"project:3"}'></tr>
+        </tbody>
+      </table>
+    `
+
+    application = Application.start()
+    application.register("tree-view-transfer", TreeViewTransferController)
+    await nextFrame()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  it("does not emit transfer events for disabled rows", () => {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-transfer")
+    const dragStartSpy = vi.fn()
+    const dragOverSpy = vi.fn()
+    const dropSpy = vi.fn()
+    element.addEventListener("tree-view-transfer:drag-start", dragStartSpy)
+    element.addEventListener("tree-view-transfer:drag-over", dragOverSpy)
+    element.addEventListener("tree-view-transfer:drop", dropSpy)
+    const disabledRow = document.querySelector("#disabled-row")
+    const dataTransfer = {
+      dropEffect: null,
+      effectAllowed: null,
+      getData: vi.fn(),
+      setData: vi.fn()
+    }
+    const preventDefault = vi.fn()
+
+    controller.start({ target: disabledRow, dataTransfer })
+    controller.over({ target: disabledRow, dataTransfer, preventDefault })
+    controller.drop({ target: disabledRow, dataTransfer, preventDefault })
+
+    expect(dataTransfer.effectAllowed).toBeNull()
+    expect(dataTransfer.dropEffect).toBeNull()
+    expect(dataTransfer.setData).not.toHaveBeenCalled()
+    expect(dataTransfer.getData).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(dragStartSpy).not.toHaveBeenCalled()
+    expect(dragOverSpy).not.toHaveBeenCalled()
+    expect(dropSpy).not.toHaveBeenCalled()
+  })
+
+  it("reports malformed source row payloads", () => {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-transfer")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-transfer:invalid-payload", eventSpy)
+    const sourceRow = document.querySelector("#source-row")
+    sourceRow.dataset.treeTransferPayload = "not-json"
+
+    controller.start({
+      target: sourceRow,
+      dataTransfer: {
+        effectAllowed: null,
+        setData: vi.fn()
+      }
+    })
+
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      value: "not-json",
+      row: sourceRow
+    })
+  })
+
+  it("reports malformed transfer data during drop", () => {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-transfer")
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-transfer:invalid-transfer", eventSpy)
+
+    controller.drop({
+      target: document.querySelector("#target-row"),
+      clientY: 45,
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        getData: (type) => (type === "application/json" ? "not-json" : "")
+      }
+    })
+
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({ value: "not-json" })
+  })
+
+  it("dispatches drag-over detail and marks the transfer as move", () => {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-transfer")
+    const targetRow = document.querySelector("#target-row")
+    targetRow.getBoundingClientRect = () => ({ top: 0, height: 90 })
+    const eventSpy = vi.fn()
+    element.addEventListener("tree-view-transfer:drag-over", eventSpy)
+    const dataTransfer = { dropEffect: null }
+    const preventDefault = vi.fn()
+
+    controller.over({
+      target: targetRow,
+      clientY: 10,
+      preventDefault,
+      dataTransfer
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(dataTransfer.dropEffect).toBe("move")
+    expect(eventSpy).toHaveBeenCalledOnce()
+    expect(eventSpy.mock.calls[0][0].detail).toMatchObject({
+      targetPayload: { key: "project:2" },
+      targetRow,
+      position: "before"
+    })
+  })
+})


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #750
Closes #758

## Issue ごとの完了内容

- #750
  - `TreeViewTransferController` の disabled row、invalid row payload、invalid transfer payload、drag-over detail を Vitest spec で固定しました。
  - event name / detail key / drop position calculation / runtime controller behavior は変更していません。
- #758
  - `TreeViewSelectionController` の hidden input sync、`change` detail、max-count exceeded detail、invalid payload detail を Vitest spec で固定しました。
  - cascade / indeterminate behavior、public event name、hidden input generation behavior は変更していません。

## 変更内容

- `app/javascript/tree_view/selection_transfer_contract.test.js` を追加
  - selection controller の representative host-form integration contract を確認
  - transfer controller の representative public event / guard boundary を確認

## 改善カテゴリ

- test
- regression guard
- public event contract guard

## 既存仕様への影響

- runtime JavaScript / Rails helper / docs / public API manifest は変更していません。
- 既存 controller behavior を読み取る spec の追加のみです。
- host-app reorder logic、real browser E2E、selection visual mockup、docs guide 改稿には広げていません。

## 実施した確認

- GitHub compare: `main...quality/750-758-selection-transfer-contract-specs`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local syntax check: `node --check app/javascript/tree_view/selection_transfer_contract.test.js` success
- local `npm test` / `npm run test:js` は未実行です。
  - この実行環境では npm registry が `403 Forbidden` になり、依存関係を取得できないためです。
  - GitHub HTTPS clone/fetch も `CONNECT tunnel failed, response 403` で利用できません。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- spec-only の regression guard 追加です。runtime behavior、event contract、API、DB、認可、外部サービス契約には触れていません。

## 補足事項

- #750 と #758 はどちらも JavaScript controller の既存 public/event boundary を小さく固定する quality issue で、同じ Vitest suite に追加するのが最もレビューしやすいため1 PRに束ねています。