### PR TITLE
main CI の selection max-count mockup smoke target を同期する

### DIFF
--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -128,6 +128,11 @@ const focusedMockupSmokeTargets = [
     minimumCount: 3
   },
   {
+    file: "selection-max-count.html",
+    sample: ".mock-limit-state",
+    minimumCount: 3
+  },
+  {
     file: "empty-state.html",
     sample: "[data-tree-view-empty-state='true']",
     minimumCount: 2


### PR DESCRIPTION
## CI Fix Summary

### Failed check
- main branch GitHub Actions `CI #1207` / `javascript`

### Cause
- `test/browser/docs_mockups_smoke.spec.js` checks that `docs/mockups/README.md` mockup links match `focusedMockupSmokeTargets`.
- After `selection-max-count.html` was added to the README, the browser smoke target list did not include that file, so the list alignment assertion failed.

### Fix
- Add `selection-max-count.html` to `focusedMockupSmokeTargets` with `.mock-limit-state` as the representative sample selector.
- Keep the change limited to the smoke target list; no mockup, runtime JS, Rails helper, workflow, or assertion weakening changes.

### Verification
- [ ] local test
- [ ] lint
- [ ] typecheck
- [ ] CI rerun checked

### Risk
- low

### Notes
- Local Playwright/npm verification was not run in this environment because repository checkout and dependency install are blocked here; this PR relies on GitHub Actions for the relevant browser smoke check.
- This is a follow-up for the latest main failure after #959 merge, observed on commit `fe829c23d89a5f86b3588c84e50ae9d3ef00fef3`.