### PR TITLE
toggle icon state の focused mockup を追加する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -129,6 +129,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 | `docs/mockups/selection-max-count.html` | Technical asset | No translation needed. |
 | `docs/mockups/empty-state.html` | Technical asset | No translation needed. |
 | `docs/mockups/row-status-depth-labels.html` | Technical asset | No translation needed. |
+| `docs/mockups/toggle-icon-states.html` | Technical asset | No translation needed. |
 | `docs/mockups/default-tree.css` | Technical asset | No translation needed. |
 
 ## Ongoing maintenance

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -16,6 +16,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [current-branch-sidebar.html](current-branch-sidebar.html) | Current branch sidebar reference showing current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues without host-app navigation policy. |
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
+| [toggle-icon-states.html](toggle-icon-states.html) | Focused comparison for expanded, collapsed, leaf, loading, and depth/type-based toggle icon states without choosing a host-app icon library. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [keyboard-focus-states.html](keyboard-focus-states.html) | Focused keyboard reference showing static focus-visible samples for toggle links, native controls, toolbar actions, and row actions without promising a full keyboard model. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
@@ -41,24 +42,25 @@ They are **not** a complete Rails application and should not grow into host-app 
 3. Use [narrow-sidebar-tree.html](narrow-sidebar-tree.html) when review needs a focused pass on 22rem or 18rem frames where hierarchy cues stay visible while secondary metadata wraps below the primary label.
 4. Use [current-branch-sidebar.html](current-branch-sidebar.html) when review needs to isolate `current_item:` / `current_key:` plus `auto_expand_ancestors: true` as a visual reference for the current row, ancestor path, and collapsed siblings.
 5. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
-6. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-7. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-8. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
-9. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-10. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
-11. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-12. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-13. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-14. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-15. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-16. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-17. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-18. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-19. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-20. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-21. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-22. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-23. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+6. Use [toggle-icon-states.html](toggle-icon-states.html) when review needs to compare `toggle_icons:` expanded, collapsed, leaf, loading, and depth/type variation without selecting a final icon library.
+7. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
+8. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+9. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
+10. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+11. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
+12. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+13. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+14. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+15. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+16. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+17. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+18. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+19. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+20. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+21. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+22. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+23. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+24. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -207,6 +207,7 @@
           <a href="#gallery-default-heading">Baseline</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
           <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
+          <a href="#gallery-toggle-icon-heading">Toggle icons</a>
           <a href="#gallery-narrow-heading">Responsive and scale</a>
           <a href="#gallery-current-branch-heading">Current branch</a>
           <a href="#gallery-breadcrumb-heading">Navigation context</a>
@@ -224,6 +225,9 @@
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-status-depth-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.</p><ul class="mock-gallery-points"><li>Normal, readonly, and disabled rows</li><li>Selection availability separated from row status</li><li>Depth-label meaning kept host-app owned</li></ul><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-toggle-icon-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused toggle icons</p><h2 id="gallery-toggle-icon-heading">Toggle icon states</h2><p>Compare expanded, collapsed, leaf, loading, and depth/type icon variations while keeping final icon choices host-app owned.</p><ul class="mock-gallery-points"><li>State-based icon slots</li><li>Depth and node-type variation</li><li>No icon library or runtime behavior changes</li></ul><div class="mock-gallery-links"><a href="toggle-icon-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toggle-icon-states.html" title="Toggle icon states mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
@@ -289,6 +293,7 @@
       <table class="mock-comparison-table"><thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead><tbody>
         <tr><td>Default tree</td><td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td><td>Host-app CRUD, queries, business labels, or authorization behavior.</td></tr>
         <tr><td>Row status and depth labels</td><td>Row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
+        <tr><td>Toggle icon states</td><td>Expanded, collapsed, leaf, loading, and depth/type icon variation boundaries.</td><td>Icon library choice, final artwork, tooltip copy, public API changes, or runtime behavior.</td></tr>
         <tr><td>Resource table bridge</td><td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td><td>Saved table state, host-app queries, or business-specific row actions.</td></tr>
         <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
         <tr><td>Current branch sidebar</td><td>Current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues.</td><td>Route selection, permission-aware labels, final sidebar ordering, or host-app navigation policy.</td></tr>

