### PR TITLE
toolbar action/state contract を manifest と spec で固定する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -43,6 +43,10 @@ helper_methods:
   - tree_view_toolbar_supported_actions
   - tree_view_toolbar_actions
   - tree_view_toolbar_action_metadata
+toolbar_actions:
+  expand_all: expanded
+  collapse_all: collapsed
+  collapse_all_except_current_path: current_path
 grouped_option_keys:
   initial_expansion:
     - default

--- a/spec/tree_view_toolbar_public_contract_spec.rb
+++ b/spec/tree_view_toolbar_public_contract_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "TreeView toolbar public contract" do
+  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+  TOOLBAR_DOC_PATHS = [
+    File.expand_path("../docs/en/toolbar.md", __dir__),
+    File.expand_path("../docs/ja/toolbar.md", __dir__)
+  ].freeze
+
+  def toolbar_manifest_actions
+    YAML.safe_load_file(MANIFEST_PATH).fetch("toolbar_actions")
+  end
+
+  def toolbar_helper
+    Class.new do
+      include TreeViewHelper
+    end.new
+  end
+
+  def render_state_for_toolbar
+    ui_config = Struct.new(:calls) do
+      def toggle_all_path(state:)
+        calls << state
+        "/tree?state=#{state}"
+      end
+    end.new([])
+
+    Struct.new(:ui_config).new(ui_config)
+  end
+
+  it "keeps toolbar action names and toggle states aligned with the public API manifest" do
+    manifest_actions = toolbar_manifest_actions
+
+    expect(TreeViewHelper::Toolbar::TREE_VIEW_TOOLBAR_STATES.transform_values(&:to_s)).to eq(manifest_actions)
+    expect(toolbar_helper.tree_view_toolbar_supported_actions.map(&:to_s)).to eq(manifest_actions.keys)
+  end
+
+  it "keeps toolbar metadata state values aligned with the manifest" do
+    render_state = render_state_for_toolbar
+    actions = toolbar_helper.tree_view_toolbar_actions(
+      render_state,
+      actions: toolbar_manifest_actions.keys
+    )
+
+    expect(actions.map { |action| [action.fetch(:action).to_s, action.fetch(:state).to_s] }.to_h).to eq(toolbar_manifest_actions)
+    expect(actions).to all(include(path: a_string_matching(%r{\A/tree\?state=})))
+  end
+
+  it "keeps toolbar docs aligned with manifest action and state values" do
+    manifest_actions = toolbar_manifest_actions
+
+    TOOLBAR_DOC_PATHS.each do |path|
+      docs = File.read(path)
+
+      manifest_actions.each do |action, state|
+        expect(docs).to include(":#{action}"), "expected #{path} to document toolbar action #{action}"
+        expect(docs).to include(":#{state}"), "expected #{path} to document toolbar state #{state}"
+      end
+    end
+  end
+end

--- a/spec/tree_view_toolbar_public_contract_spec.rb
+++ b/spec/tree_view_toolbar_public_contract_spec.rb
@@ -31,10 +31,16 @@ RSpec.describe "TreeView toolbar public contract" do
     Struct.new(:ui_config).new(ui_config)
   end
 
+  def stringified_toolbar_states
+    TreeViewHelper::Toolbar::TREE_VIEW_TOOLBAR_STATES.to_h do |action, state|
+      [action.to_s, state.to_s]
+    end
+  end
+
   it "keeps toolbar action names and toggle states aligned with the public API manifest" do
     manifest_actions = toolbar_manifest_actions
 
-    expect(TreeViewHelper::Toolbar::TREE_VIEW_TOOLBAR_STATES.transform_values(&:to_s)).to eq(manifest_actions)
+    expect(stringified_toolbar_states).to eq(manifest_actions)
     expect(toolbar_helper.tree_view_toolbar_supported_actions.map(&:to_s)).to eq(manifest_actions.keys)
   end
 

--- a/spec/tree_view_toolbar_public_contract_spec.rb
+++ b/spec/tree_view_toolbar_public_contract_spec.rb
@@ -3,15 +3,15 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "TreeView toolbar public contract" do
-  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
-  TOOLBAR_DOC_PATHS = [
-    File.expand_path("../docs/en/toolbar.md", __dir__),
-    File.expand_path("../docs/ja/toolbar.md", __dir__)
-  ].freeze
+TREE_VIEW_TOOLBAR_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+TREE_VIEW_TOOLBAR_DOC_PATHS = [
+  File.expand_path("../docs/en/toolbar.md", __dir__),
+  File.expand_path("../docs/ja/toolbar.md", __dir__)
+].freeze
 
+RSpec.describe "TreeView toolbar public contract" do
   def toolbar_manifest_actions
-    YAML.safe_load_file(MANIFEST_PATH).fetch("toolbar_actions")
+    YAML.safe_load_file(TREE_VIEW_TOOLBAR_MANIFEST_PATH).fetch("toolbar_actions")
   end
 
   def toolbar_helper
@@ -58,7 +58,7 @@ RSpec.describe "TreeView toolbar public contract" do
   it "keeps toolbar docs aligned with manifest action and state values" do
     manifest_actions = toolbar_manifest_actions
 
-    TOOLBAR_DOC_PATHS.each do |path|
+    TREE_VIEW_TOOLBAR_DOC_PATHS.each do |path|
       docs = File.read(path)
 
       manifest_actions.each do |action, state|


### PR DESCRIPTION
## 対応 Issue

Closes #770

## Issue ごとの完了内容

- #770
  - `config/public_api_manifest.yml` に toolbar action key と `toggle_all_path(state:)` value の対応を追加しました。
  - helper constants / `tree_view_toolbar_supported_actions` / `tree_view_toolbar_actions` が manifest と一致することを専用 spec で固定しました。
  - 英日 toolbar docs が manifest 上の action / state を説明していることを spec で確認しました。

## 変更内容

- `config/public_api_manifest.yml`
  - `toolbar_actions` として `expand_all: expanded`、`collapse_all: collapsed`、`collapse_all_except_current_path: current_path` を追加
- `spec/tree_view_toolbar_public_contract_spec.rb`
  - toolbar helper implementation、manifest、docs の drift guard を追加

## 改善カテゴリ

- test
- public API contract guard
- docs drift guard

## 既存仕様への影響

- なし
- helper implementation、toolbar rendering、route behavior、authorization、Turbo response、UI styling は変更していません。
- manifest と spec による既存 contract の固定だけです。

## 実施した確認

- GitHub compare: `main...quality/770-toolbar-action-contract`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 2
- GitHub Actions CI `#1237`: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `gem_package`: skipped（package-sensitive change なし）
- PR metadata: `mergeable: true`
- local test は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク評価

- low
- runtime code 変更なしの spec / manifest 追加です。

## 補足事項

- toolbar action の追加・削除、UI redesign、host-app route / authorization 実装、JavaScript export 追加には広げていません。
- 初回 CI では spec key 型と standardrb の constant placement を修正し、最終 head `3dd7386fc5c50c3c395a6d6465f556e037166833` で green です。