### PR TITLE
breadcrumb unsupported mode の troubleshooting 導線を追加する

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -45,6 +45,24 @@ Read next:
 - [Turbo Frame option](turbo-frame.md)
 - [Usage](usage.md)
 
+## Breadcrumbs fail or cannot find a parent path
+
+Breadcrumb path lookup is records-mode only. TreeView can render breadcrumbs when it can walk `parent_id_method` relationships from the current record back to a root.
+
+Check these points.
+
+- Confirm the tree was built from `records:` with `parent_id_method:`. Resolver mode and adapter mode do not expose a unique parent path to the bundled breadcrumb helper.
+- If the error says parent path helpers are only supported in records mode, keep the failure as a mode boundary signal instead of trying to infer parents from graph-like data.
+- If the data is graph-like, has multiple possible parents, or comes from `GraphAdapter`, let the host app choose the breadcrumb trail and render its own links or labels.
+- Keep route, authorization, layout placement, and analytics behavior in the host app; TreeView only owns records-mode path lookup and helper HTML.
+
+Read next:
+
+- [Breadcrumb](breadcrumb.md#supported-mode)
+- [GraphAdapter](graph-adapter.md)
+- [Host App Extension Points](host-app-extension-points.md)
+- [Rendering Boundaries](rendering-boundaries.md)
+
 ## Row partial output looks broken or table cells do not line up
 
 TreeView owns the row wrapper and common tree UI cells. The host app owns the contents of `row_partial`, action cells, and the surrounding table layout.

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -45,6 +45,24 @@ toolbar action は、TreeView がその action の path を作れないと disab
 - [Turbo Frame option](turbo-frame.md)
 - [使い方](usage.md)
 
+## breadcrumb が失敗する / 親方向の path が見つからない
+
+breadcrumb の path lookup は records mode 専用です。TreeView は、現在 record から root まで `parent_id_method` の関係を辿れる場合に breadcrumb を描画できます。
+
+次を確認してください。
+
+- tree が `records:` と `parent_id_method:` から構築されているか。resolver mode と adapter mode は、bundled breadcrumb helper が使う一意な親方向 path を公開しません。
+- error が parent path helpers は records mode 専用だと示している場合は、graph-like data から親を推測しようとせず、mode 境界の signal として扱う。
+- data が graph-like、複数の parent 候補を持つ、または `GraphAdapter` 由来の場合は、host app 側で breadcrumb trail を選び、独自の link または label を描画する。
+- route、authorization、layout placement、analytics behavior は host app 側で管理する。TreeView が担当するのは records-mode path lookup と helper HTML です。
+
+次に読む文書:
+
+- [Breadcrumb](breadcrumb.md#対応mode)
+- [GraphAdapter](graph-adapter.md)
+- [Host App 拡張ポイント](host-app-extension-points.md)
+- [Rendering Boundaries](rendering-boundaries.md)
+
 ## row partial の表示が崩れる / table cell 数が合わない
 
 TreeView は row wrapper と共通 tree UI cell を担当し、`row_partial` の中身、action cell、周囲の table layout は host app が担当します。


### PR DESCRIPTION
## 対応 Issue

Closes #1138

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `docs/en/troubleshooting.md` / `docs/ja/troubleshooting.md` に breadcrumb / parent path lookup の症状エントリを追加しました。
- records-mode tree では TreeView が `parent_id_method` による path lookup と helper HTML を担当することを整理しました。
- resolver mode / adapter mode / graph-like data では bundled breadcrumb helper に一意な parent path がなく、host app が breadcrumb trail を選ぶ責務境界を明記しました。
- `breadcrumb.md`、`graph-adapter.md`、host app extension / rendering boundary docs への読み先を追加しました。

## 根拠

- `docs/en|ja/breadcrumb.md` は breadcrumb helper が records-mode tree 前提であることを説明しています。
- `lib/tree_view/tree.rb` の `path_for` は `ancestors_for` 経由で `ensure_records_path_helpers!` を呼び、resolver / adapter mode では `ConfigurationError` を出します。
- 既存 troubleshooting には toggle、toolbar、row partial、lazy loading、selection、persisted state、node key などの逆引きはありますが、breadcrumb unsupported mode / path lookup の症状入口がありませんでした。

## 非目標

- breadcrumb helper の mode support 追加
- resolver / adapter mode の path inference 実装
- GraphAdapter traversal policy の変更
- host app route / authorization / layout policy の設計
- runtime Ruby / JavaScript / spec の変更

## 確認内容

- GitHub compare: `main...docs/1138-breadcrumb-troubleshooting-v2`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 36 / deletions: 0
- GitHub Actions CI #1381: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - representative Rails lanes: docs-only skip path で success
  - `javascript`: docs-only / non-mockup skip path で success
  - `gem_package`: skipped
- PR metadata: `mergeable: true`
- local test / lint は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` のため、connector 経由で変更しています。

## リスク

- low
- 既存実装の mode boundary と既存 breadcrumb docs への troubleshooting 導線追加に閉じ、仕様追加やコード変更はしていません。