### PR TITLE
drag-and-drop docs に operation / outcome 境界を補う

### DIFF
--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -114,6 +114,20 @@ The transfer controller exposes these reader-facing details:
 
 `position` is a TreeView-owned coarse cue for where the pointer sits inside the target row: the top third is `before`, the middle third is `inside`, and the bottom third is `after`. Treat it as input to host-app business rules, not as final authorization or persistence policy. For example, a host app may ignore `inside` for leaf-only trees, reject drops across projects, or translate `before` / `after` into an ordering update.
 
+### Transfer operation and outcome boundary
+
+TreeView sets the browser transfer cue to `move` by using `DataTransfer.effectAllowed` on drag start and `DataTransfer.dropEffect` while hovering over a valid row. That cue only says the current TreeView helper is row-transfer oriented; it does not decide the host app's business operation.
+
+| Question | TreeView boundary | Host app boundary |
+|---|---|---|
+| Is this a row transfer from TreeView? | Copies a row payload to `DataTransfer` when available and reports transfer events. | Decides whether to accept TreeView row transfers on a given target. |
+| Is the business operation a reorder, parent move, copy, attach, or link? | Uses the browser `move` cue and reports `sourcePayload`, `targetPayload`, and `position`. | Maps those details to the domain operation, or rejects operations that are not supported. |
+| What happens after drop? | Dispatches the drop event and parse/integration signals. | Shows pending, accepted, rejected, retry, or undo UI; persists changes; logs failures. |
+
+If a product conceptually treats a drop as copy, attach, link, or another operation, keep that policy in the host app. TreeView does not expose a transfer operation kind today, and the `move` cue should not be read as a persistence guarantee or authorization result.
+
+For static review of possible post-drop UI states, see [post-drop-outcome-states.html](../mockups/post-drop-outcome-states.html). That page is a visual reference only; the runtime state model and final outcome copy remain host-app decisions.
+
 ### Missing or invalid source payloads
 
 Source payload availability is separate from host-app move validation.
