### PR TITLE
LocalizedNames の default fallback contract を固定する

### DIFF
--- a/docs/en/localized-names.md
+++ b/docs/en/localized-names.md
@@ -29,7 +29,12 @@ en:
         other: "Documents"
 ```
 
-If ActiveModel naming is unavailable, TreeView falls back to a humanized class name.
+If ActiveModel naming is unavailable, TreeView falls back to a humanized class name. Pass `default:` when a host app wants a specific label for missing translations or plain Ruby objects:
+
+```ruby
+TreeView.model_name_for(Document, default: "File")
+TreeView.model_name_for(ExternalItem, default: "External item")
+```
 
 ## Attribute names
 
@@ -54,7 +59,11 @@ en:
         published_at: "Published at"
 ```
 
-If ActiveModel attribute naming is unavailable, TreeView falls back to a humanized attribute name.
+If ActiveModel attribute naming is unavailable, TreeView falls back to a humanized attribute name. Pass `default:` to provide a stable label when the translation may be missing:
+
+```ruby
+TreeView.attribute_name_for(Document, :status, default: "Lifecycle status")
+```
 
 ## Node type names
 
@@ -74,7 +83,11 @@ en:
       document: "Document"
 ```
 
-If the translation is missing, TreeView falls back to a humanized `node_type` value.
+If the translation is missing, TreeView falls back to a humanized `node_type` value. Pass `default:` when the caller already has the best fallback label, including nodes whose `node_type` is blank:
+
+```ruby
+TreeView.type_name_for(node, default: "Workspace item")
+```
 
 ## Toolbar action labels
 

--- a/docs/ja/localized-names.md
+++ b/docs/ja/localized-names.md
@@ -27,7 +27,12 @@ ja:
       document: "ドキュメント"
 ```
 
-ActiveModel naming が使えない場合は、class名を素朴に humanize します。
+ActiveModel naming が使えない場合は、class名を素朴に humanize します。translation が無い場合や plain Ruby object に明示的な表示名を出したい場合は `default:` を渡せます。
+
+```ruby
+TreeView.model_name_for(Document, default: "ファイル")
+TreeView.model_name_for(ExternalItem, default: "外部項目")
+```
 
 ## Attribute names
 
@@ -52,7 +57,11 @@ ja:
         published_at: "公開日時"
 ```
 
-ActiveModel attribute naming が使えない場合は、attribute名を素朴に humanize します。
+ActiveModel attribute naming が使えない場合は、attribute名を素朴に humanize します。translation が無い可能性がある field に安定した label を出したい場合は `default:` を渡せます。
+
+```ruby
+TreeView.attribute_name_for(Document, :status, default: "状態")
+```
 
 ## Node type names
 
@@ -72,7 +81,11 @@ ja:
       document: "ドキュメント"
 ```
 
-translation が見つからない場合は、`node_type` の値を humanize します。
+translation が見つからない場合は、`node_type` の値を humanize します。caller 側で最適な fallback label を持っている場合や `node_type` が空の node を扱う場合は `default:` を渡せます。
+
+```ruby
+TreeView.type_name_for(node, default: "ワークスペース項目")
+```
 
 ## Toolbar action labels
 

--- a/spec/lib/tree_view/localized_names_spec.rb
+++ b/spec/lib/tree_view/localized_names_spec.rb
@@ -67,9 +67,19 @@ RSpec.describe TreeView::LocalizedNames do
     expect(TreeView.model_name_for(LocalizedNamesTestDocument.new)).to eq("Document")
   end
 
+  it "uses default model names when ActiveModel translations are missing" do
+    expect(described_class.model_name_for(LocalizedNamesTestDocument, default: "Fallback document")).to eq("Fallback document")
+    expect(described_class.model_name_for(LocalizedNamesPlainDocument, default: "Plain fallback")).to eq("Plain fallback")
+  end
+
   it "resolves attribute names through ActiveModel-compatible naming and I18n" do
     expect(described_class.attribute_name_for(LocalizedNamesTestDocument, :title)).to eq("Title")
     expect(TreeView.attribute_name_for(LocalizedNamesTestDocument.new, :title)).to eq("Title")
