### PR TITLE
docs i18n page pair の欠落ガードを追加する

### DIFF
--- a/spec/docs_i18n_pairing_spec.rb
+++ b/spec/docs_i18n_pairing_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+RSpec.describe "docs i18n page pairing" do
+  DOCS_LOCALES = %w[en ja].freeze
+  INTENTIONALLY_ONE_SIDED_BILINGUAL_DOCS = [].freeze
+
+  let(:docs_root) { Pathname.new(__dir__).parent.join("docs") }
+
+  it "keeps user-facing English and Japanese docs pages paired" do
+    aggregate_failures do
+      DOCS_LOCALES.permutation(2) do |source_locale, target_locale|
+        missing_paths = missing_paths(source_locale:, target_locale:)
+
+        expect(missing_paths).to be_empty, <<~MESSAGE
+          Missing #{target_locale} docs pages for #{source_locale} sources:
+          #{missing_paths.join("\n")}
+        MESSAGE
+      end
+    end
+  end
+
+  def page_names_for(locale)
+    docs_root.join(locale).glob("*.md").map { |path| path.basename.to_s }.sort - INTENTIONALLY_ONE_SIDED_BILINGUAL_DOCS
+  end
+
+  def missing_paths(source_locale:, target_locale:)
+    (page_names_for(source_locale) - page_names_for(target_locale)).map do |page_name|
+      "docs/#{target_locale}/#{page_name}"
+    end
+  end
+end

--- a/spec/docs_i18n_pairing_spec.rb
+++ b/spec/docs_i18n_pairing_spec.rb
@@ -3,14 +3,13 @@
 require "pathname"
 
 RSpec.describe "docs i18n page pairing" do
-  DOCS_LOCALES = %w[en ja].freeze
-  INTENTIONALLY_ONE_SIDED_BILINGUAL_DOCS = [].freeze
-
+  let(:docs_locales) { %w[en ja] }
+  let(:intentionally_one_sided_bilingual_docs) { [] }
   let(:docs_root) { Pathname.new(__dir__).parent.join("docs") }
 
   it "keeps user-facing English and Japanese docs pages paired" do
     aggregate_failures do
-      DOCS_LOCALES.permutation(2) do |source_locale, target_locale|
+      docs_locales.permutation(2) do |source_locale, target_locale|
         missing_paths = missing_paths(source_locale:, target_locale:)
 
         expect(missing_paths).to be_empty, <<~MESSAGE
@@ -22,7 +21,7 @@ RSpec.describe "docs i18n page pairing" do
   end
 
   def page_names_for(locale)
-    docs_root.join(locale).glob("*.md").map { |path| path.basename.to_s }.sort - INTENTIONALLY_ONE_SIDED_BILINGUAL_DOCS
+    docs_root.join(locale).glob("*.md").map { |path| path.basename.to_s }.sort - intentionally_one_sided_bilingual_docs
   end
 
   def missing_paths(source_locale:, target_locale:)


### PR DESCRIPTION
## 対応 Issue

Closes #1081

## Issue ごとの完了内容

- #1081
  - `docs/en/*.md` と `docs/ja/*.md` の user-facing bilingual docs page が同名ペアで揃っていることを確認する RSpec guard を追加しました。
  - 失敗時は欠けている language side と `docs/<locale>/<page>.md` の path が分かる message を出します。
  - root-level maintenance docs や mockup technical assets は `docs/en` / `docs/ja` 直下の Markdown inventory ではないため対象外にしています。

## 変更内容

- `spec/docs_i18n_pairing_spec.rb` を追加
  - `docs/en/*.md` と `docs/ja/*.md` の basename を双方向に比較
  - intentionally one-sided bilingual docs は空の allowlist として明示
  - link existence / anchor / translation body comparison は扱わない

## 改善カテゴリ

- test
- docs drift guard
- maintenance

## 既存仕様への影響

- runtime code、public API、docs content、CI workflow は変更していません。
- #926 の relative link check とは別責務として、docs pair inventory の欠落だけを検出します。

## 実施した確認

- GitHub compare: `main...quality/1081-docs-i18n-pair-guard`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 1 (`spec/docs_i18n_pairing_spec.rb`)
- ローカル RSpec / Ruby syntax check は未実行です。
  - この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗します。
  - このコンテナには `ruby` コマンドがなく、`ruby -c` も実行できませんでした。

## リスク評価

- low
- spec-only の lightweight docs inventory guard です。対象は `docs/en` / `docs/ja` 直下の Markdown basename 比較に限定しています。

## 補足事項

- intentionally one-sided docs が将来必要になった場合は、spec 内の allowlist に明示できます。