### PR TITLE
event detail keys を entrypoint smoke で検証する

### DIFF
--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -49,6 +49,36 @@ function assertFrozenObject(value, name, { deep = false } = {}) {
   })
 }
 
+function assertUniqueStringList(values, name) {
+  assert(Array.isArray(values), `${name} must be an array`)
+  assert(values.length > 0, `${name} must not be empty`)
+
+  const seenValues = new Set()
+
+  values.forEach((value) => {
+    assert(typeof value === "string" && value.length > 0, `${name} contains a non-string detail key`)
+    assert(!seenValues.has(value), `${name} contains duplicate detail key: ${value}`)
+    seenValues.add(value)
+  })
+}
+
+function assertEventDetailKeysMatchEventNames(eventNames, eventDetailKeysManifest) {
+  const eventDetailKeys = deepCamelizeKeys(eventDetailKeysManifest)
+
+  Object.entries(eventDetailKeys).forEach(([group, events]) => {
+    assert(group in eventNames, `event_detail_keys.${group} does not match an exported event group`)
+    assert(events && typeof events === "object" && !Array.isArray(events), `event_detail_keys.${group} must be an object`)
+
+    Object.entries(events).forEach(([eventKey, detailKeys]) => {
+      assert(
+        eventKey in eventNames[group],
+        `event_detail_keys.${group}.${eventKey} does not match an exported event name`
+      )
+      assertUniqueStringList(detailKeys, `event_detail_keys.${group}.${eventKey}`)
+    })
+  })
+}
+
 const javascriptPackageManifest = loadJavascriptPackageManifest()
 const entrypointModule = await import(new URL("../app/javascript/tree_view/index.js", import.meta.url).href)
 
@@ -100,6 +130,7 @@ assert(
   "TreeViewEventNames export is out of sync"
 )
 assertFrozenObject(entrypointModule.TreeViewEventNames, "TreeViewEventNames", { deep: true })
+assertEventDetailKeysMatchEventNames(entrypointModule.TreeViewEventNames, javascriptPackageManifest.event_detail_keys)
 
 const expectedTransferDropPositions = javascriptPackageManifest.transfer_drop_positions
 assert(


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1047

## Issue ごとの完了内容

- #1047
  - `script/test_entrypoints.mjs` に `javascript_package_root.event_detail_keys` の軽量検証を追加しました。
  - detail key の group / event が exported `TreeViewEventNames` と対応していること、detail key list が空でない string list であること、重複がないことを確認します。
  - controller dispatch source の詳細検証は既存 RSpec compatibility spec の責務として残しました。

## 変更内容

- `assertUniqueStringList` を追加し、manifest detail key list の空配列・非文字列・重複を検出します。
- `assertEventDetailKeysMatchEventNames` を追加し、`event_detail_keys` の group / event key を `TreeViewEventNames` と照合します。
- 既存の event name export sync 確認の直後に detail key manifest shape check を呼び出します。

## 改善カテゴリ

- test
- devops / lightweight smoke

## 既存仕様への影響

- 既存仕様への影響はありません。
- JavaScript event contract、event detail payload、controller runtime behavior、manifest schema、public API は変更していません。
- source parsing や dispatch detail の正確性チェックには広げていません。

## 実施した確認内容

- GitHub compare: `main...quality/1047-event-detail-entrypoint-smoke`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_entrypoints.mjs`)
- local `npm run test:entrypoints` / RSpec は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- entrypoint smoke の additive guard のみで、runtime と公開契約は変更していません。