### PR TITLE
Filtered Trees の入口を README / docs index に追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Key documents:
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |
 | PathTreeBuilder | [PathTreeBuilder](docs/en/path-tree-builder.md) | [PathTreeBuilder](docs/ja/path-tree-builder.md) |
 | ReverseTree | [ReverseTree](docs/en/reverse-tree.md) | [ReverseTree](docs/ja/reverse-tree.md) |
+| Filtered Trees | [Filtered Trees](docs/en/filtered-trees.md) | [Filtered Trees](docs/ja/filtered-trees.md) |
 | Public API compatibility policy | [Public API](docs/en/public-api.md) | [Public API](docs/ja/public-api.md) |
 | Host app extension boundary | [Host App Extension Points](docs/en/host-app-extension-points.md) | [Host App 拡張ポイント](docs/ja/host-app-extension-points.md) |
 | Migration and upgrade guide | [Migration guide](docs/en/migration.md) | [移行ガイド](docs/ja/migration.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@
 - [日本語API概要: adapter mode](ja/api-overview.md#adapter-mode): API仕様やCookbookの性能メモへ進む前に確認するGraphAdapterの短い入口。
 - [English ReverseTree](en/reverse-tree.md): child-to-parent path entry point when matched records should be visible roots and ancestors should appear below them.
 - [日本語ReverseTree](ja/reverse-tree.md): matched recordを表示上のrootにし、ancestorをその下に並べるchild-to-parent pathの入口。
+- [English Filtered Trees](en/filtered-trees.md): render search or filter results as trees while keeping path-generated folders and child-to-parent paths separate.
+- [日本語Filtered Trees](ja/filtered-trees.md): 検索・絞り込み結果をtreeとして表示する入口。path生成folderやchild-to-parent pathとは使い分けます。
 - [English FAQ](en/faq.md): quick answers about responsibility boundaries and common misunderstandings.
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.


### PR DESCRIPTION
## 対応 Issue

Closes #1071

## 変更内容

- root `README.md` の Key documents table に Filtered Trees への英日リンクを追加しました。
- `docs/README.md` の Recommended entry points に、検索・絞り込み結果を tree として表示する入口として Filtered Trees を追加しました。
- `docs/README.md` では PathTree / ReverseTree との役割差分を乱さないよう、path-generated folders と child-to-parent paths は別用途として短く補足しました。

## 判定分類

- docs-missing
- 既存 `docs/en|ja/filtered-trees.md` と言語別 README には本文・入口がありますが、root README / root docs index から直接辿りにくい状態だったため、入口だけを補いました。

## 変更範囲

- docs only
- `README.md`
- `docs/README.md`

## 確認内容

- GitHub compare: `main...docs/1071-filtered-trees-entrypoints`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- 追加内容が Issue #1071 の受け入れ条件に沿っていることを目視確認しました。
- docs-only のリンク追加のため、local test / lint は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で更新しています。

## 補足

- 先に作成した PR #1096 は、main が連続して進んだため branch を最新 main に載せ直した際に一度差分なしとなり自動 close されました。この PR は同じ docs 差分を最新 main から再適用した replacement PR です。

## 非目標

- FilteredTree API の変更
- filtered tree docs 本文の rewrite
- mockup HTML / CSS の変更
- runtime code、public API manifest、CI 設定の変更