### PR TITLE
Diagnostics.run の aggregate contract spec を強化する

### DIFF
--- a/spec/lib/tree_view/diagnostics_spec.rb
+++ b/spec/lib/tree_view/diagnostics_spec.rb
@@ -49,6 +49,33 @@ RSpec.describe TreeView::Diagnostics do
     expect(result.errors.first[:message]).to match(/duplicate node_key/)
   end
 
+  it "collects unknown check failures with the supported check list" do
+    result = described_class.run(checks: [:not_a_check])
+
+    expect(result).not_to be_success
+    expect(result.errors).to contain_exactly(
+      include(
+        check: :not_a_check,
+        error: be_a(TreeView::ConfigurationError),
+        message: include(
+          "unknown diagnostics check: :not_a_check",
+          "supported checks are: node_keys, dom_ids, orphans, cycles"
+        )
+      )
+    )
+    expect(result.warnings).to eq([])
+  end
+
+  it "collects required object failures across aggregate checks" do
+    result = described_class.run(checks: %i[node_keys dom_ids])
+
+    expect(result).not_to be_success
+    expect(result.errors).to contain_exactly(
+      include(check: :node_keys, message: "node_keys diagnostics require tree: or render_state:"),
+      include(check: :dom_ids, message: "dom_ids diagnostics require render_state:")
+    )
+  end
+
   it "can raise the first diagnostics failure" do
     first = diagnostic_node(id: 1, parent_id: nil, name: "First")
     duplicate = diagnostic_node(id: 1, parent_id: nil, name: "Duplicate")
@@ -59,7 +86,16 @@ RSpec.describe TreeView::Diagnostics do
     end.to raise_error(TreeView::DuplicateNodeKeyError, /duplicate node_key/)
   end
 
-  it "reports orphan nodes as warnings" do
+  it "raises unknown check failures when raise_errors is enabled" do
+    expect do
+      described_class.run(checks: [:not_a_check], raise_errors: true)
+    end.to raise_error(
+      TreeView::ConfigurationError,
+      /unknown diagnostics check: :not_a_check; supported checks are: node_keys, dom_ids, orphans, cycles/
+    )
+  end
+
+  it "reports orphan nodes as warnings without failing the result" do
     root = diagnostic_node(id: 1, parent_id: nil, name: "Root")
     orphan = diagnostic_node(id: 2, parent_id: 99, name: "Orphan")
     tree = TreeView::Tree.new(records: [root, orphan], parent_id_method: :parent_id)
@@ -67,8 +103,14 @@ RSpec.describe TreeView::Diagnostics do
     result = described_class.run(tree: tree, checks: [:orphans])
 
     expect(result).to be_success
-    expect(result.warnings.first).to include(check: :orphans)
-    expect(result.warnings.first[:message]).to match(/orphan nodes detected/)
+    expect(result.errors).to eq([])
+    expect(result.warnings).to contain_exactly(
+      include(
+        check: :orphans,
+        message: "orphan nodes detected: 2",
+        details: contain_exactly(include(key: 2, missing_parent_id: 99))
+      )
+    )
   end
 
   it "reports missing inputs as diagnostics errors" do


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1015

## Issue ごとの完了内容

- #1015
  - `TreeView::Diagnostics.run` の aggregate result behavior を既存 `spec/lib/tree_view/diagnostics_spec.rb` に追記して固定しました。
  - unknown check が `errors` に入り、supported checks を message に含めることを確認しました。
  - `tree:` / `render_state:` 不足時の required-object error が複数 check で集約されることを確認しました。
  - `raise_errors: true` で unknown check が即時 raise されることを確認しました。
  - orphan report が warning として集まり、単独では `success?` を false にしないことを詳細付きで固定しました。

## 変更内容

- `spec/lib/tree_view/diagnostics_spec.rb`
  - Planner handoff の受け入れ条件に合わせて、既存 diagnostics spec に representative cases を追加しました。
  - runtime code、docs、public API は変更していません。

## 改善カテゴリ

- test
- behavior contract guard
- 小さな内部品質改善

## 既存仕様への影響

- 既存仕様への影響はありません。
- 現在の `Diagnostics.run` の戻り値・error / warning collection contract を spec で固定するだけです。
- diagnostics API、check 名、`Result` 構造、orphan warning の扱いは変更していません。

## 実施した確認内容

- GitHub compare: `main...quality/1015-diagnostics-run-contract`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local test は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- spec-only の変更です。runtime、DB、認可、外部 API、UI には触れていません。

## 補足事項

- Planner 指示どおり、docs reverse lookup issue など他 issue とは束ねず単独対応にしています。