### PR TITLE
docs drift guard spec を追加する

### DIFF
--- a/spec/docs_drift_guard_spec.rb
+++ b/spec/docs_drift_guard_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe "documentation drift guards" do
+  ROOT = File.expand_path("..", __dir__)
+
+  def read_repo_file(path)
+    File.read(File.join(ROOT, path))
+  end
+
+  def expect_link(markdown, target, source_path)
+    expect(markdown).to include("(#{target})"), "expected #{source_path} to link #{target}"
+  end
+
+  def high_lane_paths
+    audit = read_repo_file("docs/i18n-audit.md")
+
+    audit.each_line.filter_map do |line|
+      next unless line.include?("| High |")
+
+      line.scan(/`([^`]+)`/).flatten
+    end.flatten.uniq
+  end
+
+  it "keeps i18n High lane pages present and reachable from docs entry points" do
+    paths = high_lane_paths
+
+    expect(paths).to include(
+      "docs/README.md",
+      "docs/en/README.md",
+      "docs/ja/README.md",
+      "docs/en/installation.md",
+      "docs/ja/installation.md",
+      "docs/en/minimal-usage.md",
+      "docs/ja/minimal-usage.md",
+      "docs/en/usage.md",
+      "docs/ja/usage.md",
+      "docs/en/api-overview.md",
+      "docs/ja/api-overview.md"
+    )
+
+    paths.each do |path|
+      expect(File).to exist(File.join(ROOT, path)), "expected i18n High lane doc to exist: #{path}"
+    end
+
+    root_docs = read_repo_file("docs/README.md")
+    expect_link(root_docs, "en/README.md", "docs/README.md")
+    expect_link(root_docs, "ja/README.md", "docs/README.md")
+    expect_link(root_docs, "i18n-audit.md", "docs/README.md")
+
+    {
+      "docs/en/README.md" => paths.grep(%r{\Adocs/en/}).map { |path| path.delete_prefix("docs/en/") },
+      "docs/ja/README.md" => paths.grep(%r{\Adocs/ja/}).map { |path| path.delete_prefix("docs/ja/") }
+    }.each do |entry_path, linked_paths|
+      entry = read_repo_file(entry_path)
+
+      linked_paths.each do |target|
+        expect_link(entry, target, entry_path)
+      end
+    end
+  end
+
+  it "keeps documented Ruby and Rails minimum versions aligned with the gemspec" do
+    gemspec = read_repo_file("tree_view.gemspec")
+    ruby_version = gemspec.match(/required_ruby_version = ">= ([^"]+)"/)[1]
+    rails_version = gemspec.match(/add_dependency "railties", ">= ([^"]+)"/)[1]
+
+    expectations = {
+      "README.md" => ["Ruby #{ruby_version} or later", "Rails #{rails_version} or later"],
+      "docs/en/installation.md" => ["Ruby #{ruby_version} or later", "Rails #{rails_version} or later"],
+      "docs/ja/installation.md" => ["Ruby #{ruby_version} 以上", "Rails #{rails_version} 以上"]
+    }
+
+    expectations.each do |path, phrases|
+      content = read_repo_file(path)
+
+      phrases.each do |phrase|
+        expect(content).to include(phrase), "expected #{path} to document #{phrase} from tree_view.gemspec"
+      end
+    end
+  end
+end

--- a/spec/docs_drift_guard_spec.rb
+++ b/spec/docs_drift_guard_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe "documentation drift guards" do
-  ROOT = File.expand_path("..", __dir__)
+  def repo_root
+    @repo_root ||= File.expand_path("..", __dir__)
+  end
 
   def read_repo_file(path)
-    File.read(File.join(ROOT, path))
+    File.read(File.join(repo_root, path))
   end
 
   def expect_link(markdown, target, source_path)
@@ -19,6 +21,12 @@ RSpec.describe "documentation drift guards" do
 
       line.scan(/`([^`]+)`/).flatten
     end.flatten.uniq
+  end
+
+  def language_docs_for(paths, language)
+    paths.grep(%r{\Adocs/#{language}/})
+      .map { |path| path.delete_prefix("docs/#{language}/") }
+      .reject { |path| path == "README.md" }
   end
 
   it "keeps i18n High lane pages present and reachable from docs entry points" do
@@ -39,7 +47,7 @@ RSpec.describe "documentation drift guards" do
     )
 
     paths.each do |path|
-      expect(File).to exist(File.join(ROOT, path)), "expected i18n High lane doc to exist: #{path}"
+      expect(File).to exist(File.join(repo_root, path)), "expected i18n High lane doc to exist: #{path}"
     end
 
     root_docs = read_repo_file("docs/README.md")
@@ -48,8 +56,8 @@ RSpec.describe "documentation drift guards" do
     expect_link(root_docs, "i18n-audit.md", "docs/README.md")
 
     {
-      "docs/en/README.md" => paths.grep(%r{\Adocs/en/}).map { |path| path.delete_prefix("docs/en/") },
-      "docs/ja/README.md" => paths.grep(%r{\Adocs/ja/}).map { |path| path.delete_prefix("docs/ja/") }
+      "docs/en/README.md" => language_docs_for(paths, "en"),
+      "docs/ja/README.md" => language_docs_for(paths, "ja")
     }.each do |entry_path, linked_paths|
       entry = read_repo_file(entry_path)
 


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1100
Closes #1101

## Issue ごとの完了内容

- #1100
  - `docs/i18n-audit.md` の High lane 行から backtick path を読み取り、High lane の日英 doc pair と entry docs が存在することを確認する RSpec を追加しました。
  - `docs/README.md` が language README と i18n audit にリンクしていること、`docs/en/README.md` / `docs/ja/README.md` が High lane の language doc にリンクしていることを確認します。
  - prose 差分、翻訳品質、anchor slug の完全一致検査には広げていません。
- #1101
  - `tree_view.gemspec` の `required_ruby_version` と `railties` dependency から minimum version を読み取り、README / English installation / Japanese installation の代表表記と一致することを確認する RSpec を追加しました。
  - Ruby / Rails support version、gemspec dependency policy、Rails matrix CI、lockfile policy は変更していません。

## 変更内容

- `spec/docs_drift_guard_spec.rb` を追加
  - i18n High lane docs の存在と entry link の軽量 smoke
  - gemspec と installation docs の minimum Ruby / Rails requirements 同期 guard

## 改善カテゴリ

- test
- docs sync guard
- maintenance

## 既存仕様への影響

- runtime code、public API、UI、DB、認可、CI 設定、docs 本文は変更していません。
- docs / gemspec drift を検出する spec の追加のみです。

## 実施した確認内容

- GitHub compare: `main...quality/1100-1101-docs-drift-guards`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 1 (`spec/docs_drift_guard_spec.rb`)
- 追加ファイルを connector で読み返し、対象が #1100 / #1101 の guard に閉じていることを確認しました。
- 初回 CI `#1343` は RSpec / lint の spec 側期待値で失敗し、自己リンク除外と StandardRB 対応を追加しました。
- GitHub Actions CI `#1344`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success (`npm run test:js` success、browser smoke は docs-only 条件で skipped)
  - PR Rails compatibility Rails 7.0 / 7.2 / 8.0: success
  - `rails_matrix` / `ruby_matrix` / `gem_package`: skipped by current change classification
- PR metadata: `mergeable: true`
- local RSpec / Ruby syntax check は未実行です。
  - この実行環境では Ruby が利用できず、GitHub HTTPS checkout も `CONNECT tunnel failed, response 403` で制限されているため、GitHub Actions で確認しました。

## リスク評価

- low
- 失敗時は docs/gemspec の同期漏れを検出するだけで、公開挙動は変わりません。

## 補足事項

- #1099 は `agent:planned` が付いていないため、今回の実装対象から外しています。