### PR TITLE
js-events docs に TreeViewEventNames 導線を追加する

### DIFF
--- a/docs/en/js-events.md
+++ b/docs/en/js-events.md
@@ -158,6 +158,19 @@ Dispatched when transferred JSON cannot be parsed.
 |---|---|---|
 | `value` | String | Raw transferred value that could not be parsed as JSON. |
 
+## Using TreeViewEventNames in host-app code
+
+The raw event strings above remain the public contract. When wiring listeners in host-app JavaScript, you can import `TreeViewEventNames` from `tree_view/index.js` and use the matching package-root export instead of hand-copying strings:
+
+```js
+import { TreeViewEventNames } from "tree_view/index.js"
+
+element.addEventListener(TreeViewEventNames.selection.change, handleSelectionChange)
+element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStateChange)
+```
+
+`TreeViewEventNames.hostLifecycle.*` is for host apps dispatching lazy-loading request lifecycle events such as `tree-view:loading`; TreeView controller-emitted remote-state events on this page use `TreeViewEventNames.remoteState.*`.
+
 ## Compatibility policy
 
 The machine-readable public API manifest mirrors the event names and representative required `event.detail` keys documented on this page so compatibility specs can detect drift; this page remains the primary contract.

--- a/docs/ja/js-events.md
+++ b/docs/ja/js-events.md
@@ -158,6 +158,19 @@ transferred JSON をparseできないときに発火します。
 |---|---|---|
 | `value` | String | JSON parse できなかった raw transferred value。 |
 
+## host app code で TreeViewEventNames を使う
+
+上記の raw event string は引き続き公開契約です。host app の JavaScript で listener を配線するときは、`tree_view/index.js` から `TreeViewEventNames` を import し、event name string を写経せずに対応する package-root export を使えます。
+
+```js
+import { TreeViewEventNames } from "tree_view/index.js"
+
+element.addEventListener(TreeViewEventNames.selection.change, handleSelectionChange)
+element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStateChange)
+```
+
+`TreeViewEventNames.hostLifecycle.*` は、`tree-view:loading` など lazy-loading request lifecycle event を host app 側で dispatch するための surface です。このページで説明している TreeView controller 自身が emit する remote-state event は `TreeViewEventNames.remoteState.*` を使います。
+
 ## 互換性方針
 
 machine-readable public API manifest は、このページで文書化している event name と代表的な必須 `event.detail` key を写して drift を検知するための guard です。一次の契約は引き続きこのページです。


### PR DESCRIPTION
## 対応 Issue

Closes #1089

## 変更内容

- `docs/en/js-events.md` に `TreeViewEventNames` の host-app listener wiring 例を追加しました。
- `docs/ja/js-events.md` に同じ意味の日本語導線を追加しました。
- raw event string は引き続き一次の public contract として残し、host app code では package-root export を使えることだけを補足しました。
- `TreeViewEventNames.hostLifecycle.*` と `TreeViewEventNames.remoteState.*` の責務差分を、既存 `public-api` docs と同じ境界で明記しました。

## 判定分類

- docs-missing
- docs-sync

## 根拠

- `app/javascript/tree_view/index.js` は `TreeViewEventNames` を package-root export として公開しています。
- `config/public_api_manifest.yml` は event names / detail keys を machine-readable contract として持っています。
- `docs/en|ja/public-api.md` では `TreeViewEventNames` と `hostLifecycle` / `remoteState` の使い分けを説明済みです。
- `docs/en|ja/js-events.md` は event contract の primary docs ですが、host app が listener を書くときの export 導線が不足していました。

## 変更範囲

- docs only
- `docs/en/js-events.md`
- `docs/ja/js-events.md`

## 確認内容

- GitHub compare: `main...docs/1089-event-names-js-events`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- 更新後の該当箇所を connector で読み返し、英日で同じ例と責務境界になっていることを確認しました。
- docs-only の追記のため local test / lint は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で更新しています。

## 非目標

- runtime JavaScript の変更
- `config/public_api_manifest.yml` の変更
- event name / detail key / payload shape / controller behavior の変更
- compatibility spec の追加
- js-events docs 全体の table rewrite