+  end
+
+  it "uses default attribute names when translations are missing" do
+    expect(described_class.attribute_name_for(LocalizedNamesTestDocument, :status, default: "Lifecycle status")).to eq("Lifecycle status")
+    expect(described_class.attribute_name_for(LocalizedNamesPlainDocument, :published_at, default: "Publication date")).to eq("Publication date")
   end
 
   it "resolves node type names through tree_view.node_types translations" do
@@ -77,6 +87,14 @@ RSpec.describe TreeView::LocalizedNames do
 
     expect(described_class.type_name_for(node)).to eq("Folder")
     expect(TreeView.type_name_for(node)).to eq("Folder")
+  end
+
+  it "uses default node type names when node type translations are missing" do
+    generated_node = LocalizedNamesTypedNode.new(node_type: :generated_folder)
+    blank_node = LocalizedNamesTypedNode.new(node_type: "")
+
+    expect(described_class.type_name_for(generated_node, default: "Generated folder fallback")).to eq("Generated folder fallback")
+    expect(described_class.type_name_for(blank_node, default: "Untyped node")).to eq("Untyped node")
   end
 
   it "falls back to humanized class and attribute names" do

--- a/spec/lib/tree_view/localized_names_spec.rb
+++ b/spec/lib/tree_view/localized_names_spec.rb
@@ -67,8 +67,7 @@ RSpec.describe TreeView::LocalizedNames do
     expect(TreeView.model_name_for(LocalizedNamesTestDocument.new)).to eq("Document")
   end
 
-  it "uses default model names when ActiveModel translations are missing" do
-    expect(described_class.model_name_for(LocalizedNamesTestDocument, default: "Fallback document")).to eq("Fallback document")
+  it "uses default model names when plain class fallback would otherwise be humanized" do
     expect(described_class.model_name_for(LocalizedNamesPlainDocument, default: "Plain fallback")).to eq("Plain fallback")
   end
 


### PR DESCRIPTION
## 対応 Issue

Closes #763

## 変更内容

- `spec/lib/tree_view/localized_names_spec.rb` に `default:` fallback の代表ケースを追加しました。
- `model_name_for` の plain class fallback、`attribute_name_for` の missing translation / plain fallback、`type_name_for` の missing / blank node type fallback で `default:` が優先されることを guard しました。
- `docs/en/localized-names.md` と `docs/ja/localized-names.md` に、host app が明示 fallback label を渡す使いどころを最小追記しました。

## Issue ごとの完了内容

- #763
  - plain class の model-name fallback で `default:` が humanize より優先されることを spec で固定しました。
  - missing attribute translation と plain attribute fallback の `default:` を spec で固定しました。
  - missing / blank node type の `default:` fallback を spec で固定しました。
  - 日英 docs に `default:` guidance を追加しました。

## 改善カテゴリ

- test
- docs
- regression guard

## 既存仕様への影響

- runtime code は変更していません。
- public method signature、I18n key hierarchy、既存 fallback priority は変更していません。
- NodePresenter、row rendering、toolbar label fallback には広げていません。

## 実施した確認

- GitHub compare: `main...quality/763-localized-names-default-fallback`
- GitHub Actions CI `#1217`: 初回 failure
  - 原因: 翻訳が存在する ActiveModel model name で `default:` が翻訳より優先されるという誤った spec 期待値
  - 対応: 現行挙動に合わせ、plain class fallback の代表 case に修正
- local RSpec は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- 最新 head の GitHub Actions CI で再確認します。

## リスク評価

- low
- spec/docs のみの変更で、既存挙動を固定する guard です。

## 補足事項

- docs は `default:` の使いどころに限定し、localized names guide の全面改稿にはしていません。