### PR TITLE
table caption context の focused mockup を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -15,6 +15,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [current-branch-sidebar.html](current-branch-sidebar.html) | Current branch sidebar reference showing current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues without host-app navigation policy. |
+| [table-caption-context.html](table-caption-context.html) | Focused reference showing host-app-owned page heading, table caption, summary text, and adjacent actions around TreeView-owned row hierarchy cues. |
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
 | [toggle-icon-states.html](toggle-icon-states.html) | Focused comparison for expanded, collapsed, leaf, loading, and depth/type-based toggle icon states without choosing a host-app icon library. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
@@ -42,28 +43,29 @@ They are **not** a complete Rails application and should not grow into host-app 
 2. Open the linked full mockup page when one surface needs deeper inspection or longer notes.
 3. Use [narrow-sidebar-tree.html](narrow-sidebar-tree.html) when review needs a focused pass on 22rem or 18rem frames where hierarchy cues stay visible while secondary metadata wraps below the primary label.
 4. Use [current-branch-sidebar.html](current-branch-sidebar.html) when review needs to isolate `current_item:` / `current_key:` plus `auto_expand_ancestors: true` as a visual reference for the current row, ancestor path, and collapsed siblings.
-5. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
-6. Use [toggle-icon-states.html](toggle-icon-states.html) when review needs to compare `toggle_icons:` expanded, collapsed, leaf, loading, and depth/type variation without selecting a final icon library.
-7. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-8. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-9. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
-10. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
-11. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-12. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
-13. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-14. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-15. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-16. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-17. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-18. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-19. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-20. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-21. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-22. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-23. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
-24. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-25. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-26. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+5. Use [table-caption-context.html](table-caption-context.html) when review needs to compare host-app-owned page heading, table caption, summary text, and adjacent actions around TreeView-owned row hierarchy cues.
+6. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
+7. Use [toggle-icon-states.html](toggle-icon-states.html) when review needs to compare `toggle_icons:` expanded, collapsed, leaf, loading, and depth/type variation without selecting a final icon library.
+8. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
+9. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+10. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
+11. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
+12. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+13. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
+14. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+15. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+16. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+17. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+18. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+19. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+20. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+21. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+22. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
+25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -10,29 +10,44 @@
   max-width: 1320px;
 }
 
