### PR TITLE
Public API docs に manifest の packaged artifact 境界を追加する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -2,6 +2,12 @@
 
 This page describes which APIs host Rails apps may depend on directly, which parts are internal, and how compatibility is handled.
 
+## Public API manifest role
+
+`config/public_api_manifest.yml` is both the machine-readable source of truth for selected documented surfaces and a packaged audit artifact for release and compatibility review. It is included in the gem package so maintainers and downstream audits can compare helper methods, grouped options, JavaScript exports, and controller identifiers against the docs and compatibility specs.
+
+Host apps should use the documented Ruby helpers, configuration options, JavaScript package-root exports, events, and CSS / DOM hooks described below. They should not treat the manifest itself as a runtime API that application code reads during normal TreeView usage.
+
 ## Stable public entry points
 
 Host apps may use these entry points directly:

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -2,6 +2,12 @@
 
 このページでは、host Rails app が直接使ってよい公開API、内部API、互換性方針を整理します。
 
+## Public API manifest の位置づけ
+
+`config/public_api_manifest.yml` は、一部の documented surface の machine-readable source of truth であると同時に、release / compatibility review 用に gem package へ含める packaged audit artifact です。maintainer や downstream audit は、この manifest を helper method、grouped option、JavaScript export、controller identifier が docs と compatibility spec に揃っているか確認する材料として使えます。
+
+host app は、下で説明する documented Ruby helper、configuration option、JavaScript package-root export、event、CSS / DOM hook を通常利用してください。通常の TreeView 利用時に application code が manifest 自体を読み込む runtime API として扱うものではありません。
+
 ## 安定した公開入口
 
 host app が直接使ってよい主な入口は以下です。


### PR DESCRIPTION
## 対応 Issue

Closes #1149

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` に `config/public_api_manifest.yml` の位置づけを短く追加しました。
- manifest は machine-readable source of truth であると同時に、gem package に含まれる audit artifact / compatibility contract であることを明記しました。
- host app が通常使う runtime surface は documented Ruby helpers / options / JavaScript exports / events / CSS-DOM hooks であり、manifest 自体を runtime API として読むものではない、という境界を追加しました。

## 根拠

- `tree_view.gemspec` は `config/public_api_manifest.yml` を `spec.files` に含めています。
- `script/check_gem_package_contents.rb` は `config/public_api_manifest.yml` を required packaged path として検証しています。
- `.github/workflows/ci.yml` の `package_sensitive` 判定は `config/public_api_manifest.yml` を含みます。
- 既存 Public API docs は manifest を machine-readable source of truth として説明していましたが、packaged audit artifact と runtime API の境界説明が薄い状態でした。

## 非目標

- public API manifest schema の再設計
- manifest を host app runtime API として正式化すること
- `tree_view.gemspec` / CI / package verification の変更
- Public API docs 全体の rewrite
- #981 の close 判断

## 確認内容

- GitHub compare: `main...docs/1149-public-api-manifest-role`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 12 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 既存 package / CI / docs の境界説明を補うだけで、runtime behavior や public manifest schema は変更していません。