### PR TITLE
reduced-motion state cue mockup を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
         run: npx playwright install --with-deps chromium
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.mockups_changed == 'true'
         run: npm run test:browser
 
   gem_package:

--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -18,6 +18,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [row-status-depth-labels.html](row-status-depth-labels.html) | Focused comparison for row-wide status cues, selection checkbox disabled state, and depth labels without host-app authorization or business wording. |
 | [toggle-icon-states.html](toggle-icon-states.html) | Focused comparison for expanded, collapsed, leaf, loading, and depth/type-based toggle icon states without choosing a host-app icon library. |
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
+| [reduced-motion-state-cues.html](reduced-motion-state-cues.html) | Focused low-motion reference for loading, retry, current/selected, and drop-target cues that remain readable without animation. |
 | [keyboard-focus-states.html](keyboard-focus-states.html) | Focused keyboard reference showing static focus-visible samples for toggle links, native controls, toolbar actions, and row actions without promising a full keyboard model. |
 | [high-contrast-state-cues/index.html](high-contrast-state-cues/index.html) | Focused high-contrast reference for current, selected, focus-visible, error/retry, and drop-target cues that remain distinguishable beyond color alone. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
@@ -48,25 +49,26 @@ They are **not** a complete Rails application and should not grow into host-app 
 6. Use [toggle-icon-states.html](toggle-icon-states.html) when review needs to compare `toggle_icons:` expanded, collapsed, leaf, loading, and depth/type variation without selecting a final icon library.
 7. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 8. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-9. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
-10. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
-11. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-12. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
-13. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-14. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-15. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-16. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-17. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-18. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-19. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-20. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-21. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
-22. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
-25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
-27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+9. Use [reduced-motion-state-cues.html](reduced-motion-state-cues.html) when review needs to compare loading, retry, current/selected, and drop-target cues without relying on animation.
+10. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
+11. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
+12. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+13. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
+14. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+15. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+16. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+17. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+18. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+19. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+20. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+21. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+22. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
+23. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+24. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+25. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
+26. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+27. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
+28. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 
@@ -111,6 +113,11 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 - Use focused static mockups to compare coarse visual cues such as dragging, valid target, blocked target, drop position, and invalid transfer boundaries.
 - Treat final move authorization, persistence, audit trails, and business copy as host-app responsibilities.
+
+## Motion guidance
+
+- Use `reduced-motion-state-cues.html` when the review question is whether loading, retry, current/selected, or drop-target states remain understandable without animation.
+- Keep animation policy, visual regression baselines, and runtime event behavior in separate implementation or quality issues.
 
 ## Keyboard focus guidance
 

