### PR TITLE
selection multi-tree mockup の hidden input 境界を実装契約に合わせる

### DIFF
--- a/docs/mockups/selection-multi-tree-form.html
+++ b/docs/mockups/selection-multi-tree-form.html
@@ -312,14 +312,18 @@
     <section class="mock-section" aria-labelledby="hidden-sync-heading">
       <div class="mock-selection-hidden-stack">
         <h2 id="hidden-sync-heading">Generated hidden input boundary</h2>
-        <p class="mock-selection-note">These rows are shown as a review aid only. In a real form, generated hidden inputs stay internal and the host app decides how much summary copy to expose.</p>
+        <p class="mock-selection-note">Each row below represents one generated hidden input for one checked payload. Source ids keep each TreeView controller separated; the host app decides how to group submitted values.</p>
         <div class="mock-selection-hidden-row">
-          <strong>Policy source</strong>
-          <span class="mock-selection-code">name="bulk_review[policy_ids]" data-tree-view-selection-source-id="policies" value='["policy-101","policy-122"]'</span>
+          <strong>Policy payload 1 of 2</strong>
+          <span class="mock-selection-code">name="bulk_review[policy_ids][]" data-tree-view-selection-source-id="policies" value='{"id":"policy-101","label":"Operations handbook"}'</span>
         </div>
         <div class="mock-selection-hidden-row">
-          <strong>Asset source</strong>
-          <span class="mock-selection-code">name="bulk_review[asset_ids]" data-tree-view-selection-source-id="assets" value='["asset-folder-204"]'</span>
+          <strong>Policy payload 2 of 2</strong>
+          <span class="mock-selection-code">name="bulk_review[policy_ids][]" data-tree-view-selection-source-id="policies" value='{"id":"policy-122","label":"Escalation matrix"}'</span>
+        </div>
+        <div class="mock-selection-hidden-row">
+          <strong>Asset payload 1 of 1</strong>
+          <span class="mock-selection-code">name="bulk_review[asset_ids][]" data-tree-view-selection-source-id="assets" value='{"id":"asset-folder-204","label":"Launch banners"}'</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 対応Issue

- Closes #1035

## 置き換え元

Supersedes #1044

## 採用した方針

- スケジュール実行のためユーザー選択待ちは挟まず、Planner handoff に沿って static mockup の hidden input 表現だけを修正する低リスク案を採用しました。
- `1 payload = 1 generated hidden input` が読めるようにしつつ、`data-tree-view-selection-source-id="policies"` / `"assets"` による controller ごとの分離は残しています。
- README / review-gallery は既に `selection-multi-tree-form.html` への導線を持ち、今回の変更目的を満たすための追加同期は不要と判断しました。

## 比較した案

- 案A: hidden input boundary section の表示だけを per-payload rows に直す
  - 採用。runtime behavior や docs 構成に触れず、#1035 の誤読リスクだけを下げられます。
- 案B: README / review-gallery の説明もまとめて強める
  - 不採用。既存導線は足りており、mockup の役割説明以上に書くと #1037 の docs track に踏み込みます。
- 案C: selection docs / smoke test まで同時に更新する
  - 不採用。docs track / quality track の #1037 / #1036 に分かれているため、この PR では design slice に閉じました。

## 変更内容

- `docs/mockups/selection-multi-tree-form.html` の `Generated hidden input boundary` を更新しました。
- source ごとの配列値に見えていた例を、policy 2件 / asset 1件の per-payload hidden input rows に変更しました。
- 説明文を、generated hidden input は payload ごとで、source id は controller 分離、submitted values の grouping は host app responsibility であることが分かる文言にしました。

## 変更した画面・コンポーネント

- `docs/mockups/selection-multi-tree-form.html`

## 確認内容

- lint: 未実行
- typecheck: 該当なし
- UI表示確認: GitHub connector で branch 上の hidden input boundary section を確認
- レスポンシブ確認: code text は既存 `.mock-selection-code { overflow-wrap: anywhere; }` のまま維持し、行数追加だけに留めています
- アクセシビリティ確認: 見出し構造、section label、source id text を維持
- GitHub compare: `main...design/1035-selection-hidden-input-boundary`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1

## スクリーンショット

<!-- connector-only 実行のため未添付 -->

## リスク

- low
- static mockup の表示修正のみです。runtime JavaScript、Ruby helper、public API manifest、hidden input sync behavior、selection params parser、bulk action toolbar、server-side grouping policy は変更していません。

## 補足

- local clone / browser smoke は、この環境では GitHub HTTPS remote が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR 作成後に GitHub Actions を確認します。