### PR TITLE
drag/drop の missing source payload 境界を docs に追記する

### DIFF
--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -114,6 +114,16 @@ The transfer controller exposes these reader-facing details:
 
 `position` is a TreeView-owned coarse cue for where the pointer sits inside the target row: the top third is `before`, the middle third is `inside`, and the bottom third is `after`. Treat it as input to host-app business rules, not as final authorization or persistence policy. For example, a host app may ignore `inside` for leaf-only trees, reject drops across projects, or translate `before` / `after` into an ordering update.
 
+### Missing or invalid source payloads
+
+Source payload availability is separate from host-app move validation.
+
+When `DataTransfer` is missing or does not contain `application/json` or `text/plain`, TreeView leaves `sourcePayload` as `null` on the `tree-view-transfer:drop` event. This covers cases such as an external drag source, an empty transfer value, or a browser event where no transferable TreeView row payload was available. The host app should treat `sourcePayload: null` as an untrusted or unsupported move and decide the final rejection copy, logging, and UI response.
+
+When `DataTransfer` contains a non-empty value but that value cannot be parsed as JSON, TreeView dispatches `tree-view-transfer:invalid-transfer` with the raw `value` and still leaves the source payload unavailable. That event is an integration signal, not a business-level authorization result.
+
+When a source payload is present and valid, the host app still owns final validation. For example, it may reject a drop because the current user lacks permission, the target project is different, the target row cannot accept children, or the requested `before` / `after` / `inside` position is not allowed.
+
 For the full JavaScript event contract, see [JavaScript event contract](js-events.md#transfer-events).
 
 ## Responsibility boundary
@@ -125,6 +135,8 @@ For the full JavaScript event contract, see [JavaScript event contract](js-event
 | dragstart helper | yes | wires action |
 | interactive-control drag-start guard | yes | marks custom widgets when needed |
 | transfer event detail | yes | listens and applies business behavior |
+| source payload parse failure | reports `invalid-transfer` for non-empty invalid JSON | decides user-facing rejection, logging, and recovery |
+| missing source payload | reports `sourcePayload: null` on drop | rejects or handles unsupported drops according to host-app policy |
 | coarse drop position | reports `before`, `inside`, or `after` | decides whether the position is allowed and how to persist it |
 | drop target | no | yes |
 | reorder / move persistence | no | yes |

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -114,6 +114,16 @@ transfer controller が読者向けに公開する主なdetailは次のとおり
 
 `position` は、target row内でpointerがどこにあるかを示すTreeView側の粗いcueです。上 1/3 は `before`、中央 1/3 は `inside`、下 1/3 は `after` になります。これはhost appの業務ルールへの入力として扱い、最終的な許可・保存方針として扱わないでください。たとえば、leaf-only treeでは `inside` を無視したり、projectをまたぐdropを拒否したり、`before` / `after` を並び順更新へ変換したりできます。
 
+### source payload がない、または壊れている場合
+
+source payload が取れるかどうかと、host app の move validation は別の論点です。
+
+`DataTransfer` がない、または `application/json` / `text/plain` に値がない場合、TreeView は `tree-view-transfer:drop` event の `sourcePayload` を `null` にします。これは external drag source、empty transfer value、TreeView row payload を持たない browser event などを含みます。host app は `sourcePayload: null` を untrusted または unsupported な move として扱い、最終的な拒否文言、logging、UI response を決めてください。
+
+`DataTransfer` に空ではない値があるものの JSON として parse できない場合、TreeView は raw `value` を含む `tree-view-transfer:invalid-transfer` を dispatch し、source payload は利用不可のままにします。この event は integration signal であり、business-level authorization result ではありません。
+
+source payload が有効な場合でも、最終的な validation は host app の責務です。たとえば、現在ユーザーに権限がない、target project が違う、target row が children を受け付けない、`before` / `after` / `inside` の position がその画面では許可されない、といった理由で drop を拒否できます。
+
 JavaScript event contract全体は [JavaScript event contract](js-events.md#transfer-events) を参照してください。
 
 ## 責務範囲
@@ -125,6 +135,8 @@ JavaScript event contract全体は [JavaScript event contract](js-events.md#tran
 | dragstart helper | yes | wires action |
 | interactive-control drag-start guard | yes | marks custom widgets when needed |
 | transfer event detail | yes | listens and applies business behavior |
+| source payload parse failure | 空ではない invalid JSON では `invalid-transfer` を通知する | user-facing rejection、logging、recovery を決める |
+| missing source payload | drop event で `sourcePayload: null` を返す | unsupported drop を reject / handle する policy を決める |
 | coarse drop position | `before`, `inside`, `after` を返す | そのpositionを許可するか、どう保存するかを決める |
 | drop target | no | yes |
 | reorder / move persistence | no | yes |


### PR DESCRIPTION
## 対応 Issue

Closes #1004

## 変更内容

- `docs/en/drag-and-drop.md` に missing / invalid source payload の責務境界を追記しました。
- `docs/ja/drag-and-drop.md` に同内容の日本語説明を追記しました。
- `DataTransfer` がない、空、外部 drag などで `sourcePayload: null` になるケースと、invalid JSON で `tree-view-transfer:invalid-transfer` が通知されるケースを分けて説明しました。
- host app が final rejection copy、logging、authorization、validation、persistence を owns することを responsibility table に追加しました。

## 判定分類

- code-ahead-of-docs
- 現状の `app/javascript/tree_view/transfer_controller.js` の挙動に対して、drag/drop docs の reverse lookup が不足していたため、docs 側を追従しました。

## 変更範囲

- `docs/en/drag-and-drop.md`
- `docs/ja/drag-and-drop.md`

runtime JavaScript、public API manifest、event detail key、mockup、host-app-specific authorization / persistence examples は変更していません。

## 確認

- GitHub compare: `main...docs/1004-transfer-invalid-boundary`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- docs-only 変更のため local test / lint は未実行です。
- GitHub Actions は PR 作成後に確認します。

## リスク

- low
- #1001 / #1003 の public event behavior / detail 拡張判断は先取りせず、current code から確認できる責務境界だけに閉じています。