### PR TITLE
table caption context mockup を最新 main に載せ直す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
         run: npx playwright install --with-deps chromium
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.mockups_changed == 'true'
         run: npm run test:browser
 
   gem_package:

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -13,6 +13,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the current baseline and focused mockup references, with review-path jump links, embedded previews, and links to each full page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
+| [table-caption-context.html](table-caption-context.html) | Focused table caption and surrounding page structure reference showing host-app-owned heading, caption, summary, and actions around TreeView-owned row cues. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [current-branch-sidebar.html](current-branch-sidebar.html) | Current branch sidebar reference showing current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues without host-app navigation policy. |
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
@@ -47,26 +48,27 @@ They are **not** a complete Rails application and should not grow into host-app 
 5. Use [row-status-depth-labels.html](row-status-depth-labels.html) when review needs to compare row-wide readonly/disabled cues, selection checkbox disabled state, and depth-label meaning boundaries.
 6. Use [toggle-icon-states.html](toggle-icon-states.html) when review needs to compare `toggle_icons:` expanded, collapsed, leaf, loading, and depth/type variation without selecting a final icon library.
 7. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
-8. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-9. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
-10. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
-11. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-12. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
-13. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-14. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-15. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-16. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-17. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-18. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-19. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-20. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-21. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
-22. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
-25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
-27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+8. Use [table-caption-context.html](table-caption-context.html) when review needs to compare host-app-owned heading, caption, summary, and adjacent actions around TreeView-owned row hierarchy cues.
+9. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
+10. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
+11. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
+12. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+13. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
+14. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+15. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+16. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+17. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+18. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+19. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+20. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+21. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+22. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
+23. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+24. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+25. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
+26. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+27. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
+28. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -205,6 +205,7 @@
         <p>Jump to the first card in a state family, then continue through nearby cards for related comparisons.</p>
         <div class="mock-gallery-review-path-links">
           <a href="#gallery-default-heading">Baseline</a>
+          <a href="#gallery-table-caption-heading">Page structure</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
           <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
           <a href="#gallery-toggle-icon-heading">Toggle icons</a>
@@ -233,6 +234,9 @@
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-table-caption-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused page structure</p><h2 id="gallery-table-caption-heading">Table caption context</h2><p>Compare host-app-owned heading, caption, summary, and adjacent actions around TreeView-owned row cues.</p><ul class="mock-gallery-points"><li>Host-owned page heading and table caption</li><li>Adjacent actions outside TreeView scope</li><li>TreeView row hierarchy cues inside the table body</li></ul><div class="mock-gallery-links"><a href="table-caption-context.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="table-caption-context.html" title="Table caption context mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading">
         <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
@@ -303,6 +307,7 @@
         <tr><td>Row status and depth labels</td><td>Row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
         <tr><td>Toggle icon states</td><td>Expanded, collapsed, leaf, loading, and depth/type icon variation boundaries.</td><td>Icon library choice, final artwork, tooltip copy, public API changes, or runtime behavior.</td></tr>
         <tr><td>Resource table bridge</td><td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td><td>Saved table state, host-app queries, or business-specific row actions.</td></tr>
+        <tr><td>Table caption context</td><td>Host-app-owned heading, caption, summary, and adjacent actions around TreeView-owned row cues.</td><td>Caption helper APIs, treegrid semantics, CRUD routes, authorization, or final business copy.</td></tr>
         <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
         <tr><td>Current branch sidebar</td><td>Current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues.</td><td>Route selection, permission-aware labels, final sidebar ordering, or host-app navigation policy.</td></tr>
         <tr><td>Interaction states</td><td>Loading, retry, pagination, and general drag or drop status cues.</td><td>Real Turbo responses, route wiring, or persistence behavior.</td></tr>

