### PR TITLE
ReverseTree の入口を root docs から辿りやすくする

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Key documents:
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |
 | PathTreeBuilder | [PathTreeBuilder](docs/en/path-tree-builder.md) | [PathTreeBuilder](docs/ja/path-tree-builder.md) |
+| ReverseTree | [ReverseTree](docs/en/reverse-tree.md) | [ReverseTree](docs/ja/reverse-tree.md) |
 | Public API compatibility policy | [Public API](docs/en/public-api.md) | [Public API](docs/ja/public-api.md) |
 | Host app extension boundary | [Host App Extension Points](docs/en/host-app-extension-points.md) | [Host App 拡張ポイント](docs/ja/host-app-extension-points.md) |
 | Migration and upgrade guide | [Migration guide](docs/en/migration.md) | [移行ガイド](docs/ja/migration.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@
 - [日本語API判断ガイド](ja/decision-guide.md): use caseからAPIやoptionを選ぶための入口。異種node混在やgraph-like nodeでGraphAdapter adapter modeを選ぶ場面も確認できます。
 - [English API overview: adapter mode](en/api-overview.md#adapter-mode): quick GraphAdapter entry point before moving to the full API reference or cookbook performance notes.
 - [日本語API概要: adapter mode](ja/api-overview.md#adapter-mode): API仕様やCookbookの性能メモへ進む前に確認するGraphAdapterの短い入口。
+- [English ReverseTree](en/reverse-tree.md): child-to-parent path entry point when matched records should be visible roots and ancestors should appear below them.
+- [日本語ReverseTree](ja/reverse-tree.md): matched recordを表示上のrootにし、ancestorをその下に並べるchild-to-parent pathの入口。
 - [English FAQ](en/faq.md): quick answers about responsibility boundaries and common misunderstandings.
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.


### PR DESCRIPTION
## 対応 Issue

Closes #1075

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `README.md`
  - Key documents table に `ReverseTree` の日英 docs 行を追加しました。
- `docs/README.md`
  - Recommended entry points に日英 `ReverseTree` の短い入口を追加しました。

## 根拠

- `README.md` の Features では `ReverseTree` が child-to-parent paths として既に紹介されています。
- `docs/en/README.md` / `docs/ja/README.md` では `ReverseTree` docs への導線が既にあります。
- root `README.md` と root `docs/README.md` からは dedicated entry がなく、PathTreeBuilder / Filtered Trees / Breadcrumb と用途を混同しやすい状態でした。

## 確認内容

- GitHub compare: `main...docs/1075-reverse-tree-entry-points`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- 変更は docs-only です。
- runtime code、public API manifest、mockup HTML/CSS、仕様本文の全面 rewrite は変更していません。
- ローカル clone/fetch はこの実行環境で `CONNECT tunnel failed, response 403` のため未実施です。

## リスク

- low
- 既存 `ReverseTree` docs への入口追加に閉じています。API behavior や docs 本文の仕様判断は変更していません。