### PR TITLE
selection hidden input docs と mockup境界を同期する

### DIFF
--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -139,6 +139,8 @@ With `data-tree-view-selection-hidden-input-name-value`, TreeView writes one hid
 
 When one form contains multiple `tree-view-selection` controllers, TreeView tags each generated hidden input with `data-tree-view-selection-source-id` so one controller only removes and rewrites its own generated inputs. If the controller element already has `data-tree-view-selection-source-id`, TreeView reuses that value; otherwise it assigns a generated source id on connect. Use separate `data-tree-view-selection-hidden-input-name-value` names when the host app wants separate submitted params for each tree. Reuse a name only when the server-side action intentionally accepts one combined array.
 
+Static mockups such as [selection-multi-tree-form.html](../mockups/selection-multi-tree-form.html) can show generated hidden inputs as a review aid, but this section is the submission contract: TreeView mirrors one JSON payload per hidden input, while the host app owns final params grouping and summary copy.
+
 ## Selection max count
 
 Host apps can limit the number of checked boxes on the JavaScript controller.

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -139,6 +139,8 @@ tree が通常の HTML form の中にある場合、同じ controller で checke
 
 1つの form に複数の `tree-view-selection` controller がある場合、TreeView は生成した hidden input に `data-tree-view-selection-source-id` を付けます。これにより、各 controller は自分が生成した hidden input だけを削除・再生成します。controller element に `data-tree-view-selection-source-id` がすでにある場合はその値を使い、なければ connect 時に自動生成します。tree ごとに別々の params として受け取りたい場合は、`data-tree-view-selection-hidden-input-name-value` に別々の名前を指定してください。同じ名前を使うのは、server-side action が1つの配列としてまとめて受け取る設計のときに限ります。
 
+[selection-multi-tree-form.html](../mockups/selection-multi-tree-form.html) などの static mockup は generated hidden input を review aid として見せることがありますが、送信 contract の正本はこの節です。TreeView は 1 hidden input に 1 JSON payload をミラーし、最終的な params grouping と summary copy は host app 側で決めます。
+
 ## 最大選択数
 
 JavaScript controller側で、checked checkboxの最大数を制限できます。

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -33,7 +33,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [node-presenter-row-partials.html](node-presenter-row-partials.html) | Focused NodePresenter row partial reference showing resolver-provided label, href, tooltip, badge, icon, and optional action beside host-app-owned columns and permissions. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [selection-max-count.html](selection-max-count.html) | Focused selection max-count reference showing below-limit, limit-reached, and limit-exceeded feedback while keeping final action copy host-app owned. |
-| [selection-multi-tree-form.html](selection-multi-tree-form.html) | Focused multi-tree selection form reference showing source-specific selected counts, submit summary, empty state, and generated hidden input boundary. |
+| [selection-multi-tree-form.html](selection-multi-tree-form.html) | Focused multi-tree selection form reference showing source-specific selected counts, submit summary, empty state, and generated hidden input boundary as a review aid. |
 | [toolbar-actions.html](toolbar-actions.html) | Expand-all, collapse-all, and collapse-to-current-path toolbar reference showing enabled, disabled, current-state, and long/localized label variants without host-app routes or authorization copy. |
 | [empty-state.html](empty-state.html) | No-root-items and no-results reference for the empty-row wrapper hook, full-width message slot, and host-app-owned copy. |
 | [default-tree.css](default-tree.css) | Shared CSS for the static mockups. |
@@ -63,7 +63,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 21. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
 22. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
 23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries.
+24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
 25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
 26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
 27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
@@ -79,6 +79,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 - `toolbar-actions.html` intentionally includes a narrow long/localized label stress case so reviewers can inspect wrapping and disabled/current cues without choosing final translations.
 - Final labels, localization, permission messaging, and business wording remain host-app responsibilities.
 - If a future mockup intentionally uses another language, document that exception here so reviewers know it is deliberate.
+
+## Selection form guidance
+
+- Use selection form mockups to compare visible counts, source separation, and generated hidden input boundaries at review time.
+- Treat [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) as the source of truth for hidden input sync: TreeView mirrors one JSON payload per hidden input, and host apps own final params grouping, submit summaries, and business action copy.
 
 ## Narrow-width guidance
 


### PR DESCRIPTION
## 対応 Issue

Closes #1037

## replacement

- 旧 PR: #1039
- #1039 は current `main` へ載せ直すためにブランチを一度 `main` と同一にした際、差分なしとして自動 close されました。
- この PR は #1039 と同じ docs-only 目的の replacement です。

## 判定分類

- `docs-sync`
- `docs-missing`

## 変更内容

- `docs/en/selection.md`
  - hidden input sync の正本が selection docs であり、mockup の hidden input 表示は review aid であることを追記しました。
- `docs/ja/selection.md`
  - 英語版と同等の説明を追加しました。
- `docs/mockups/README.md`
  - `selection-multi-tree-form.html` の hidden input rows は review aid として扱い、per-payload hidden input contract は selection docs を参照するよう導線を補いました。
  - selection form mockup guidance を追加し、final params grouping / submit summary / business action copy は host app responsibility と明記しました。

## 非目標

- hidden input sync behavior の変更
- `selection-multi-tree-form.html` の visual redesign / payload 表現修正
- public data hook export / public API manifest の変更
- server-side bulk action params policy の決定

## 確認内容

- GitHub compare: `main...docs/1037-selection-hidden-input-boundary-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 3 docs files
- runtime code / public API manifest / mockup HTML は未変更です。
- docs-only のため local test / lint は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 実装済み controller behavior と既存 selection docs の責務境界を補足するだけで、仕様追加やコード変更はしていません。