--- a/docs/mockups/reduced-motion-state-cues.html
+++ b/docs/mockups/reduced-motion-state-cues.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView low-motion state cues mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.low-motion-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.low-motion-panel {
+  border: 1px solid #d8e0ea;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.low-motion-panel__header {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #e4e7eb;
+  background: #f8fafc;
+}
+
+.low-motion-panel__header h3,
+.low-motion-panel__header p {
+  margin: 0;
+}
+
+.low-motion-panel__header p {
+  color: #52606d;
+}
+
+.low-motion-note-list {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0.85rem 1rem 1rem;
+  padding-left: 1.15rem;
+  color: #334e68;
+}
+
+.low-motion-table-wrap {
+  overflow-x: auto;
+}
+
+.low-motion-cue-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 700;
+}
+
+.low-motion-cue-label::before {
+  content: "";
+  inline-size: 0.65rem;
+  block-size: 0.65rem;
+  border: 2px solid currentColor;
+  border-radius: 999px;
+  background: #fff;
+}
+
+.low-motion-plain-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-inline-size: 1.45rem;
+  min-block-size: 1.45rem;
+  border: 1px solid #94a3b8;
+  border-radius: 6px;
+  color: #334155;
+  font-weight: 800;
+}
+
+.tree-row.low-motion-row--current {
+  box-shadow: inset 4px 0 0 #1d4ed8;
+}
+
+.tree-row.low-motion-row--target {
+  outline: 2px solid #16a34a;
+  outline-offset: -3px;
+}
+
+@media (max-width: 720px) {
+  .low-motion-panel__header {
+    padding: 0.75rem;
+  }
+
+  .low-motion-note-list {
+    margin-inline: 0.75rem;
+  }
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView low-motion state cues mock</h1>
+      <p>
+        Static HTML for reviewing loading, retry, current or selected, and drop-target cues when reviewers assume reduced or no animation.
+        The samples keep state differences visible through labels, borders, row shape, and adjacent explanatory copy rather than motion alone.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="low-motion-overview-heading" data-tree-view-sample="reduced-motion-state-cues">
+      <h2 id="low-motion-overview-heading">State cue comparison without animation</h2>
+      <div class="low-motion-grid">
+        <article class="low-motion-panel" aria-labelledby="low-motion-loading-heading">
+          <div class="low-motion-panel__header">
+            <h3 id="low-motion-loading-heading">Loading in progress</h3>
+            <p>Use a stable pending row, busy attribute, explicit status label, and disabled action instead of depending on a spinner.</p>
+          </div>
+          <div class="low-motion-table-wrap">
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">state cue</th>
+                  <th scope="col">action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-loading" id="low_motion_loading" data-tree-node-key="folder:loading" data-tree-depth="0" data-tree-remote-state="loading" aria-level="1" aria-expanded="false" aria-busy="true">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Loading children">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__action tree-toggle__action--pending">load</span><span class="tree-toggle__level">pending</span></span>
+                    </span>
+                  </td>
+                  <td><span class="low-motion-cue-label">Loading folder</span></td>
+                  <td><span class="mock-status mock-status--pending">loading children</span></td>
+                  <td class="tree-row-actions"><button type="button" disabled>Loading</button></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <ul class="low-motion-note-list">
+            <li>Stable text keeps the state readable if spinner animation is removed.</li>
+            <li><code>aria-busy="true"</code> and the disabled action describe the same pending boundary.</li>
+          </ul>
+        </article>
+
+        <article class="low-motion-panel" aria-labelledby="low-motion-retry-heading">
+          <div class="low-motion-panel__header">
+            <h3 id="low-motion-retry-heading">Retry or error state</h3>
+            <p>Combine the retry affordance with an error row shape and plain status text so the failed state is not color-only.</p>
+          </div>
+          <div class="low-motion-table-wrap">
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">state cue</th>
+                  <th scope="col">action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-error" id="low_motion_retry" data-tree-node-key="folder:retry" data-tree-depth="0" data-tree-remote-state="error" aria-level="1" aria-expanded="false">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Loading failed">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">retry</a><span class="tree-toggle__level">error</span></span>
+                    </span>
+                  </td>
+                  <td><span class="low-motion-cue-label">Failed folder</span></td>
+                  <td><span class="mock-status mock-status--error">load failed</span></td>
+                  <td class="tree-row-actions"><button type="button">Retry</button></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <ul class="low-motion-note-list">
+            <li>Retry copy appears in both the toggle control and the action column.</li>
+            <li>The row background, status pill, and explicit label carry the cue without motion.</li>
+          </ul>
+        </article>
+
+        <article class="low-motion-panel" aria-labelledby="low-motion-current-heading">
+          <div class="low-motion-panel__header">
+            <h3 id="low-motion-current-heading">Current and selected state</h3>
+            <p>Keep the current row visible through the row state, aria-current, a leading edge, and a selected label.</p>
+          </div>
+          <div class="low-motion-table-wrap">
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">state cue</th>
+                  <th scope="col">action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-selected low-motion-row--current" id="low_motion_current" data-tree-node-key="folder:current" data-tree-depth="1" aria-level="2" aria-current="page">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Current selection">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">current</span></span>
+                    </span>
+                  </td>
+                  <td><span class="low-motion-cue-label">Current branch</span></td>
+                  <td><span class="mock-status mock-status--active">selected current page</span></td>
+                  <td class="tree-row-actions"><button type="button">Open</button></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <ul class="low-motion-note-list">
+            <li>The cue combines row fill, leading edge, and <code>aria-current="page"</code>.</li>
+            <li>Final navigation and route selection remain host-app responsibilities.</li>
+          </ul>
+        </article>
+
+        <article class="low-motion-panel" aria-labelledby="low-motion-drop-heading">
+          <div class="low-motion-panel__header">
+            <h3 id="low-motion-drop-heading">Drop target or invalid transfer</h3>
+            <p>Show valid and blocked transfer outcomes through row outline, plain icons, and status labels instead of animated drag feedback.</p>
+          </div>
+          <div class="low-motion-table-wrap">
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">state cue</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-drop-target low-motion-row--target" id="low_motion_drop_target" data-tree-node-key="folder:target" data-tree-drop-position="inside" aria-level="1">
+                  <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">target</span></span></span></td>
+                  <td><span class="low-motion-plain-icon" aria-hidden="true">+</span> Valid folder target</td>
+                  <td><span class="mock-status mock-status--active">drop inside</span></td>
+                </tr>
+                <tr class="tree-row is-drop-disabled" id="low_motion_drop_blocked" data-tree-node-key="folder:blocked" data-tree-drop-disabled-reason="Readonly branch" aria-level="1" aria-disabled="true">
+                  <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__control"><span class="tree-toggle__level">blocked</span></span></span></td>
+                  <td><span class="low-motion-plain-icon" aria-hidden="true">!</span> Readonly target</td>
+                  <td><span class="mock-status mock-status--error">drop disabled</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <ul class="low-motion-note-list">
+            <li>Shape and text differentiate valid and blocked transfer states.</li>
+            <li>Move authorization, persistence, and final business copy stay outside this mockup.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -10,52 +10,19 @@
   max-width: 1320px;
 }
 
