### PR TITLE
breadcrumb helper option keys を public manifest に追加する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -43,6 +43,24 @@ helper_methods:
   - tree_view_toolbar_supported_actions
   - tree_view_toolbar_actions
   - tree_view_toolbar_action_metadata
+helper_option_keys:
+  tree_view_breadcrumb:
+    - label_builder
+    - path_builder
+    - separator
+    - nav_class
+    - list_class
+    - item_class
+    - link_class
+    - current_class
+    - separator_class
+    - aria_label
+    - html
+    - list_html
+    - item_html
+    - link_html
+    - current_html
+    - separator_html
 toolbar_actions:
   expand_all: expanded
   collapse_all: collapsed

--- a/docs/en/breadcrumb.md
+++ b/docs/en/breadcrumb.md
@@ -99,6 +99,8 @@ For markup changes that need custom wrappers, conditional authorization copy, or
 | `separator:` | Separator between items. |
 | `aria_label:` | Accessible label for the breadcrumb `<nav>` element. |
 
+The option names in this table are also listed in `config/public_api_manifest.yml` under `helper_option_keys.tree_view_breadcrumb`. That manifest-backed list is a compatibility contract for the existing helper option surface; it does not add markup, route, or authorization behavior.
+
 ## Supported mode
 
 The breadcrumb helper expects a records-mode tree.

--- a/docs/ja/breadcrumb.md
+++ b/docs/ja/breadcrumb.md
@@ -99,6 +99,8 @@ TreeView は、これらの属性をbuilt-in classやaccessibility属性とmerge
 | `separator:` | item間のseparator。 |
 | `aria_label:` | breadcrumb の `<nav>` 要素に付与するaccessible label。 |
 
+この表の option 名は、`config/public_api_manifest.yml` の `helper_option_keys.tree_view_breadcrumb` にも載っています。この manifest-backed list は既存 helper option surface の互換性 contract であり、markup、route、authorization behavior を追加するものではありません。
+
 ## 対応mode
 
 breadcrumb helper は records mode のtreeを前提にします。

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -24,9 +24,14 @@ RENDER_STATE_GROUPED_OPTION_KEY_RESOLVERS = {
 RSpec.describe "Public API compatibility" do
   def public_api_manifest
     # The machine-readable manifest covers Ruby/module/helper entrypoints,
-    # grouped option keys, package-root exports, and required JavaScript event
-    # detail keys. Broader behavior and docs sync stay explicit here.
+    # helper option keys, grouped option keys, package-root exports, and
+    # required JavaScript event detail keys. Broader behavior and docs sync stay
+    # explicit here.
     @public_api_manifest ||= YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH)
+  end
+
+  def public_helper_option_keys
+    public_api_manifest.fetch("helper_option_keys")
   end
 
   def public_javascript_manifest
@@ -48,6 +53,12 @@ RSpec.describe "Public API compatibility" do
   def javascript_controller_source(group_name)
     @javascript_controller_sources ||= {}
     @javascript_controller_sources[group_name] ||= File.read(JAVASCRIPT_CONTROLLER_PATHS.fetch(group_name))
+  end
+
+  def breadcrumb_helper_keyword_option_keys
+    TreeViewBreadcrumbHelper.instance_method(:tree_view_breadcrumb).parameters.filter_map do |parameter_type, parameter_name|
+      parameter_name.to_s if %i[key keyreq].include?(parameter_type)
+    end
   end
 
   def camelize_manifest_key(value)
@@ -233,6 +244,13 @@ RSpec.describe "Public API compatibility" do
     public_api_manifest.fetch("helper_methods").each do |method_name|
       expect(TreeViewHelper.public_instance_methods).to include(method_name.to_sym), "expected TreeViewHelper##{method_name} to remain public"
     end
+  end
+
+  it "keeps breadcrumb helper option keys aligned with the public helper signature" do
+    manifest_keys = public_helper_option_keys.fetch("tree_view_breadcrumb")
+
+    expect(manifest_keys).to eq(breadcrumb_helper_keyword_option_keys),
+      "expected tree_view_breadcrumb option keys to stay aligned with the public keyword signature"
   end
 
   it "keeps documented lazy-loading helper behavior available through TreeViewHelper" do


### PR DESCRIPTION
breadcrumb helper の既存 keyword option surface を machine-readable manifest と compatibility spec で固定します。

## 対応 Issue

Closes #1070

## 変更内容

- `config/public_api_manifest.yml` に `helper_option_keys.tree_view_breadcrumb` を追加し、現行 `tree_view_breadcrumb` の keyword option keys を列挙しました。
- `spec/public_api_compatibility_spec.rb` に、manifest の breadcrumb option list が `TreeViewBreadcrumbHelper#tree_view_breadcrumb` の public keyword signature と一致することを確認する guard を追加しました。
- `docs/en/breadcrumb.md` / `docs/ja/breadcrumb.md` に、Builders table の option 名が manifest-backed compatibility contract であることを短く追記しました。

## 受け入れ条件との対応

- manifest に `tree_view_breadcrumb` の既存 option keys を machine-readable に載せました。
- compatibility spec が helper signature と manifest list の drift を検出できます。
- 英日 breadcrumb docs の option table と manifest の責務を同期しました。
- helper behavior、breadcrumb markup、ARIA、route handling、authorization policy は変更していません。

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_api_compatibility_spec.rb`
- `docs/en/breadcrumb.md`
- `docs/ja/breadcrumb.md`

## 実施した確認

- GitHub compare: `main...feature/1070-breadcrumb-option-manifest`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- ローカル RSpec / lint は未実行です。
  - この実行環境では Ruby がありません。
  - GitHub HTTPS clone/fetch も `CONNECT tunnel failed, response 403` のため、connector 経由で変更しています。
- PR 作成後の GitHub Actions で `spec/public_api_compatibility_spec.rb` を含む CI を確認します。

## リスク

- medium
- public helper option surface を manifest-backed compatibility contract として明示します。既存 signature と docs の同期だけに閉じ、option の追加・rename・削除はしていません。

## 未対応・補足

- `docs/en/api.md` / `docs/ja/api.md` は helper entry と breadcrumb guide の責務分担が現状で十分なため変更していません。
- NodePresenter / toolbar helper contract、manifest schema 全体の再設計には広げていません。