### PR TITLE
LocalizedNames の Public API 境界説明を補強する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -120,6 +120,8 @@ Documented localized display-name helpers include:
 - `TreeView.attribute_name_for(item_or_class, attribute, default: nil)`
 - `TreeView.type_name_for(item, count: 1, default: nil)`
 
+Localized display-name helpers resolve labels through the host app's Rails / ActiveModel / I18n locale data when available, then fall back to humanized names or an explicit `default:` value. They only return display names; host app row partials, helpers, or presenters still decide where those names appear in the UI. See [Localized names](localized-names.md) for fallback behavior and row-rendering examples.
+
 Documented Turbo UI options include:
 
 - `UiConfig#turbo_frame`

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -120,6 +120,8 @@ toolbar helper もこの公開 helper surface に含まれます。
 - `TreeView.attribute_name_for(item_or_class, attribute, default: nil)`
 - `TreeView.type_name_for(item, count: 1, default: nil)`
 
+localized display-name helper は、利用できる場合に host app の Rails / ActiveModel / I18n locale data から表示名を解決し、その後 humanize した名前または明示的な `default:` 値へ fallback します。これらは表示名を返すだけで、UI のどこに表示するかは host app の row partial、helper、presenter が決めます。fallback behavior と row rendering 例は [Localized names](localized-names.md) を参照してください。
+
 公開 Turbo UI option には以下を含めます。
 
 - `UiConfig#turbo_frame`


### PR DESCRIPTION
## 対応 Issue

Closes #1156

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の localized display-name helper 一覧直後に、fallback と host-app locale の責務境界を短く追記しました。
- `TreeView.model_name_for` / `attribute_name_for` / `type_name_for` は表示名解決 helper であり、row partial / helper / presenter が最終的な UI 表示場所を決めることを明記しました。
- 既存の `docs/en/localized-names.md` / `docs/ja/localized-names.md` への導線を保ち、fallback behavior と row-rendering examples を専用 guide に委譲しています。

## 根拠

- `config/public_api_manifest.yml` は `model_name_for` / `attribute_name_for` / `type_name_for` と `TreeView::LocalizedNames` を public surface として持っています。
- dedicated LocalizedNames docs では fallback、`default:`, host-app locale、UI 非自動描画の境界がすでに説明されています。
- Public API docs 側は helper 名の列挙が中心で、translation completeness や UI rendering responsibility を TreeView が持つと誤読しないための短い境界説明が不足していました。

## 非目標

- public API manifest / compatibility spec の変更
- I18n lookup behavior / fallback behavior の変更
- translation generator / completeness checker の追加
- LocalizedNames docs 全体の rewrite
- host-app 固有 locale examples の追加

## 確認内容

- GitHub compare: `main...docs/1156-localized-names-public-api`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 既存 public surface と既存 LocalizedNames guide の導線補強に閉じ、runtime behavior や public contract は変更していません。