### PR TITLE
test: public API manifest と docs 入口の同期を確認する

### DIFF
--- a/spec/public_api_docs_entrypoints_spec.rb
+++ b/spec/public_api_docs_entrypoints_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "Public API documentation entrypoints" do
+  repository_root = File.expand_path("..", __dir__)
+  manifest_path = File.join(repository_root, "config/public_api_manifest.yml")
+  docs_root = File.join(repository_root, "docs")
+
+  def manifest
+    @manifest ||= YAML.safe_load_file(self.class.metadata.fetch(:manifest_path))
+  end
+
+  def read_doc(relative_path)
+    File.read(File.join(self.class.metadata.fetch(:docs_root), relative_path))
+  end
+
+  before do |example|
+    example.metadata[:manifest_path] = manifest_path
+    example.metadata[:docs_root] = docs_root
+  end
+
+  it "keeps public API and JavaScript event docs reachable from the language docs indexes" do
+    root_index = read_doc("README.md")
+    english_index = read_doc("en/README.md")
+    japanese_index = read_doc("ja/README.md")
+
+    expect(root_index).to include("en/public-api.md")
+    expect(root_index).to include("ja/public-api.md")
+
+    expect(english_index).to include("public-api.md")
+    expect(english_index).to include("js-events.md")
+
+    expect(japanese_index).to include("public-api.md")
+    expect(japanese_index).to include("js-events.md")
+  end
+
+  it "keeps manifest-backed Ruby surfaces documented in both public API entrypoints" do
+    public_api_docs = {
+      english: read_doc("en/public-api.md"),
+      japanese: read_doc("ja/public-api.md")
+    }
+
+    public_api_docs.each do |language, doc|
+      manifest.fetch("module_methods").each do |method_name|
+        expect(doc).to include("TreeView.#{method_name}"),
+          "expected #{language} public API docs to mention TreeView.#{method_name}"
+      end
+
+      manifest.fetch("public_constants").each do |constant_name|
+        expect(doc).to include("TreeView::#{constant_name}"),
+          "expected #{language} public API docs to mention TreeView::#{constant_name}"
+      end
+
+      manifest.fetch("helper_methods").each do |helper_name|
+        expect(doc).to include(helper_name),
+          "expected #{language} public API docs to mention #{helper_name}"
+      end
+    end
+  end
+
+  it "keeps manifest-backed JavaScript event names documented in both event entrypoints" do
+    event_docs = {
+      english: read_doc("en/js-events.md"),
+      japanese: read_doc("ja/js-events.md")
+    }
+    event_names = manifest.fetch("javascript_package_root").fetch("event_names").values.flat_map(&:values)
+
+    event_docs.each do |language, doc|
+      event_names.each do |event_name|
+        expect(doc).to include(event_name),
+          "expected #{language} JavaScript event docs to mention #{event_name}"
+      end
+    end
+  end
+end

--- a/spec/public_api_docs_entrypoints_spec.rb
+++ b/spec/public_api_docs_entrypoints_spec.rb
@@ -3,22 +3,17 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "Public API documentation entrypoints" do
-  repository_root = File.expand_path("..", __dir__)
-  manifest_path = File.join(repository_root, "config/public_api_manifest.yml")
-  docs_root = File.join(repository_root, "docs")
+PUBLIC_API_DOCS_REPOSITORY_ROOT = File.expand_path("..", __dir__)
+PUBLIC_API_DOCS_MANIFEST_PATH = File.join(PUBLIC_API_DOCS_REPOSITORY_ROOT, "config/public_api_manifest.yml")
+PUBLIC_API_DOCS_ROOT = File.join(PUBLIC_API_DOCS_REPOSITORY_ROOT, "docs")
 
+RSpec.describe "Public API documentation entrypoints" do
   def manifest
-    @manifest ||= YAML.safe_load_file(self.class.metadata.fetch(:manifest_path))
+    @manifest ||= YAML.safe_load_file(PUBLIC_API_DOCS_MANIFEST_PATH)
   end
 
   def read_doc(relative_path)
-    File.read(File.join(self.class.metadata.fetch(:docs_root), relative_path))
-  end
-
-  before do |example|
-    example.metadata[:manifest_path] = manifest_path
-    example.metadata[:docs_root] = docs_root
+    File.read(File.join(PUBLIC_API_DOCS_ROOT, relative_path))
   end
 
   it "keeps public API and JavaScript event docs reachable from the language docs indexes" do


### PR DESCRIPTION
## 対応 Issue

Closes #1139

## Issue ごとの完了内容

- public API manifest の主要カテゴリが代表 docs entrypoint に残っているかを確認する lightweight spec を追加しました。
- canonical entrypoint は `docs/en/public-api.md` / `docs/ja/public-api.md` と `docs/en/js-events.md` / `docs/ja/js-events.md` に絞りました。
- language docs indexes から public API / JavaScript event docs へ辿れることも確認します。

## 変更内容

- `spec/public_api_docs_entrypoints_spec.rb` を追加しました。
- Ruby surface は module methods / public constants / helper methods を public API docs で確認します。
- JavaScript surface は manifest-backed event names を js-events docs で確認します。

## 改善カテゴリ

- test
- docs drift guard
- maintenance

## 既存仕様への影響

- なし。runtime code、public API manifest、docs本文は変更していません。
- public API の追加・削除・rename、JavaScript event payload 変更、manifest schema 変更には広げていません。

## 実施した確認

- GitHub compare: `main...quality/1139-public-api-docs-drift`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 1 (`spec/public_api_docs_entrypoints_spec.rb`)
- local `bundle exec rspec spec/public_api_docs_entrypoints_spec.rb` は未実行です。
  - この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後の GitHub Actions で確認します。

## リスク評価

- medium
- docs drift guard の追加のみですが、manifest-backed public surface を docs に要求する spec なので、将来の manifest 更新時には docs 導線更新も必要になります。

## 補足事項

- false positive を抑えるため、全文 docs coverage や translation diff の完全検証には広げていません。