### PR TITLE
JS event docs と manifest の同期ガードを追加する

### DIFF
--- a/docs/en/js-events.md
+++ b/docs/en/js-events.md
@@ -81,6 +81,14 @@ Dispatched when retry is requested for a remote row.
 
 `event.detail` contains `row`, `childrenUrl`, and `nodeKey`.
 
+## Host lifecycle events
+
+### `tree-view:loading` / `tree-view:loaded` / `tree-view:error` / `tree-view:retry`
+
+Host apps may dispatch these lifecycle events on a lazy-loading TreeView row so the remote-state controller can mark that row as loading, loaded, error, or retrying.
+
+These events do not define public `event.detail` fields in the manifest. Put row-specific remote-state data on the row attributes documented for lazy loading instead of relying on payload fields.
+
 ## Transfer events
 
 ### `tree-view-transfer:drag-start`
@@ -111,6 +119,10 @@ Dispatched when a payload is dropped on a target row.
 ### `tree-view-transfer:invalid-payload` / `tree-view-transfer:invalid-transfer`
 
 Dispatched when row payload JSON or transferred JSON cannot be parsed.
+
+`tree-view-transfer:invalid-payload` detail contains `value` and `row`.
+
+`tree-view-transfer:invalid-transfer` detail contains `value`.
 
 ## Compatibility policy
 

--- a/docs/ja/js-events.md
+++ b/docs/ja/js-events.md
@@ -81,6 +81,14 @@ remote row のretryが要求されたときに発火します。
 
 `event.detail` は `row`, `childrenUrl`, `nodeKey` を含みます。
 
+## Host lifecycle events
+
+### `tree-view:loading` / `tree-view:loaded` / `tree-view:error` / `tree-view:retry`
+
+host app は、lazy-loading TreeView row 上でこれらの lifecycle event を発火し、remote-state controller にその row を loading、loaded、error、retrying として扱わせることができます。
+
+これらの event は、manifest 上で公開 `event.detail` field を定義していません。payload field に依存せず、lazy loading docs で案内している row attribute に remote-state data を置いてください。
+
 ## Transfer events
 
 ### `tree-view-transfer:drag-start`
@@ -111,6 +119,10 @@ payloadがtarget rowにdropされたときに発火します。
 ### `tree-view-transfer:invalid-payload` / `tree-view-transfer:invalid-transfer`
 
 row payload JSON または transferred JSON をparseできないときに発火します。
+
+`tree-view-transfer:invalid-payload` の detail は `value` と `row` を含みます。
+
+`tree-view-transfer:invalid-transfer` の detail は `value` を含みます。
 
 ## 互換性方針
 

--- a/spec/public_api_event_docs_compatibility_spec.rb
+++ b/spec/public_api_event_docs_compatibility_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "JavaScript event docs compatibility" do
+  PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+  JAVASCRIPT_EVENT_DOC_PATHS = {
+    "English docs" => File.expand_path("../docs/en/js-events.md", __dir__),
+    "Japanese docs" => File.expand_path("../docs/ja/js-events.md", __dir__)
+  }.freeze
+
+  def public_api_manifest
+    @public_api_manifest ||= YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH)
+  end
+
+  def public_javascript_manifest
+    public_api_manifest.fetch("javascript_package_root")
+  end
+
+  def public_javascript_event_names
+    public_javascript_manifest.fetch("event_names")
+  end
+
+  def public_javascript_event_detail_keys
+    public_javascript_manifest.fetch("event_detail_keys")
+  end
+
+  def javascript_event_docs
+    @javascript_event_docs ||= JAVASCRIPT_EVENT_DOC_PATHS.transform_values { |path| File.read(path) }
+  end
+
+  def event_section(source, event_name)
+    lines = source.lines
+    start_index = lines.index { |line| line.start_with?("### ") && line.include?("`#{event_name}`") }
+
+    return nil unless start_index
+
+    next_heading_offset = lines[(start_index + 1)..].index do |line|
+      line.start_with?("### ") || line.start_with?("## ")
+    end
+    end_index = next_heading_offset ? start_index + 1 + next_heading_offset : lines.length
+
+    lines[start_index...end_index].join
+  end
+
+  it "keeps manifest JavaScript event names documented in both event docs" do
+    public_javascript_event_names.each do |group_name, events|
+      events.each_value do |event_name|
+        javascript_event_docs.each do |doc_label, source|
+          expect(event_section(source, event_name)).not_to be_nil,
+            "expected #{doc_label} to document #{event_name} from the #{group_name} event manifest"
+        end
+      end
+    end
+  end
+
+  it "keeps manifest JavaScript event detail keys documented near their events" do
+    public_javascript_event_detail_keys.each do |group_name, events|
+      events.each do |event_key, detail_keys|
+        event_name = public_javascript_event_names.fetch(group_name).fetch(event_key)
+
+        javascript_event_docs.each do |doc_label, source|
+          section = event_section(source, event_name)
+
+          expect(section).not_to be_nil,
+            "expected #{doc_label} to document #{event_name} before checking detail keys"
+
+          detail_keys.each do |detail_key|
+            expect(section).to include("`#{detail_key}`"),
+              "expected #{doc_label} to document #{detail_key} near #{event_name}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/public_api_event_docs_compatibility_spec.rb
+++ b/spec/public_api_event_docs_compatibility_spec.rb
@@ -3,15 +3,15 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "JavaScript event docs compatibility" do
-  PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
-  JAVASCRIPT_EVENT_DOC_PATHS = {
-    "English docs" => File.expand_path("../docs/en/js-events.md", __dir__),
-    "Japanese docs" => File.expand_path("../docs/ja/js-events.md", __dir__)
-  }.freeze
+PUBLIC_API_EVENT_DOCS_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+JAVASCRIPT_EVENT_DOC_PATHS = {
+  "English docs" => File.expand_path("../docs/en/js-events.md", __dir__),
+  "Japanese docs" => File.expand_path("../docs/ja/js-events.md", __dir__)
+}.freeze
 
