### PR TITLE
Toolbar helper docs に label resolution を同期する

### DIFF
--- a/docs/en/toolbar.md
+++ b/docs/en/toolbar.md
@@ -51,6 +51,27 @@ For a static comparison of expand-all, collapse-all, and current-path-preserving
 
 Use that mockup as a visual companion to this helper boundary: it highlights action affordances and the `:current_path` contract without defining routes, authorization copy, or Turbo response behavior.
 
+## Label resolution
+
+`tree_view_toolbar`, `tree_view_toolbar_actions`, and `tree_view_toolbar_action_metadata` resolve action labels in this order:
+
+1. An explicit `labels:` entry for the action, such as `{ expand_all: "Open all" }`.
+2. The current locale's `tree_view.toolbar.labels.*` translation.
+3. TreeView's built-in English fallback label.
+
+Supported translation keys are:
+
+```yml
+tree_view:
+  toolbar:
+    labels:
+      expand_all: "Expand all"
+      collapse_all: "Collapse all"
+      collapse_all_except_current_path: "Collapse all except current path"
+```
+
+Use locale files for the host app's usual toolbar wording. Use `labels:` only for screen-specific copy that should override the locale default. TreeView provides the keys and fallback labels; the host app still owns final wording, locale-file policy, and any product-specific terminology.
+
 ## Custom labels, classes, and attributes
 
 ```erb
@@ -92,5 +113,6 @@ Host apps own:
 - authorization
 - persistence of expanded keys
 - semantics of `:current_path`
+- final labels, locale files, and screen-specific wording passed through `labels:`
 - analytics, test hooks, and screen-specific attributes passed through `html:` or `action_html:`
 - visual styling beyond default class names

--- a/docs/ja/toolbar.md
+++ b/docs/ja/toolbar.md
@@ -51,6 +51,27 @@ expand-all、collapse-all、current path を残す toolbar state を静的に見
 
 この mockup は、この helper の責務境界を視覚的に補うためのものです。action の見え方と `:current_path` contract を確認できますが、route、authorization copy、Turbo response behavior 自体を定義するものではありません。
 
+## label resolution
+
+`tree_view_toolbar`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` は、action label を次の順で解決します。
+
+1. `labels:` に渡した action 別の明示 override。例: `{ expand_all: "Open all" }`
+2. current locale の `tree_view.toolbar.labels.*` translation
+3. TreeView に組み込まれている英語 fallback label
+
+対応する translation key は以下です。
+
+```yml
+tree_view:
+  toolbar:
+    labels:
+      expand_all: "Expand all"
+      collapse_all: "Collapse all"
+      collapse_all_except_current_path: "Collapse all except current path"
+```
+
+host app の通常の toolbar 文言は locale file で管理してください。`labels:` は画面固有の文言で locale default を上書きしたい場合だけ使います。TreeView は key と fallback label を提供しますが、最終文言、locale file policy、product-specific terminology は host app 側の責務です。
+
 ## label、class、attribute の変更
 
 ```erb
@@ -92,5 +113,6 @@ host appは以下を担当します。
 - authorization
 - expanded keys の保存
 - `:current_path` の意味づけ
+- final label、locale file、`labels:` で渡す screen-specific wording
 - `html:` / `action_html:` で渡す analytics、test hook、screen-specific attribute
 - default class names 以上の見た目調整


### PR DESCRIPTION
## 対応 Issue

Closes #1059

## 判定分類

- `docs-sync`
- `docs-missing`

## 変更内容

- `docs/en/toolbar.md` / `docs/ja/toolbar.md` に toolbar action label resolution を追加しました。
- `labels:` 明示 override、`tree_view.toolbar.labels.*` translation、built-in English fallback の優先順を明記しました。
- supported translation keys と、final wording / locale-file policy / product-specific terminology は host app が所有する責務境界を追記しました。
- responsibility boundary に label / locale file ownership を追加しました。

## 非目標

- runtime Ruby helper behavior の変更
- toolbar markup / CSS / JavaScript の変更
- default locale YAML の追加
- new toolbar action の追加
- host app の最終文言や translation strategy の決定

## 確認内容

- `app/helpers/tree_view_helper/toolbar.rb` の `tree_view_toolbar_default_label` と `labels:` override behavior を確認
- `spec/helpers/tree_view_toolbar_helper_spec.rb` の translation / explicit override / fallback spec を確認
- `docs/en/usage.md` / `docs/ja/usage.md` の existing guidance と矛盾しないことを確認
- GitHub compare: `main...docs/1059-toolbar-i18n-labels`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- docs-only のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 実装済み helper behavior と usage docs の説明を専用 toolbar docs に同期するだけで、仕様追加やコード変更はしていません。