### PR TITLE
NodePresenter row partial の focused mockup を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -29,6 +29,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [breadcrumb-paths.html](breadcrumb-paths.html) | Focused comparison for breadcrumb-path context beside the tree's own current-row cue, without modeling host-app routes or Turbo navigation. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [path-tree-builder-rows.html](path-tree-builder-rows.html) | Focused PathTreeBuilder comparison for generated folder rows versus record-backed rows, keeping host-app columns/actions outside the gem contract. |
+| [node-presenter-row-partials.html](node-presenter-row-partials.html) | Focused NodePresenter row partial reference showing resolver-provided label, href, tooltip, badge, icon, and optional action beside host-app-owned columns and permissions. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [selection-max-count.html](selection-max-count.html) | Focused selection max-count reference showing below-limit, limit-reached, and limit-exceeded feedback while keeping final action copy host-app owned. |
 | [selection-multi-tree-form.html](selection-multi-tree-form.html) | Focused multi-tree selection form reference showing source-specific selected counts, submit summary, empty state, and generated hidden input boundary. |
@@ -58,12 +59,13 @@ They are **not** a complete Rails application and should not grow into host-app 
 18. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
 19. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
 20. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-21. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-22. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-23. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
-24. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-25. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
-26. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+21. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
+22. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
+25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 

