### PR TITLE
NodePresenter row partial の focused mockup を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -29,6 +29,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [breadcrumb-paths.html](breadcrumb-paths.html) | Focused comparison for breadcrumb-path context beside the tree's own current-row cue, without modeling host-app routes or Turbo navigation. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [path-tree-builder-rows.html](path-tree-builder-rows.html) | Focused PathTreeBuilder comparison for generated folder rows versus record-backed rows, keeping host-app columns/actions outside the gem contract. |
+| [node-presenter-row-partials.html](node-presenter-row-partials.html) | Focused NodePresenter row partial reference showing resolver-provided label, href, tooltip, badge, icon, and optional action beside host-app-owned columns and permissions. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [selection-max-count.html](selection-max-count.html) | Focused selection max-count reference showing below-limit, limit-reached, and limit-exceeded feedback while keeping final action copy host-app owned. |
 | [selection-multi-tree-form.html](selection-multi-tree-form.html) | Focused multi-tree selection form reference showing source-specific selected counts, submit summary, empty state, and generated hidden input boundary. |
@@ -58,12 +59,13 @@ They are **not** a complete Rails application and should not grow into host-app 
 18. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
 19. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
 20. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-21. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-22. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-23. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
-24. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-25. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-26. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+21. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
+22. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
+25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 

