### PR TITLE
docs/mockups 変更時に browser smoke を走らせる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      mockups_changed: ${{ steps.detect.outputs.mockups_changed }}
       package_sensitive: ${{ steps.detect.outputs.package_sensitive }}
     steps:
       - uses: actions/checkout@v6
@@ -21,6 +22,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "mockups_changed=false" >> "$GITHUB_OUTPUT"
             echo "package_sensitive=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -34,6 +36,7 @@ jobs:
           fi
 
           docs_only=true
+          mockups_changed=false
           package_sensitive=false
           while IFS= read -r file; do
             [ -z "$file" ] && continue
@@ -42,6 +45,12 @@ jobs:
               README.md|docs/*|Product\ Profile.md|CHANGELOG.md|AGENTS.md) ;;
               *)
                 docs_only=false
+                ;;
+            esac
+
+            case "$file" in
+              docs/mockups/*|docs/mockups/**)
+                mockups_changed=true
                 ;;
             esac
 
@@ -55,6 +64,7 @@ jobs:
           EOF
 
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "mockups_changed=$mockups_changed" >> "$GITHUB_OUTPUT"
           echo "package_sensitive=$package_sensitive" >> "$GITHUB_OUTPUT"
 
   lint:
@@ -161,21 +171,23 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true'
-        run: 'echo "Docs-only PR: skipping JavaScript browser and entrypoint checks."'
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true'
+        run: 'echo "Docs-only PR without mockup changes: skipping JavaScript browser and entrypoint checks."'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
         uses: actions/checkout@v6
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
         run: npm install
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
         run: npx playwright install --with-deps chromium
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed == 'true'
+        run: npm run test:browser
 
   gem_package:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && needs.changes.outputs.package_sensitive == 'true'


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #996

## Issue ごとの完了内容

- #996
  - `changes` job に `mockups_changed` output を追加し、`docs/mockups/**` の変更を prose docs-only と区別できるようにしました。
  - pull request が docs-only でも `docs/mockups/**` を含む場合は `javascript` job で checkout / Node setup / npm install / Playwright install / `npm run test:browser` を実行します。
  - runtime JS など docs-only 以外の変更では従来どおり `npm run test:js` を実行します。
  - mockup を含まない prose docs-only PR は従来どおり JavaScript checks を軽く skip します。

## 変更内容

- `.github/workflows/ci.yml`
  - `mockups_changed` output を追加
  - `docs/mockups/*|docs/mockups/**` を mockup change として検出
  - `javascript` job の条件を、prose docs-only skip / mockup docs-only browser smoke /通常 full JS check に分岐

## 改善カテゴリ

- CI 改善
- test guard
- docs/mockups smoke coverage

## 既存仕様への影響

- なし
- runtime JavaScript、Rails helper、public API、mockup HTML/CSS、Rails matrix、gem package job は変更していません。
- required check name は `javascript` のまま維持しています。

## 実施した確認内容

- GitHub compare: `main...quality/996-mockups-browser-smoke`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- workflow 条件を目視確認
  - prose docs-only: skip message のみ
  - docs/mockups docs-only: `npm run test:browser`
  - docs-only 以外: `npm run test:js`
- local CI / Playwright は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- docs-only skip の軽さを通常 prose docs では維持し、mockup docs change にだけ browser smoke を足す CI 条件変更です。

## 補足事項

- #811 の全 docs link crawler や visual regression baseline には広げていません。