### PR TITLE
GraphAdapter resolver の troubleshooting 導線を追加する

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -88,6 +88,26 @@ Read next:
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## GraphAdapter rows look duplicated, incomplete, or shaped differently than expected
+
+GraphAdapter symptoms usually come from the host app's resolver output or node-key strategy. TreeView normalizes resolver results so it can render rows, but it does not decide traversal policy, authorization, cycle handling, or query planning for graph-like data.
+
+Check these points before changing row partials or TreeView internals.
+
+- Confirm each `children_resolver` branch returns the child collection the host app actually wants to render. Return arrays for predictable rendering and performance.
+- Remember that `nil` becomes an empty child list and a single object is wrapped as one child. If that surprises the screen, make the resolver branch explicit.
+- If the same logical node appears under multiple parents, decide in the host app whether that duplicate path is intentional or should be filtered before building the tree.
+- For heterogeneous nodes, pass a `node_key_resolver:` that namespaces node keys by type or source system.
+- If cycles or duplicate keys appear, use diagnostics first instead of adding GraphAdapter-specific validation behavior.
+- Keep authorization, eager loading, cache, pagination, and cycle policy in the host app; GraphAdapter only supplies roots and child arrays to `TreeView::Tree`.
+
+Read next:
+
+- [GraphAdapter](graph-adapter.md)
+- [Cookbook: GraphAdapter and ActiveRecord performance](cookbook.md#graphadapter-and-activerecord-performance)
+- [Tree diagnostics](tree-diagnostics.md)
+- [Node keys](node-keys.md)
+
 ## CSS or JavaScript integration does not seem to apply
 
 Start with installation wiring.

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -88,6 +88,26 @@ tree を描画しているときの Rails log で次を確認します。
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## GraphAdapter の行が重複する / 足りない / 想定と違う形になる
+
+GraphAdapter で起きる症状は、多くの場合 host app 側の resolver 出力または node key strategy から来ます。TreeView は行を描画できるよう resolver 結果を正規化しますが、graph-like data の traversal policy、authorization、cycle handling、query planning は決めません。
+
+row partial や TreeView 内部を変える前に次を確認してください。
+
+- `children_resolver` の各 branch が、その画面で本当に描画したい child collection を返しているか。予測しやすい描画と性能のため、配列を返してください。
+- `nil` は空の child list になり、単一 object は 1 child として包まれます。その挙動が画面の期待と違う場合は resolver branch を明示してください。
+- 同じ logical node が複数 parent の下に出る場合、それを意図した duplicate path として扱うか、tree 構築前に host app 側で絞るかを決めてください。
+- heterogeneous node では、type や source system で namespace した `node_key_resolver:` を渡してください。
+- cycle や duplicate key が見える場合、GraphAdapter 固有の validation behavior を足す前に diagnostics を使ってください。
+- authorization、eager loading、cache、pagination、cycle policy は host app 側に置いてください。GraphAdapter は roots と child arrays を `TreeView::Tree` に渡すだけです。
+
+次に読む文書:
+
+- [GraphAdapter](graph-adapter.md)
+- [Cookbook: GraphAdapter と ActiveRecord の性能](cookbook.md#graphadapter-と-activerecord-の性能)
+- [Tree diagnostics](tree-diagnostics.md)
+- [Node keys](node-keys.md)
+
 ## CSS や JavaScript の統合が効いていないように見える
 
 まず導入 wiring を確認してください。


### PR DESCRIPTION
## 対応 Issue

Closes #1136

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `docs/en/troubleshooting.md` / `docs/ja/troubleshooting.md` に GraphAdapter の resolver / data-shape pitfall を症状から逆引きする entry を追加しました。
- `children_resolver` の戻り値境界、`nil` / single object normalization、duplicate path、heterogeneous node key、cycle / duplicate key diagnostics の確認観点を整理しました。
- GraphAdapter guide、Cookbook、Tree diagnostics、Node keys への相互導線を追加しました。

## 根拠

- `lib/tree_view/graph_adapter.rb` は resolver 結果を TreeView に渡す薄い adapter surface で、traversal policy / authorization / query planning / cycle policy は host app responsibility です。
- #1137 により GraphAdapter guide は main に入っており、troubleshooting から専用 guide へ安全にリンクできる状態になりました。
- 既存 troubleshooting は repeated query と duplicate key / cycle の断片を持っていますが、GraphAdapter 固有の resolver/data-shape symptoms からの entry が不足していました。

## 非目標

- GraphAdapter implementation / API の変更
- cycle detection / duplicate node key validation の新機能追加
- ActiveRecord eager loading strategy の実装
- API overview / cookbook の全面 rewrite

## 確認内容

- GitHub compare: `main...docs/1136-graph-adapter-troubleshooting`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 40 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 既存 GraphAdapter guide と troubleshooting の導線補強に閉じ、runtime behavior や public API contract は変更していません。