### PR TITLE
日本語 locale / release docs を package verification に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -3,6 +3,8 @@
 
 require "rubygems/package"
 
+# Keep representative English and Japanese files in this list so package
+# verification covers the bilingual locale and release docs shipped by the gem.
 REQUIRED_PACKAGED_PATHS = %w[
   app/helpers/tree_view_helper.rb
   app/views/tree_view/_tree_row.html.erb
@@ -16,7 +18,9 @@ REQUIRED_PACKAGED_PATHS = %w[
   config/importmap.tree_view.rb
   config/public_api_manifest.yml
   config/locales/tree_view.toolbar.en.yml
+  config/locales/tree_view.toolbar.ja.yml
   docs/en/release.md
+  docs/ja/release.md
 ].freeze
 
 root = File.expand_path("..", __dir__)


### PR DESCRIPTION
## 対応 Issue

Closes #1148

## Issue ごとの完了内容

- #1148
  - `script/check_gem_package_contents.rb` の required packaged path に `config/locales/tree_view.toolbar.ja.yml` を追加しました。
  - 同じく `docs/ja/release.md` を追加し、英日 locale / release docs の代表ファイル欠落を検出できるようにしました。
  - required path list の意図が分かるよう、英日 representative file を package verification で見るための短いコメントを追加しました。

## 変更内容

- `script/check_gem_package_contents.rb`
  - bilingual locale / release docs の代表 guard として日本語 locale / 日本語 release docs を required path に追加

## 改善カテゴリ

- test
- CI / package verification
- maintenance

## 既存仕様への影響

- runtime code、public API、locale key schema、docs content、version、release workflow は変更していません。
- gemspec の `config/locales/**/*` / `docs/**/*` 方針と揃える package contents guard の補強だけです。

## 実施した確認内容

- `main` 上で以下のファイルが存在することを connector で確認しました。
  - `config/locales/tree_view.toolbar.ja.yml`
  - `docs/ja/release.md`
- GitHub compare: `main...quality/1148-ja-package-guard`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local `gem build tree_view.gemspec` / `ruby script/check_gem_package_contents.rb tree_view-*.gem` は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後の GitHub Actions で確認します。

## リスク評価

- low
- package verification の required path 追加のみです。日本語 locale / docs は既に gemspec の include pattern に含まれている既存ファイルで、公開挙動は変わりません。

## 補足事項

- package contents の全面 inventory 化、docs 全ページの網羅 check、release docs 内容更新には広げていません。