### PR TITLE
Diagnostics の public API contract を spec で固定する

### DIFF
--- a/spec/lib/tree_view/diagnostics_public_api_spec.rb
+++ b/spec/lib/tree_view/diagnostics_public_api_spec.rb
@@ -2,9 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe TreeView::Diagnostics do
-  TestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
+DiagnosticsPublicApiTestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
 
+RSpec.describe TreeView::Diagnostics do
   def dom_id_suffix(item_or_id)
     return item_or_id.id if item_or_id.respond_to?(:id)
 
@@ -12,8 +12,8 @@ RSpec.describe TreeView::Diagnostics do
   end
 
   def public_tree
-    root = TestNode.new(id: 1, parent_id: nil, name: "Root")
-    child = TestNode.new(id: 2, parent_id: 1, name: "Child")
+    root = DiagnosticsPublicApiTestNode.new(id: 1, parent_id: nil, name: "Root")
+    child = DiagnosticsPublicApiTestNode.new(id: 2, parent_id: 1, name: "Child")
 
     TreeView::Tree.new(records: [root, child], parent_id_method: :parent_id)
   end

--- a/spec/lib/tree_view/diagnostics_public_api_spec.rb
+++ b/spec/lib/tree_view/diagnostics_public_api_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe TreeView::Diagnostics do
+  TestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
+
+  def dom_id_suffix(item_or_id)
+    return item_or_id.id if item_or_id.respond_to?(:id)
+
+    item_or_id
+  end
+
+  def public_tree
+    root = TestNode.new(id: 1, parent_id: nil, name: "Root")
+    child = TestNode.new(id: 2, parent_id: 1, name: "Child")
+
+    TreeView::Tree.new(records: [root, child], parent_id_method: :parent_id)
+  end
+
+  def public_ui_config
+    TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{dom_id_suffix(item_or_id)}" },
+      button_dom_id_builder: ->(item_or_id) { "node_button_#{dom_id_suffix(item_or_id)}" },
+      show_button_dom_id_builder: ->(item_or_id) { "node_show_button_#{dom_id_suffix(item_or_id)}" }
+    )
+  end
+
+  def public_render_state(tree)
+    TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "items/tree_columns",
+      ui_config: public_ui_config
+    )
+  end
+
+  it "returns a successful Result for the default diagnostics checks" do
+    tree = public_tree
+    result = described_class.run(tree: tree, render_state: public_render_state(tree))
+
+    expect(result).to be_a(TreeView::Diagnostics::Result)
+    expect(result.checks).to eq(TreeView::Diagnostics::DEFAULT_CHECKS)
+    expect(result.errors).to eq([])
+    expect(result.warnings).to eq([])
+    expect(result.success?).to be(true)
+  end
+
+  it "runs only the requested diagnostics checks" do
+    tree = public_tree
+    result = described_class.run(render_state: public_render_state(tree), checks: :dom_ids)
+
+    expect(result.checks).to eq([:dom_ids])
+    expect(result.errors).to eq([])
+    expect(result.success?).to be(true)
+  end
+
+  it "records unknown checks unless raise_errors is enabled" do
+    result = described_class.run(tree: public_tree, checks: :unknown)
+
+    expect(result.success?).to be(false)
+    expect(result.errors.length).to eq(1)
+    expect(result.errors.first).to include(check: :unknown)
+    expect(result.errors.first.fetch(:error)).to be_a(TreeView::ConfigurationError)
+    expect(result.errors.first.fetch(:message)).to include("unknown diagnostics check: :unknown")
+
+    expect do
+      described_class.run(tree: public_tree, checks: :unknown, raise_errors: true)
+    end.to raise_error(TreeView::ConfigurationError, /unknown diagnostics check: :unknown/)
+  end
+
+  it "reports representative missing input errors" do
+    missing_tree = described_class.run(checks: :node_keys)
+    missing_render_state = described_class.run(tree: public_tree, checks: :dom_ids)
+
+    expect(missing_tree.success?).to be(false)
+    expect(missing_tree.errors.first).to include(check: :node_keys)
+    expect(missing_tree.errors.first.fetch(:message)).to eq("node_keys diagnostics require tree: or render_state:")
+
+    expect(missing_render_state.success?).to be(false)
+    expect(missing_render_state.errors.first).to include(check: :dom_ids)
+    expect(missing_render_state.errors.first.fetch(:message)).to eq("dom_ids diagnostics require render_state:")
+  end
+end


### PR DESCRIPTION
## 対応 Issue

Closes #843

## Issue ごとの完了内容

- #843
  - `TreeView::Diagnostics.run` が `TreeView::Diagnostics::Result` を返し、default checks で成功する代表ケースを追加しました。
  - `checks:` 指定時に対象 check だけが `result.checks` に反映されることを確認しました。
  - unknown check の `raise_errors: false` / `raise_errors: true` 両方の挙動を固定しました。
  - `tree` / `render_state` が必要な代表 check の missing input error を固定しました。

## 変更内容

- `spec/lib/tree_view/diagnostics_public_api_spec.rb` を追加しました。
- `public_tree` / `public_ui_config` 相当の小さな fixture を spec 内に置き、Diagnostics の public result / dispatch contract に閉じて確認しています。

## 改善カテゴリ

- test
- public API compatibility
- regression guard

## 既存仕様への影響

- runtime code、public API、error shape、docs 本文、JavaScript、CI workflow は変更していません。
- property-based / fuzz spec、大量 node 生成、cycle/orphan の網羅には広げていません。

## 実施した確認

- GitHub compare: `main...quality/843-diagnostics-public-api-spec`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local RSpec は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions CI を確認します。

## リスク評価

- low
- spec-only の public API regression guard です。既存挙動を固定するだけで、実装・契約変更はありません。

## 補足事項

- Planner handoff は既存 public API compatibility spec を primary としていましたが、既存の大きな互換性specをさらに肥大化させず、Diagnostics 専用 spec に分けました。確認対象と完了条件は handoff の範囲内に閉じています。