### PR TITLE
packaged stylesheet の方向依存 selector を spec で守る

### DIFF
--- a/spec/assets/tree_view_stylesheet_source_spec.rb
+++ b/spec/assets/tree_view_stylesheet_source_spec.rb
@@ -20,4 +20,33 @@ RSpec.describe "tree_view stylesheet source" do
       expect(stylesheet_source).to include(".tree-toggle__action:focus:not(:focus-visible)")
     end
   end
+
+  it "keeps the LTR branch connector selectors visible for future direction-aware review" do
+    aggregate_failures do
+      expect(stylesheet_source).to include(<<~CSS.strip)
+        .tree-toggle__branch-slot.has-line::before{
+          content: "";
+          position: absolute;
+          top: -0.35rem;
+          bottom: -0.35rem;
+          left: 50%;
+      CSS
+      expect(stylesheet_source).to include(<<~CSS.strip)
+        .tree-toggle__branch-slot.is-current::after{
+          content: "";
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          right: 0;
+      CSS
+    end
+  end
+
+  it "keeps the current-row cue anchored to the first rendered table cell" do
+    expect(stylesheet_source).to include(<<~CSS.strip)
+      .tree-row[aria-current="page"] > td:first-child{
+        box-shadow: inset 3px 0 0 rgba(13, 110, 253, 0.45);
+      }
+    CSS
+  end
 end


### PR DESCRIPTION
## 対応 Issue

Closes #984

## Issue ごとの完了内容

- #984
  - packaged stylesheet 内の LTR 前提がある branch connector selector を source-level spec で固定しました。
  - current-row cue が first rendered table cell に anchored されていることを source-level spec で固定しました。
  - RTL 対応、logical property 置換、visual regression / screenshot baseline には広げていません。

## 変更内容

- `spec/assets/tree_view_stylesheet_source_spec.rb`
  - branch connector の `left` / `right` を含む代表 selector を inventory として確認
  - current-row cue の `td:first-child` / inset shadow を確認

## 改善カテゴリ

- test
- CSS guard
- maintenance

## 既存仕様への影響

- なし
- runtime CSS / HTML / JavaScript は変更していません。
- packaged stylesheet の見た目、ARIA、keyboard behavior、host app integration は変更していません。

## 実施した確認

- GitHub compare: `main...quality/984-direction-sensitive-css-guard`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local test は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- spec-only の source guard で、公開挙動やスタイル出力は変えていません。

## 補足事項

- #983 の visual mockup 側とは役割を分け、こちらは source-level inventory に閉じています。