--- a/docs/mockups/node-presenter-row-partials.html
+++ b/docs/mockups/node-presenter-row-partials.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NodePresenter row partial mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-presenter-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 0.8fr);
+  gap: 18px;
+}
+
+.mock-presenter-note {
+  margin: 0;
+  color: #52606d;
+}
+
+.mock-presenter-card {
+  border: 1px solid #dde4ec;
+  border-radius: 12px;
+  background: #fff;
+  padding: 16px;
+}
+
+.mock-presenter-card h3,
+.mock-presenter-card p {
+  margin-top: 0;
+}
+
+.mock-presenter-list {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.mock-presenter-link {
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-presenter-link:hover,
+.mock-presenter-link:focus {
+  text-decoration: underline;
+}
+
+.mock-presenter-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.7rem;
+  min-height: 1.7rem;
+  border-radius: 8px;
+  background: #e0f2fe;
+  color: #075985;
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.mock-presenter-action {
+  color: #1d4ed8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.mock-presenter-action[aria-disabled="true"] {
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.mock-presenter-action:hover,
+.mock-presenter-action:focus {
+  text-decoration: underline;
+}
+
+.mock-presenter-boundary-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mock-presenter-boundary-table th,
+.mock-presenter-boundary-table td {
+  border-bottom: 1px solid #e4e7eb;
+  padding: 0.7rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.mock-presenter-boundary-table th {
+  background: #f1f5f9;
+  color: #334e68;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+@media (max-width: 820px) {
+  .mock-presenter-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tree-view-table {
+    display: block;
+    overflow-x: auto;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>NodePresenter row partial mock</h1>
+      <p>
+        Focused static reference for reviewing how a host app row partial can use NodePresenter values without turning TreeView into a CRUD, permission, or column DSL.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="presenter-rows-heading">
+      <h2 id="presenter-rows-heading">Presenter-backed row partial sample</h2>
+      <p class="mock-presenter-note">
+        The first column shows resolver-provided label, href, tooltip, badge, icon, and optional action cues. Adjacent columns stay host-app owned.
+      </p>
+      <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+        <thead>
+          <tr>
+            <th scope="col">tree node</th>
+            <th scope="col">host column</th>
+            <th scope="col">host status</th>
+            <th scope="col">host action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="presenter_node_1" class="tree-row is-expanded" data-tree-node-key="node:platform" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+            <td class="btn-cell tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Platform root expanded">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span>
+              </span>
+              <span class="mock-node-stack">
+                <span class="mock-node-primary"><span class="mock-presenter-icon" aria-hidden="true">P</span><a class="mock-presenter-link" href="#platform" title="Open Platform group">Platform group</a><span class="tree-node-badge tree-node-badge--info" title="Resolver badge">resolver badge</span></span>
+                <span class="mock-node-secondary">Label, href, title, icon, and badge come from the presenter.</span>
+              </span>
+            </td>
+            <td>Host-owned count: 8 child records</td>
+            <td><span class="mock-status mock-status--active">ready</span></td>
+            <td class="tree-row-actions"><a class="mock-presenter-action" href="#platform-details">Open details</a></td>
+          </tr>
+          <tr id="presenter_node_2" class="tree-row is-selected" data-tree-node-key="node:admin" data-tree-parent-key="node:platform" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-current="page">
+            <td class="btn-cell tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Admin leaf">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                <span class="tree-toggle__control"><span class="tree-toggle__level">child</span></span>
+              </span>
+              <span class="mock-node-stack">
+                <span class="mock-node-primary"><span class="mock-presenter-icon" aria-hidden="true">A</span><a class="mock-presenter-link" href="#admin" title="Current presenter target">Admin workspace</a><span class="tree-node-badge" title="Current node">current</span></span>
+                <span class="mock-node-secondary">Current-row cue stays TreeView-owned; the row partial chooses nearby host columns.</span>
+              </span>
+            </td>
+            <td>Host-owned owner: Team B</td>
+            <td><span class="mock-status mock-status--active">current</span></td>
+            <td class="tree-row-actions"><a class="mock-presenter-action" href="#admin-open">Open</a></td>
+          </tr>
+          <tr id="presenter_node_3" class="tree-row is-collapsed" data-tree-node-key="node:archive" data-tree-parent-key="node:platform" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+            <td class="btn-cell tree-toggle-cell">
+              <span class="tree-toggle" aria-label="Archived branch collapsed">
+                <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span><span class="tree-toggle__hidden-count" title="Hidden descendants">4</span></span>
+              </span>
+              <span class="mock-node-stack">
+                <span class="mock-node-primary"><span class="mock-presenter-icon" aria-hidden="true">R</span><a class="mock-presenter-link" href="#archive" title="Open read-only branch">Reference archive</a><span class="tree-node-badge tree-node-badge--warning" title="Optional presenter badge">readonly</span></span>
+                <span class="mock-node-secondary">Optional action can render disabled while final permission behavior stays in the host app.</span>
+              </span>
+            </td>
+            <td>Host-owned policy note</td>
+            <td><span class="mock-status mock-status--archived">readonly</span></td>
+            <td class="tree-row-actions"><a class="mock-presenter-action" href="#" aria-disabled="true">Unavailable</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section mock-presenter-grid" aria-labelledby="boundary-heading">
+      <div class="mock-presenter-card">
+        <h2 id="boundary-heading">Resolver-provided surface</h2>
+        <ul class="mock-presenter-list">
+          <li>Primary label and href used by the row partial.</li>
+          <li>Tooltip or title text for presenter-owned links.</li>
+          <li>Badge, icon, and optional action metadata that remains product-neutral here.</li>
+        </ul>
+      </div>
+      <div class="mock-presenter-card">
+        <h2>Host-app-owned surface</h2>
+        <ul class="mock-presenter-list">
+          <li>Business columns, counts, routes, and authorization policy.</li>
+          <li>Final action behavior, disabled reasons, and workflow copy.</li>
+          <li>Any Column or Action DSL design beyond the row partial cookbook.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="comparison-heading">
+      <h2 id="comparison-heading">What to review</h2>
+      <table class="mock-presenter-boundary-table">
+        <thead><tr><th scope="col">Question</th><th scope="col">Expected answer</th></tr></thead>
+        <tbody>
+          <tr><td>Can the row partial show presenter label, href, tooltip, badge, icon, and optional action?</td><td>Yes, without adding runtime behavior or changing NodePresenter API.</td></tr>
+          <tr><td>Who owns table cells and permission-specific copy?</td><td>The host app; this page only shows neutral placeholders.</td></tr>
+          <tr><td>Does this mock imply a CRUD or Column DSL?</td><td>No. It stays a static visual reference for the existing cookbook boundary.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応Issue

- Closes #1030

## Superseded

この PR は作業中に `main` が進んだため `mergeable: false` になりました。最新 `main` 起点の #1040 に同じ scoped diff を載せ直したため、この PR は superseded として閉じます。

置き換え先: #1040