### PR TITLE
public_constants と API reference の同期ガードを追加する

### DIFF
--- a/spec/public_api_reference_coverage_spec.rb
+++ b/spec/public_api_reference_coverage_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Public API reference coverage" do
         signals = public_constant_reference_signals(constant_name)
 
         expect(signals.any? { |signal| source.include?(signal) }).to be(true),
-          "expected #{locale} API reference to mention #{constant_name} using one of: #{signals.join(', ')}"
+          "expected #{locale} API reference to mention #{constant_name} using one of: #{signals.join(", ")}"
       end
     end
   end

--- a/spec/public_api_reference_coverage_spec.rb
+++ b/spec/public_api_reference_coverage_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+PUBLIC_API_REFERENCE_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+PUBLIC_API_REFERENCE_DOC_PATHS = {
+  "English" => File.expand_path("../docs/en/api.md", __dir__),
+  "Japanese" => File.expand_path("../docs/ja/api.md", __dir__)
+}.freeze
+
+# Some public constants are intentionally documented through stable API-reference
+# section names or linked guide labels instead of the literal Ruby constant token.
+PUBLIC_API_REFERENCE_SIGNAL_OVERRIDES = {
+  "LocalizedNames" => ["TreeView localized names", "Localized names"],
+  "GraphAdapter" => ["TreeView::GraphAdapter", "adapter mode"],
+  "NodePresenter" => ["NodePresenter"],
+  "PathTree" => ["TreeView::PathTree", "path_tree_for(items)", "PathTree"],
+  "ReverseTree" => ["ReverseTree", "reverse_tree_for(items)"],
+  "Diagnostics" => ["Tree diagnostics"]
+}.freeze
+
+# Keep omissions narrow and named so a future API-reference section can remove the
+# exception instead of silently letting manifest/docs drift grow.
+PUBLIC_API_REFERENCE_OMISSIONS = {
+  "ResourceTableRenderState" => "Resource-table integration is documented in focused resource-table guides; api.md does not yet expose a dedicated Ruby API section for this state object."
+}.freeze
+
+RSpec.describe "Public API reference coverage" do
+  def public_api_reference_manifest
+    @public_api_reference_manifest ||= YAML.safe_load_file(PUBLIC_API_REFERENCE_MANIFEST_PATH)
+  end
+
+  def public_api_reference_docs
+    @public_api_reference_docs ||= PUBLIC_API_REFERENCE_DOC_PATHS.transform_values { |path| File.read(path) }
+  end
+
+  def public_constant_reference_signals(constant_name)
+    (["TreeView::#{constant_name}"] + PUBLIC_API_REFERENCE_SIGNAL_OVERRIDES.fetch(constant_name, [])).uniq
+  end
+
+  it "keeps manifest public constants traceable from the English and Japanese API references" do
+    constants = public_api_reference_manifest.fetch("public_constants")
+
+    public_api_reference_docs.each do |locale, source|
+      constants.each do |constant_name|
+        next if PUBLIC_API_REFERENCE_OMISSIONS.key?(constant_name)
+
+        signals = public_constant_reference_signals(constant_name)
+
+        expect(signals.any? { |signal| source.include?(signal) }).to be(true),
+          "expected #{locale} API reference to mention #{constant_name} using one of: #{signals.join(', ')}"
+      end
+    end
+  end
+
+  it "keeps intentionally omitted public constants explicit" do
+    constants = public_api_reference_manifest.fetch("public_constants")
+
+    expect(PUBLIC_API_REFERENCE_OMISSIONS.keys).to all(satisfy { |constant_name| constants.include?(constant_name) })
+  end
+end


### PR DESCRIPTION
## 対応 Issue

Closes #1074

## Issue ごとの完了内容

- #1074
  - `config/public_api_manifest.yml` の `public_constants` が英日 `docs/*/api.md` から辿れることを確認する RSpec guard を追加しました。
  - docs prose の完全一致ではなく、literal Ruby constant token または安定した section / guide label signal に絞っています。
  - API reference にまだ dedicated section を持たない `ResourceTableRenderState` は、理由付きの明示的な omission として spec 内に固定しました。

## 変更内容

- `spec/public_api_reference_coverage_spec.rb` を追加
  - manifest の `public_constants` を読み込む
  - `docs/en/api.md` / `docs/ja/api.md` を対象に traceability を確認する
  - literal token ではない既存導線は named override として明示する
  - omission list が manifest 上の現存 constant だけを指すことを確認する
- 初回 CI の lint 指摘を受け、StandardRB style を修正しました。

## 改善カテゴリ

- test
- docs drift guard
- public API compatibility guard

## 既存仕様への影響

- runtime code、helper behavior、JavaScript behavior、public constants、API docs 本文は変更していません。
- 新しい public API、manifest schema、docs policy は追加していません。

## 実施した確認

- GitHub compare: `main...quality/1074-api-reference-constant-guard`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 1 (`spec/public_api_reference_coverage_spec.rb`)
- GitHub Actions CI `#1324`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success
  - PR Rails compatibility Rails 7.0 / 7.2 / 8.0: success
- ローカル RSpec / lint は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗し、ローカル checkout を作れませんでした。

## リスク評価

- low
- spec-only の drift guard です。既存仕様や公開挙動は変更していません。

## 補足事項

- `ResourceTableRenderState` は omission 理由を spec に残しました。将来 API reference に dedicated section を追加する場合は、この例外を削除できます。