### PR TITLE
root docs index に主要機能 guide の入口を補う

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,12 @@
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
+- [English Selection](en/selection.md): checkbox selection hooks, disabled state, cascade behavior, and submitted value parsing.
+- [日本語Selection](ja/selection.md): checkbox selection hooks、disabled state、cascade、submitted value parsing の入口。
+- [English Lazy Loading](en/lazy-loading.md): load children on demand through host-app routes and TreeView remote-state hooks.
+- [日本語Lazy Loading](ja/lazy-loading.md): host app の route と TreeView remote-state hooks で子nodeを必要時に読み込む入口。
+- [English Windowed Rendering](en/windowed-rendering.md): render visible rows by offset and limit while host apps keep query and paging ownership.
+- [日本語Windowed Rendering](ja/windowed-rendering.md): offset / limit で visible rows を描画し、query や paging は host app が所有する前提の入口。
 - [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure and interaction states. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
 - [English demo application boundary](en/demo-application-boundary.md): decide when to use static mockups versus a real Rails demo app, without adding private or unavailable demo links.
 - [日本語Demo application boundary](ja/demo-application-boundary.md): static mockup と real Rails demo app の役割分担、未公開 demo link を増やさない方針。


### PR DESCRIPTION
## 対応 Issue

Closes #1048

## 判定分類

- `docs-sync`
- `docs-missing`

## 変更内容

- `docs/README.md` の Recommended entry points に英日ペアで以下の導線を追加しました。
  - Selection
  - Lazy Loading
  - Windowed Rendering

## 根拠

- root `README.md` の Features は checkbox selection、lazy-loading hooks、RenderWindow / windowed rendering を主要機能として列挙しています。
- `docs/en/README.md` / `docs/ja/README.md` は各 guide を user-facing docs map に持っています。
- root docs index の Recommended entry points には、これら主要 guide への直接リンクがありませんでした。

## 非目標

- feature docs 本文の改稿
- runtime code / API / mockups の変更
- docs 情報設計全体の再構成

## 確認内容

- GitHub compare: `main...docs/1048-root-docs-feature-entrypoints`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 docs file
- docs-only のリンク導線追加のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 既存 docs への導線追加のみで、仕様・実装・public API は変更していません。