--- a/docs/mockups/table-caption-context.html
+++ b/docs/mockups/table-caption-context.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Table caption context mock</title>
+<link rel="stylesheet" href="default-tree.css">
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Table caption context mock</h1>
+      <p>
+        Static reference for placing TreeView rows inside host-app-owned page structure.
+        The heading, table caption, summary, and adjacent actions are intentionally product-neutral host app content; TreeView owns the hierarchy row cues inside the table body.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="host-page-heading">
+      <p class="mock-kicker">Host app page structure</p>
+      <h2 id="host-page-heading">Workspace hierarchy</h2>
+      <p>
+        This header, summary text, and action row stand in for content supplied by the host application.
+        They should explain the screen purpose without implying that TreeView provides routing, authorization, CRUD actions, or final business copy.
+      </p>
+
+      <div class="mock-filter-bar" aria-label="Host app actions">
+        <span class="mock-filter-chip">Host-owned summary: 4 visible nodes</span>
+        <button type="button">Host action</button>
+        <button type="button">Secondary action</button>
+      </div>
+
+      <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+        <caption>
+          Host-owned table caption describing the current workspace hierarchy and review context.
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">select</th>
+            <th scope="col">tree</th>
+            <th scope="col">name</th>
+            <th scope="col">owner</th>
+            <th scope="col">status</th>
+            <th scope="col">actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="context_project_1" class="tree-row is-expanded" data-tree-node-key="context-project:1" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true" aria-selected="false">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_1_selection" name="selected_nodes[]" type="checkbox" value='{"key":"context-project:1","id":1,"type":"Project"}' data-tree-selection-payload='{"key":"context-project:1","id":1,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_1_button">
+              <span class="tree-toggle" aria-label="Root row expanded">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                  <span class="tree-toggle__level">root</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="Folder">folder</span>
+              <span class="tree-depth-label">L0</span>
+            </td>
+            <td>Platform program</td>
+            <td>Team A</td>
+            <td><span class="mock-status mock-status--active">active</span></td>
+            <td class="tree-row-actions"><button type="button">Open</button></td>
+          </tr>
+
+          <tr id="context_project_2" class="tree-row is-selected" data-tree-node-key="context-project:2" data-tree-parent-key="context-project:1" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-selected="true" aria-current="page">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_2_selection" name="selected_nodes[]" type="checkbox" checked value='{"key":"context-project:2","id":2,"type":"Project"}' data-tree-selection-payload='{"key":"context-project:2","id":2,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_2_button">
+              <span class="tree-toggle" aria-label="Selected child row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">child</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="Folder">folder</span>
+              <span class="tree-depth-label">L1</span>
+              <span class="tree-node-badge tree-node-badge--info" title="Current row">current</span>
+            </td>
+            <td>Operations surface</td>
+            <td>Team B</td>
+            <td><span class="mock-status mock-status--active">active</span></td>
+            <td class="tree-row-actions"><button type="button">Open</button></td>
+          </tr>
+
+          <tr id="context_project_3" class="tree-row is-leaf" data-tree-node-key="context-project:3" data-tree-parent-key="context-project:2" data-tree-depth="2" data-tree-expanded="false" aria-level="3" aria-selected="false">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_3_selection" name="selected_nodes[]" type="checkbox" value='{"key":"context-project:3","id":3,"type":"Project"}' data-tree-selection-payload='{"key":"context-project:3","id":3,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_3_button">
+              <span class="tree-toggle" aria-label="Leaf row">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <span class="tree-toggle__level">leaf</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="File">file</span>
+              <span class="tree-depth-label">L2</span>
+            </td>
+            <td>Review checklist</td>
+            <td>Team B</td>
+            <td><span class="mock-status">ready</span></td>
+            <td class="tree-row-actions"><button type="button">Open</button></td>
+          </tr>
+
+          <tr id="context_project_4" class="tree-row is-collapsed" data-tree-node-key="context-project:4" data-tree-parent-key="context-project:1" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false" aria-selected="false">
+            <td class="tree-selection-cell">
+              <input class="tree-selection-checkbox" id="context_project_4_selection" name="selected_nodes[]" type="checkbox" disabled title="Host app disabled this selection" value='{"key":"context-project:4","id":4,"type":"Project"}' data-tree-selection-disabled-reason="Host app disabled this selection" data-tree-selection-payload='{"key":"context-project:4","id":4,"type":"Project"}'>
+            </td>
+            <td class="btn-cell tree-toggle-cell" id="context_project_4_button">
+              <span class="tree-toggle" aria-label="Collapsed row with hidden descendants">
+                <span class="tree-toggle__branches" aria-hidden="true">
+                  <span class="tree-toggle__branch-slot has-line"></span>
+                  <span class="tree-toggle__branch-slot is-current is-last"></span>
+                </span>
+                <span class="tree-toggle__control">
+                  <a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a>
+                  <span class="tree-toggle__level">child</span>
+                  <span class="tree-toggle__hidden-count" title="Hidden descendants">5</span>
+                </span>
+              </span>
+              <span class="tree-node-marker" title="Archive">archive</span>
+              <span class="tree-depth-label">L1</span>
+              <span class="tree-node-badge tree-node-badge--warning" title="Host app status">archived</span>
+            </td>
+            <td>Archived workstream</td>
+            <td>Team C</td>
+            <td><span class="mock-status mock-status--archived">archived</span></td>
+            <td class="tree-row-actions"><button type="button" disabled>Open</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="boundary-heading">
+      <h2 id="boundary-heading">Responsibility boundary</h2>
+      <ul>
+        <li>Host app owns page heading, caption copy, summary text, action labels, routes, authorization, and final business wording.</li>
+        <li>TreeView owns row hierarchy cues such as branch lines, toggle affordances, depth labels, hidden counts, and selection payload hooks.</li>
+        <li>This mock does not introduce a caption helper, treegrid semantics, CRUD flow, route policy, or public API option.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -40,6 +40,7 @@ async function expectNoDocumentHorizontalOverflow(page) {
 const focusedMockupSmokeTargets = [
   { file: "default-tree.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
   { file: "resource-table-bridge.html", sample: ".mock-bridge-table tbody tr", minimumCount: 4 },
+  { file: "table-caption-context.html", sample: ".tree-view-table caption", minimumCount: 1 },
   { file: "narrow-sidebar-tree.html", sample: ".mock-narrow-frame", minimumCount: 2 },
   { file: "current-branch-sidebar.html", sample: ".tree-row.is-selected[aria-current='page']", minimumCount: 1 },
   { file: "row-status-depth-labels.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },


### PR DESCRIPTION
## 対応Issue

- Closes #1013
- Supersedes #1023

## 採用した方針

- review follow-up の修正要求に従い、stale / diverged になっていた #1023 を current `main` から作り直しました。
- runtime Ruby / JavaScript、ARIA policy、public API manifest、host-app route / authorization / CRUD には触れず、static mockup と README / review gallery / browser smoke target の同期に閉じました。
- #1023 の review comment で指摘されていた `mergeable:false`、mockup inventory drift、browser smoke 証拠不足を解消するため、最新 main から replacement branch を切り直しています。

## 比較した案

- 案A: 既存 PR #1023 の branch を更新する
  - PR metadata が `mergeable:false` で、repository は PR branch update を許可していないため見送りました。
- 案B: 最新 `main` から replacement branch を作り、同じ focused mockup を小さく載せ直す
  - 採用案です。`behind_by: 0` を確保し、mockup README / review gallery / smoke target の同期を current main 上で取り直せます。
- 案C: runtime helper や caption API まで追加する
  - #1013 の non-goal なので見送りました。

## 変更内容

- `docs/mockups/table-caption-context.html` を追加
  - host-app-owned heading / caption / summary / adjacent actions を含む静的ページを追加
  - TreeView-owned row hierarchy cues は既存 table mockup classes に揃えました
  - caption helper、treegrid semantics、CRUD / route / authorization / public API は追加していません
- `docs/mockups/README.md` を更新
  - Files table に新 mockup を追加
  - Recommended review flow に caption context の確認タイミングを追加
- `docs/mockups/review-gallery.html` を更新
  - review path / gallery card / iframe preview / comparison cue に新 mockup を追加
- `test/browser/docs_mockups_smoke.spec.js` を更新
  - README Files table と browser smoke target の同期 guard に `table-caption-context.html` を追加
- `.github/workflows/ci.yml` を更新
  - mockup changed PR で `test/browser/docs_mockups_smoke.spec.js` も更新した場合でも `npm run test:browser` が実行されるよう、browser smoke の条件を `mockups_changed == true` に寄せました。

## 変更した画面・コンポーネント

- `docs/mockups/table-caption-context.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `test/browser/docs_mockups_smoke.spec.js`
- `.github/workflows/ci.yml`

## 確認内容

- lint: GitHub Actions CI #1387 success
- typecheck: runtime code 変更なし
- UI表示確認: GitHub Actions CI #1387 `javascript` job で `npm run test:browser` success
- レスポンシブ確認: browser smoke の代表 viewport check は既存 coverage 範囲で success。新 mockup は既存 `default-tree.css` の mock page / table behavior に乗せています。
- アクセシビリティ確認: `h1`、section heading、table `caption`、return nav、代表 table row states を source 上で確認
- GitHub compare: `main...design/1013-table-caption-context-refresh`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 5
- CI: GitHub Actions CI #1387 success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success, including `npm run test:browser`
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `gem_package`: success

## スクリーンショット

<!-- connector-only 実行のため未添付 -->

## リスク

- low
- static mockup / README / review gallery / browser smoke target / CI condition のみの変更です。runtime JavaScript、Ruby helper、public API manifest、ARIA policy、host-app route / authorization / CRUD は変更していません。

## 補足

- この実行環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- 旧 PR #1023 は diverged / `mergeable:false` のため close し、この PR へレビュー対象を一本化しました。