-.mock-gallery-return-nav {
+.mock-gallery-return-nav,
+.mock-gallery-review-path-links,
+.mock-gallery-links {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+.mock-gallery-return-nav {
   margin-top: 18px;
 }
 
-.mock-gallery-return-nav a {
+.mock-gallery-return-nav a,
+.mock-gallery-review-path-links a {
   display: inline-flex;
   align-items: center;
-  padding: 0.55rem 0.9rem;
+  min-height: 2.35rem;
+  padding: 0.5rem 0.8rem;
   border: 1px solid #cbd5e1;
   border-radius: 999px;
   background: #fff;
-  color: #0f172a;
+  color: #1d4ed8;
   font-weight: 700;
   text-decoration: none;
 }
 
+.mock-gallery-return-nav a {
+  color: #0f172a;
+}
+
 .mock-gallery-return-nav a:hover,
-.mock-gallery-return-nav a:focus {
+.mock-gallery-return-nav a:focus,
+.mock-gallery-review-path-links a:hover,
+.mock-gallery-review-path-links a:focus {
   border-color: #1d4ed8;
+  background: #eff6ff;
   color: #1d4ed8;
+  outline: 2px solid transparent;
 }
 
 .mock-gallery-review-paths {
@@ -48,32 +63,6 @@
 .mock-gallery-review-paths h2,
 .mock-gallery-review-paths p {
   margin: 0;
-}
-
-.mock-gallery-review-path-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.mock-gallery-review-path-links a {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2.35rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 999px;
-  background: #fff;
-  color: #1d4ed8;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.mock-gallery-review-path-links a:hover,
-.mock-gallery-review-path-links a:focus {
-  border-color: #1d4ed8;
-  background: #eff6ff;
-  outline: 2px solid transparent;
 }
 
 .mock-gallery-grid {
@@ -114,12 +103,6 @@
 .mock-gallery-points {
   padding-left: 1.2rem;
   color: #334e68;
-}
-
-.mock-gallery-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
 }
 
 .mock-gallery-links a {
@@ -205,6 +188,7 @@
         <p>Jump to the first card in a state family, then continue through nearby cards for related comparisons.</p>
         <div class="mock-gallery-review-path-links">
           <a href="#gallery-default-heading">Baseline</a>
+          <a href="#gallery-caption-context-heading">Page context</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
           <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
           <a href="#gallery-toggle-icon-heading">Toggle icons</a>
@@ -238,6 +222,9 @@
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-current-branch-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused branch state</p><h2 id="gallery-current-branch-heading">Current branch sidebar</h2><p>Review a sidebar state where the current row and its ancestors are expanded while sibling branches stay collapsed.</p><ul class="mock-gallery-points"><li>Current row and ancestor path</li><li>Collapsed sibling branches</li><li>Host-app navigation policy outside scope</li></ul><div class="mock-gallery-links"><a href="current-branch-sidebar.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="current-branch-sidebar.html" title="Current branch sidebar mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-caption-context-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused page context</p><h2 id="gallery-caption-context-heading">Table caption context</h2><p>Review host-app-owned page heading, table caption, summary text, and adjacent actions around TreeView-owned hierarchy cues.</p><ul class="mock-gallery-points"><li>Caption and heading outside the gem contract</li><li>TreeView row cues remain unchanged</li><li>No route, authorization, or helper API changes</li></ul><div class="mock-gallery-links"><a href="table-caption-context.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="table-caption-context.html" title="Table caption context mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
@@ -279,16 +266,16 @@
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-selection-limit-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Attempted checkbox restored after limit-exceeded</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Server validation outside scope</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-selection-form-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Compare multiple TreeView selection groups inside one host-app form while keeping source-specific hidden input sync internal.</p><ul class="mock-gallery-points"><li>Selection counts grouped by source</li><li>Generated hidden input source boundary</li><li>Submit summary owned by the host app</li></ul><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused multi-tree form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Review multiple TreeView selection groups inside one host-app form, including grouped counts and generated hidden input boundaries.</p><ul class="mock-gallery-points"><li>Source-specific selected counts</li><li>Hidden input sync boundary</li><li>Final submit behavior outside scope</li></ul><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Toolbar actions</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Review expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Tree-wide action grouping</li><li>Disabled and current-state variants</li><li>Host-app route policy outside scope</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Spacing and fallback</p><h2 id="gallery-empty-heading">Empty state</h2><p>Compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.</p><ul class="mock-gallery-points"><li>Reusable empty-row wrapper hook</li><li>Full-width message slot behavior</li><li>Difference from a populated row</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Empty state</p><h2 id="gallery-empty-heading">Empty state</h2><p>Compare no-root-items and no-results rows, the reusable empty-row wrapper hook, and host-app-owned copy boundary.</p><ul class="mock-gallery-points"><li>No-root-items and filtered empty cases</li><li>Full-width message slot</li><li>CTA and filter reset outside scope</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
       </article>
     </section>
 
@@ -296,6 +283,7 @@
       <h2 id="comparison-cues-heading">Comparison cues</h2>
       <table class="mock-comparison-table"><thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead><tbody>
         <tr><td>Default tree</td><td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td><td>Host-app CRUD, queries, business labels, or authorization behavior.</td></tr>
+        <tr><td>Table caption context</td><td>Page heading, table caption, summary text, and adjacent action placement around TreeView rows.</td><td>Caption helper API, business action behavior, routes, permissions, or final copy.</td></tr>
         <tr><td>Row status and depth labels</td><td>Row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
         <tr><td>Toggle icon states</td><td>Expanded, collapsed, leaf, loading, and depth/type icon variation boundaries.</td><td>Icon library choice, final artwork, tooltip copy, public API changes, or runtime behavior.</td></tr>
         <tr><td>Resource table bridge</td><td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td><td>Saved table state, host-app queries, or business-specific row actions.</td></tr>

--- a/docs/mockups/table-caption-context.html
+++ b/docs/mockups/table-caption-context.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Table caption context mock</title>
+<link rel="stylesheet" href="default-tree.css">
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Table caption context mock</h1>
+      <p>
+        Static reference for placing TreeView rows inside host-app-owned page structure.
+        The heading, table caption, summary, and adjacent actions are intentionally product-neutral host app content; TreeView owns the hierarchy row cues inside the table body.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="host-page-heading">
+      <p class="mock-kicker">Host app page structure</p>
+      <h2 id="host-page-heading">Workspace hierarchy</h2>
+      <p>
+        This header, summary text, and action row stand in for content supplied by the host application.
+        They should explain the screen purpose without implying that TreeView provides routing, authorization, CRUD actions, or final business copy.
+      </p>
+
+      <div class="mock-filter-bar" aria-label="Host app actions">
+        <span class="mock-filter-chip">Host-owned summary: 4 visible nodes</span>
+        <button type="button">Host action</button>
+        <button type="button">Secondary action</button>
+      </div>
+
+      <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+        <caption>
+          Host-owned table caption describing the current workspace hierarchy and review context.
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">select</th>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">owner</th>
+            <th scope="col">status</th>
+            <th scope="col">actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="context_project_1" class="tree-row is-expanded" data-tree-node-key="context-project:1" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true" aria-selected="false">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_1_selection" name="selected_nodes[]" type="checkbox" value='{"key":"context-project:1","id":1,"type":"Project"}' data-tree-selection-payload='{"key":"context-project:1","id":1,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_1_button">
+              <span class="tree-toggle" aria-label="Root row expanded">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                  <span class="tree-toggle__level">root</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="Folder">folder</span>
+              <span class="tree-depth-label">L0</span>
+            </td>
+            <td>Platform program</td>
+            <td>Team A</td>
+            <td><span class="mock-status mock-status--active">active</span></td>
+            <td class="tree-row-actions"><button type="button">Open</button></td>
+          </tr>
+
+          <tr id="context_project_2" class="tree-row is-selected" data-tree-node-key="context-project:2" data-tree-parent-key="context-project:1" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-selected="true" aria-current="page">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_2_selection" name="selected_nodes[]" type="checkbox" checked value='{"key":"context-project:2","id":2,"type":"Project"}' data-tree-selection-payload='{"key":"context-project:2","id":2,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_2_button">
+              <span class="tree-toggle" aria-label="Selected child row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">child</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="Folder">folder</span>
+              <span class="tree-depth-label">L1</span>
+              <span class="tree-node-badge tree-node-badge--info" title="Current row">current</span>
+            </td>
+            <td>Operations surface</td>
+            <td>Team B</td>
+            <td><span class="mock-status mock-status--active">active</span></td>
+            <td class="tree-row-actions"><button type="button">Open</button></td>
+          </tr>
+
+          <tr id="context_project_3" class="tree-row is-leaf" data-tree-node-key="context-project:3" data-tree-parent-key="context-project:2" data-tree-depth="2" data-tree-expanded="false" aria-level="3" aria-selected="false">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_3_selection" name="selected_nodes[]" type="checkbox" value='{"key":"context-project:3","id":3,"type":"Project"}' data-tree-selection-payload='{"key":"context-project:3","id":3,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_3_button">
+              <span class="tree-toggle" aria-label="Leaf row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">leaf</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="File">file</span>
+              <span class="tree-depth-label">L2</span>
+            </td>
+            <td>Review checklist</td>
+            <td>Team B</td>
+            <td><span class="mock-status">ready</span></td>
+            <td class="tree-row-actions"><button type="button">Open</button></td>
+          </tr>
+
+          <tr id="context_project_4" class="tree-row is-collapsed" data-tree-node-key="context-project:4" data-tree-parent-key="context-project:1" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false" aria-selected="false">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_4_selection" name="selected_nodes[]" type="checkbox" disabled title="Host app disabled this selection" value='{"key":"context-project:4","id":4,"type":"Project"}' data-tree-selection-disabled-reason="Host app disabled this selection" data-tree-selection-payload='{"key":"context-project:4","id":4,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_4_button">
+              <span class="tree-toggle" aria-label="Collapsed row with hidden descendants">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a>
+                  <span class="tree-toggle__level">child</span>
+                  <span class="tree-toggle__hidden-count" title="Hidden descendants">5</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="Archive">archive</span>
+              <span class="tree-depth-label">L1</span>
+              <span class="tree-node-badge tree-node-badge--warning" title="Host app status">archived</span>
+            </td>
+            <td>Archived workstream</td>
+            <td>Team C</td>
+            <td><span class="mock-status mock-status--archived">archived</span></td>
+            <td class="tree-row-actions"><button type="button" disabled>Open</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="boundary-heading">
+      <h2 id="boundary-heading">Responsibility boundary</h2>
+      <ul>
+        <li>Host app owns page heading, caption copy, summary text, action labels, routes, authorization, and final business wording.</li>
+        <li>TreeView owns row hierarchy cues such as branch lines, toggle affordances, depth labels, hidden counts, and selection payload hooks.</li>
+        <li>This mock does not introduce a caption helper, treegrid semantics, CRUD flow, route policy, or public API option.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -53,6 +53,11 @@ const focusedMockupSmokeTargets = [
     minimumCount: 1
   },
   {
+    file: "table-caption-context.html",
+    sample: ".tree-view-table caption, .tree-view-table tbody tr",
+    minimumCount: 5
+  },
+  {
     file: "row-status-depth-labels.html",
     sample: ".tree-view-table tbody tr",
     minimumCount: 3


### PR DESCRIPTION
## 対応Issue

- Closes #1013

## 採用した方針

- Planner handoff に沿い、runtime / API / ARIA policy は触らず `docs/mockups/` の static visual reference に閉じました。
- 自動実行のため、最も低リスクで既存 mockup design に沿う「新規 focused mockup + README / gallery / smoke 導線更新」を採用しました。
- 新 mockup では、page heading / table caption / summary / adjacent actions は host app owned、TreeView row hierarchy cue は gem owned、という境界が読み取れる構成にしています。

## 比較した案

- 案A: README への説明追記だけに留める
  - 低コストですが、caption / surrounding page structure の見た目をレビューできないため #1013 の目的に弱いです。
- 案B: 新規 focused mockup を追加し、既存 review 導線に同期する
  - 採用案です。既存 HTML/CSS の見え方に合わせつつ、責務境界を単独ページと gallery で確認できます。
- 案C: 共通 CSS や gallery layout を大きく再設計する
  - review surface は広がりますが、今回の low-risk lane には変化量が大きいため見送りました。

## 変更内容

- `docs/mockups/table-caption-context.html` を追加
  - host-app-owned heading / caption / summary / action controls を含む静的ページを追加
  - TreeView-owned row / toggle / selection / current-state cue は既存 mockup の table classes に揃えました
  - caption helper、treegrid semantics、CRUD / route / authorization / public API は追加していません
- `docs/mockups/README.md` を更新
  - Files table に新 mockup を追加
  - Recommended review flow に新 mockup の確認タイミングを追加
- `docs/mockups/review-gallery.html` を更新
  - 新 mockup の gallery card / iframe preview / comparison cue を追加
- `test/browser/docs_mockups_smoke.spec.js` を更新
  - README Files table と browser smoke target の同期 guard に新 mockup を追加

## 変更した画面・コンポーネント

- `docs/mockups/table-caption-context.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- lint: GitHub Actions CI `#1274` success
- typecheck: 該当なし
- UI表示確認: 未完了
  - review follow-up で確認したところ、CI `#1274` の `javascript` job では `npm run test:browser` step が skipped でした。
  - mockup 追加 PR としては、最新 head で browser smoke が実行された証拠がまだ不足しています。
- レスポンシブ確認: 未完了（browser smoke 実行証拠待ち）
- アクセシビリティ確認: source 上で heading / caption / nav / representative table region を確認
- GitHub compare: `main...design/1013-table-caption-context-latest`
  - 2026-06-01 review follow-up 時点で `ahead_by: 4` / `behind_by: 14` / `status: diverged`
  - changed files: 4

## スクリーンショット

<!-- この実行環境では GitHub HTTPS clone/fetch が CONNECT tunnel failed, response 403 で失敗するため、ローカルスクリーンショット添付は未実施です。 -->

## リスク

- low
- static mockup / README / gallery / browser smoke target のみの変更です。
- runtime JavaScript、Ruby helper、public API manifest、ARIA policy、host-app route / authorization / CRUD は変更していません。

## 補足

- 初回 CI `#1271` では mockup inventory / browser smoke target の同期漏れで失敗しました。
- `review-gallery.html` と `test/browser/docs_mockups_smoke.spec.js` は追従済みです。
- ただし、再実行 CI `#1274` では `npm run test:browser` が skipped だったため、mockup UI 表示確認としては未完了です。
- 進めるには current `main` へ載せ直し、最新 head で browser smoke が実行された CI 証拠を取り直す必要があります。