### PR TITLE
Unreleased changelog に recent contract / mockup 更新を同期する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,12 +63,15 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added a host-app extension hook reverse lookup table in Japanese and English.
 - Added toolbar disabled-action troubleshooting guidance in Japanese and English.
 - Added transfer disabled / invalid boundary states to the drop-position mockup and updated the mockup review guidance.
+- Added static mockup references for multi-tree selection forms, toggle icon states, and high-contrast state cues.
+- Clarified that `docs/mockups/README.md` is the source of truth for mockup technical asset inventory.
 
 ### Tests
 
 - Added localized names specs and public API compatibility coverage.
 - Added Turbo Frame option unit and integration specs.
 - Added toolbar helper specs.
+- Added toolbar action/state manifest and docs drift guard coverage.
 - Added `NodePresenter` specs and `RenderState` integration specs.
 - Added generator specs for persisted state owner concern injection.
 - Added RenderState specs for current node ancestor auto-expansion.


### PR DESCRIPTION
## 対応 Issue

Closes #998

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased` に、merge 済みの recent public contract / mockup 変更だけを短く追記しました。
- Documentation:
  - multi-tree selection form / toggle icon state / high-contrast state cue の static mockup references を追加
  - `docs/mockups/README.md` を mockup technical asset inventory の source of truth とする整理を追加
- Tests:
  - toolbar action/state manifest と docs drift guard coverage を追加

## 反映対象として確認した merged PR

- #894: multi-tree selection form mockup
- #979: toggle icon state mockup
- #1011: high-contrast state cue mockup
- #1019: mockup technical asset inventory policy
- #993: toolbar action/state manifest and docs drift guard

## 非目標

- 未マージ PR の内容を release note として先取りすること
- release 実行 / tag 作成 / version bump
- runtime behavior、public API、mockup HTML、CI workflow の変更

## 確認内容

- GitHub compare: `main...docs/998-changelog-public-contract-mockups`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`CHANGELOG.md`)
- docs-only の changelog 追記のため、local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- release note の短い追記だけで、未マージの #880 / #995 / #967 / #1020 / #1024 は確定済み事実として書いていません。