+RSpec.describe "JavaScript event docs compatibility" do
   def public_api_manifest
-    @public_api_manifest ||= YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH)
+    @public_api_manifest ||= YAML.safe_load_file(PUBLIC_API_EVENT_DOCS_MANIFEST_PATH)
   end
 
   def public_javascript_manifest
@@ -37,7 +37,7 @@ RSpec.describe "JavaScript event docs compatibility" do
     return nil unless start_index
 
     next_heading_offset = lines[(start_index + 1)..].index do |line|
-      line.start_with?("### ") || line.start_with?("## ")
+      line.start_with?("### ", "## ")
     end
     end_index = next_heading_offset ? start_index + 1 + next_heading_offset : lines.length
 


### PR DESCRIPTION
## 対応 Issue

Closes #1056

## Issue ごとの完了内容

- #1056
  - `config/public_api_manifest.yml` の public JavaScript event names が英日 `docs/*/js-events.md` から辿れることを確認する RSpec guard を追加しました。
  - manifest の `event_detail_keys` が、対応 event section の近くに backtick token として文書化されていることを確認する guard を追加しました。
  - guard が通るよう、manifest にある host lifecycle event names と transfer invalid event detail keys を英日 docs に最小限同期しました。

## 変更内容

- `spec/public_api_event_docs_compatibility_spec.rb` を追加
  - manifest / 英日 docs を読み、event name と detail key の docs drift を検出します。
  - event section heading と code token に絞って確認し、翻訳文や prose 全体は固定していません。
- `docs/en/js-events.md` / `docs/ja/js-events.md` を更新
  - `tree-view:loading` / `tree-view:loaded` / `tree-view:error` / `tree-view:retry` の host lifecycle event section を追加しました。
  - `tree-view-transfer:invalid-payload` / `tree-view-transfer:invalid-transfer` の representative detail keys を明記しました。

## 改善カテゴリ

- test
- docs-sync
- public API contract guard

## 既存仕様への影響

- runtime Ruby / JavaScript behavior は変更していません。
- event name、event detail shape、manifest schema、controller implementation は変更していません。
- docs と spec による同期確認のみです。

## 実施した確認

- GitHub compare: `main...quality/1056-js-event-docs-manifest-guard`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 3
- GitHub Actions CI `#1314`: success
  - `lint`: success
  - `pr_specs`: success
  - `changes`: success
  - `javascript`: success
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
  - `gem_package`: skipped
- 初回 CI `#1313` は新規 spec の StandardRB 指摘で lint failed でした。最終 head `930be897b4de11e105c1855c51a9bf52d0685934` では修正済みです。
- ローカル RSpec は未実行です。
  - この実行環境では Ruby がありません。
  - GitHub HTTPS clone/fetch も `CONNECT tunnel failed, response 403` のため、connector 経由で変更しています。

## リスク評価

- low
- 既存 public event contract を変えず、manifest と docs の drift guard を追加するだけです。

## 補足事項

- Planner handoff では既存 compatibility spec への追加が推奨されていましたが、既存 source-code compatibility spec と docs drift guard の責務を分け、同じ RSpec 導線に乗る新規 focused spec としました。