### PR TITLE
keyboard navigation の visible row traversal を spec で固定する

### DIFF
--- a/app/javascript/tree_view/index.test.js
+++ b/app/javascript/tree_view/index.test.js
@@ -13,6 +13,13 @@ function nextFrame() {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
+function setOffsetParent(element, offsetParent) {
+  Object.defineProperty(element, "offsetParent", {
+    configurable: true,
+    get: () => offsetParent
+  })
+}
+
 describe("tree view interactive target helpers", () => {
   afterEach(() => {
     document.body.innerHTML = ""
@@ -166,6 +173,9 @@ describe("TreeViewStateController", () => {
           <tr id="row-1" data-tree-view-state-target="node" data-tree-view-state-node-key="project:1" data-tree-view-state-expanded="true">
             <td><button class="remove-button" type="button"></button></td>
           </tr>
+          <tr id="row-hidden" data-tree-view-state-target="node" data-tree-view-state-node-key="project:hidden" data-tree-view-state-expanded="false" hidden>
+            <td><button class="show-button" type="button"></button></td>
+          </tr>
           <tr id="row-2" data-tree-view-state-target="node" data-tree-view-state-node-key="project:2" data-tree-view-state-expanded="false">
             <td>
               <button class="show-button" type="button"></button>
@@ -208,6 +218,35 @@ describe("TreeViewStateController", () => {
 
     expect(row.dataset.treeViewStateExpanded).toBe("true")
     expect(controller.expandedKeys()).toEqual(["project:1", "project:2"])
+  })
+
+  it("moves keyboard focus through visible rows only", () => {
+    const element = document.querySelector("[data-controller='tree-view-state']")
+    const controller = application.getControllerForElementAndIdentifier(element, "tree-view-state")
+    const row1 = document.querySelector("#row-1")
+    const hiddenRow = document.querySelector("#row-hidden")
+    const row2 = document.querySelector("#row-2")
+    const preventDefault = vi.fn()
+
+    setOffsetParent(row1, element)
+    setOffsetParent(hiddenRow, null)
+    setOffsetParent(row2, element)
+
+    row1.focus()
+    controller.keydown({ key: "ArrowDown", preventDefault, target: row1 })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(document.activeElement).toBe(row2)
+
+    controller.keydown({ key: "ArrowUp", preventDefault, target: row2 })
+
+    expect(preventDefault).toHaveBeenCalledTimes(2)
+    expect(document.activeElement).toBe(row1)
+
+    controller.keydown({ key: "ArrowUp", preventDefault, target: row1 })
+
+    expect(preventDefault).toHaveBeenCalledTimes(3)
+    expect(document.activeElement).toBe(row1)
   })
 
   it("uses keyboard navigation to activate row toggles", () => {


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #973

## Issue ごとの完了内容

- #973
  - `TreeViewStateController` の JS spec に ArrowDown / ArrowUp の visible-row traversal guard を追加しました。
  - jsdom では layout がないため、`offsetParent` を spec 内で明示的に mock し、hidden row が traversal target に入らない代表ケースを確認します。
  - 先頭行で ArrowUp しても focus が外へ移動しない boundary case も確認します。

## 変更内容

- `app/javascript/tree_view/index.test.js` に `setOffsetParent` helper を追加しました。
- state controller fixture に hidden row を追加しました。
- ArrowDown が hidden row を飛ばして次の visible row に移動し、ArrowUp が戻ることを spec で固定しました。

## 改善カテゴリ

- テスト追加・改善
- regression guard

## 既存仕様への影響

- runtime JavaScript は変更していません。
- Home / End / typeahead / roving tabindex / full treegrid keyboard model 追加には広げていません。
- interactive target ignore や toggle activation の既存 spec は維持しています。

## 実施した確認

- GitHub compare: `main...quality/973-keyboard-visible-row-spec`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- ローカル `npm test` は未実行です。
  - この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗し、対象 repo のローカル checkout がありません。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- spec-only の変更で、公開挙動・API・DOM構造・ARIA contract は変更していません。

## 補足事項

- browser smoke、docs全面改稿、keyboard behavior 拡張には広げていません。