### PR TITLE
minimal-usage docs の相対リンクを修正する

### DIFF
--- a/docs/en/minimal-usage.md
+++ b/docs/en/minimal-usage.md
@@ -85,12 +85,12 @@ Set `selection.enabled` to `true` to enable checkbox selection.
 
 `visibility: :leaves` renders checkboxes only for leaf nodes.
 
-See [Selection](../selection.md) for details.
+See [Selection](selection.md) for details.
 
 ## Next steps
 
 - [Installation](installation.md)
 - [Usage](usage.md)
 - [API overview](api-overview.md)
-- [API reference](../api.md)
-- [Selection](../selection.md)
+- [API reference](api.md)
+- [Selection](selection.md)

--- a/docs/ja/minimal-usage.md
+++ b/docs/ja/minimal-usage.md
@@ -85,12 +85,12 @@ end
 
 `visibility: :leaves` はleaf nodeだけにcheckboxを表示します。
 
-詳しくは [Selection](../selection.md) を参照してください。
+詳しくは [Selection](selection.md) を参照してください。
 
 ## 次に読むもの
 
 - [導入手順](installation.md)
-- [使い方](../usage.md)
+- [使い方](usage.md)
 - [API概要](api-overview.md)
-- [API仕様](../api.md)
-- [Selection](../selection.md)
+- [API仕様](api.md)
+- [Selection](selection.md)


### PR DESCRIPTION
## 対応 Issue

Closes #1108

## 変更内容

- `docs/en/minimal-usage.md` の Selection / API reference links を同じ `docs/en/` ディレクトリ内の local docs へ修正しました。
- `docs/ja/minimal-usage.md` の Selection / 使い方 / API仕様 links を同じ `docs/ja/` ディレクトリ内の local docs へ修正しました。
- 英日とも、初回導入ページから次に読む docs への導線だけを直しています。

## 判定分類

- docs-stale
- docs-sync

## 根拠

- 現行 main では `docs/en|ja/minimal-usage.md` から `../selection.md` / `../api.md` / `../usage.md` を参照しており、実際の同言語 docs は `docs/en|ja/selection.md` / `api.md` / `usage.md` にあります。
- Issue #1108 の受け入れ条件どおり、generic link checker や docs navigation 全体の再設計には広げていません。

## 変更範囲

- docs only
- `docs/en/minimal-usage.md`
- `docs/ja/minimal-usage.md`

## 確認内容

- GitHub compare: `main...docs/1108-minimal-usage-links`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- 変更後のリンク先が同一言語ディレクトリ内の既存 docs を指すことを確認しました。
- docs link の置換のみのため local test / lint は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で更新しています。

## 非目標

- Markdown link checker の実装
- minimal-usage docs の全面 rewrite
- API docs / selection docs / usage docs の内容変更
- runtime code、mockup HTML/CSS、CI workflow の変更