### PR TITLE
docs: packaged stylesheet の上書き境界を導入手順に補足する

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -66,6 +66,10 @@ Example:
 @import "tree_view";
 ```
 
+The packaged stylesheet is a quick-start baseline for TreeView's reusable structure and lightweight state cues. It covers common row states such as selected, current, collapsed, loading, error, and drop target rows, but the final theme, density, brand colors, and product wording remain host-app responsibilities.
+
+When the host app needs a different visual language, keep the import and override the documented row, toggle, and table selectors in the host app stylesheet after the TreeView import. Do not treat the packaged colors as a required public theme API; they are defaults that host apps may replace with their own class selector rules.
+
 ## JavaScript / importmap
 
 Add the TreeView importmap pin when the JavaScript controllers are needed.

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -66,6 +66,10 @@ host app 側の stylesheet で TreeView 用CSSを読み込みます。
 @import "tree_view";
 ```
 
+同梱 stylesheet は、TreeView の再利用可能な構造と軽量な state cue をすぐ確認するための quick-start baseline です。selected、current、collapsed、loading、error、drop target など代表的な row state の見た目は含みますが、最終的な theme、density、brand color、product wording は host app 側の責務です。
+
+host app 側の見た目に合わせる場合も import は残し、TreeView import の後に host app の stylesheet で documented な row / toggle / table selector を上書きしてください。同梱色を必須の public theme API として扱う必要はありません。host app は class selector rules で独自の見た目へ置き換えられます。
+
 ## JavaScript / importmap
 
 必要に応じて importmap に TreeView 用のpinを追加します。


### PR DESCRIPTION
## 対応 Issue

Closes #943

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/installation.md` / `docs/ja/installation.md` の CSS import section に、同梱 stylesheet の責務境界を追記しました。
- packaged stylesheet は quick-start baseline であり、selected / current / collapsed / loading / error / drop target などの軽量 state cue を含む一方、最終 theme / density / brand styling は host app が owns することを明記しました。
- CSS custom properties や新しい public theme API には広げず、現状の class selector override 方針だけを案内しています。

## 根拠

- `README.md` と installation docs は `@import "tree_view";` を案内しています。
- `app/assets/stylesheets/tree_view.scss` は quick-start 用の lightweight state cues を持ち、コメントでも host app override を前提にしています。
- #941 の CSS custom properties 判断を先取りせず、現行 stylesheet と矛盾しない docs-only guidance に閉じています。

## 確認

- GitHub compare: `main...docs/943-stylesheet-override-boundary-current`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- connector-only の docs 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions `CI` を確認します。

## リスク

- low
- docs-only の導入手順補足です。runtime code、stylesheet、public API manifest、mockup、CSS custom property API には触れていません。