### PR TITLE
public API manifest を package / release guard に含める

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             esac
 
             case "$file" in
-              tree_view.gemspec|script/check_gem_package_contents.rb|.github/workflows/ci.yml|config/importmap.tree_view.rb|lib/*|lib/**|app/helpers/*|app/helpers/**|app/views/*|app/views/**|app/assets/*|app/assets/**|app/javascript/*|app/javascript/**|config/locales/*|config/locales/**)
+              tree_view.gemspec|script/check_gem_package_contents.rb|.github/workflows/ci.yml|config/importmap.tree_view.rb|config/public_api_manifest.yml|lib/*|lib/**|app/helpers/*|app/helpers/**|app/views/*|app/views/**|app/assets/*|app/assets/**|app/javascript/*|app/javascript/**|config/locales/*|config/locales/**)
                 package_sensitive=true
                 ;;
             esac

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -59,7 +59,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, verifies the gem can be built, confirms release-facing files are packaged, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The main-push `gem_package` CI job additionally runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem so representative Rails helper, view partial, locale, docs, JavaScript, CSS, and importmap files remain packaged. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
+`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, verifies the gem can be built, confirms release-facing files are packaged, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The main-push `gem_package` CI job additionally runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem so representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, and public API manifest files remain packaged. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
 
 Pull request CI checks:
 
@@ -69,14 +69,14 @@ Pull request CI checks:
 - JavaScript tests through `npm install`, Playwright browser setup, and `npm run test:js`
 - Gem package verification when the PR touches package-sensitive paths
 
-Package-sensitive PR paths include `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb` and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Prose-only docs PRs keep the lighter docs-only behavior unless they also touch one of those package-sensitive paths.
+Package-sensitive PR paths include `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb`, `config/public_api_manifest.yml`, and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Prose-only docs PRs keep the lighter docs-only behavior unless they also touch one of those package-sensitive paths.
 
 Main-push CI checks:
 
 - Ruby version matrix
 - Rails version matrix
 - JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
-- Gem package verification, including representative Rails helper, view partial, locale, docs, JavaScript, CSS, and importmap file contents
+- Gem package verification, including representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, and public API manifest file contents
 
 PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes full compatibility matrices, JavaScript coverage, and unconditional package verification.
 
@@ -142,6 +142,7 @@ Before release:
   - `app/javascript/tree_view/index.js`
   - `app/assets/stylesheets/tree_view.scss`
   - `config/importmap.tree_view.rb`
+  - `config/public_api_manifest.yml`
   - `config/locales/tree_view.toolbar.en.yml`
   - `README.md`
   - `CHANGELOG.md`

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -59,7 +59,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。main-push の `gem_package` CI job では、built gem に Rails helper / view partial / locale / docs / JavaScript / CSS / importmap の代表ファイルが残っていることを `ruby script/check_gem_package_contents.rb tree_view-*.gem` でも確認します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
+`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。main-push の `gem_package` CI job では、built gem に Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest の代表ファイルが残っていることを `ruby script/check_gem_package_contents.rb tree_view-*.gem` でも確認します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
 
 Pull Request CI の確認項目:
 
@@ -69,14 +69,14 @@ Pull Request CI の確認項目:
 - JavaScript tests: `npm install`、Playwright browser setup、`npm run test:js`
 - package-sensitive path を触るPRでの Gem package verification
 
-package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb` と `config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。prose-only docs PR は、その package-sensitive path も触らない限り、従来どおり軽い docs-only 挙動を維持します。
+package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb`、`config/public_api_manifest.yml`、`config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。prose-only docs PR は、その package-sensitive path も触らない限り、従来どおり軽い docs-only 挙動を維持します。
 
 `main` push CI の確認項目:
 
 - Ruby version matrix
 - Rails version matrix
 - `package-lock.json` が `package.json` と同期するまでの間は、`npm install` と `npm run test:js` による JavaScript tests
-- Rails helper / view partial / locale / docs / JavaScript / CSS / importmap の代表ファイルを含む Gem package verification
+- Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest の代表ファイルを含む Gem package verification
 
 merge前にPR CIを通します。release判定には、full compatibility matrices、JavaScript coverage、unconditional package verificationを含む、より広い `main` CIを使います。
 
@@ -142,6 +142,7 @@ release前に確認すること:
   - `app/javascript/tree_view/index.js`
   - `app/assets/stylesheets/tree_view.scss`
   - `config/importmap.tree_view.rb`
+  - `config/public_api_manifest.yml`
   - `config/locales/tree_view.toolbar.en.yml`
   - `README.md`
   - `CHANGELOG.md`

--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -14,6 +14,7 @@ REQUIRED_PACKAGED_PATHS = %w[
   app/javascript/tree_view/state_controller.js
   app/javascript/tree_view/transfer_controller.js
   config/importmap.tree_view.rb
+  config/public_api_manifest.yml
   config/locales/tree_view.toolbar.en.yml
   docs/en/release.md
 ].freeze

--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
       "app/javascript/tree_view/**/*",
       "app/views/tree_view/**/*",
       "config/importmap.tree_view.rb",
+      "config/public_api_manifest.yml",
       "config/locales/**/*",
       "docs/**/*",
       "lib/**/*",


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1026

## Issue ごとの完了内容

- #1026
  - `config/public_api_manifest.yml` を gem package の対象に追加しました。
  - package contents check の required path に manifest を追加しました。
  - CI の `package_sensitive` 判定に manifest path を追加し、manifest-only 変更でも gem package verification が走るようにしました。
  - 英日 release docs の package-sensitive path / package checklist を同期しました。

## 変更内容

- `tree_view.gemspec`
  - `config/public_api_manifest.yml` を packaged config file として追加
- `script/check_gem_package_contents.rb`
  - `REQUIRED_PACKAGED_PATHS` に manifest を追加
- `.github/workflows/ci.yml`
  - `package_sensitive` path 判定に manifest を追加
- `docs/en/release.md` / `docs/ja/release.md`
  - release / package verification の説明を manifest 同梱に合わせて更新

## 改善カテゴリ

- packaging guard
- CI
- docs
- release verification

## 既存仕様への影響

- 既存仕様への影響はありません。
- public API manifest schema、public API surface、runtime load behavior、helper / JavaScript behavior は変更していません。
- manifest を出荷物と package verification の代表ファイルに含めるだけです。

## 実施した確認内容

- GitHub compare: `main...quality/1026-package-public-api-manifest`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 5
- local `gem build tree_view.gemspec` / `ruby script/check_gem_package_contents.rb tree_view-*.gem` は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- medium
- release/package guard と CI path 判定に触りますが、runtime code や public API 契約は変更していません。

## 補足事項

- manifest schema redesign、runtime manifest loader、release automation rewrite、public API の追加 / 削除には広げていません。