### PR TITLE
development docs に npm run test:js を明示する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -28,10 +28,13 @@ Keep using `npm install` for now. The repository has a committed `package-lock.j
 bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
+npm run test:js
 npm test
 npm run test:entrypoints
 npm run test:browser
 ```
+
+Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use the individual npm commands when you are narrowing a failure.
 
 For the Rails version matrix:
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -28,10 +28,13 @@ docker compose run --rm app npm install
 bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
+npm run test:js
 npm test
 npm run test:entrypoints
 npm run test:browser
 ```
+
+CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
 
 Rails version matrixを確認する場合:
 


### PR DESCRIPTION
## 対応 Issue

Closes #1042

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/development.md`
  - Common commands に `npm run test:js` を追加しました。
  - CI の JavaScript lane と同じ entrypoint / unit / browser smoke coverage をまとめて確認する用途を短く追記しました。
- `docs/ja/development.md`
  - 英語版と同じ内容を日本語 docs に同期しました。

## 根拠

- `package.json` の `test:js` は `npm run test:entrypoints && npm test && npm run test:browser` です。
- `.github/workflows/ci.yml` の JavaScript job は通常 PR lane で `npm run test:js` を実行します。
- 既存 development docs の CI policy には `npm run test:js` がある一方、Common commands には載っていませんでした。

## 非目標

- npm scripts の追加・変更
- CI workflow の変更
- lockfile / `npm install` / `npm ci` policy の変更
- JavaScript test suite の拡張

## 確認内容

- GitHub compare: `main...docs/1042-test-js-common-command`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- docs-only のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 実装済み package script と CI policy を Common commands に追記するだけで、コード・CI・lockfile 運用は変更していません。