### PR TITLE
public API docs から render_log_level 導線を補強する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -114,6 +114,8 @@ Documented configuration options include:
 - `initial_state`
 - `render_log_level`
 
+`TreeView.configure`, `TreeView.configuration`, and `TreeView.reset_configuration!` are the stable configuration entry points. Depend on documented option names and behavior rather than the internal shape of the configuration object. See [Render log level](render-log-level.md) for the `render_log_level` values, default, disable path, and host-app logging boundary.
+
 Documented localized display-name helpers include:
 
 - `TreeView.model_name_for(item_or_class, count: 1, default: nil)`

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -114,6 +114,8 @@ toolbar helper もこの公開 helper surface に含まれます。
 - `initial_state`
 - `render_log_level`
 
+`TreeView.configure`、`TreeView.configuration`、`TreeView.reset_configuration!` は安定した configuration entry point です。configuration object の内部形状ではなく、documented option name と documented behavior に依存してください。`render_log_level` の値、既定値、無効化方法、host app logging との責務境界は [render log level](render-log-level.md) を参照してください。
+
 公開 localized display-name helper には以下を含めます。
 
 - `TreeView.model_name_for(item_or_class, count: 1, default: nil)`


### PR DESCRIPTION
## 対応 Issue

Closes #970

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の Public option surface に configuration entry point と option guidance の短い境界説明を追加しました。
- `render_log_level` の値、既定値、無効化方法、host-app logging boundary は dedicated docs へ委譲する導線を追加しました。

## 根拠

- Public API docs は `TreeView.configure` / `TreeView.configuration` / `TreeView.reset_configuration!` と `render_log_level` を公開 surface として載せています。
- `docs/en/render-log-level.md` / `docs/ja/render-log-level.md` は既に詳細な責務境界を説明しています。
- 現状では Public API docs から dedicated render log docs へ辿る導線が薄く、configuration method surface と configuration option surface の読み分けが弱い状態でした。

## 非目標

- `TreeView::Configuration` public constant 化判断
- `config/public_api_manifest.yml` の変更
- configuration behavior / render log behavior の変更
- configuration docs の全面 rewrite

## 確認内容

- GitHub compare: `main...docs/970-render-log-public-api`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 既存 public API docs と既存 render-log-level docs の導線補強に閉じ、runtime behavior や public constant contract は変更していません。