### PR TITLE
selection hidden input cleanup を source id 文字列に強くする

### DIFF
--- a/app/javascript/tree_view/selection_controller.js
+++ b/app/javascript/tree_view/selection_controller.js
@@ -136,11 +136,13 @@ export class TreeViewSelectionController extends Controller {
   }
 
   removeSyncedHiddenInputs(form) {
+    const sourceId = this.hiddenInputSourceId()
+
     form
-      .querySelectorAll(
-        `[data-tree-view-selection-generated-hidden-input="true"][data-tree-view-selection-source-id="${this.hiddenInputSourceId()}"]`
-      )
-      .forEach((input) => input.remove())
+      .querySelectorAll("[data-tree-view-selection-generated-hidden-input=\"true\"]")
+      .forEach((input) => {
+        if (input.dataset.treeViewSelectionSourceId === sourceId) input.remove()
+      })
   }
 
   enforceMaxCount(checkbox, attemptedChecked) {

--- a/app/javascript/tree_view/selection_transfer_contract.test.js
+++ b/app/javascript/tree_view/selection_transfer_contract.test.js
@@ -74,6 +74,31 @@ describe("TreeViewSelectionController integration contracts", () => {
     expect(new Set(hiddenInputs.map((input) => input.dataset.treeViewSelectionSourceId)).size).toBe(1)
   })
 
+  it("keeps selector-sensitive source ids isolated when syncing hidden inputs", () => {
+    const element = document.querySelector("[data-controller='tree-view-selection']")
+    element.dataset.treeViewSelectionSourceId = 'team "alpha" [owner]'
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-selection")
+    const [checkbox] = document.querySelectorAll(".tree-selection-checkbox")
+
+    const unrelatedInput = document.createElement("input")
+    unrelatedInput.type = "hidden"
+    unrelatedInput.name = "selected_projects[]"
+    unrelatedInput.value = JSON.stringify({ key: "keep-me" })
+    unrelatedInput.dataset.treeViewSelectionGeneratedHiddenInput = "true"
+    unrelatedInput.dataset.treeViewSelectionSourceId = "other source"
+    document.querySelector("#selection-form").appendChild(unrelatedInput)
+
+    checkbox.checked = true
+    controller.toggle({ target: checkbox })
+    checkbox.checked = false
+    controller.toggle({ target: checkbox })
+
+    const hiddenInputs = Array.from(
+      document.querySelectorAll("#selection-form input[type='hidden'][name='selected_projects[]']")
+    )
+    expect(hiddenInputs).toEqual([unrelatedInput])
+  })
+
   it("restores the attempted checkbox and reports max-count boundary detail", () => {
     const element = document.querySelector("[data-controller='tree-view-selection']")
     const controller = application.getControllerForElementAndIdentifier(element, "tree-view-selection")


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #988

## Issue ごとの完了内容

- #988
  - selection hidden input cleanup が source id を CSS attribute selector に直接埋め込まないようにしました。
  - quote / bracket / whitespace を含む既存 `data-tree-view-selection-source-id` でも、同じ form 内の別 controller の hidden input を残したまま自分の generated input だけ更新できる contract test を追加しました。

## 変更内容

- `app/javascript/tree_view/selection_controller.js`
  - generated hidden input を広く取得し、`dataset.treeViewSelectionSourceId` の値比較で削除対象を判定するよう変更しました。
  - `CSS.escape` 依存は追加していません。
- `app/javascript/tree_view/selection_transfer_contract.test.js`
  - selector-sensitive source id の代表ケースと、別 source id の generated input を削除しないことを確認しました。

## 改善カテゴリ

- error handling / robustness
- test
- 小さな内部整理

## 既存仕様への影響

- 既存仕様への影響はありません。
- hidden input sync、event payload、max-count behavior、source id の生成・再利用方針は変更していません。
- public data hook export 判断や source id format guarantee には広げていません。

## 実施した確認内容

- GitHub compare: `main...quality/988-selection-source-id-cleanup-current`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- local JS test は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- 削除対象の絞り込み方法を selector 依存から値比較へ変えるだけで、生成する hidden input と submit payload は変えていません。

## 補足事項

- #890 の public export / data hook boundary とは混ぜていません。