### PR TITLE
FAQ から tree diagnostics の逆引き導線を補う

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -73,6 +73,20 @@ See also:
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Host App Extension Points](host-app-extension-points.md)
 
+## Why do rows look duplicated, disappear, or fail before rendering?
+
+Start with tree diagnostics before changing the row partial or JavaScript wiring. Duplicate node keys can make expansion and persisted state look unstable, orphan records can appear when filtering or permission scopes hide parents, DOM ID collisions can break browser-facing targets, and cycles can make parent-path traversal invalid.
+
+Use the focused pre-render checks when a test targets one risk: `validate_node_keys: true`, `orphan_strategy:`, `render_state.validate_unique_dom_ids!`, `TreeView::CycleDiagnostics.new(tree).report`, or `tree.stats` for large-tree strategy review. Use `TreeView::Diagnostics.run` when you want one aggregate result with errors and warnings from multiple checks.
+
+TreeView reports the risk. The host app still owns data correction, filtering policy, authorization scope, and the chosen large-tree rendering strategy.
+
+See also:
+
+- [Tree diagnostics](tree-diagnostics.md)
+- [Troubleshooting](troubleshooting.md#duplicate-node-keys-orphan-records-dom-id-collisions-or-cycles-appear)
+- [Node keys](node-keys.md)
+
 ## Why does persisted state save as soon as the page loads?
 
 The `tree-view-state:state-changed` event is dispatched on initial connect as well as after `refresh` and expand/collapse updates. The first event is a snapshot of the current expanded state, not proof that the user changed the tree.

--- a/docs/ja/faq.md
+++ b/docs/ja/faq.md
@@ -73,6 +73,20 @@ TreeView は host app の path builder を呼んだり、host app の row partia
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Host App Extension Points](host-app-extension-points.md)
 
+## row が重複する / 消える / 描画前に失敗する場合はどこを見ますか？
+
+row partial や JavaScript wiring を変える前に tree diagnostics から確認してください。node key の重複は展開状態や persisted state を不安定に見せることがあり、filter や permission scope で親が隠れると orphan が出ます。DOM ID collision は browser 向け target を壊し、cycle は parent path traversal を不正にします。
+
+単一のリスクを test したい場合は、個別の描画前チェックを使います。`validate_node_keys: true`、`orphan_strategy:`、`render_state.validate_unique_dom_ids!`、`TreeView::CycleDiagnostics.new(tree).report`、大きな tree の戦略確認には `tree.stats` が入口です。複数の check をまとめて errors / warnings として見たい場合は `TreeView::Diagnostics.run` を使います。
+
+TreeView はリスクを報告します。data correction、filtering policy、authorization scope、大きな tree の rendering strategy は host app 側の責務です。
+
+関連:
+
+- [Tree diagnostics](tree-diagnostics.md)
+- [Troubleshooting](troubleshooting.md#duplicate-node-key--orphan--dom-id-collision--cycle-が出る)
+- [Node keys](node-keys.md)
+
 ## persisted state が画面表示直後に保存されるのはなぜですか？
 
 `tree-view-state:state-changed` event は、初回 connect 時にも、`refresh` や expand/collapse update 後にも dispatch されます。最初の event は現在の展開状態の snapshot であり、ユーザーが tree を変更した証拠ではありません。


### PR DESCRIPTION
## 対応 Issue

Closes #1014

## 判定分類

- `docs-sync`
- current `docs/en|ja/troubleshooting.md` には diagnostics 入口が既にありましたが、FAQ 側から症状ベースで `TreeView::Diagnostics.run` / 個別 pre-render check / large tree stats へ辿る導線が不足していました。

## 変更内容

- `docs/en/faq.md`
  - row duplicate / disappearing rows / pre-render failure から tree diagnostics を見る FAQ を追加
  - duplicate node keys、orphan records、DOM ID collisions、cycles、large-tree stats の確認入口を短く整理
  - 個別 pre-render check と `TreeView::Diagnostics.run` の使い分けを補足
- `docs/ja/faq.md`
  - 英語版と同等の FAQ を追加

## 非目標

- diagnostics helper の API 変更
- Ruby code / JavaScript / public API manifest の変更
- host-app data correction policy、authorization policy、large-tree rendering strategy の新規設計

## 確認内容

- GitHub compare: `main...docs/1014-diagnostics-reverse-lookup-current`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- docs-only のためローカル test は未実行です。

## リスク

- low
- FAQ の導線追加のみで、current code や existing diagnostics docs と矛盾しない範囲に閉じています。