--- a/docs/mockups/toggle-icon-states.html
+++ b/docs/mockups/toggle-icon-states.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView toggle icon states mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-icon-layout {
+  display: grid;
+  gap: 18px;
+}
+
+.mock-icon-note-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.mock-icon-note {
+  border: 1px solid #d8e0ea;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 14px;
+}
+
+.mock-icon-note h3,
+.mock-icon-note p {
+  margin: 0;
+}
+
+.mock-icon-note h3 {
+  margin-bottom: 0.4rem;
+}
+
+.mock-icon-note p {
+  color: #52606d;
+}
+
+.mock-toggle-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  min-height: 2rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  color: #0f172a;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.mock-toggle-chip--expanded {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.mock-toggle-chip--collapsed {
+  border-color: #0f766e;
+  background: #f0fdfa;
+  color: #0f766e;
+}
+
+.mock-toggle-chip--leaf {
+  border-color: #cbd5e1;
+  background: #f8fafc;
+  color: #64748b;
+}
+
+.mock-toggle-chip--loading {
+  border-color: #d97706;
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.mock-toggle-chip--type-root {
+  border-color: #4f46e5;
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+.mock-toggle-chip--type-folder {
+  border-color: #0891b2;
+  background: #ecfeff;
+  color: #155e75;
+}
+
+.mock-toggle-chip--type-record {
+  border-color: #16a34a;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.mock-icon-code-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mock-icon-code-list code {
+  display: inline-block;
+  max-width: 100%;
+  border-radius: 6px;
+  background: #e2e8f0;
+  color: #1e293b;
+  padding: 0.12rem 0.35rem;
+  overflow-wrap: anywhere;
+  font-size: 0.82rem;
+}
+
+.mock-icon-table-note {
+  margin: 0.35rem 0 0;
+  color: #52606d;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 760px) {
+  .tree-view-table {
+    min-width: 720px;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView toggle icon states mock</h1>
+      <p>
+        This static HTML compares custom toggle icon states for expanded, collapsed, leaf, and loading rows.
+        It also shows one depth or node-type variation pass without choosing a final icon set for host apps.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-icon-layout" aria-labelledby="state-comparison-heading">
+      <div>
+        <h2 id="state-comparison-heading">State-based icon comparison</h2>
+        <p>
+          The toggle cell keeps the same hierarchy branch slots while the visible icon changes by state.
+          Copy and final icon artwork remain host-app responsibilities.
+        </p>
+      </div>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">icon state</th>
+            <th scope="col">generated boundary</th>
+            <th scope="col">review note</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="tree-row is-expanded" data-tree-node-key="root:workspace" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Expanded workspace">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true" aria-label="Collapse Workspace"><span class="mock-toggle-chip mock-toggle-chip--expanded" aria-hidden="true">-</span></a>
+                  <span class="mock-node-title">Workspace root</span>
+                </span>
+              </span>
+            </td>
+            <td><span class="mock-status mock-status--active">expanded</span></td>
+            <td>
+              <ul class="mock-icon-code-list" aria-label="Expanded icon hooks">
+                <li><code>toggle_icons[:expanded]</code></li>
+                <li><code>aria-expanded="true"</code></li>
+              </ul>
+            </td>
+            <td>Expanded rows still expose the collapse action; icon shape should not be the only cue.</td>
+          </tr>
+          <tr class="tree-row" data-tree-node-key="folder:planning" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Collapsed planning folder">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true" aria-label="Expand Planning"><span class="mock-toggle-chip mock-toggle-chip--collapsed" aria-hidden="true">+</span></a>
+                  <span class="mock-node-title">Planning folder</span>
+                </span>
+              </span>
+            </td>
+            <td><span class="mock-status mock-status--pending">collapsed</span></td>
+            <td>
+              <ul class="mock-icon-code-list" aria-label="Collapsed icon hooks">
+                <li><code>toggle_icons[:collapsed]</code></li>
+                <li><code>aria-expanded="false"</code></li>
+              </ul>
+            </td>
+            <td>Collapsed rows keep the branch path visible before the icon so depth stays readable.</td>
+          </tr>
+          <tr class="tree-row" data-tree-node-key="record:notes" data-tree-depth="2" aria-level="3">
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Leaf notes record">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level"><span class="mock-toggle-chip mock-toggle-chip--leaf" aria-hidden="true">leaf</span></span>
+                  <span class="mock-node-title">Notes record</span>
+                </span>
+              </span>
+            </td>
+            <td><span class="mock-status">leaf</span></td>
+            <td>
+              <ul class="mock-icon-code-list" aria-label="Leaf icon hooks">
+                <li><code>toggle_icons[:leaf]</code></li>
+                <li><code>no expand action</code></li>
+              </ul>
+            </td>
+            <td>Leaf rows can carry a placeholder icon, but should not look actionable unless the host app adds an action.</td>
+          </tr>
+          <tr class="tree-row is-loading" data-tree-node-key="folder:loading" data-tree-depth="2" data-tree-loading="true" aria-level="3" aria-busy="true">
+            <td class="tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Loading child folder">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level"><span class="mock-toggle-chip mock-toggle-chip--loading" aria-hidden="true">...</span></span>
+                  <span class="mock-node-title">Loading children</span>
+                </span>
+              </span>
+            </td>
+            <td><span class="mock-status mock-status--pending">loading</span></td>
+            <td>
+              <ul class="mock-icon-code-list" aria-label="Loading icon hooks">
+                <li><code>toggle_icons[:loading]</code></li>
+                <li><code>aria-busy="true"</code></li>
+              </ul>
+            </td>
+            <td>Loading icon is a temporary state cue; fetch timing and retry behavior stay outside this mockup.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section mock-icon-layout" aria-labelledby="variation-heading">
+      <div>
+        <h2 id="variation-heading">Depth and type variation</h2>
+        <p>
+          This pass shows how state icons can vary by depth or node type while using the same table and branch structure.
+          It is a visual boundary reference, not a shipped icon pack.
+        </p>
+      </div>
+      <table class="tree-view-table">
+        <thead>
+          <tr>
+            <th scope="col">tree</th>
+            <th scope="col">variation source</th>
+            <th scope="col">review note</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="tree-row is-expanded" data-tree-node-key="type:root" data-tree-depth="0" data-tree-node-type="root" aria-level="1" aria-expanded="true">
+            <td class="tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#" aria-label="Collapse root"><span class="mock-toggle-chip mock-toggle-chip--type-root" aria-hidden="true">R-</span></a><span class="mock-node-title">Root type</span></span></span></td>
+            <td><code>by_type[:root][:expanded]</code></td>
+            <td>Type-specific root icon can be distinct without changing row structure.</td>
+          </tr>
+          <tr class="tree-row" data-tree-node-key="type:folder" data-tree-depth="1" data-tree-node-type="folder" aria-level="2" aria-expanded="false">
+            <td class="tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#" aria-label="Expand folder"><span class="mock-toggle-chip mock-toggle-chip--type-folder" aria-hidden="true">F+</span></a><span class="mock-node-title">Folder type</span></span></span></td>
+            <td><code>by_type[:folder][:collapsed]</code></td>
+            <td>Folder icon can communicate grouping while final labels and color stay host-app owned.</td>
+          </tr>
+          <tr class="tree-row" data-tree-node-key="type:record" data-tree-depth="2" data-tree-node-type="record" aria-level="3">
+            <td class="tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level"><span class="mock-toggle-chip mock-toggle-chip--type-record" aria-hidden="true">R</span></span><span class="mock-node-title">Record type</span></span></span></td>
+            <td><code>by_depth[2][:leaf]</code></td>
+            <td>Depth variation should help scanning, not replace the branch line or accessible label.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="boundary-heading">
+      <h2 id="boundary-heading">Responsibility boundary</h2>
+      <div class="mock-icon-note-grid">
+        <article class="mock-icon-note">
+          <h3>TreeView-owned</h3>
+          <p>Stable slots, state lookup order, branch structure, and rendered action or leaf placement.</p>
+        </article>
+        <article class="mock-icon-note">
+          <h3>Host-app-owned</h3>
+          <p>Final icon set, color tokens, business copy, tooltip wording, and product-specific state meaning.</p>
+        </article>
+        <article class="mock-icon-note">
+          <h3>Accessibility</h3>
+          <p>Do not rely on icon shape alone. Pair icon changes with text, ARIA state, or host-owned labels where needed.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -58,6 +58,11 @@ const focusedMockupSmokeTargets = [
     minimumCount: 3
   },
   {
+    file: "toggle-icon-states.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 7
+  },
+  {
     file: "interaction-states.html",
     sample: ".tree-view-table tbody tr",
     minimumCount: 5


### PR DESCRIPTION
## 対応Issue

- Closes #962

## 採用した方針

- スケジュール実行のためユーザー選択待ちは挟まず、Planner handoff に沿って `docs/mockups/toggle-icon-states.html` を focused subpage として追加する低リスク案を採用しました。
- runtime Ruby / JavaScript behavior、public API manifest、icon library、host app route / authorization / business copy には触れず、static mockup と review 導線に閉じています。

## 比較した案

- 案A: 既存 `default-tree.html` または `row-status-depth-labels.html` に toggle icon section を追加する
  - 不採用。既存ページの責務が広がり、row status / default output と icon hook boundary が混ざりやすいため。
- 案B: `toggle-icon-states.html` を focused subpage として追加し、README / review-gallery / browser smoke に登録する
  - 採用。expanded / collapsed / leaf / loading と depth/type variation を同一ページで比較でき、既存 mockup の baseline structure を壊しません。
- 案C: `RenderState` や public API manifest、icon library adoption まで変更する
  - 不採用。#962 は design lane の static visual reference であり、runtime/API 変更に広げないため。

## 変更内容

- `docs/mockups/toggle-icon-states.html` を追加
  - expanded / collapsed / leaf / loading の state-based icon comparison
  - `by_type` / `by_depth` 風の variation comparison
  - TreeView-owned / host-app-owned / accessibility の責務境界メモ
- `docs/mockups/README.md` の Files table と Recommended review flow に新規 page を追加
- `docs/mockups/review-gallery.html` に preview card、review path、comparison cue を追加
- `test/browser/docs_mockups_smoke.spec.js` に新規 mockup を smoke target として登録
- `docs/i18n-audit.md` の technical asset inventory に新規 mockup を追加

## 変更した画面・コンポーネント

- `docs/mockups/toggle-icon-states.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `docs/i18n-audit.md`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- lint: GitHub Actions CI #1226 `lint` success
- typecheck: runtime code 変更なし
- UI表示確認: GitHub Actions CI #1226 `javascript` success（`npm run test:js` 内で browser smoke 実行）
- レスポンシブ確認: 760px 以下では table を横スクロール前提にし、branch cue と icon cell が折れすぎない構成にしています
- アクセシビリティ確認: icon shape だけに依存しないよう、state text、`aria-expanded`、`aria-busy`、review note を併記しています
- CI: GitHub Actions CI #1226 success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success

## スクリーンショット

<!-- connector-only 実行のため未添付 -->

## リスク

- low
- static mockup / docs link / browser smoke registration / docs inventory のみです。runtime behavior、public API、host-app route、authorization、icon library には触れていません。

## 補足

- GitHub HTTPS clone/fetch は `CONNECT tunnel failed, response 403` で使えないため、GitHub connector 経由で変更しています。
- #978 は作成中に `main` が進んだため close し、このPRに current main ベースで載せ直しました。
- 初回 CI #1224 は `docs/i18n-audit.md` の technical asset inventory 未同期で失敗しました。最終差分では inventory を更新し、#1226 は green です。