### PR TITLE
windowed rendering metadata の pagination cue を docs に追加する

### DIFF
--- a/docs/en/windowed-rendering.md
+++ b/docs/en/windowed-rendering.md
@@ -47,10 +47,31 @@ Main metadata:
 | `after_count` | Number of visible rows after the current window. |
 | `has_previous?` | Whether a previous window exists. |
 | `has_next?` | Whether a next window exists. |
+| `previous_offset` | Offset to pass back when rendering the previous window, or `nil` when there is no previous window. |
+| `next_offset` | Offset to pass forward when rendering the next window, or `nil` when there is no next window. |
 
 `before_count` and `after_count` are summary metadata. Use them when the host app wants to show labels such as "20 rows before this window" or "35 rows remaining after this window" without recalculating those counts from `offset`, `limit`, and `total_count`.
 
 They never return negative values. If the requested offset is beyond the visible row count, `before_count` is capped at `total_count` and `after_count` is `0`.
+
+A small host-app pagination cue can combine the summary counts and offsets without making TreeView own the route or UI policy:
+
+```ruby
+limit = 50
+window = tree_view_window(@render_state, offset: params.fetch(:tree_offset, 0).to_i, limit: limit)
+```
+
+```erb
+<p>
+  Showing <%= window.rows.size %> of <%= window.total_count %> visible rows
+  (<%= window.before_count %> before, <%= window.after_count %> after)
+</p>
+
+<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.has_previous? %>
+<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.has_next? %>
+```
+
+The label text, route helper, parameter name, disabled-button treatment, and whether this appears as links, buttons, or a Turbo Frame toolbar are all host-app decisions.
 
 ## Visual reference
 

--- a/docs/ja/windowed-rendering.md
+++ b/docs/ja/windowed-rendering.md
@@ -47,10 +47,31 @@ window = tree_view_window(@render_state, offset: 0, limit: 50)
 | `after_count` | 現在のwindowより後ろに残るvisible row数。 |
 | `has_previous?` | 前のwindowが存在するか。 |
 | `has_next?` | 次のwindowが存在するか。 |
+| `previous_offset` | 前のwindowを描画するときに渡すoffset。前のwindowがない場合は `nil`。 |
+| `next_offset` | 次のwindowを描画するときに渡すoffset。次のwindowがない場合は `nil`。 |
 
 `before_count` / `after_count` は summary 用metadataです。host app が「このwindowの前に20件ある」「このwindowの後ろに35件残っている」のような表示を作るとき、`offset` / `limit` / `total_count` から毎回再計算せずに利用できます。
 
 どちらも負の値は返しません。指定されたoffsetがvisible row数を超える場合、`before_count` は `total_count` で止まり、`after_count` は `0` になります。
+
+小さな host-app pagination cue は、summary count と offset を組み合わせて作れます。TreeView が route や UI policy を所有するわけではありません。
+
+```ruby
+limit = 50
+window = tree_view_window(@render_state, offset: params.fetch(:tree_offset, 0).to_i, limit: limit)
+```
+
+```erb
+<p>
+  表示中: <%= window.rows.size %> / <%= window.total_count %> visible rows
+  （前に <%= window.before_count %> 件、後ろに <%= window.after_count %> 件）
+</p>
+
+<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.has_previous? %>
+<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.has_next? %>
+```
+
+表示文言、route helper、param 名、disabled button の扱い、リンク・ボタン・Turbo Frame toolbar のどれで出すかはすべて host app 側で決めます。
 
 ## Visual reference
 


### PR DESCRIPTION
windowed rendering docs に RenderWindow metadata を使った host-app pagination cue の最小例を追加します。

## 対応 Issue

Closes #1119

## 変更内容

- `docs/en/windowed-rendering.md` / `docs/ja/windowed-rendering.md` の `tree_view_window` metadata 表に `previous_offset` / `next_offset` を追加しました。
- `before_count` / `after_count` / `previous_offset` / `next_offset` を使った小さな表示範囲ラベルと前後リンク例を英日で追加しました。
- route helper、param 名、disabled button、Turbo Frame toolbar などは host app 側の責務であることを明記しました。

## 受け入れ条件との対応

- `before_count` / `after_count` / `next_offset` / `previous_offset` の representative usage を docs から辿れるようにしました。
- `tree_view_window` は metadata が必要な場合、`tree_view_rows(..., window:)` は行描画だけの場合、という既存の使い分けを維持しています。
- route params、pagination controls、query strategy、scroll behavior は host app responsibility として明記しています。
- children pagination / lazy loading / virtual scroll には広げず、既存リンクと責務境界を維持しています。

## 変更範囲

- docs only
- `docs/en/windowed-rendering.md`
- `docs/ja/windowed-rendering.md`

## 実施した確認

- GitHub compare: `main...docs/1119-windowed-rendering-metadata-cues`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- 英日 docs の追加内容が同じ意味になることを確認しました。
- production code / helper API / specs は変更していないため、local test / lint は未実行です。
- この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク

- medium
- docs-only ですが、windowed rendering を server-side pagination や virtual scroll と誤読させないよう、host app ownership を明記しています。

## 未対応・補足

- new public helper / route helper / controller generator は追加していません。
- `TreeView::RenderWindow` pagination math、server-side pagination、infinite scroll、virtual scroll 実装は変更していません。