### PR TITLE
design: high contrast mockup を通常 smoke 導線に含める

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -19,6 +19,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [toggle-icon-states.html](toggle-icon-states.html) | Focused comparison for expanded, collapsed, leaf, loading, and depth/type-based toggle icon states without choosing a host-app icon library. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [keyboard-focus-states.html](keyboard-focus-states.html) | Focused keyboard reference showing static focus-visible samples for toggle links, native controls, toolbar actions, and row actions without promising a full keyboard model. |
+| [high-contrast-state-cues/index.html](high-contrast-state-cues/index.html) | Focused high-contrast reference for current, selected, focus-visible, error/retry, and drop-target cues that remain distinguishable beyond color alone. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
 | [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus transfer disabled / invalid payload boundary states. |
 | [persisted-state-boundary.html](persisted-state-boundary.html) | Focused persisted-state reference showing before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned. |

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -15,6 +15,11 @@ function mockupUrl(file) {
   return pathToFileURL(mockupPath(file)).toString()
 }
 
+function galleryReturnHref(file) {
+  const relativePath = path.posix.relative(path.posix.dirname(file), "review-gallery.html")
+  return relativePath || "review-gallery.html"
+}
+
 function readmeMockupFiles() {
   const readme = readFileSync(mockupsReadmePath, "utf8")
   const filesTable = readme.split("## Recommended review flow")[0]
@@ -41,6 +46,7 @@ const focusedMockupSmokeTargets = [
   { file: "toggle-icon-states.html", sample: ".tree-view-table tbody tr", minimumCount: 7 },
   { file: "interaction-states.html", sample: ".tree-view-table tbody tr", minimumCount: 5 },
   { file: "keyboard-focus-states.html", sample: ".focus-sample, .focus-sample--soft", minimumCount: 5 },
+  { file: "high-contrast-state-cues/index.html", sample: "[data-tree-view-sample='high-contrast-state-cues']", minimumCount: 1 },
   { file: "lazy-loading-handoff.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
   { file: "drop-positions.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
   { file: "persisted-state-boundary.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
@@ -105,7 +111,7 @@ test.describe("docs mockup browser smoke", () => {
       await openMockup(page, mockup.file)
 
       await expect(page.locator("h1").first()).toBeVisible()
-      await expect(page.locator("a[href='review-gallery.html']").first()).toBeVisible()
+      await expect(page.locator(`a[href='${galleryReturnHref(mockup.file)}']`).first()).toBeVisible()
       expect(await page.locator(mockup.sample).count()).toBeGreaterThanOrEqual(mockup.minimumCount)
     })
   }


### PR DESCRIPTION
## 対応Issue

- Closes #1025

## 採用した方針

- スケジュール実行のため、既存 high-contrast mockup 本体や review gallery の構成は変更せず、通常 inventory と browser smoke へ含める low-risk 案を採用しました。
- `docs/mockups/README.md` の Files table と `focusedMockupSmokeTargets` を同期し、subdirectory mockup でも戻りリンクを検証できるようにしています。
- 初回PR #1078 作成直前に `main` が進んだため、最新 `main` からこの replacement branch を作り直しました。進んだ差分は spec-only で、今回の README / browser smoke 変更とは重なっていません。

## 比較した案

- 案A: README Files table と browser smoke target にだけ追加する。
- 案B: review gallery に新しい card / iframe も追加する。
- 案C: high-contrast page の visual treatment や forced-colors sample も調整する。
- 今回は案Aを採用しました。既存 page は既に representative sample / gallery return link を持っており、Issue の主題である通常導線と smoke coverage を最小差分で満たせるためです。

## 変更内容

- `docs/mockups/README.md`
  - Files table に `high-contrast-state-cues/index.html` を通常 mockup として追加しました。
- `test/browser/docs_mockups_smoke.spec.js`
  - `focusedMockupSmokeTargets` に `high-contrast-state-cues/index.html` を追加しました。
  - subdirectory mockup の back-to-gallery link が `../review-gallery.html` になるよう、戻りリンク期待値を file path から計算する helper を追加しました。

## 変更した画面・コンポーネント

- docs mockup inventory
- browser smoke test for docs mockups

## 確認内容

- lint: 未実施
- typecheck: 未実施
- UI表示確認: high-contrast mockup 本体は未変更。README inventory と smoke target の差分を確認
- レスポンシブ確認: UI本体の CSS / HTML は未変更
- アクセシビリティ確認: smoke が `h1`、gallery return link、`data-tree-view-sample="high-contrast-state-cues"` を確認する形に更新

## スクリーンショット

<!-- UI変更がある場合は添付 -->
未取得（既存 mockup 本体は変更していません）

## リスク

- low
- runtime Ruby / JavaScript behavior、public API、State cue CSS、forced-colors theme、screenshot baseline は変更していません。

## 補足

- GitHub compare: `main...design/1025-high-contrast-mockup-smoke-current`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` のため、ローカル `npm run test:browser` は未実施です。PR作成後に GitHub Actions の結果を確認します。