--- a/docs/mockups/node-presenter-row-partials.html
+++ b/docs/mockups/node-presenter-row-partials.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NodePresenter row partial mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-presenter-grid { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 0.8fr); gap: 18px; }
+.mock-presenter-note { margin: 0; color: #52606d; }
+.mock-presenter-card { border: 1px solid #dde4ec; border-radius: 12px; background: #fff; padding: 16px; }
+.mock-presenter-card h2 { margin-top: 0; }
+.mock-presenter-list { margin: 0; padding-left: 1.2rem; }
+.mock-presenter-link, .mock-presenter-action { color: #1d4ed8; font-weight: 700; text-decoration: none; }
+.mock-presenter-link:hover, .mock-presenter-link:focus, .mock-presenter-action:hover, .mock-presenter-action:focus { text-decoration: underline; }
+.mock-presenter-action[aria-disabled="true"] { color: #94a3b8; cursor: not-allowed; }
+.mock-presenter-icon { display: inline-flex; align-items: center; justify-content: center; min-width: 1.7rem; min-height: 1.7rem; border-radius: 8px; background: #e0f2fe; color: #075985; font-size: 0.9rem; font-weight: 800; }
+.mock-presenter-boundary-table { width: 100%; border-collapse: collapse; }
+.mock-presenter-boundary-table th, .mock-presenter-boundary-table td { border-bottom: 1px solid #e4e7eb; padding: 0.7rem 0.75rem; text-align: left; vertical-align: top; }
+.mock-presenter-boundary-table th { background: #f1f5f9; color: #334e68; font-size: 0.8rem; text-transform: uppercase; }
+@media (max-width: 820px) { .mock-presenter-grid { grid-template-columns: 1fr; } .tree-view-table { display: block; overflow-x: auto; } }
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>NodePresenter row partial mock</h1>
+      <p>Focused static reference for reviewing how a host app row partial can use NodePresenter values without turning TreeView into a CRUD, permission, or column DSL.</p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="presenter-rows-heading">
+      <h2 id="presenter-rows-heading">Presenter-backed row partial sample</h2>
+      <p class="mock-presenter-note">The first column shows resolver-provided label, href, tooltip, badge, icon, and optional action cues. Adjacent columns stay host-app owned.</p>
+      <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+        <thead><tr><th scope="col">tree node</th><th scope="col">host column</th><th scope="col">host status</th><th scope="col">host action</th></tr></thead>
+        <tbody>
+          <tr id="presenter_node_1" class="tree-row is-expanded" data-tree-node-key="node:platform" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Platform root expanded"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span></span><span class="mock-node-stack"><span class="mock-node-primary"><span class="mock-presenter-icon" aria-hidden="true">P</span><a class="mock-presenter-link" href="#platform" title="Open Platform group">Platform group</a><span class="tree-node-badge tree-node-badge--info" title="Resolver badge">resolver badge</span></span><span class="mock-node-secondary">Label, href, title, icon, and badge come from the presenter.</span></span></td>
+            <td>Host-owned count: 8 child records</td><td><span class="mock-status mock-status--active">ready</span></td><td class="tree-row-actions"><a class="mock-presenter-action" href="#platform-details">Open details</a></td>
+          </tr>
+          <tr id="presenter_node_2" class="tree-row is-selected" data-tree-node-key="node:admin" data-tree-parent-key="node:platform" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-current="page">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Admin leaf"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">child</span></span></span><span class="mock-node-stack"><span class="mock-node-primary"><span class="mock-presenter-icon" aria-hidden="true">A</span><a class="mock-presenter-link" href="#admin" title="Current presenter target">Admin workspace</a><span class="tree-node-badge" title="Current node">current</span></span><span class="mock-node-secondary">Current-row cue stays TreeView-owned; the row partial chooses nearby host columns.</span></span></td>
+            <td>Host-owned owner: Team B</td><td><span class="mock-status mock-status--active">current</span></td><td class="tree-row-actions"><a class="mock-presenter-action" href="#admin-open">Open</a></td>
+          </tr>
+          <tr id="presenter_node_3" class="tree-row is-collapsed" data-tree-node-key="node:archive" data-tree-parent-key="node:platform" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Archived branch collapsed"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span><span class="tree-toggle__hidden-count" title="Hidden descendants">4</span></span></span><span class="mock-node-stack"><span class="mock-node-primary"><span class="mock-presenter-icon" aria-hidden="true">R</span><a class="mock-presenter-link" href="#archive" title="Open read-only branch">Reference archive</a><span class="tree-node-badge tree-node-badge--warning" title="Optional presenter badge">readonly</span></span><span class="mock-node-secondary">Optional action can render disabled while final permission behavior stays in the host app.</span></span></td>
+            <td>Host-owned policy note</td><td><span class="mock-status mock-status--archived">readonly</span></td><td class="tree-row-actions"><a class="mock-presenter-action" href="#" aria-disabled="true">Unavailable</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section mock-presenter-grid" aria-labelledby="boundary-heading">
+      <div class="mock-presenter-card"><h2 id="boundary-heading">Resolver-provided surface</h2><ul class="mock-presenter-list"><li>Primary label and href used by the row partial.</li><li>Tooltip or title text for presenter-owned links.</li><li>Badge, icon, and optional action metadata that remains product-neutral here.</li></ul></div>
+      <div class="mock-presenter-card"><h2>Host-app-owned surface</h2><ul class="mock-presenter-list"><li>Business columns, counts, routes, and authorization policy.</li><li>Final action behavior, disabled reasons, and workflow copy.</li><li>Any Column or Action DSL design beyond the row partial cookbook.</li></ul></div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="comparison-heading">
+      <h2 id="comparison-heading">What to review</h2>
+      <table class="mock-presenter-boundary-table"><thead><tr><th scope="col">Question</th><th scope="col">Expected answer</th></tr></thead><tbody><tr><td>Can the row partial show presenter label, href, tooltip, badge, icon, and optional action?</td><td>Yes, without adding runtime behavior or changing NodePresenter API.</td></tr><tr><td>Who owns table cells and permission-specific copy?</td><td>The host app; this page only shows neutral placeholders.</td></tr><tr><td>Does this mock imply a CRUD or Column DSL?</td><td>No. It stays a static visual reference for the existing cookbook boundary.</td></tr></tbody></table>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -212,6 +212,7 @@
           <a href="#gallery-current-branch-heading">Current branch</a>
           <a href="#gallery-breadcrumb-heading">Navigation context</a>
           <a href="#gallery-path-builder-heading">Generated rows</a>
+          <a href="#gallery-node-presenter-heading">Presenter row partials</a>
           <a href="#gallery-form-heading">Editing and controls</a>
           <a href="#gallery-selection-limit-heading">Selection limits</a>
           <a href="#gallery-selection-form-heading">Selection form</a>
@@ -275,6 +276,9 @@
       <article class="mock-gallery-card" aria-labelledby="gallery-path-builder-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused builder rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows while keeping file-manager behavior outside the gem contract.</p><ul class="mock-gallery-points"><li>Generated folder row cues</li><li>Record-backed rows</li><li>Host-app file actions outside scope</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div>
       </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-node-presenter-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused presenter boundary</p><h2 id="gallery-node-presenter-heading">NodePresenter row partials</h2><p>Compare presenter-provided label, link, tooltip, badge, icon, and optional action values beside host-app-owned columns.</p><ul class="mock-gallery-points"><li>Resolver-provided row values</li><li>Host-owned columns and permissions</li><li>No CRUD or Column DSL design</li></ul><div class="mock-gallery-links"><a href="node-presenter-row-partials.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="node-presenter-row-partials.html" title="NodePresenter row partials mock preview" loading="lazy"></iframe></div>
+      </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-form-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div>
       </article>
@@ -305,7 +309,7 @@
         <tr><td>Keyboard focus states</td><td>Static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</td><td>Tab order, shortcut policy, roving tabindex, arrow-key navigation, or full treegrid behavior.</td></tr>
         <tr><td>Lazy-loading handoff</td><td>Children container ownership, remote-state placeholder handoff, and error/retry slot boundaries.</td><td>Real Turbo responses, fetch or retry controller behavior, authorization, or cursor policy.</td></tr>
         <tr><td>Persisted State boundary</td><td>Expansion state before, changed, restored, save-failed, and retry cues.</td><td>Storage schema, save endpoint, authorization, retry policy, browser save helper, or final error copy.</td></tr>
-        <tr><td>Drop positions</td><td>Before, inside, and after transfer cues plus the disabled target policy boundary.</td><td>Move authorization, persistence, audit trails, route wiring, or final business copy.</td></tr>
+        <tr><td>Drop positions</td><td>Before, inside, and after transfer cues plus the disabled target policy boundary.</td><td>Move authorization, persistence, audit trails, or final business copy.</td></tr>
         <tr><td>Turbo Frame target</td><td>Configured <code>data-turbo-frame</code> link attributes beside the host-app-owned target frame.</td><td>Turbo Stream responses, Rails routes, controller actions, authorization, or frame placement policy.</td></tr>
         <tr><td>Drag interactive controls</td><td>Plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers.</td><td>Drop targets, widget implementation details, permission rules, or business-specific drag affordances.</td></tr>
         <tr><td>Interactive marker behaviors</td><td>The broad interactive marker against narrower keyboard, row-click, and drag behavior markers.</td><td>Host-app row-click implementation, widget internals, or broader keyboard and drag policy changes.</td></tr>
@@ -313,6 +317,7 @@
         <tr><td>Breadcrumb paths</td><td>Breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</td><td>Route helpers, Turbo navigation, responsive overflow rules, and permission-aware labels.</td></tr>
         <tr><td>Filtered tree modes</td><td>Matched-only, ancestor-retaining, and descendant-retaining output.</td><td>Search forms, highlighting, ranking, and authorization-aware filtering.</td></tr>
         <tr><td>PathTreeBuilder rows</td><td>Generated folder row cues compared with record-backed rows and host-app-owned columns or actions.</td><td>File-manager routes, download behavior, record authorization, or public API changes.</td></tr>
+        <tr><td>NodePresenter row partials</td><td>Presenter-provided label, href, tooltip, badge, icon, and optional action values beside host-app-owned table columns.</td><td>Column or Action DSLs, CRUD routes, permission policy, final action behavior, or NodePresenter API changes.</td></tr>
         <tr><td>Form-editing rows</td><td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td><td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td></tr>
         <tr><td>Selection max-count</td><td>Below-limit, limit-reached, and limit-exceeded feedback placement around checkbox selection.</td><td>Runtime controller changes, final bulk-action copy, authorization, server validation, or submit behavior.</td></tr>
         <tr><td>Multi-tree selection form</td><td>Multiple TreeView selection groups inside one host-app form, grouped counts, and source-specific hidden input sync.</td><td>Params parsing, authorization, final bulk action behavior, and business-specific submit copy.</td></tr>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -32,30 +32,126 @@ async function expectNoDocumentHorizontalOverflow(page) {
 }
 
 const focusedMockupSmokeTargets = [
-  { file: "default-tree.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "resource-table-bridge.html", sample: ".mock-bridge-table tbody tr", minimumCount: 4 },
-  { file: "narrow-sidebar-tree.html", sample: ".mock-narrow-frame", minimumCount: 2 },
-  { file: "current-branch-sidebar.html", sample: ".tree-row.is-selected[aria-current='page']", minimumCount: 1 },
-  { file: "row-status-depth-labels.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
-  { file: "toggle-icon-states.html", sample: ".tree-view-table tbody tr", minimumCount: 7 },
-  { file: "interaction-states.html", sample: ".tree-view-table tbody tr", minimumCount: 5 },
-  { file: "keyboard-focus-states.html", sample: ".focus-sample, .focus-sample--soft", minimumCount: 5 },
-  { file: "lazy-loading-handoff.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "drop-positions.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
-  { file: "persisted-state-boundary.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "turbo-frame-target.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
-  { file: "drag-interactive-controls.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "interactive-marker-behaviors.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "windowed-rendering.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "breadcrumb-paths.html", sample: ".mock-breadcrumb-path", minimumCount: 2 },
-  { file: "filtered-tree-modes.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "path-tree-builder-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "node-presenter-row-partials.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
-  { file: "form-editing-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
-  { file: "toolbar-actions.html", sample: ".mock-toolbar-frame", minimumCount: 3 },
-  { file: "selection-max-count.html", sample: ".mock-limit-state", minimumCount: 3 },
-  { file: "selection-multi-tree-form.html", sample: ".mock-selection-group", minimumCount: 2 },
-  { file: "empty-state.html", sample: "[data-tree-view-empty-state='true']", minimumCount: 2 }
+  {
+    file: "default-tree.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "resource-table-bridge.html",
+    sample: ".mock-bridge-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "narrow-sidebar-tree.html",
+    sample: ".mock-narrow-frame",
+    minimumCount: 2
+  },
+  {
+    file: "current-branch-sidebar.html",
+    sample: ".tree-row.is-selected[aria-current='page']",
+    minimumCount: 1
+  },
+  {
+    file: "row-status-depth-labels.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 3
+  },
+  {
+    file: "toggle-icon-states.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 7
+  },
+  {
+    file: "interaction-states.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 5
+  },
+  {
+    file: "keyboard-focus-states.html",
+    sample: ".focus-sample, .focus-sample--soft",
+    minimumCount: 5
+  },
+  {
+    file: "lazy-loading-handoff.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "drop-positions.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 3
+  },
+  {
+    file: "persisted-state-boundary.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "turbo-frame-target.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 3
+  },
+  {
+    file: "drag-interactive-controls.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "interactive-marker-behaviors.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "windowed-rendering.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "breadcrumb-paths.html",
+    sample: ".mock-breadcrumb-path",
+    minimumCount: 2
+  },
+  {
+    file: "filtered-tree-modes.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "path-tree-builder-rows.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "node-presenter-row-partials.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 3
+  },
+  {
+    file: "form-editing-rows.html",
+    sample: ".tree-view-table tbody tr",
+    minimumCount: 4
+  },
+  {
+    file: "toolbar-actions.html",
+    sample: ".mock-toolbar-frame",
+    minimumCount: 3
+  },
+  {
+    file: "selection-max-count.html",
+    sample: ".mock-limit-state",
+    minimumCount: 3
+  },
+  {
+    file: "selection-multi-tree-form.html",
+    sample: ".mock-selection-group",
+    minimumCount: 2
+  },
+  {
+    file: "empty-state.html",
+    sample: "[data-tree-view-empty-state='true']",
+    minimumCount: 2
+  }
 ]
 
 test.describe("docs mockup browser smoke", () => {

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -17,7 +17,8 @@ function mockupUrl(file) {
 
 function readmeMockupFiles() {
   const readme = readFileSync(mockupsReadmePath, "utf8")
-  const matches = readme.matchAll(/\[[^\]]+\.html\]\(([^)]+\.html)\)/g)
+  const filesTable = readme.split("## Recommended review flow")[0]
+  const matches = filesTable.matchAll(/\[[^\]]+\.html\]\(([^)]+\.html)\)/g)
   return Array.from(new Set(Array.from(matches, (match) => match[1])))
 }
 
@@ -32,126 +33,30 @@ async function expectNoDocumentHorizontalOverflow(page) {
 }
 
 const focusedMockupSmokeTargets = [
-  {
-    file: "default-tree.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "resource-table-bridge.html",
-    sample: ".mock-bridge-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "narrow-sidebar-tree.html",
-    sample: ".mock-narrow-frame",
-    minimumCount: 2
-  },
-  {
-    file: "current-branch-sidebar.html",
-    sample: ".tree-row.is-selected[aria-current='page']",
-    minimumCount: 1
-  },
-  {
-    file: "row-status-depth-labels.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 3
-  },
-  {
-    file: "toggle-icon-states.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 7
-  },
-  {
-    file: "interaction-states.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 5
-  },
-  {
-    file: "keyboard-focus-states.html",
-    sample: ".focus-sample, .focus-sample--soft",
-    minimumCount: 5
-  },
-  {
-    file: "lazy-loading-handoff.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "drop-positions.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 3
-  },
-  {
-    file: "persisted-state-boundary.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "turbo-frame-target.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 3
-  },
-  {
-    file: "drag-interactive-controls.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "interactive-marker-behaviors.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "windowed-rendering.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "breadcrumb-paths.html",
-    sample: ".mock-breadcrumb-path",
-    minimumCount: 2
-  },
-  {
-    file: "filtered-tree-modes.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "path-tree-builder-rows.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "node-presenter-row-partials.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 3
-  },
-  {
-    file: "form-editing-rows.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "toolbar-actions.html",
-    sample: ".mock-toolbar-frame",
-    minimumCount: 3
-  },
-  {
-    file: "selection-max-count.html",
-    sample: ".mock-limit-state",
-    minimumCount: 3
-  },
-  {
-    file: "selection-multi-tree-form.html",
-    sample: ".mock-selection-group",
-    minimumCount: 2
-  },
-  {
-    file: "empty-state.html",
-    sample: "[data-tree-view-empty-state='true']",
-    minimumCount: 2
-  }
+  { file: "default-tree.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "resource-table-bridge.html", sample: ".mock-bridge-table tbody tr", minimumCount: 4 },
+  { file: "narrow-sidebar-tree.html", sample: ".mock-narrow-frame", minimumCount: 2 },
+  { file: "current-branch-sidebar.html", sample: ".tree-row.is-selected[aria-current='page']", minimumCount: 1 },
+  { file: "row-status-depth-labels.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "toggle-icon-states.html", sample: ".tree-view-table tbody tr", minimumCount: 7 },
+  { file: "interaction-states.html", sample: ".tree-view-table tbody tr", minimumCount: 5 },
+  { file: "keyboard-focus-states.html", sample: ".focus-sample, .focus-sample--soft", minimumCount: 5 },
+  { file: "lazy-loading-handoff.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "drop-positions.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "persisted-state-boundary.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "turbo-frame-target.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "drag-interactive-controls.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "interactive-marker-behaviors.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "windowed-rendering.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "breadcrumb-paths.html", sample: ".mock-breadcrumb-path", minimumCount: 2 },
+  { file: "filtered-tree-modes.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "path-tree-builder-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "node-presenter-row-partials.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "form-editing-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "toolbar-actions.html", sample: ".mock-toolbar-frame", minimumCount: 3 },
+  { file: "selection-max-count.html", sample: ".mock-limit-state", minimumCount: 3 },
+  { file: "selection-multi-tree-form.html", sample: ".mock-selection-group", minimumCount: 2 },
+  { file: "empty-state.html", sample: "[data-tree-view-empty-state='true']", minimumCount: 2 }
 ]
 
 test.describe("docs mockup browser smoke", () => {

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -32,121 +32,30 @@ async function expectNoDocumentHorizontalOverflow(page) {
 }
 
 const focusedMockupSmokeTargets = [
-  {
-    file: "default-tree.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "resource-table-bridge.html",
-    sample: ".mock-bridge-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "narrow-sidebar-tree.html",
-    sample: ".mock-narrow-frame",
-    minimumCount: 2
-  },
-  {
-    file: "current-branch-sidebar.html",
-    sample: ".tree-row.is-selected[aria-current='page']",
-    minimumCount: 1
-  },
-  {
-    file: "row-status-depth-labels.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 3
-  },
-  {
-    file: "toggle-icon-states.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 7
-  },
-  {
-    file: "interaction-states.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 5
-  },
-  {
-    file: "keyboard-focus-states.html",
-    sample: ".focus-sample, .focus-sample--soft",
-    minimumCount: 5
-  },
-  {
-    file: "lazy-loading-handoff.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "drop-positions.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 3
-  },
-  {
-    file: "persisted-state-boundary.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "turbo-frame-target.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 3
-  },
-  {
-    file: "drag-interactive-controls.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "interactive-marker-behaviors.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "windowed-rendering.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "breadcrumb-paths.html",
-    sample: ".mock-breadcrumb-path",
-    minimumCount: 2
-  },
-  {
-    file: "filtered-tree-modes.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "path-tree-builder-rows.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "form-editing-rows.html",
-    sample: ".tree-view-table tbody tr",
-    minimumCount: 4
-  },
-  {
-    file: "toolbar-actions.html",
-    sample: ".mock-toolbar-frame",
-    minimumCount: 3
-  },
-  {
-    file: "selection-max-count.html",
-    sample: ".mock-limit-state",
-    minimumCount: 3
-  },
-  {
-    file: "selection-multi-tree-form.html",
-    sample: ".mock-selection-group",
-    minimumCount: 2
-  },
-  {
-    file: "empty-state.html",
-    sample: "[data-tree-view-empty-state='true']",
-    minimumCount: 2
-  }
+  { file: "default-tree.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "resource-table-bridge.html", sample: ".mock-bridge-table tbody tr", minimumCount: 4 },
+  { file: "narrow-sidebar-tree.html", sample: ".mock-narrow-frame", minimumCount: 2 },
+  { file: "current-branch-sidebar.html", sample: ".tree-row.is-selected[aria-current='page']", minimumCount: 1 },
+  { file: "row-status-depth-labels.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "toggle-icon-states.html", sample: ".tree-view-table tbody tr", minimumCount: 7 },
+  { file: "interaction-states.html", sample: ".tree-view-table tbody tr", minimumCount: 5 },
+  { file: "keyboard-focus-states.html", sample: ".focus-sample, .focus-sample--soft", minimumCount: 5 },
+  { file: "lazy-loading-handoff.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "drop-positions.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "persisted-state-boundary.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "turbo-frame-target.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "drag-interactive-controls.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "interactive-marker-behaviors.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "windowed-rendering.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "breadcrumb-paths.html", sample: ".mock-breadcrumb-path", minimumCount: 2 },
+  { file: "filtered-tree-modes.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "path-tree-builder-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "node-presenter-row-partials.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "form-editing-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
+  { file: "toolbar-actions.html", sample: ".mock-toolbar-frame", minimumCount: 3 },
+  { file: "selection-max-count.html", sample: ".mock-limit-state", minimumCount: 3 },
+  { file: "selection-multi-tree-form.html", sample: ".mock-selection-group", minimumCount: 2 },
+  { file: "empty-state.html", sample: "[data-tree-view-empty-state='true']", minimumCount: 2 }
 ]
 
 test.describe("docs mockup browser smoke", () => {
@@ -158,9 +67,11 @@ test.describe("docs mockup browser smoke", () => {
     await expect(page.getByRole("link", { name: "Baseline" })).toHaveAttribute("href", "#gallery-default-heading")
     await expect(page.getByRole("link", { name: "Interaction states" })).toHaveAttribute("href", "#gallery-interaction-heading")
     await expect(page.getByRole("link", { name: "Current branch" })).toHaveAttribute("href", "#gallery-current-branch-heading")
+    await expect(page.getByRole("link", { name: "Presenter row partials" })).toHaveAttribute("href", "#gallery-node-presenter-heading")
     await expect(page.getByRole("link", { name: "Selection form" })).toHaveAttribute("href", "#gallery-selection-form-heading")
     await expect(page.frameLocator("iframe[title='Default tree mock preview']").getByRole("heading", { name: "Default TreeView rendering mock", level: 1 })).toBeVisible()
     await expect(page.frameLocator("iframe[title='Current branch sidebar mock preview']").getByRole("heading", { name: "Current branch sidebar mock", level: 1 })).toBeVisible()
+    await expect(page.frameLocator("iframe[title='NodePresenter row partials mock preview']").getByRole("heading", { name: "NodePresenter row partial mock", level: 1 })).toBeVisible()
     await expect(page.frameLocator("iframe[title='Multi-tree selection form mock preview']").getByRole("heading", { name: "TreeView multi-tree selection form mock", level: 1 })).toBeVisible()
 
     const linkedFiles = await page.locator("a[href]").evaluateAll((anchors) =>
@@ -175,6 +86,7 @@ test.describe("docs mockup browser smoke", () => {
     expect(linkedFiles).toContain("default-tree.html")
     expect(linkedFiles).toContain("interaction-states.html")
     expect(linkedFiles).toContain("current-branch-sidebar.html")
+    expect(linkedFiles).toContain("node-presenter-row-partials.html")
     expect(linkedFiles).toContain("selection-multi-tree-form.html")
     expect(linkedFiles).toContain("empty-state.html")
     expect(missingLinks).toEqual([])


### PR DESCRIPTION
## 対応Issue

- Closes #1030

## 採用した方針

- Planner handoff に沿い、既存 mockup へ section を混ぜず `docs/mockups/node-presenter-row-partials.html` の dedicated page を追加しました。
- runtime Ruby / JavaScript、NodePresenter API、public API manifest、Column / Action DSL には触れず、static HTML の visual reference に閉じています。
- 最初の branch は作業中に `main` が進んだため、この PR は最新 `main` から作り直した v2 branch です。

## 比較した案

- 案A: 既存 `default-tree.html` に section 追加。差分は小さいが、baseline mockup と責務境界の論点が混ざるため不採用。
- 案B: dedicated page を追加。NodePresenter row partial の境界だけを review しやすく、Planner 推奨にも一致するため採用。
- 案C: docs-only で cookbook へ説明追加。visual reference 不足という Issue の主目的に届きにくいため不採用。

## 変更内容

- NodePresenter row partial の focused static mockup を追加しました。
- resolver-provided な label / href / tooltip / badge / icon / optional action と、host-app-owned columns / permissions / business actions を同じ table 上で比較できるようにしました。
- `docs/mockups/README.md` の Files table と recommended review flow に新規 mockup への導線を追加しました。
- `docs/mockups/review-gallery.html` に新規 mockup card / review path / comparison row を追加しました。
- `test/browser/docs_mockups_smoke.spec.js` に新規 mockup の smoke target と gallery preview assertion を追加し、README の Files table だけを target source にするよう調整しました。

## 変更した画面・コンポーネント

- `docs/mockups/node-presenter-row-partials.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- GitHub compare: `main...design/1030-node-presenter-row-partial-mockup-v2`
  - `ahead_by: 6`
  - `behind_by: 0`
  - changed files: 4
- CI #1286: 失敗を確認
  - `spec/mockup_inventory_spec.rb`: README に追加した mockup が gallery iframe inventory に未反映
  - `test/browser/docs_mockups_smoke.spec.js`: focused smoke target 未反映
- 上記に対し、gallery と browser smoke target を追加修正済み
- GitHub Actions CI #1293: success
  - `lint`: success
  - `pr_specs`: success
  - `changes`: success
  - `javascript`: success（`npm run test:js` success、`npm run test:browser` は workflow 条件で skipped）
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
  - `gem_package`: skipped
- local browser: local clone は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行
- UI表示確認: source HTML 上で heading / back-to-gallery link / README link / gallery card / representative section を確認
- レスポンシブ確認: page-local CSS で table overflow と two-column boundary cards の 1-column fallback を追加
- アクセシビリティ確認: semantic headings、table header `scope`, nav `aria-label`, decorative icon `aria-hidden` を確認

## スクリーンショット

<!-- connector-only 実行でブラウザ表示確認は未実施 -->

## リスク

- low

## 補足

- stale な #1038 はこの PR で置き換え、superseded として close 済みです。