### PR TITLE
event detail key の source-to-manifest drift guard を追加する

### DIFF
--- a/spec/public_js_event_detail_drift_spec.rb
+++ b/spec/public_js_event_detail_drift_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "Public JavaScript event detail drift" do
+  PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+  JAVASCRIPT_CONTROLLER_PATHS = {
+    "state" => File.expand_path("../app/javascript/tree_view/state_controller.js", __dir__),
+    "selection" => File.expand_path("../app/javascript/tree_view/selection_controller.js", __dir__),
+    "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
+    "transfer" => File.expand_path("../app/javascript/tree_view/transfer_controller.js", __dir__)
+  }.freeze
+
+  def public_javascript_event_detail_keys
+    YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH).fetch("javascript_package_root").fetch("event_detail_keys")
+  end
+
+  def javascript_controller_source(group_name)
+    File.read(JAVASCRIPT_CONTROLLER_PATHS.fetch(group_name))
+  end
+
+  def event_dispatch_name(event_key)
+    event_key.tr("_", "-")
+  end
+
+  def source_dispatch_windows(source, dispatch_name)
+    matcher = /\b(?:dispatch|dispatch[A-Za-z]*)\("#{Regexp.escape(dispatch_name)}"/
+
+    source.to_enum(:scan, matcher).map do
+      start_index = Regexp.last_match.begin(0)
+      end_index = source.index(/\n  }\n/, start_index) || source.length
+
+      source[start_index...end_index]
+    end
+  end
+
+  def object_body_after_key(source, key)
+    source.to_enum(:scan, /#{Regexp.escape(key)}\s*:\s*\{/).map do
+      open_brace_index = source.index("{", Regexp.last_match.begin(0))
+
+      object_body(source, open_brace_index)
+    end.compact
+  end
+
+  def object_body(source, open_brace_index)
+    return nil unless open_brace_index
+
+    depth = 0
+    body_start = open_brace_index + 1
+
+    source.each_char.with_index(open_brace_index) do |char, index|
+      depth += 1 if char == "{"
+      depth -= 1 if char == "}"
+
+      return source[body_start...index] if depth.zero?
+    end
+
+    nil
+  end
+
+  def first_argument_object_body(window)
+    open_brace_index = window.index("{")
+
+    object_body(window, open_brace_index)
+  end
+
+  def detail_object_bodies(window)
+    bodies = object_body_after_key(window, "detail")
+    return bodies unless bodies.empty?
+
+    # dispatchTransferEvent(name, detail) treats the second argument as the public detail object.
+    return [first_argument_object_body(window)].compact if window.match?(/\bdispatch[A-Za-z]*\("/)
+
+    []
+  end
+
+  def source_mentions_shorthand_detail?(window)
+    window.match?(/\bdetail\s*[},]/)
+  end
+
+  def method_return_object_body(source, method_name)
+    method_source = source[/\n  #{Regexp.escape(method_name)}\([^)]*\) \{.*?\n  \}/m]
+    return nil unless method_source
+
+    open_brace_index = method_source.index("{", method_source.index(/\breturn\s*\{/))
+
+    object_body(method_source, open_brace_index)
+  end
+
+  def object_key_names(body)
+    return [] unless body
+
+    explicit_keys = body.scan(/(?:^|[,{]\s*)([A-Za-z_$][\w$]*)\s*:/m).flatten
+    shorthand_keys = body.scan(/(?:^|[,{]\s*)([A-Za-z_$][\w$]*)\s*(?=,|\z)/m).flatten
+
+    (explicit_keys + shorthand_keys).uniq
+  end
+
+  def source_detail_keys_for_dispatch(source, dispatch_name)
+    source_dispatch_windows(source, dispatch_name).flat_map do |window|
+      keys = detail_object_bodies(window).flat_map { |body| object_key_names(body) }
+
+      if source_mentions_shorthand_detail?(window)
+        keys.concat(object_key_names(method_return_object_body(source, "selectionDetail")))
+      end
+
+      keys
+    end.uniq
+  end
+
+  it "keeps controller dispatch detail keys registered in the public manifest" do
+    public_javascript_event_detail_keys.each do |group_name, events|
+      source = javascript_controller_source(group_name)
+
+      events.each do |event_key, manifest_keys|
+        dispatch_name = event_dispatch_name(event_key)
+        source_keys = source_detail_keys_for_dispatch(source, dispatch_name)
+        undocumented_keys = source_keys - manifest_keys
+
+        expect(undocumented_keys).to be_empty,
+          "expected #{group_name} #{dispatch_name} detail keys #{source_keys.inspect} " \
+          "to stay within manifest keys #{manifest_keys.inspect}; " \
+          "add public keys to config/public_api_manifest.yml or keep private details out of the public dispatch payload"
+      end
+    end
+  end
+end

--- a/spec/public_js_event_detail_drift_spec.rb
+++ b/spec/public_js_event_detail_drift_spec.rb
@@ -3,15 +3,15 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "Public JavaScript event detail drift" do
-  EVENT_DETAIL_DRIFT_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
-  EVENT_DETAIL_DRIFT_CONTROLLER_PATHS = {
-    "state" => File.expand_path("../app/javascript/tree_view/state_controller.js", __dir__),
-    "selection" => File.expand_path("../app/javascript/tree_view/selection_controller.js", __dir__),
-    "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
-    "transfer" => File.expand_path("../app/javascript/tree_view/transfer_controller.js", __dir__)
-  }.freeze
+EVENT_DETAIL_DRIFT_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+EVENT_DETAIL_DRIFT_CONTROLLER_PATHS = {
+  "state" => File.expand_path("../app/javascript/tree_view/state_controller.js", __dir__),
+  "selection" => File.expand_path("../app/javascript/tree_view/selection_controller.js", __dir__),
+  "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
+  "transfer" => File.expand_path("../app/javascript/tree_view/transfer_controller.js", __dir__)
+}.freeze
 
+RSpec.describe "Public JavaScript event detail drift" do
   def public_javascript_event_detail_keys
     YAML.safe_load_file(EVENT_DETAIL_DRIFT_MANIFEST_PATH).fetch("javascript_package_root").fetch("event_detail_keys")
   end

--- a/spec/public_js_event_detail_drift_spec.rb
+++ b/spec/public_js_event_detail_drift_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 require "yaml"
 
 RSpec.describe "Public JavaScript event detail drift" do
-  PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
-  JAVASCRIPT_CONTROLLER_PATHS = {
+  EVENT_DETAIL_DRIFT_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+  EVENT_DETAIL_DRIFT_CONTROLLER_PATHS = {
     "state" => File.expand_path("../app/javascript/tree_view/state_controller.js", __dir__),
     "selection" => File.expand_path("../app/javascript/tree_view/selection_controller.js", __dir__),
     "remote_state" => File.expand_path("../app/javascript/tree_view/remote_state_controller.js", __dir__),
@@ -13,11 +13,11 @@ RSpec.describe "Public JavaScript event detail drift" do
   }.freeze
 
   def public_javascript_event_detail_keys
-    YAML.safe_load_file(PUBLIC_API_MANIFEST_PATH).fetch("javascript_package_root").fetch("event_detail_keys")
+    YAML.safe_load_file(EVENT_DETAIL_DRIFT_MANIFEST_PATH).fetch("javascript_package_root").fetch("event_detail_keys")
   end
 
   def javascript_controller_source(group_name)
-    File.read(JAVASCRIPT_CONTROLLER_PATHS.fetch(group_name))
+    File.read(EVENT_DETAIL_DRIFT_CONTROLLER_PATHS.fetch(group_name))
   end
 
   def event_dispatch_name(event_key)

--- a/spec/public_js_event_detail_drift_spec.rb
+++ b/spec/public_js_event_detail_drift_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Public JavaScript event detail drift" do
     depth = 0
     body_start = open_brace_index + 1
 
-    source.each_char.with_index(open_brace_index) do |char, index|
+    source[open_brace_index..].each_char.with_index(open_brace_index) do |char, index|
       depth += 1 if char == "{"
       depth -= 1 if char == "}"
 
@@ -70,7 +70,7 @@ RSpec.describe "Public JavaScript event detail drift" do
     return bodies unless bodies.empty?
 
     # dispatchTransferEvent(name, detail) treats the second argument as the public detail object.
-    return [first_argument_object_body(window)].compact if window.match?(/\bdispatch[A-Za-z]*\("/)
+    return [first_argument_object_body(window)].compact if window.match?(/\bdispatchTransferEvent\("/)
 
     []
   end

--- a/spec/public_js_event_detail_drift_spec.rb
+++ b/spec/public_js_event_detail_drift_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe "Public JavaScript event detail drift" do
   def object_key_names(body)
     return [] unless body
 
-    explicit_keys = body.scan(/(?:^|[,{]\s*)([A-Za-z_$][\w$]*)\s*:/m).flatten
-    shorthand_keys = body.scan(/(?:^|[,{]\s*)([A-Za-z_$][\w$]*)\s*(?=,|\z)/m).flatten
+    explicit_keys = body.scan(/(?:^|[,{])\s*([A-Za-z_$][\w$]*)\s*:/m).flatten
+    shorthand_keys = body.scan(/(?:^|[,{])\s*([A-Za-z_$][\w$]*)\s*(?=,|\z)/m).flatten
 
     (explicit_keys + shorthand_keys).uniq
   end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #808

## Issue ごとの完了内容

- #808
  - JavaScript controller source の public dispatch detail key を読み取り、manifest 未記載の key が混ざった場合に失敗する focused spec を追加しました。
  - 既存の manifest -> controller source guard はそのまま維持し、逆向きの source -> manifest drift だけを補う形にしました。
  - `dispatchTransferEvent(name, detail)` の wrapper と、selection controller の `detail` shorthand / `selectionDetail()` helper を代表ケースとして扱います。

## 変更内容

- `spec/public_js_event_detail_drift_spec.rb` を追加
  - `config/public_api_manifest.yml` の `javascript_package_root.event_detail_keys` を source of truth として読み込み
  - `state` / `selection` / `remote_state` / `transfer` controller の dispatch detail key を抽出
  - source に見える public-looking detail key が manifest の event key list 外に出ていないことを確認

## 改善カテゴリ

- test
- public API drift guard
- maintenance

## 既存仕様への影響

- 既存仕様への影響はありません。
- runtime controller behavior、event payload shape、event name、manifest schema、docs content は変更していません。
- JavaScript parser / AST analyzer の導入や TypeScript definition 追加には広げていません。

## 実施した確認内容

- GitHub compare: `main...quality/808-event-detail-source-drift-spec`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 1
- GitHub Actions CI `#1342`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - PR Rails compatibility Rails 7.0 / 7.2 / 8.0: success
  - `rails_matrix` / `ruby_matrix` / `gem_package`: skipped by current change classification
- PR metadata: `mergeable: true`
- local RSpec は未実行です。
  - この実行環境では Ruby が利用できず、GitHub raw/checkout も制限されるため、GitHub Actions で確認しました。

## リスク評価

- low
- spec-only の追加です。検出対象は manifest に既に載っている public event detail の representative controller source に閉じています。

## 補足事項

- 初回 CI `#1341` は StandardRB の `Lint/ConstantDefinitionInBlock` で失敗し、定数を example group 外へ移して `#1342` で green になっています。
- docs の event payload 表現変更は行っていません。
- public export 追加、event detail rename、payload restructure は行っていません。