### PR TITLE
GraphAdapter の usage / responsibility boundary docs を追加する（replacement）

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Key documents:
 | Tree identity and diagnostics | [Node keys](docs/en/node-keys.md) and [Tree diagnostics](docs/en/tree-diagnostics.md) | [Node key 設計](docs/ja/node-keys.md) and [Tree diagnostics](docs/ja/tree-diagnostics.md) |
 | Rendering scale and boundaries | [Render Scale](docs/en/render-scale.md), [Rendering Boundaries](docs/en/rendering-boundaries.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
+| GraphAdapter | [GraphAdapter](docs/en/graph-adapter.md) | [GraphAdapter](docs/ja/graph-adapter.md) |
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |
 | PathTreeBuilder | [PathTreeBuilder](docs/en/path-tree-builder.md) | [PathTreeBuilder](docs/ja/path-tree-builder.md) |
 | ReverseTree | [ReverseTree](docs/en/reverse-tree.md) | [ReverseTree](docs/ja/reverse-tree.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@
 - [日本語API判断ガイド](ja/decision-guide.md): use caseからAPIやoptionを選ぶための入口。異種node混在やgraph-like nodeでGraphAdapter adapter modeを選ぶ場面も確認できます。
 - [English API overview: adapter mode](en/api-overview.md#adapter-mode): quick GraphAdapter entry point before moving to the full API reference or cookbook performance notes.
 - [日本語API概要: adapter mode](ja/api-overview.md#adapter-mode): API仕様やCookbookの性能メモへ進む前に確認するGraphAdapterの短い入口。
+- [English GraphAdapter](en/graph-adapter.md): usage, node key strategy, and host-app responsibility boundary for heterogeneous or graph-like nodes.
+- [日本語GraphAdapter](ja/graph-adapter.md): 異種nodeやgraph-like nodeを扱う場合の使い方、node key設計、host app責務境界。
 - [English ReverseTree](en/reverse-tree.md): child-to-parent path entry point when matched records should be visible roots and ancestors should appear below them.
 - [日本語ReverseTree](ja/reverse-tree.md): matched recordを表示上のrootにし、ancestorをその下に並べるchild-to-parent pathの入口。
 - [English Filtered Trees](en/filtered-trees.md): render search or filter results as trees while keeping path-generated folders and child-to-parent paths separate.

--- a/docs/en/graph-adapter.md
+++ b/docs/en/graph-adapter.md
@@ -1,0 +1,105 @@
+# GraphAdapter
+
+Use `TreeView::GraphAdapter` when the host app needs TreeView rows for heterogeneous or graph-like nodes that do not fit one parent-id column.
+
+GraphAdapter is intentionally small. It gives `TreeView::Tree` three things:
+
+| Input | Required | Purpose |
+|---|---:|---|
+| `roots:` | yes | Top-level nodes TreeView starts from. |
+| `children_resolver:` | yes | Callable that returns the children for a node. `nil` becomes an empty array, and a single child is wrapped in an array. |
+| `node_key_resolver:` | no | Callable that returns the stable node key. Without it, TreeView uses `[node.class.name, node.public_send(id_method)]`. |
+
+## Minimal example
+
+```ruby
+adapter = TreeView::GraphAdapter.new(
+  roots: [workspace],
+  children_resolver: ->(node) {
+    case node
+    when Workspace
+      node.projects.visible_to(current_user).to_a
+    when Project
+      node.documents.visible_to(current_user).to_a
+    else
+      []
+    end
+  },
+  node_key_resolver: ->(node) { TreeView.node_key(node.class.name, node.id) }
+)
+
+tree = TreeView::Tree.new(adapter: adapter)
+
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "workspaces/tree_columns",
+  ui_config: tree_ui
+)
+```
+
+This keeps the tree rendering API the same as records mode while letting the host app decide how each node type finds its children.
+
+## When to use it
+
+Use GraphAdapter when:
+
+- one `parent_id_method` cannot describe the hierarchy;
+- a tree mixes model classes, external nodes, generated nodes, or edge-derived children;
+- the host app already has a traversal policy and only needs TreeView rendering and interaction hooks.
+
+Prefer records mode when every row is the same model shape and a parent-id column describes the tree. Prefer `PathTreeBuilder` when records expose path-like values and the host app wants generated folder nodes.
+
+## Responsibility boundary
+
+TreeView traverses the roots and child arrays returned by the adapter. The host app owns:
+
+- graph traversal policy and which node types may appear;
+- authorization and visibility filtering before children are returned;
+- query planning, eager loading, caching, and pagination strategy;
+- cycle prevention or cycle handling policy;
+- stable node key design across heterogeneous node types;
+- row partials, labels, routes, and business actions.
+
+GraphAdapter does not add a cycle-detection engine, authorization layer, query optimizer, persistence model, or business graph DSL. If the same node can appear through multiple paths, decide whether that is valid for your screen before passing nodes to TreeView.
+
+## Node keys
+
+For heterogeneous nodes, pass a `node_key_resolver:` that namespaces by type or source system.
+
+```ruby
+node_key_resolver = ->(node) {
+  TreeView.node_key(node.class.name, node.id)
+}
+```
+
+Use the same key strategy when configuring initial expansion, persisted state, row IDs, or host-app routes that need to refer to the same logical node. See [Node keys](node-keys.md) and [API overview: Node keys and UI identifiers](api-overview.md#node-keys-and-ui-identifiers) for details.
+
+## Performance notes
+
+Materialize children before returning them from the resolver when rows may be rendered more than once.
+
+```ruby
+children_by_project_id = Project.visible_to(current_user).to_a.index_with do |project|
+  project.documents.visible_to(current_user).includes(:latest_version).to_a
+end
+
+adapter = TreeView::GraphAdapter.new(
+  roots: projects,
+  children_resolver: ->(node) {
+    node.is_a?(Project) ? children_by_project_id.fetch(node.id, []) : []
+  },
+  node_key_resolver: ->(node) { TreeView.node_key(node.class.name, node.id) }
+)
+```
+
+For more practical checklist items, see [Cookbook: GraphAdapter and ActiveRecord performance](cookbook.md#graphadapter-and-activerecord-performance).
+
+## Related documents
+
+- [Decision guide](decision-guide.md)
+- [API overview: adapter mode](api-overview.md#adapter-mode)
+- [API reference: TreeView::Tree](api.md#treeviewtree)
+- [Node keys](node-keys.md)
+- [Tree diagnostics](tree-diagnostics.md)
+- [Cookbook: GraphAdapter and ActiveRecord performance](cookbook.md#graphadapter-and-activerecord-performance)

--- a/docs/ja/graph-adapter.md
+++ b/docs/ja/graph-adapter.md
@@ -1,0 +1,105 @@
+# GraphAdapter
+
+`TreeView::GraphAdapter` は、1つの parent id column では表しにくい異種 node や graph-like node を TreeView の行として描画したいときに使います。
+
+GraphAdapter は意図的に小さい adapter です。`TreeView::Tree` に次の3つを渡します。
+
+| 入力 | 必須 | 役割 |
+|---|---:|---|
+| `roots:` | yes | TreeView が開始する top-level node。 |
+| `children_resolver:` | yes | node の子を返す callable。`nil` は空配列になり、単一の child object は配列で包まれます。 |
+| `node_key_resolver:` | no | 安定した node key を返す callable。省略時は `[node.class.name, node.public_send(id_method)]` を使います。 |
+
+## 最小例
+
+```ruby
+adapter = TreeView::GraphAdapter.new(
+  roots: [workspace],
+  children_resolver: ->(node) {
+    case node
+    when Workspace
+      node.projects.visible_to(current_user).to_a
+    when Project
+      node.documents.visible_to(current_user).to_a
+    else
+      []
+    end
+  },
+  node_key_resolver: ->(node) { TreeView.node_key(node.class.name, node.id) }
+)
+
+tree = TreeView::Tree.new(adapter: adapter)
+
+render_state = TreeView::RenderState.new(
+  tree: tree,
+  root_items: tree.root_items,
+  row_partial: "workspaces/tree_columns",
+  ui_config: tree_ui
+)
+```
+
+records mode と同じ描画 API を使いつつ、各 node type が子をどう見つけるかは host app 側で決められます。
+
+## 使う場面
+
+GraphAdapter は次のような場合に使います。
+
+- 1つの `parent_id_method` では hierarchy を表せない
+- model class、外部 node、生成 node、edge 由来の child が同じ tree に混ざる
+- host app 側に traversal policy があり、TreeView には描画と interaction hook だけを任せたい
+
+すべての行が同じ model shape で parent-id column から tree を作れる場合は records mode を優先してください。record が path-like value を持ち、生成 folder node を作りたい場合は `PathTreeBuilder` を優先してください。
+
+## 責務境界
+
+TreeView は adapter が返す roots と child arrays を辿ります。次の責務は host app が持ちます。
+
+- graph traversal policy と、どの node type を表示対象にするか
+- children を返す前の authorization / visibility filtering
+- query planning、eager loading、cache、pagination strategy
+- cycle prevention または cycle handling policy
+- 異種 node 間で安定する node key 設計
+- row partial、label、route、business action
+
+GraphAdapter は cycle-detection engine、authorization layer、query optimizer、persistence model、business graph DSL を追加しません。同じ node が複数 path から現れ得る場合は、それを画面上の正しい状態として扱うかどうかを TreeView に渡す前に host app 側で決めてください。
+
+## Node key
+
+異種 node を扱う場合は、type や source system で namespace した `node_key_resolver:` を渡します。
+
+```ruby
+node_key_resolver = ->(node) {
+  TreeView.node_key(node.class.name, node.id)
+}
+```
+
+initial expansion、persisted state、row ID、host-app route などで同じ logical node を参照する場合は、同じ key strategy を使ってください。詳しくは [Node key 設計](node-keys.md) と [API概要: Node keys and UI identifiers](api-overview.md#node-keys-and-ui-identifiers) を参照してください。
+
+## 性能メモ
+
+行が複数回描画され得る場合は、resolver から返す children を事前に materialize してください。
+
+```ruby
+children_by_project_id = Project.visible_to(current_user).to_a.index_with do |project|
+  project.documents.visible_to(current_user).includes(:latest_version).to_a
+end
+
+adapter = TreeView::GraphAdapter.new(
+  roots: projects,
+  children_resolver: ->(node) {
+    node.is_a?(Project) ? children_by_project_id.fetch(node.id, []) : []
+  },
+  node_key_resolver: ->(node) { TreeView.node_key(node.class.name, node.id) }
+)
+```
+
+実装時の checklist は [Cookbook: GraphAdapter と ActiveRecord の性能](cookbook.md#graphadapter-と-activerecord-の性能) も参照してください。
+
+## 関連ドキュメント
+
+- [API判断ガイド](decision-guide.md)
+- [API概要: adapter mode](api-overview.md#adapter-mode)
+- [API仕様: TreeView::Tree](api.md#treeviewtree)
+- [Node key 設計](node-keys.md)
+- [Tree diagnostics](tree-diagnostics.md)
+- [Cookbook: GraphAdapter と ActiveRecord の性能](cookbook.md#graphadapter-と-activerecord-の性能)


### PR DESCRIPTION
## 対応 Issue

Closes #1117

## 元 PR

- Replaces #1122
- #1122 は review follow-up で current `main` へ branch を合わせた瞬間に差分なしとして auto-close されたため、同じ branch に docs 差分を再適用して replacement PR として開き直しています。

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/en/graph-adapter.md` / `docs/ja/graph-adapter.md` を追加しました。
  - `roots:` / `children_resolver:` / `node_key_resolver:` の役割を整理しました。
  - heterogeneous / graph-like nodes 向けの最小例を追加しました。
  - traversal policy、authorization、query planning、cycle policy、row partial / route / business action は host app responsibility と明記しました。
- `README.md` の Key documents に GraphAdapter の英日導線を追加しました。
- `docs/README.md` の Recommended entry points に GraphAdapter の英日導線を追加しました。

## 根拠

- `README.md` の Features は `GraphAdapter` を heterogeneous or graph-like nodes 向け機能として案内しています。
- `lib/tree_view/graph_adapter.rb` は `roots:`、`children_resolver:`、任意の `node_key_resolver:` を受け取り、children を `Array(...)` で正規化します。
- `spec/lib/tree_view/graph_adapter_spec.rb` は roots / children / default node key / custom node key / nil child / single child / enumerable-like children を確認しています。

## 非目標

- GraphAdapter API の追加 / rename / 削除
- cycle detection engine、authorization、query optimizer、business graph DSL の追加
- runtime code、public API manifest、spec の変更
- Tree / RenderState docs の全面 rewrite

## 確認内容

- GitHub compare: `main...docs/1117-graph-adapter-guide`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4 docs files
  - additions: 213 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` のため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 実装済み GraphAdapter surface に対する利用導線と責務境界の補足に閉じ、仕様追加やコード変更はしていません。