### PR TITLE
TreeView::Configuration を public API surface に同期する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -14,6 +14,7 @@ public_constants:
   - DuplicateNodeKeyError
   - CycleDetectedError
   - InvalidRenderWindowError
+  - Configuration
   - LocalizedNames
   - Tree
   - RenderState

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -20,6 +20,7 @@ Host apps may use these entry points directly:
 - `TreeView::DuplicateNodeKeyError`
 - `TreeView::CycleDetectedError`
 - `TreeView::InvalidRenderWindowError`
+- `TreeView::Configuration`
 - `TreeView::LocalizedNames`
 - `TreeView::Tree`
 - `TreeView::RenderState`
@@ -46,6 +47,8 @@ Host apps may use these entry points directly:
 - `tree_view_toolbar_action_metadata(render_state, action, ...)`
 
 Use `TreeView::ResourceTableRenderState.call` when another table layer already owns column inference and table state, and TreeView should only build the hierarchical render state. See [Resource table bridge](resource-table-bridge.md).
+
+`TreeView::Configuration` is the documented owner of TreeView's configuration option surface. Host apps should normally use `TreeView.configure` and `TreeView.configuration`; the class constant is public for compatibility, but its private normalization helpers and internal constants are not part of the public contract.
 
 ## Public error surface
 
@@ -113,6 +116,8 @@ Documented configuration options include:
 
 - `initial_state`
 - `render_log_level`
+
+`TreeView::Configuration` exposes these documented option readers and writers, and `TreeView.configure` / `TreeView.configuration` remain the preferred host-app integration path. Option-specific behavior is described in the dedicated configuration docs, such as [Render log level](render-log-level.md).
 
 Documented localized display-name helpers include:
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -20,6 +20,7 @@ host app が直接使ってよい主な入口は以下です。
 - `TreeView::DuplicateNodeKeyError`
 - `TreeView::CycleDetectedError`
 - `TreeView::InvalidRenderWindowError`
+- `TreeView::Configuration`
 - `TreeView::LocalizedNames`
 - `TreeView::Tree`
 - `TreeView::RenderState`
@@ -46,6 +47,8 @@ host app が直接使ってよい主な入口は以下です。
 - `tree_view_toolbar_action_metadata(render_state, action, ...)`
 
 `TreeView::ResourceTableRenderState.call` は、別の table layer が列推論や table state を持っていて、TreeView には階層 render state の組み立てだけを任せたい場合の公開入口です。詳細は [Resource table bridge](resource-table-bridge.md) を参照してください。
+
+`TreeView::Configuration` は TreeView の configuration option surface を所有する documented class です。host app は通常 `TreeView.configure` と `TreeView.configuration` を使ってください。class constant は互換性のため public ですが、private normalization method や内部 constant は public contract に含めません。
 
 ## Public error surface
 
@@ -113,6 +116,8 @@ toolbar helper もこの公開 helper surface に含まれます。
 
 - `initial_state`
 - `render_log_level`
+
+`TreeView::Configuration` はこれらの documented option の reader / writer を公開しますが、host app の通常の統合経路は `TreeView.configure` / `TreeView.configuration` です。option ごとの挙動は [Render log level](render-log-level.md) などの dedicated configuration docs に委譲します。
 
 公開 localized display-name helper には以下を含めます。
 


### PR DESCRIPTION
TreeView::Configuration を documented public constant として manifest / docs に同期します。

## 対応 Issue

Closes #969

## 変更内容

- `config/public_api_manifest.yml`
  - `public_constants` に `Configuration` を追加しました。
- `docs/en/public-api.md`
  - stable public entry points に `TreeView::Configuration` を追加しました。
  - `TreeView::Configuration` は configuration option surface の所有 class だが、host app は通常 `TreeView.configure` / `TreeView.configuration` 経由で扱う境界を明記しました。
  - private normalization helpers / internal constants は public contract に含めないことを明記しました。
- `docs/ja/public-api.md`
  - 英語版と同じ境界を日本語 docs に同期しました。

## 受け入れ条件との対応

- `TreeView::Configuration` を public constant として扱う方針を manifest と docs に反映しました。
- 既存の public constants compatibility spec は `config/public_api_manifest.yml` を読むため、manifest 追加後に `TreeView.const_defined?("Configuration")` を検知できます。
- public API docs は constant そのものを stable surface に含めつつ、推奨利用は `TreeView.configure` / `TreeView.configuration` 経由であると明記しました。
- `initial_state` / `render_log_level` 以外の configuration option は追加していません。
- private normalization methods / internal constants / implementation details は public API として宣言していません。

## 変更範囲

- public API manifest
- public API docs（日英）

runtime behavior、configuration semantics、new configuration option、render log behavior、DB、認可、JavaScript、parent #353 全体は変更していません。

## 実施した確認

- GitHub compare: `main...feature/969-configuration-public-surface-latest`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- local `bundle exec rspec spec/public_api_compatibility_spec.rb` は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク

- medium
- public compatibility surface の additive change です。ただし既に require され、`TreeView.configuration` の返り値として露出している class を manifest / docs に同期するだけで、runtime 挙動は変更していません。

## 未対応・補足

- #970 の docs navigation lane、parent #353 全体、他の public surface issue は吸収していません。