### PR TITLE
selection hidden input sync の troubleshooting 導線を補う

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -164,7 +164,10 @@ Check these points.
 - In JavaScript, remember that TreeView only reports checked and enabled checkboxes.
 - Invalid JSON payloads are omitted from the selected payload array and reported through `tree-view-selection:invalid-payload`.
 - Use grouped `selection:` options for row payload generation, disabled-state decisions, and checkbox visibility.
-- If the tree sits inside a regular form, configure `data-tree-view-selection-hidden-input-name-value` on the `tree-view-selection` host element so checked payloads are mirrored into hidden inputs.
+- If a user can check boxes but a regular HTML form submit sends no selection params, configure `data-tree-view-selection-hidden-input-name-value` on the `tree-view-selection` host element. Listening for `tree-view-selection:selected` or `tree-view-selection:change` alone does not create form params.
+- Hidden input sync writes one hidden input per valid checked payload to the nearest form. If the tree is outside the form, TreeView still dispatches selection events but does not create hidden inputs.
+- Disabled checkboxes and invalid JSON payloads are skipped for hidden inputs, matching the JavaScript event payload behavior.
+- When one form contains multiple trees, use separate hidden input names when the server should receive separate params. Reuse a name only when the host app intentionally accepts one combined array; TreeView uses source ids only to keep each controller from removing another controller's generated inputs.
 - If you expect client-side max-count limits or linked checkbox behavior, configure `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, and `data-tree-view-selection-indeterminate-value` on the same host element.
 - Cascade and indeterminate behavior only affects rendered rows in the current DOM.
 

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -164,7 +164,10 @@ selection checkbox の送信値は plain ID ではなく JSON string です。
 - JavaScript では checked かつ enabled な checkbox だけが対象になる
 - JSON が壊れている値は selected payload array から除外され、`tree-view-selection:invalid-payload` で通知される
 - row payload 生成、disabled-state 判定、checkbox visibility は grouped `selection:` option 側で設定する
-- tree が通常 form の中にある場合は、`tree-view-selection` host element に `data-tree-view-selection-hidden-input-name-value` を設定し、checked payload を hidden input に同期させる
+- checkbox は見えているのに通常 form submit で selection params が送られない場合は、`tree-view-selection` host element に `data-tree-view-selection-hidden-input-name-value` を設定する。`tree-view-selection:selected` や `tree-view-selection:change` を listen するだけでは form params は作られません
+- hidden input 同期は、valid な checked payload ごとに hidden input を 1 つずつ最寄りの form に書き込みます。tree が form の外にある場合、TreeView は selection event だけを dispatch し、hidden input は生成しません
+- disabled checkbox と不正な JSON payload は、JavaScript event payload と同じく hidden input でも skip されます
+- 1つの form に複数 tree がある場合、server 側で別々の params として受け取りたいなら hidden input name を分ける。同じ name を使うのは、host app が1つの配列としてまとめて受け取る設計のときだけです。TreeView の source id は、各 controller が他 controller の generated input を消さないために使われます
 - client-side の最大選択数制限や連動 checkbox 挙動を使う場合は、同じ host element に `data-tree-view-selection-max-count-value`、`data-tree-view-selection-cascade-value`、`data-tree-view-selection-indeterminate-value` を設定する
 - cascade と indeterminate は、現在 DOM に描画されている row にだけ効く
 


### PR DESCRIPTION
## 対応 Issue

Closes #1006

## 判定分類

- code-ahead-of-docs
- `app/javascript/tree_view/selection_controller.js` と `docs/en|ja/selection.md` では hidden input sync の挙動が説明済みでしたが、症状ベースの Troubleshooting から regular form submit の逆引き導線が不足していました。

## 変更内容

- `docs/en/troubleshooting.md` の selection payload troubleshooting を更新しました。
- `docs/ja/troubleshooting.md` に同等の日本語説明を追加しました。
- regular form submit で params が空になる場合は `data-tree-view-selection-hidden-input-name-value` が必要であり、selection events だけでは form params を作らないことを明記しました。
- hidden input は nearest form に valid checked payload ごとに生成され、form 外では生成されないことを補足しました。
- disabled / invalid payload の skip、multi-tree form の name 分離 / intentional combined array、source id の責務境界を短く整理しました。

## 変更範囲

- `docs/en/troubleshooting.md`
- `docs/ja/troubleshooting.md`

JavaScript controller、Ruby helper、public API manifest、selection event payload、host-app business action / authorization policy は変更していません。

## 確認

- GitHub compare: `main...docs/1006-selection-hidden-input-troubleshooting`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- docs-only 変更のため local test / lint は未実行です。
- GitHub Actions は PR 作成後に確認します。

## リスク

- low
- 既存 selection controller と selection docs に基づく troubleshooting 追記のみです。runtime behavior や public API surface は広げていません。