### PR TITLE
docs: toggle icon customization のCookbook導線を補う

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -16,6 +16,7 @@ For API details, see:
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
 - [Localized names](localized-names.md)
+- [Toggle icon customization](toggle-icons.md)
 
 ## Row customization quick guide
 
@@ -30,6 +31,7 @@ Use the smallest TreeView extension point that matches the UI you are adding.
 | Badges, status pills, or marker-like labels | `badge_builder` | Status names, classes, and product semantics |
 | Locale-aware row labels, type badges, or tooltips | `TreeView::NodePresenter` plus LocalizedNames helpers | Locale files, final copy, and business wording |
 | Legacy/direct toggle-cell marker text | `marker_builder` when rendering toggle cells directly | Marker naming and classes |
+| Expand/collapse control icons | `toggle_icons` or `toggle_icon_builder` | Icon set, tooltip/title copy, and accessibility copy |
 | Folder/file icons or type labels | `badge_builder`, `icon_builder`, or a cell in `row_partial` | Icon set, labels, and accessibility copy |
 | Current row highlighting or archived/disabled styling | `row_class_builder`, `row_data_builder`, and row-status docs | State rules and behavior |
 
@@ -128,6 +130,8 @@ badge_builder = ->(document) {
 ```
 
 `badge_builder` may return text or a hash-like object with `text` or `label`, optional `class`, `title`, and `data`. For legacy direct rendering of toggle cells, `marker_builder` follows the same marker-style idea; prefer `badge_builder` with `RenderState` in new code.
+
+Use `toggle_icons:` or `toggle_icon_builder:` when you want to replace the expand/collapse control's own visual content while TreeView keeps ownership of the toggle link, ARIA state, lazy-loading semantics, and branch layout. See [Toggle icon customization](toggle-icons.md) for state, depth, and node-type examples. Keep the icon set, title/tooltip copy, and accessibility wording in the host app.
 
 Use a badge or icon builder for compact folder/file type labels, or put richer icon markup in `row_partial` so the host app controls the HTML and accessibility copy.
 

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -16,6 +16,7 @@ cookbook は、個別APIの詳細仕様ではなく、host appでよく使う構
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
 - [Localized names](localized-names.md)
+- [toggle icon のカスタマイズ](toggle-icons.md)
 
 ## 行customization quick guide
 
@@ -30,6 +31,7 @@ cookbook は、個別APIの詳細仕様ではなく、host appでよく使う構
 | badge、status pill、marker風label | `badge_builder` | status名、class、product semantics |
 | localeに沿ったrow label、type badge、tooltip | `TreeView::NodePresenter` と LocalizedNames helpers | locale file、最終copy、業務文言 |
 | legacy / direct toggle-cell marker text | toggle cellを直接描画する場合の `marker_builder` | marker名とclass |
+| expand / collapse control icon | `toggle_icons` または `toggle_icon_builder` | icon set、tooltip / title copy、accessibility文言 |
 | folder/file iconやtype label | `badge_builder`、`icon_builder`、または `row_partial` 内のcell | icon set、label、accessibility文言 |
 | current row highlight、archived / disabled styling | `row_class_builder`、`row_data_builder`、Row status docs | 状態判定ruleとbehavior |
 
@@ -128,6 +130,8 @@ badge_builder = ->(document) {
 ```
 
 `badge_builder` はtext、または `text` / `label`、任意の `class`、`title`、`data` を持つHash-like objectを返せます。toggle cellをlegacy / direct renderingする場合は `marker_builder` も同じmarker風labelとして使えます。新しい `RenderState` codeでは `badge_builder` を優先します。
+
+expand / collapse control 自体の見た目を差し替えたい場合は `toggle_icons:` または `toggle_icon_builder:` を使います。TreeView は toggle link、ARIA state、lazy-loading semantics、branch layout を引き続き管理し、host app は icon set、title / tooltip copy、accessibility文言を所有します。state、depth、node type ごとの例は [toggle icon のカスタマイズ](toggle-icons.md) を参照してください。
 
 folder/file type labelを小さく表示する場合は badge / icon builder を使えます。より複雑なicon markupが必要なら、HTMLとaccessibility文言をhost appが管理できるよう `row_partial` に置きます。
 


### PR DESCRIPTION
## 対応Issue

Closes #961

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/cookbook.md` / `docs/ja/cookbook.md` の API details list に toggle icon customization guide を追加しました。
- Row customization quick guide に、expand / collapse control icon は `toggle_icons` / `toggle_icon_builder` を使うことを追加しました。
- depth label / badge / icon customization section から、toggle control の中身だけを差し替える場合の責務境界を短く説明し、既存 `toggle-icons.md` へ誘導しました。

## 根拠

- `docs/en/toggle-icons.md` / `docs/ja/toggle-icons.md` は既に存在し、`toggle_icons:` / `toggle_icon_builder:` の state / depth / node type 例を持っています。
- 一方で Cookbook の row customization entry では、folder/file icon と toggle control icon の使い分けが見つけにくい状態でした。
- runtime behavior、manifest schema、public API surface は変更していません。

## 確認

- GitHub compare: `main...docs/961-toggle-icon-cookbook-boundary`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- connector-only の docs 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions `CI` を確認します。

## リスク

- low
- 既存 docs への導線と責務境界の追記のみです。コード、manifest、mockup、実装仕様には触れていません。