### PR TITLE
FilteredTree を public API manifest に同期する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -20,6 +20,7 @@ public_constants:
   - ResourceTableRenderState
   - VisibleRows
   - RenderWindow
+  - FilteredTree
   - UiConfig
   - UiConfigBuilder
   - GraphAdapter

--- a/docs/en/filtered-trees.md
+++ b/docs/en/filtered-trees.md
@@ -27,6 +27,8 @@ render_state = TreeView::RenderState.new(
 )
 ```
 
+`TreeView::FilteredTree` is a manifest-backed public constant, but host apps should usually obtain instances through `TreeView::Tree#filtered_tree_for` so mode validation and base-tree behavior stay in one place.
+
 ## Modes
 
 | mode | meaning |

--- a/docs/ja/filtered-trees.md
+++ b/docs/ja/filtered-trees.md
@@ -27,6 +27,8 @@ render_state = TreeView::RenderState.new(
 )
 ```
 
+`TreeView::FilteredTree` は manifest-backed public constant です。ただし host app は通常 `TreeView::Tree#filtered_tree_for` 経由で instance を取得し、mode validation と base-tree behavior を同じ入口に保ってください。
+
 ## mode
 
 | mode | 意味 |


### PR DESCRIPTION
`TreeView::FilteredTree` を manifest-backed public constant として同期します。

## 対応 Issue

Closes #1069

## 変更内容

- `config/public_api_manifest.yml` の `public_constants` に `FilteredTree` を追加しました。
- `docs/en/filtered-trees.md` / `docs/ja/filtered-trees.md` に、`TreeView::FilteredTree` は manifest-backed public constant だが通常は `TreeView::Tree#filtered_tree_for` 経由で取得する boundary を短く追記しました。

## 受け入れ条件との対応

- `TreeView::FilteredTree` が manifest の public constant set に含まれます。
- 既存 `spec/public_api_compatibility_spec.rb` は manifest の `public_constants` を `TreeView.const_defined?` で確認するため、追加後は `FilteredTree` も同じ guard に乗ります。
- 英日 filtered-tree docs は direct constant dependency を強く促さず、`filtered_tree_for(items, mode:)` の利用入口を維持しています。
- mode 追加、rename、behavior change、mockup変更、public API manifest schema変更には広げていません。

## 変更範囲

- public API manifest
- filtered tree docs（日英）

## 実施した確認

- GitHub compare: `main...feature/1069-filtered-tree-public-constant-current`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- `docs/en/api.md` / `docs/ja/api.md` には既に `TreeView::FilteredTree` の dedicated section があることを確認しました。
- `docs/en/filtered-trees.md` / `docs/ja/filtered-trees.md` が `filtered_tree_for` 経由の利用例に留まっていることを確認しました。
- GitHub Actions CI `#1330`: success
  - `pr_specs`: success
  - `lint`: success
  - `gem_package`: success
  - `javascript`: success
  - PR Rails compatibility Rails 7.0 / 7.2 / 8.0: success
- local `bundle exec rspec spec/public_api_compatibility_spec.rb` は未実行です。
  - この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク

- medium
- public compatibility promise を強める additive sync です。runtime behavior は変更していません。

## 未対応・補足

- `TreeView::FilteredTree` の modes、traversal、sorting、descendant count behavior は変更していません。
- CHANGELOG / release note は、この小さな manifest/docs sync では追加していません。