### PR TITLE
public API manifest の toolbar/error 互換性ガードを追加する

### DIFF
--- a/spec/public_error_compatibility_spec.rb
+++ b/spec/public_error_compatibility_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+PublicErrorCompatibilityTestNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
+PUBLIC_ERROR_COMPATIBILITY_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+RSpec.describe "TreeView public error compatibility" do
+  def public_api_manifest
+    @public_api_manifest ||= YAML.safe_load_file(PUBLIC_ERROR_COMPATIBILITY_MANIFEST_PATH)
+  end
+
+  def expected_error_hierarchy
+    {
+      "Error" => ArgumentError,
+      "ConfigurationError" => TreeView::Error,
+      "InvalidTreeError" => TreeView::Error,
+      "DuplicateNodeKeyError" => TreeView::InvalidTreeError,
+      "CycleDetectedError" => TreeView::InvalidTreeError,
+      "InvalidRenderWindowError" => TreeView::Error
+    }
+  end
+
+  it "keeps documented public error constants in the public manifest" do
+    public_constants = public_api_manifest.fetch("public_constants")
+
+    expected_error_hierarchy.each_key do |constant_name|
+      expect(public_constants).to include(constant_name),
+        "expected TreeView::#{constant_name} to stay listed in the public API manifest"
+    end
+  end
+
+  it "keeps the documented public error hierarchy stable" do
+    expected_error_hierarchy.each do |constant_name, parent_class|
+      error_class = TreeView.const_get(constant_name)
+
+      expect(error_class.superclass).to eq(parent_class),
+        "expected TreeView::#{constant_name} to keep #{parent_class} as its direct parent"
+    end
+  end
+
+  it "raises documented public error subclasses for representative validation failures" do
+    duplicate_records = [
+      PublicErrorCompatibilityTestNode.new(id: 1, parent_id: nil, name: "Root"),
+      PublicErrorCompatibilityTestNode.new(id: 1, parent_id: nil, name: "Duplicate root")
+    ]
+    duplicate_tree = TreeView::Tree.new(records: duplicate_records, parent_id_method: :parent_id)
+
+    expect { duplicate_tree.validate_unique_node_keys! }.to raise_error(TreeView::DuplicateNodeKeyError)
+
+    cyclic_records = [
+      PublicErrorCompatibilityTestNode.new(id: 1, parent_id: 2, name: "First"),
+      PublicErrorCompatibilityTestNode.new(id: 2, parent_id: 1, name: "Second")
+    ]
+    cyclic_tree = TreeView::Tree.new(records: cyclic_records, parent_id_method: :parent_id)
+
+    expect { cyclic_tree.descendant_counts }.to raise_error(TreeView::CycleDetectedError)
+    expect { TreeView::RenderWindow.new([], offset: -1, limit: 1) }.to raise_error(TreeView::InvalidRenderWindowError)
+  end
+end

--- a/spec/tree_view_toolbar_manifest_compatibility_spec.rb
+++ b/spec/tree_view_toolbar_manifest_compatibility_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+TREE_VIEW_TOOLBAR_MANIFEST_COMPATIBILITY_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+TreeViewToolbarManifestRenderState = Struct.new(:ui_config, keyword_init: true)
+
+RSpec.describe "TreeView toolbar manifest compatibility" do
+  def public_api_manifest
+    @public_api_manifest ||= YAML.safe_load_file(TREE_VIEW_TOOLBAR_MANIFEST_COMPATIBILITY_PATH)
+  end
+
+  def toolbar_actions_manifest
+    public_api_manifest.fetch("toolbar_actions").transform_keys(&:to_sym).transform_values(&:to_sym)
+  end
+
+  def helper
+    @helper ||= Class.new do
+      include TreeViewHelper
+    end.new
+  end
+
+  it "keeps toolbar supported actions aligned with the public manifest" do
+    expect(helper.tree_view_toolbar_supported_actions).to eq(toolbar_actions_manifest.keys)
+  end
+
+  it "keeps toolbar action metadata state and data hooks aligned with the public manifest" do
+    path_config = Class.new do
+      def toggle_all_path(state:)
+        "/tree?state=#{state}"
+      end
+    end.new
+    render_state = TreeViewToolbarManifestRenderState.new(ui_config: path_config)
+
+    toolbar_actions_manifest.each do |action, state|
+      metadata = helper.tree_view_toolbar_action_metadata(render_state, action)
+
+      expect(metadata).to include(
+        action: action,
+        state: state,
+        path: "/tree?state=#{state}",
+        disabled: false
+      )
+      expect(metadata.fetch(:data)).to include(tree_view_toolbar_action: action)
+      expect(metadata.fetch(:data)).not_to have_key(:tree_view_toolbar_disabled)
+    end
+  end
+
+  it "keeps disabled toolbar action data hooks stable when no toggle path is available" do
+    action = toolbar_actions_manifest.keys.first
+    render_state = TreeViewToolbarManifestRenderState.new(ui_config: Object.new)
+    metadata = helper.tree_view_toolbar_action_metadata(render_state, action)
+
+    expect(metadata).to include(action: action, path: nil, disabled: true)
+    expect(metadata.fetch(:data)).to include(
+      tree_view_toolbar_action: action,
+      tree_view_toolbar_disabled: true
+    )
+  end
+end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1088
Closes #1090

## Issue ごとの完了内容

- #1088
  - `config/public_api_manifest.yml` の `toolbar_actions` mapping を直接読む spec を追加しました。
  - `tree_view_toolbar_supported_actions` が manifest key set と一致することを確認します。
  - `tree_view_toolbar_action_metadata` の `state` / `path` / disabled data hooks が manifest と既存 helper behavior に沿うことを確認します。
- #1090
  - public error constants が manifest に残っていることを確認する spec を追加しました。
  - `TreeView::Error < ArgumentError` と documented subclasses の direct parent relationship を固定しました。
  - duplicate node key / cycle / invalid render window の代表発生条件が documented public subclasses を投げることを確認します。

## 変更内容

- `spec/tree_view_toolbar_manifest_compatibility_spec.rb` を追加
- `spec/public_error_compatibility_spec.rb` を追加

## 改善カテゴリ

- test
- public API compatibility guard
- maintenance

## 既存仕様への影響

- 既存仕様への影響はありません。
- runtime code、public API manifest、docs、JavaScript、helper behavior、error hierarchy は変更していません。
- 既存 contract の drift を検出する spec 追加のみです。

## 実施した確認内容

- GitHub compare: `main...quality/1088-1090-public-api-guards-current`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 spec files
- local RSpec / lint は未実行です。
  - この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗し、Ruby も利用できません。
- PR 作成後に GitHub Actions CI を確認します。

## リスク評価

- low
- spec-only の guard 追加です。error message wording の完全固定、toolbar action 追加/rename、UI redesign、validation behavior 変更には広げていません。

## 補足事項

- #1088 と #1090 はどちらも public API compatibility drift guard で、同じ manifest/docs/implementation 同期の品質改善としてまとめています。