+.mock-gallery-return-nav,
+.mock-gallery-review-path-links,
+.mock-gallery-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .mock-gallery-return-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
   margin-top: 18px;
 }
 
-.mock-gallery-return-nav a {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.55rem 0.9rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 999px;
-  background: #fff;
-  color: #0f172a;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.mock-gallery-return-nav a:hover,
-.mock-gallery-return-nav a:focus {
-  border-color: #1d4ed8;
-  color: #1d4ed8;
-}
-
-.mock-gallery-review-paths {
-  display: grid;
-  gap: 12px;
-  margin-top: 18px;
-  padding: 18px;
-  border: 1px solid #d8e0ea;
-  border-radius: 12px;
-  background: #f8fafc;
-}
-
-.mock-gallery-review-paths h2,
-.mock-gallery-review-paths p {
-  margin: 0;
-}
-
-.mock-gallery-review-path-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
+.mock-gallery-return-nav a,
 .mock-gallery-review-path-links a {
   display: inline-flex;
   align-items: center;
@@ -69,11 +36,35 @@
   text-decoration: none;
 }
 
+.mock-gallery-return-nav a:first-child {
+  color: #0f172a;
+}
+
+.mock-gallery-return-nav a:hover,
+.mock-gallery-return-nav a:focus,
 .mock-gallery-review-path-links a:hover,
 .mock-gallery-review-path-links a:focus {
   border-color: #1d4ed8;
   background: #eff6ff;
   outline: 2px solid transparent;
+}
+
+.mock-gallery-review-paths {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+  padding: 18px;
+  border: 1px solid #d8e0ea;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.mock-gallery-review-paths h2,
+.mock-gallery-review-paths p,
+.mock-gallery-card h2,
+.mock-gallery-card p,
+.mock-gallery-card ul {
+  margin: 0;
 }
 
 .mock-gallery-grid {
@@ -92,12 +83,6 @@
   padding: 20px;
 }
 
-.mock-gallery-card h2,
-.mock-gallery-card p,
-.mock-gallery-card ul {
-  margin: 0;
-}
-
 .mock-gallery-eyebrow {
   color: #52606d;
   font-size: 0.8rem;
@@ -114,12 +99,6 @@
 .mock-gallery-points {
   padding-left: 1.2rem;
   color: #334e68;
-}
-
-.mock-gallery-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
 }
 
 .mock-gallery-links a {
@@ -206,6 +185,7 @@
         <div class="mock-gallery-review-path-links">
           <a href="#gallery-default-heading">Baseline</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
+          <a href="#gallery-reduced-motion-heading">Low-motion cues</a>
           <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
           <a href="#gallery-toggle-icon-heading">Toggle icons</a>
           <a href="#gallery-narrow-heading">Responsive and scale</a>
@@ -222,82 +202,35 @@
     </section>
 
     <section class="mock-gallery-grid" aria-label="Mockup comparison gallery">
-      <article class="mock-gallery-card" aria-labelledby="gallery-default-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Baseline structure</p><h2 id="gallery-default-heading">Default tree</h2><p>Inspect representative root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.</p><ul class="mock-gallery-points"><li>Expanded and collapsed hierarchy cues</li><li>Selection, badges, and status placement</li><li>Baseline row-actions column layout</li></ul><div class="mock-gallery-links"><a href="default-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-status-depth-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.</p><ul class="mock-gallery-points"><li>Normal, readonly, and disabled rows</li><li>Selection availability separated from row status</li><li>Depth-label meaning kept host-app owned</li></ul><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-toggle-icon-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused toggle icons</p><h2 id="gallery-toggle-icon-heading">Toggle icon states</h2><p>Compare expanded, collapsed, leaf, loading, and depth/type icon variations while keeping final icon choices host-app owned.</p><ul class="mock-gallery-points"><li>State-based icon slots</li><li>Depth and node-type variation</li><li>No icon library or runtime behavior changes</li></ul><div class="mock-gallery-links"><a href="toggle-icon-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toggle-icon-states.html" title="Toggle icon states mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-current-branch-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused branch state</p><h2 id="gallery-current-branch-heading">Current branch sidebar</h2><p>Review a sidebar state where the current row and its ancestors are expanded while sibling branches stay collapsed.</p><ul class="mock-gallery-points"><li>Current row and ancestor path</li><li>Collapsed sibling branches</li><li>Host-app navigation policy outside scope</li></ul><div class="mock-gallery-links"><a href="current-branch-sidebar.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="current-branch-sidebar.html" title="Current branch sidebar mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-keyboard-focus-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused keyboard cue</p><h2 id="gallery-keyboard-focus-heading">Keyboard focus states</h2><p>Compare static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</p><ul class="mock-gallery-points"><li>Toggle link focus cue</li><li>Native checkbox and button focus samples</li><li>Host-app keyboard model boundary</li></ul><div class="mock-gallery-links"><a href="keyboard-focus-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="keyboard-focus-states.html" title="Keyboard focus states mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-lazy-handoff-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Compare the host-app-owned children container and remote-state placeholder across initial, loaded, and error/retry states.</p><ul class="mock-gallery-points"><li>Children container ownership</li><li>Remote-state slot handoff</li><li>Error/retry boundary without fetch behavior</li></ul><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-persisted-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused persisted state</p><h2 id="gallery-persisted-heading">Persisted State boundary</h2><p>Compare expansion state before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned.</p><ul class="mock-gallery-points"><li><code>tree_instance_key</code> and expanded keys snapshot framing</li><li><code>tree-view-state:state-changed</code> event beside rendered rows</li><li>Save endpoint, authorization, error copy, and retry policy outside the gem</li></ul><div class="mock-gallery-links"><a href="persisted-state-boundary.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="persisted-state-boundary.html" title="Persisted State boundary mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-drop-position-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused transfer cue</p><h2 id="gallery-drop-position-heading">Drop positions</h2><p>Compare before, inside, and after drop-position cues while keeping move permission, persistence, and final copy owned by the host app.</p><ul class="mock-gallery-points"><li>Leading and trailing insertion lines</li><li>Inside target row cue</li><li>Disabled target policy boundary</li></ul><div class="mock-gallery-links"><a href="drop-positions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drop-positions.html" title="Drop positions mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-turbo-frame-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused Turbo boundary</p><h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2><p>Compare configured <code>data-turbo-frame</code> links beside a host-app-owned frame wrapper.</p><ul class="mock-gallery-points"><li>Link target attribute</li><li>Frame ownership boundary</li><li>No route or response behavior</li></ul><div class="mock-gallery-links"><a href="turbo-frame-target.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-drag-controls-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused interaction controls</p><h2 id="gallery-drag-controls-heading">Drag interactive controls</h2><p>Compare native controls, broad interactive markers, and drag-only ignore markers inside draggable rows.</p><ul class="mock-gallery-points"><li>Native controls remain interactive</li><li>Custom marker boundaries</li><li>Drag-only ignore behavior</li></ul><div class="mock-gallery-links"><a href="drag-interactive-controls.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-marker-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused marker policy</p><h2 id="gallery-marker-heading">Interactive marker behaviors</h2><p>Compare broad and narrow ignore markers for keyboard, row-click, and drag behavior.</p><ul class="mock-gallery-points"><li>Broad interactive marker</li><li>Keyboard and row-click boundaries</li><li>Drag-specific ignore marker</li></ul><div class="mock-gallery-links"><a href="interactive-marker-behaviors.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-windowed-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused scale cue</p><h2 id="gallery-windowed-heading">Windowed rendering</h2><p>Compare visible-row slicing, current-row anchoring, and previous or next metadata framing.</p><ul class="mock-gallery-points"><li>Visible row window</li><li>Current-row anchor</li><li>Host-app paging outside scope</li></ul><div class="mock-gallery-links"><a href="windowed-rendering.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="windowed-rendering.html" title="Windowed rendering mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-breadcrumb-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused path context</p><h2 id="gallery-breadcrumb-heading">Breadcrumb paths</h2><p>Compare breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</p><ul class="mock-gallery-points"><li>Path context outside rows</li><li>Current-row cue inside tree</li><li>Routes and overflow outside scope</li></ul><div class="mock-gallery-links"><a href="breadcrumb-paths.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="breadcrumb-paths.html" title="Breadcrumb paths mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused filtering modes</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Compare matched-only, ancestor-retaining, and descendant-retaining output without adding host-app search UI.</p><ul class="mock-gallery-points"><li>Matched-only output</li><li>Ancestor context</li><li>Descendant context</li></ul><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-path-builder-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused builder rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows while keeping file-manager behavior outside the gem contract.</p><ul class="mock-gallery-points"><li>Generated folder row cues</li><li>Record-backed rows</li><li>Host-app file actions outside scope</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-node-presenter-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused presenter boundary</p><h2 id="gallery-node-presenter-heading">NodePresenter row partials</h2><p>Compare presenter-provided label, link, tooltip, badge, icon, and optional action values beside host-app-owned columns.</p><ul class="mock-gallery-points"><li>Resolver-provided row values</li><li>Host-owned columns and permissions</li><li>No CRUD or Column DSL design</li></ul><div class="mock-gallery-links"><a href="node-presenter-row-partials.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="node-presenter-row-partials.html" title="NodePresenter row partials mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-form-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-selection-limit-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Attempted checkbox restored after limit-exceeded</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-selection-form-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Compare multiple TreeView selection groups inside one host-app form while keeping source-specific hidden input sync internal.</p><ul class="mock-gallery-points"><li>Selection counts grouped by source</li><li>Generated hidden input source boundary</li><li>Submit summary owned by the host app</li></ul><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Spacing and fallback</p><h2 id="gallery-empty-heading">Empty state</h2><p>Compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.</p><ul class="mock-gallery-points"><li>Reusable empty-row wrapper hook</li><li>Full-width message slot behavior</li><li>Difference from a populated row</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
-      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-default-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Baseline structure</p><h2 id="gallery-default-heading">Default tree</h2><p>Inspect representative root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.</p><ul class="mock-gallery-points"><li>Expanded and collapsed hierarchy cues</li><li>Selection, badges, and status placement</li><li>Baseline row-actions column layout</li></ul><div class="mock-gallery-links"><a href="default-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-status-depth-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.</p><ul class="mock-gallery-points"><li>Normal, readonly, and disabled rows</li><li>Selection availability separated from row status</li><li>Depth-label meaning kept host-app owned</li></ul><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-toggle-icon-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused toggle icons</p><h2 id="gallery-toggle-icon-heading">Toggle icon states</h2><p>Compare expanded, collapsed, leaf, loading, and depth/type icon variations while keeping final icon choices host-app owned.</p><ul class="mock-gallery-points"><li>State-based icon slots</li><li>Depth and node-type variation</li><li>No icon library or runtime behavior changes</li></ul><div class="mock-gallery-links"><a href="toggle-icon-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toggle-icon-states.html" title="Toggle icon states mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-current-branch-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused branch state</p><h2 id="gallery-current-branch-heading">Current branch sidebar</h2><p>Review a sidebar state where the current row and its ancestors are expanded while sibling branches stay collapsed.</p><ul class="mock-gallery-points"><li>Current row and ancestor path</li><li>Collapsed sibling branches</li><li>Host-app navigation policy outside scope</li></ul><div class="mock-gallery-links"><a href="current-branch-sidebar.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="current-branch-sidebar.html" title="Current branch sidebar mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-reduced-motion-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Low-motion reference</p><h2 id="gallery-reduced-motion-heading">Low-motion state cues</h2><p>Compare loading, retry, current/selected, and drop-target states when animation is reduced or absent.</p><ul class="mock-gallery-points"><li>Text and status labels beside row states</li><li>Border and shape cues beyond color alone</li><li>No runtime animation or event contract changes</li></ul><div class="mock-gallery-links"><a href="reduced-motion-state-cues.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="reduced-motion-state-cues.html" title="Low-motion state cues mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-keyboard-focus-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused keyboard cue</p><h2 id="gallery-keyboard-focus-heading">Keyboard focus states</h2><p>Compare static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</p><ul class="mock-gallery-points"><li>Toggle link focus cue</li><li>Native checkbox and button focus samples</li><li>Host-app keyboard model boundary</li></ul><div class="mock-gallery-links"><a href="keyboard-focus-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="keyboard-focus-states.html" title="Keyboard focus states mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-lazy-handoff-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Compare the host-app-owned children container and remote-state placeholder across initial, loaded, and error/retry states.</p><ul class="mock-gallery-points"><li>Children container ownership</li><li>Remote-state slot handoff</li><li>Error/retry boundary without fetch behavior</li></ul><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-persisted-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused persisted state</p><h2 id="gallery-persisted-heading">Persisted State boundary</h2><p>Compare expansion state before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned.</p><ul class="mock-gallery-points"><li><code>tree_instance_key</code> and expanded keys snapshot framing</li><li><code>tree-view-state:state-changed</code> event beside rendered rows</li><li>Save endpoint, authorization, error copy, and retry policy outside the gem</li></ul><div class="mock-gallery-links"><a href="persisted-state-boundary.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="persisted-state-boundary.html" title="Persisted State boundary mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-drop-position-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused transfer cue</p><h2 id="gallery-drop-position-heading">Drop positions</h2><p>Compare before, inside, and after drop-position cues while keeping move permission, persistence, and final copy owned by the host app.</p><ul class="mock-gallery-points"><li>Leading and trailing insertion lines</li><li>Inside target row cue</li><li>Disabled target policy boundary</li></ul><div class="mock-gallery-links"><a href="drop-positions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drop-positions.html" title="Drop positions mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-turbo-frame-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused Turbo boundary</p><h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2><p>Compare configured <code>data-turbo-frame</code> links beside a host-app-owned frame wrapper.</p><ul class="mock-gallery-points"><li>Link target attribute</li><li>Frame ownership boundary</li><li>No route or response behavior</li></ul><div class="mock-gallery-links"><a href="turbo-frame-target.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-drag-controls-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused interaction controls</p><h2 id="gallery-drag-controls-heading">Drag interactive controls</h2><p>Compare native controls, broad interactive markers, and drag-only ignore markers inside draggable rows.</p><ul class="mock-gallery-points"><li>Native controls remain interactive</li><li>Custom marker boundaries</li><li>Drag-only ignore behavior</li></ul><div class="mock-gallery-links"><a href="drag-interactive-controls.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-marker-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused marker policy</p><h2 id="gallery-marker-heading">Interactive marker behaviors</h2><p>Compare broad and narrow ignore markers for keyboard, row-click, and drag behavior.</p><ul class="mock-gallery-points"><li>Broad interactive marker</li><li>Keyboard and row-click boundaries</li><li>Drag-specific ignore marker</li></ul><div class="mock-gallery-links"><a href="interactive-marker-behaviors.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-windowed-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused scale cue</p><h2 id="gallery-windowed-heading">Windowed rendering</h2><p>Compare visible-row slicing, current-row anchoring, and previous or next metadata framing.</p><ul class="mock-gallery-points"><li>Visible row window</li><li>Current-row anchor</li><li>Host-app paging outside scope</li></ul><div class="mock-gallery-links"><a href="windowed-rendering.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="windowed-rendering.html" title="Windowed rendering mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-breadcrumb-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused path context</p><h2 id="gallery-breadcrumb-heading">Breadcrumb paths</h2><p>Compare breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</p><ul class="mock-gallery-points"><li>Path context outside rows</li><li>Current-row cue inside tree</li><li>Routes and overflow outside scope</li></ul><div class="mock-gallery-links"><a href="breadcrumb-paths.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="breadcrumb-paths.html" title="Breadcrumb paths mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused filtering modes</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Compare matched-only, ancestor-retaining, and descendant-retaining output without adding host-app search UI.</p><ul class="mock-gallery-points"><li>Matched-only output</li><li>Ancestor context</li><li>Descendant context</li></ul><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-path-builder-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused builder rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows while keeping file-manager behavior outside the gem contract.</p><ul class="mock-gallery-points"><li>Generated folder row cues</li><li>Record-backed rows</li><li>Host-app file actions outside scope</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-node-presenter-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused presenter boundary</p><h2 id="gallery-node-presenter-heading">NodePresenter row partials</h2><p>Compare presenter-provided label, link, tooltip, badge, icon, and optional action values beside host-app-owned columns.</p><ul class="mock-gallery-points"><li>Resolver-provided row values</li><li>Host-owned columns and permissions</li><li>No CRUD or Column DSL design</li></ul><div class="mock-gallery-links"><a href="node-presenter-row-partials.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="node-presenter-row-partials.html" title="NodePresenter row partials mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-form-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-selection-limit-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Attempted checkbox restored after limit-exceeded</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-selection-form-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Compare multiple TreeView selection groups inside one host-app form while keeping source-specific hidden input sync internal.</p><ul class="mock-gallery-points"><li>Selection counts grouped by source</li><li>Generated hidden input source boundary</li><li>Submit summary owned by the host app</li></ul><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Spacing and fallback</p><h2 id="gallery-empty-heading">Empty state</h2><p>Compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.</p><ul class="mock-gallery-points"><li>Reusable empty-row wrapper hook</li><li>Full-width message slot behavior</li><li>Difference from a populated row</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div></article>
     </section>
 
-    <section class="mock-section" aria-labelledby="comparison-cues-heading">
-      <h2 id="comparison-cues-heading">Comparison cues</h2>
+    <section class="mock-section" aria-labelledby="comparison-heading">
+      <h2 id="comparison-heading">Comparison cues</h2>
       <table class="mock-comparison-table"><thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead><tbody>
         <tr><td>Default tree</td><td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td><td>Host-app CRUD, queries, business labels, or authorization behavior.</td></tr>
         <tr><td>Row status and depth labels</td><td>Row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
@@ -306,6 +239,7 @@
         <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
         <tr><td>Current branch sidebar</td><td>Current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues.</td><td>Route selection, permission-aware labels, final sidebar ordering, or host-app navigation policy.</td></tr>
         <tr><td>Interaction states</td><td>Loading, retry, pagination, and general drag or drop status cues.</td><td>Real Turbo responses, route wiring, or persistence behavior.</td></tr>
+        <tr><td>Low-motion state cues</td><td>Loading, retry, current/selected, and drop-target cues that remain readable without animation.</td><td>Animation policy, visual regression baseline, runtime event behavior, or host-app accessibility policy.</td></tr>
         <tr><td>Keyboard focus states</td><td>Static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</td><td>Tab order, shortcut policy, roving tabindex, arrow-key navigation, or full treegrid behavior.</td></tr>
         <tr><td>Lazy-loading handoff</td><td>Children container ownership, remote-state placeholder handoff, and error/retry slot boundaries.</td><td>Real Turbo responses, fetch or retry controller behavior, authorization, or cursor policy.</td></tr>
         <tr><td>Persisted State boundary</td><td>Expansion state before, changed, restored, save-failed, and retry cues.</td><td>Storage schema, save endpoint, authorization, retry policy, browser save helper, or final error copy.</td></tr>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -45,6 +45,7 @@ const focusedMockupSmokeTargets = [
   { file: "row-status-depth-labels.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
   { file: "toggle-icon-states.html", sample: ".tree-view-table tbody tr", minimumCount: 7 },
   { file: "interaction-states.html", sample: ".tree-view-table tbody tr", minimumCount: 5 },
+  { file: "reduced-motion-state-cues.html", sample: "[data-tree-view-sample='reduced-motion-state-cues'] .tree-view-table tbody tr", minimumCount: 5 },
   { file: "keyboard-focus-states.html", sample: ".focus-sample, .focus-sample--soft", minimumCount: 5 },
   { file: "high-contrast-state-cues/index.html", sample: "[data-tree-view-sample='high-contrast-state-cues']", minimumCount: 1 },
   { file: "lazy-loading-handoff.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
@@ -92,6 +93,7 @@ test.describe("docs mockup browser smoke", () => {
 
     expect(linkedFiles).toContain("default-tree.html")
     expect(linkedFiles).toContain("interaction-states.html")
+    expect(linkedFiles).toContain("reduced-motion-state-cues.html")
     expect(linkedFiles).toContain("current-branch-sidebar.html")
     expect(linkedFiles).toContain("node-presenter-row-partials.html")
     expect(linkedFiles).toContain("selection-multi-tree-form.html")


### PR DESCRIPTION
## 対応Issue

- Closes #1140

## 採用した方針

- スケジュール実行のため、ユーザー選択待ちはせず Planner handoff の低リスク方針を採用しました。
- 既存 `interaction-states.html` や `high-contrast-state-cues/index.html` へ統合せず、`docs/mockups/reduced-motion-state-cues.html` を dedicated focused page として追加しました。
- runtime JavaScript behavior、loading / retry event contract、animation framework、visual regression baseline、host-app 固有 copy には触れていません。

## 比較した案

- 案A: `interaction-states.html` に reduced-motion section を追加
  - 低コストですが、既存ページが loading / retry / pagination / drag-drop を広く扱っており、motion 抑制の review 観点が埋もれやすいため見送りました。
- 案B: `high-contrast-state-cues/index.html` に統合
  - 色以外の cue という近いテーマはありますが、high-contrast と reduced-motion は review question が異なるため見送りました。
- 案C: dedicated focused page を追加し、README / review gallery / browser smoke target を同期
  - 採用案です。Planner handoff の first slice と一致し、代表状態を loading / retry / current-selected / drop-target に絞れます。

## 変更内容

- `docs/mockups/reduced-motion-state-cues.html` を追加
  - loading in progress
  - retry / error state
  - current / selected state
  - drop target / invalid transfer cue
- motion に頼らず、text / border / icon shape / status label / adjacent copy で状態差を読めるようにしました。
- `docs/mockups/README.md` の Files table、Recommended review flow、Motion guidance に導線を追加しました。
- `docs/mockups/review-gallery.html` に low-motion card、review path、comparison cue を追加しました。
- `test/browser/docs_mockups_smoke.spec.js` の README 同期対象に新規 mockup を追加しました。

## 変更した画面・コンポーネント

- `docs/mockups/reduced-motion-state-cues.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- lint: 未実行
- typecheck: 該当なし
- UI表示確認: 未実行
- レスポンシブ確認: 未実行
- アクセシビリティ確認: mockup source 上で `aria-busy`, `aria-current`, `aria-disabled` と text / border / status label cue を確認
- GitHub compare: `main...design/1140-reduced-motion-state-cues`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- `npm run test:browser` は未実行です。この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。PR 作成後に GitHub Actions で確認します。

## スクリーンショット

<!-- static mockup 追加。ブラウザ表示確認は PR 作成後の CI / browser smoke を確認します。 -->

## リスク

- low
- static mockup / docs / browser smoke target の追加に閉じています。主なリスクは mockup inventory と gallery 導線の同期漏れです。

## 補足

- `review-gallery.html` は新規 card / review path / comparison cue を入れるために再構成していますが、既存の card link、iframe preview、comparison table の役割は維持しています。