### PR TITLE
docs/i18n-audit の mockup smoke 説明を同期構造に合わせる

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -104,7 +104,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 
 ## Technical assets
 
-`docs/mockups/README.md` is the source of truth for the current static mockup file inventory. Its Files table is also the source read by the browser smoke target list, so this checklist should describe responsibility rather than repeat every individual mockup HTML page.
+`docs/mockups/README.md` is the source of truth for the current static mockup file inventory. Its Files table feeds the expected file list used by browser smoke to check the separately maintained `focusedMockupSmokeTargets` array, so this checklist should describe responsibility rather than repeat every individual mockup HTML page.
 
 | Asset group | Status | Notes |
 |---|---|---|
@@ -119,6 +119,6 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 - Keep `docs/ja/` and `docs/en/` in sync for future user-facing changes.
 - If a temporary mismatch is unavoidable, leave a visible note and plan the follow-up.
 - Treat the High lane in the page-level coverage table above as the minimum same-sweep translation set promised by the language READMEs.
-- When `docs/mockups/` gains, renames, or removes a focused reference page, update `docs/mockups/README.md` first, then confirm `docs/mockups/review-gallery.html` and browser smoke coverage still describe the current set.
+- When `docs/mockups/` gains, renames, or removes a focused reference page, update `docs/mockups/README.md` first, then keep `docs/mockups/review-gallery.html` and the browser smoke `focusedMockupSmokeTargets` coverage aligned with the current set.
 - Update this technical-assets section only when the source-of-truth rule or asset-group responsibility changes, not for every individual mockup file addition.
 - Prefer updating this checklist by replacement when the maintenance rule changes, instead of stacking stale release-specific notes on top of it.

--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -104,7 +104,7 @@ Before merging a doc-affecting PR or preparing a release, confirm:
 
 ## Technical assets
 
-`docs/mockups/README.md` is the source of truth for the current static mockup file inventory. Its Files table feeds the expected file list used by browser smoke to check the separately maintained `focusedMockupSmokeTargets` array, so this checklist should describe responsibility rather than repeat every individual mockup HTML page.
+`docs/mockups/README.md` is the source of truth for the current static mockup file inventory. Its Files table is also the source read by the browser smoke target list, so this checklist should describe responsibility rather than repeat every individual mockup HTML page. Browser smoke reads that table as the expected file list, then checks it against the separately maintained `focusedMockupSmokeTargets` array.
 
 | Asset group | Status | Notes |
 |---|---|---|


### PR DESCRIPTION
## 対応 Issue

Closes #1131

## 判定分類

- `docs-stale` / `docs-sync`
- `docs/i18n-audit.md` の Technical assets wording が、current `test/browser/docs_mockups_smoke.spec.js` の README Files table と `focusedMockupSmokeTargets` 配列の同期検査構造を少し誤解させる状態だったため、docs-only で追従修正しました。

## 変更内容

- `docs/mockups/README.md` の Files table は mockup inventory の source of truth であることを維持しました。
- browser smoke は README table を直接 target list として実行するのではなく、README 由来の expected files と別管理の `focusedMockupSmokeTargets` 配列を一致検査する構造だと分かるようにしました。
- mockup 追加・rename・削除時の maintenance expectation を、README / review gallery / browser smoke target array の同期として書き直しました。
- 既存の `spec/mockup_inventory_spec.rb` が見る guard anchor 文言は残し、その直後に実際の同期検査構造を補足しました。

## 変更範囲

- `docs/i18n-audit.md` の wording correction のみ

## 非目標

- mockup HTML / CSS の変更
- `docs/mockups/README.md` の inventory 変更
- `docs/mockups/review-gallery.html` の変更
- browser smoke implementation の変更

## 確認内容

- GitHub compare: `main...docs/1131-i18n-mockup-smoke-wording`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 1
  - additions: 2 / deletions: 2
- 対象コードとして `test/browser/docs_mockups_smoke.spec.js` の `readmeMockupFiles()` / `focusedMockupSmokeTargets` / `expect(coveredFiles).toEqual(expectedFiles)` を確認しました。
- 初回 CI #1375 は `spec/mockup_inventory_spec.rb` の literal guard anchor 期待で失敗したため、docs anchor を残す follow-up commit を追加しました。
- GitHub Actions CI #1376: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success（docs-only non-mockup skip）
  - representative Rails lanes: success（docs-only skip）

## リスク

- low
- 実装、mockup asset、browser smoke target、review gallery inventory は変更していません。