### PR TITLE
TreeView.configure option keys を public manifest に追加する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -7,6 +7,10 @@ module_methods:
   - model_name_for
   - attribute_name_for
   - type_name_for
+configuration_options:
+  tree_view_configure:
+    - initial_state
+    - render_log_level
 public_constants:
   - Error
   - ConfigurationError

--- a/docs/en/render-log-level.md
+++ b/docs/en/render-log-level.md
@@ -11,6 +11,8 @@ TreeView.configure do |config|
 end
 ```
 
+`render_log_level` is one of the manifest-backed `TreeView.configure` option keys in `config/public_api_manifest.yml`. This page documents its accepted values and logging boundary; it does not add a new configuration option.
+
 ## Changing the level
 
 Set `render_log_level` to any standard Ruby logger level name when the host app needs a different threshold.

--- a/docs/ja/render-log-level.md
+++ b/docs/ja/render-log-level.md
@@ -11,6 +11,8 @@ TreeView.configure do |config|
 end
 ```
 
+`render_log_level` は `config/public_api_manifest.yml` に載る manifest-backed な `TreeView.configure` option key の 1 つです。このページは指定可能な値と logging の責務境界を説明するもので、新しい configuration option は追加しません。
+
 ## level を変更する
 
 host app 側で別の閾値にしたい場合は、標準の Ruby logger level 名を指定します。

--- a/spec/public_configuration_options_manifest_spec.rb
+++ b/spec/public_configuration_options_manifest_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "Public configuration option manifest" do
+  let(:manifest_path) { File.expand_path("../config/public_api_manifest.yml", __dir__) }
+  let(:configuration_option_keys) do
+    YAML.safe_load_file(manifest_path).fetch("configuration_options").fetch("tree_view_configure")
+  end
+
+  it "keeps TreeView.configure option keys machine-readable" do
+    expect(configuration_option_keys).to eq(%w[initial_state render_log_level])
+  end
+
+  it "keeps manifest-backed configuration options available on TreeView::Configuration" do
+    configuration = TreeView::Configuration.new
+
+    configuration_option_keys.each do |option_key|
+      expect(configuration).to respond_to(option_key.to_sym),
+        "expected TreeView::Configuration##{option_key} to remain public"
+      expect(configuration).to respond_to(:"#{option_key}="),
+        "expected TreeView::Configuration##{option_key}= to remain public"
+    end
+  end
+
+  it "keeps representative TreeView.configure option behavior available" do
+    configuration = TreeView::Configuration.new
+
+    expect(configuration.initial_state).to eq(:expanded)
+    expect(configuration.render_log_level).to eq(:warn)
+
+    configuration.initial_state = :collapsed
+    configuration.render_log_level = :info
+
+    expect(configuration.initial_state).to eq(:collapsed)
+    expect(configuration.render_log_level).to eq(:info)
+  end
+end


### PR DESCRIPTION
TreeView.configure の既存 option keys を manifest-backed public contract として固定します。

## 対応 Issue

Closes #1073

## 変更内容

- `config/public_api_manifest.yml` に `configuration_options.tree_view_configure` を追加し、既存 option key の `initial_state` / `render_log_level` を machine-readable にしました。
- `spec/public_configuration_options_manifest_spec.rb` を追加し、manifest の key list、`TreeView::Configuration` reader/writer、代表 default / assignment behavior を確認します。
- `docs/en/render-log-level.md` / `docs/ja/render-log-level.md` に、`render_log_level` が manifest-backed な `TreeView.configure` option key であることを追記しました。

## 受け入れ条件との対応

- `TreeView.configure` option keys を manifest-backed contract に含める判断を、この PR の manifest / spec / docs で明確化しました。
- manifest が `initial_state` / `render_log_level` を machine-readable に持ちます。
- spec が option key の存在と代表 behavior を守ります。
- 既存 API docs は既に `TreeView.configure` の2 optionsを表で説明しており、render-log-level docs も manifest-backed option surface と矛盾しないよう同期しました。
- configuration option の追加・rename・削除、挙動、validation、default value は変更していません。

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_configuration_options_manifest_spec.rb`
- `docs/en/render-log-level.md`
- `docs/ja/render-log-level.md`

## 実施した確認

- GitHub compare: `main...feature/1073-config-option-manifest`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- local RSpec / lint は未実行です。
  - この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク

- medium
- 既存 option を public manifest contract として明示するため、将来の rename / removal に対する互換性期待が強くなります。runtime behavior は変更していません。

## 未対応・補足

- 新しい configuration option は追加していません。
- `initial_state` / `render_log_level` の validation、default value、render log suppression behavior は変更していません。
- public API manifest schema 全体の再設計、release 作業、version bump、changelog には広げていません。