@@ -133,12 +147,15 @@ For the full JavaScript event contract, see [JavaScript event contract](js-event
 | row transfer payload builder validation | yes | provides builder |
 | transfer data attributes | yes | consumes them |
 | dragstart helper | yes | wires action |
+| browser transfer cue | sets the current helper cue to `move` | decides the business operation and final UX |
 | interactive-control drag-start guard | yes | marks custom widgets when needed |
 | transfer event detail | yes | listens and applies business behavior |
 | source payload parse failure | reports `invalid-transfer` for non-empty invalid JSON | decides user-facing rejection, logging, and recovery |
 | missing source payload | reports `sourcePayload: null` on drop | rejects or handles unsupported drops according to host-app policy |
 | coarse drop position | reports `before`, `inside`, or `after` | decides whether the position is allowed and how to persist it |
 | drop target | no | yes |
+| operation kind | no | maps the drop to reorder, move, copy, attach, link, or rejection |
+| post-drop outcome UI | no | shows pending, accepted, rejected, retry, undo, or other product-specific states |
 | reorder / move persistence | no | yes |
 | authorization | no | yes |
 | validation | no | yes |

--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -126,7 +126,7 @@ TreeView sets the browser transfer cue to `move` by using `DataTransfer.effectAl
 
 If a product conceptually treats a drop as copy, attach, link, or another operation, keep that policy in the host app. TreeView does not expose a transfer operation kind today, and the `move` cue should not be read as a persistence guarantee or authorization result.
 
-For static review of possible post-drop UI states, see [post-drop-outcome-states.html](../mockups/post-drop-outcome-states.html). That page is a visual reference only; the runtime state model and final outcome copy remain host-app decisions.
+Post-drop states such as pending, accepted, rejected, retry, or undo are host-app UI and workflow decisions. TreeView only reports the transfer boundary; it does not define a runtime state model or final outcome copy for those states.
 
 ### Missing or invalid source payloads
 

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -114,6 +114,20 @@ transfer controller が読者向けに公開する主なdetailは次のとおり
 
 `position` は、target row内でpointerがどこにあるかを示すTreeView側の粗いcueです。上 1/3 は `before`、中央 1/3 は `inside`、下 1/3 は `after` になります。これはhost appの業務ルールへの入力として扱い、最終的な許可・保存方針として扱わないでください。たとえば、leaf-only treeでは `inside` を無視したり、projectをまたぐdropを拒否したり、`before` / `after` を並び順更新へ変換したりできます。
 
+### transfer operation と outcome の境界
+
+TreeView は drag start 時の `DataTransfer.effectAllowed` と、valid row 上で hover している間の `DataTransfer.dropEffect` を `move` に設定します。この cue は、現在の TreeView helper が row transfer 向けであることを示すだけで、host app の業務上の operation を決めるものではありません。
+
+| Question | TreeView boundary | Host app boundary |
+|---|---|---|
+| これは TreeView 由来の row transfer か | 可能な場合に row payload を `DataTransfer` へコピーし、transfer event を通知する | その target で TreeView row transfer を受け入れるか決める |
+| 業務上は reorder、parent move、copy、attach、link のどれか | browser の `move` cue と `sourcePayload` / `targetPayload` / `position` を返す | detail を業務 operation に対応づけるか、非対応 operation として拒否する |
+| drop 後に何を表示・保存するか | drop event と parse / integration signal を dispatch する | pending、accepted、rejected、retry、undo などのUIを表示し、保存や失敗記録を行う |
+
+製品上の意味として drop を copy、attach、link、または別の operation として扱う場合、その方針は host app 側に置いてください。TreeView は現在 transfer operation kind を公開していません。また `move` cue を、保存成功や認可結果の保証として読まないでください。
+
+pending、accepted、rejected、retry、undo などの drop 後状態は、host app の UI / workflow 判断です。TreeView が担当するのは transfer 境界の通知までであり、それらの状態の runtime state model や最終的な表示文言は定義しません。
+
 ### source payload がない、または壊れている場合
 
 source payload が取れるかどうかと、host app の move validation は別の論点です。
@@ -133,12 +147,15 @@ JavaScript event contract全体は [JavaScript event contract](js-events.md#tran
 | row transfer payload builder validation | yes | provides builder |
 | transfer data attributes | yes | consumes them |
 | dragstart helper | yes | wires action |
+| browser transfer cue | 現在の helper cue を `move` にする | 業務 operation と最終UXを決める |
 | interactive-control drag-start guard | yes | marks custom widgets when needed |
 | transfer event detail | yes | listens and applies business behavior |
 | source payload parse failure | 空ではない invalid JSON では `invalid-transfer` を通知する | user-facing rejection、logging、recovery を決める |
 | missing source payload | drop event で `sourcePayload: null` を返す | unsupported drop を reject / handle する policy を決める |
 | coarse drop position | `before`, `inside`, `after` を返す | そのpositionを許可するか、どう保存するかを決める |
 | drop target | no | yes |
+| operation kind | no | reorder、move、copy、attach、link、rejection などに対応づける |
+| post-drop outcome UI | no | pending、accepted、rejected、retry、undo などの product-specific state を表示する |
 | reorder / move persistence | no | yes |
 | authorization | no | yes |
 | validation | no | yes |


### PR DESCRIPTION
## 対応 Issue

Closes #992

## 判定分類

- `code-ahead-of-docs`
- `app/javascript/tree_view/transfer_controller.js` は `DataTransfer.effectAllowed` / `dropEffect` を `move` にしており、既存 docs は drop validation の責務境界を説明済みでしたが、browser cue と host app の業務 operation / drop 後 outcome UI の切り分けが薄い状態でした。

## 変更内容

- `docs/en/drag-and-drop.md`
  - `Transfer operation and outcome boundary` を追加
  - `move` browser cue、reorder / parent move / copy / attach / link の host-app mapping、pending / accepted / rejected / retry / undo UI の責務を整理
  - Responsibility boundary に browser transfer cue / operation kind / post-drop outcome UI を追加
- `docs/ja/drag-and-drop.md`
  - 英語版と同等の説明を追加

## 非目標

- transfer operation kind の仕様決定
- runtime controller / event detail shape / public API surface の変更
- static mockup HTML/CSS の追加
- authorization / validation / persistence policy の新規設計

## 確認内容

- GitHub compare: `main...docs/992-drag-drop-operation-outcome-boundary`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 2 (`docs/en/drag-and-drop.md`, `docs/ja/drag-and-drop.md`)
- docs-only のためローカル test は未実行です。

## リスク

- low
- current controller behavior と既存 docs の host-app responsibility boundary を明文化するだけで、未実装の operation kind や mockup page へのリンクは先取りしていません。