### PR TITLE
toolbar action の long/localized label 導線を README に同期する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -33,7 +33,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [selection-max-count.html](selection-max-count.html) | Focused selection max-count reference showing below-limit, limit-reached, and limit-exceeded feedback while keeping final action copy host-app owned. |
 | [selection-multi-tree-form.html](selection-multi-tree-form.html) | Focused multi-tree selection form reference showing source-specific selected counts, submit summary, empty state, and generated hidden input boundary. |
-| [toolbar-actions.html](toolbar-actions.html) | Expand-all, collapse-all, and collapse-to-current-path toolbar reference showing enabled, disabled, and current-state variants without host-app routes or authorization copy. |
+| [toolbar-actions.html](toolbar-actions.html) | Expand-all, collapse-all, and collapse-to-current-path toolbar reference showing enabled, disabled, current-state, and long/localized label variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
 
@@ -64,7 +64,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
 24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
 25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, or collapse-to-current-path affordances instead of row-by-row hierarchy layout.
+26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
 27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
@@ -75,6 +75,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 ## Copy and language policy
 
 - Mockups use short, product-neutral English copy so reviewers can compare layout and state cues without language changes becoming visual noise.
+- `toolbar-actions.html` intentionally includes a narrow long/localized label stress case so reviewers can inspect wrapping and disabled/current cues without choosing final translations.
 - Final labels, localization, permission messaging, and business wording remain host-app responsibilities.
 - If a future mockup intentionally uses another language, document that exception here so reviewers know it is deliberate.
 


### PR DESCRIPTION
## 対応Issue

- Closes #1061

## 採用した方針

- Planner handoff に沿い、`toolbar-actions.html` 本体は既存の `Long and localized labels` section を維持しました。
- 実装は README の導線・説明だけに閉じ、reviewer が long/localized label stress case を Files table / review flow / language policy から見つけられるようにしました。
- scheduled run のためユーザー選択待ちは挟まず、最も低リスクで既存 mockup に沿う docs-only 案を採用しました。

## 比較した案

- 案A: `toolbar-actions.html` 本体を作り直す
  - 既に main 上で long/localized label section が存在するため、不要な visual churn になるリスクが高いです。
- 案B: README と gallery の両方を同期する
  - 導線は最も厚くなりますが、`review-gallery.html` は長い単一行 card が多く、今回の完了条件には README から辿れることでも届きます。
- 案C: README の Files / review flow / Copy policy だけを同期する
  - 今回採用。既存 mockup section を壊さず、非 English copy の例外説明も明示できます。

## 変更内容

- `docs/mockups/README.md` の `toolbar-actions.html` 説明に long/localized label variants を追加しました。
- Recommended review flow の toolbar action 項目に long/localized label wrapping affordance を追加しました。
- Copy and language policy に、`toolbar-actions.html` だけが意図的に long/localized label stress case を持つことを追記しました。

## 変更した画面・コンポーネント

- `docs/mockups/README.md`
- verify only: `docs/mockups/toolbar-actions.html` の既存 `Long and localized labels` section

## 確認内容

- lint: 未実行（docs-only / connector 経由）
- typecheck: 該当なし
- UI表示確認: `toolbar-actions.html` に既存の `Long and localized labels` section があることを source 確認
- レスポンシブ確認: README 文言のみのため対象外
- アクセシビリティ確認: README 文言のみのため対象外
- GitHub compare: `main...design/1061-toolbar-label-review-guidance`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1

## スクリーンショット

<!-- README-only change のため未添付 -->

## リスク

- low

## 補足

- `review-gallery.html` は今回は未変更です。README から stress case を見つけられるようにする最小 slice とし、gallery の長い単一行 card/table へ不要な churn を入れませんでした。