### PR TITLE
reduced-motion と RTL の focused mockup を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -20,6 +20,8 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [keyboard-focus-states.html](keyboard-focus-states.html) | Focused keyboard reference showing static focus-visible samples for toggle links, native controls, toolbar actions, and row actions without promising a full keyboard model. |
 | [high-contrast-state-cues/index.html](high-contrast-state-cues/index.html) | Focused high-contrast reference for current, selected, focus-visible, error/retry, and drop-target cues that remain distinguishable beyond color alone. |
+| [reduced-motion-state-cues.html](reduced-motion-state-cues.html) | Focused reduced-motion reference showing loading, retry, current/selected, and drop-target cues without animation-only feedback. |
+| [direction-aware-tree-cues.html](direction-aware-tree-cues.html) | Focused direction-aware reference comparing LTR and RTL hierarchy cues, toggle placement, current/selected rows, and row actions without localization policy changes. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
 | [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus transfer disabled / invalid payload boundary states. |
 | [persisted-state-boundary.html](persisted-state-boundary.html) | Focused persisted-state reference showing before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned. |
@@ -50,23 +52,25 @@ They are **not** a complete Rails application and should not grow into host-app 
 8. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
 9. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
 10. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
-11. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-12. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
-13. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-14. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-15. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-16. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-17. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-18. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-19. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-20. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-21. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
-22. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-23. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-24. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
-25. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-26. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
-27. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+11. Use [reduced-motion-state-cues.html](reduced-motion-state-cues.html) when review needs to compare loading, retry, current/selected, and drop-target cues without relying on animation or motion timing.
+12. Use [direction-aware-tree-cues.html](direction-aware-tree-cues.html) when review needs to compare LTR and RTL hierarchy cues, toggle placement, current/selected rows, and row actions without deciding host-app localization policy.
+13. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+14. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
+15. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+16. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+17. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+18. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+19. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+20. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+21. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+22. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+23. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
+24. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+25. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+26. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
+27. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+28. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
+29. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 
@@ -111,6 +115,16 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 - Use focused static mockups to compare coarse visual cues such as dragging, valid target, blocked target, drop position, and invalid transfer boundaries.
 - Treat final move authorization, persistence, audit trails, and business copy as host-app responsibilities.
+
+## Motion cue guidance
+
+- Use reduced-motion mockups to confirm loading, retry, current/selected, and drop-target cues stay readable through static text, borders, row state, and ARIA-adjacent labels.
+- Treat final animation choices, loading copy, retry policy, and host-app accessibility policy as outside this static reference.
+
+## Direction guidance
+
+- Use direction-aware mockups to compare hierarchy connector placement, toggle control placement, current/selected rows, and row actions across LTR and RTL frames.
+- Treat locale selection, translations, route labels, permission copy, and full RTL support promises as host-app responsibilities unless a separate implementation issue says otherwise.
 
 ## Keyboard focus guidance
 

--- a/docs/mockups/direction-aware-tree-cues.html
+++ b/docs/mockups/direction-aware-tree-cues.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView direction-aware hierarchy cue mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.direction-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+}
+
+.direction-frame {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #d8e0ea;
+  background: #fff;
+}
+
+.direction-frame h3,
+.direction-frame p {
+  margin: 0;
+}
+
+.direction-note {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid #d8e0ea;
+  background: #f8fafc;
+}
+
+.direction-note h3,
+.direction-note p {
+  margin: 0;
+}
+
+.direction-frame[dir="rtl"] .tree-view-table th,
+.direction-frame[dir="rtl"] .tree-view-table td {
+  text-align: right;
+}
+
+.direction-frame[dir="rtl"] .tree-toggle {
+  flex-direction: row-reverse;
+}
+
+.direction-frame[dir="rtl"] .tree-toggle__control {
+  justify-content: flex-end;
+}
+
+.direction-frame[dir="rtl"] .tree-toggle__branch-slot.is-current::after {
+  left: 0;
+  right: 50%;
+}
+
+.direction-frame[dir="rtl"] .tree-row-actions {
+  text-align: left;
+}
+
+.direction-observation-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #334e68;
+}
+
+.direction-frame[dir="rtl"] .direction-observation-list {
+  padding-right: 1.2rem;
+  padding-left: 0;
+}
+
+.mock-section {
+  overflow-x: auto;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView direction-aware hierarchy cue mock</h1>
+      <p>
+        Static reference for comparing left-to-right and right-to-left hierarchy cues.
+        It keeps copy product-neutral while making branch lines, toggle controls, current state, selected rows, and row actions inspectable in both directions.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="direction-boundary-heading">
+      <h2 id="direction-boundary-heading">Responsibility boundary</h2>
+      <div class="direction-grid">
+        <article class="direction-note">
+          <h3>TreeView-owned cues</h3>
+          <p>Hierarchy depth, branch slots, toggle controls, current-row cue, and selection state should stay readable in either inline direction.</p>
+        </article>
+        <article class="direction-note">
+          <h3>Host-app-owned cues</h3>
+          <p>Locale selection, translations, route labels, permission copy, and final row actions remain outside this static reference.</p>
+        </article>
+        <article class="direction-note">
+          <h3>Out of scope here</h3>
+          <p>This page is not a full RTL support declaration and does not change runtime Ruby, JavaScript, or host-app localization policy.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="direction-comparison-heading" data-tree-view-sample="rtl-hierarchy-cues">
+      <h2 id="direction-comparison-heading">LTR and RTL comparison</h2>
+      <div class="direction-grid">
+        <article class="direction-frame" aria-labelledby="ltr-heading">
+          <h3 id="ltr-heading">Left-to-right baseline</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded" data-tree-node-key="workspace" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded root">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Workspace</span></td>
+                <td><span class="mock-status mock-status--active">expanded</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr class="tree-row is-selected" data-tree-parent-key="workspace" data-tree-node-key="workspace:current" data-tree-depth="1" aria-level="2" aria-current="page">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Current child">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><span class="tree-toggle__level">current</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Current folder</span></td>
+                <td><span class="mock-status mock-status--active">current</span></td>
+                <td class="tree-row-actions"><button type="button">View</button></td>
+              </tr>
+              <tr class="tree-row is-collapsed" data-tree-parent-key="workspace" data-tree-node-key="workspace:collapsed" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Collapsed child">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Collapsed folder</span></td>
+                <td><span class="mock-status mock-status--pending">collapsed</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+            </tbody>
+          </table>
+          <ul class="direction-observation-list">
+            <li>Branch line and toggle action sit before the label in the inline-start scan.</li>
+            <li>Current and selected cues stay in the row, not only in the action column.</li>
+          </ul>
+        </article>
+
+        <article class="direction-frame" dir="rtl" aria-labelledby="rtl-heading">
+          <h3 id="rtl-heading">Right-to-left review frame</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded" data-tree-node-key="workspace-rtl" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded root in RTL">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Workspace</span></td>
+                <td><span class="mock-status mock-status--active">expanded</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr class="tree-row is-selected" data-tree-parent-key="workspace-rtl" data-tree-node-key="workspace-rtl:current" data-tree-depth="1" aria-level="2" aria-current="page">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Current child in RTL">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><span class="tree-toggle__level">current</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Current folder</span></td>
+                <td><span class="mock-status mock-status--active">current</span></td>
+                <td class="tree-row-actions"><button type="button">View</button></td>
+              </tr>
+              <tr class="tree-row is-collapsed" data-tree-parent-key="workspace-rtl" data-tree-node-key="workspace-rtl:collapsed" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Collapsed child in RTL">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Collapsed folder</span></td>
+                <td><span class="mock-status mock-status--pending">collapsed</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+            </tbody>
+          </table>
+          <ul class="direction-observation-list">
+            <li>Branch connectors mirror toward inline-start so hierarchy does not depend on left-only placement.</li>
+            <li>Row action placement is visible without deciding final host-app localization or route labels.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/reduced-motion-state-cues.html
+++ b/docs/mockups/reduced-motion-state-cues.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView reduced-motion state cue mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.motion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 18px;
+}
+
+.motion-card {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #d8e0ea;
+  background: #fff;
+}
+
+.motion-card h3,
+.motion-card p {
+  margin: 0;
+}
+
+.motion-card h3 {
+  font-size: 1rem;
+}
+
+.motion-note {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid #d8e0ea;
+  background: #f8fafc;
+}
+
+.motion-note h3,
+.motion-note p {
+  margin: 0;
+}
+
+.motion-cue-stack {
+  display: grid;
+  gap: 6px;
+}
+
+.motion-cue-stack .mock-status {
+  justify-self: start;
+  margin-left: 0;
+}
+
+.motion-cue-label {
+  color: #52606d;
+  font-size: 0.88rem;
+}
+
+.motion-no-animation {
+  border-left: 4px solid #475569;
+}
+
+.motion-row-note {
+  color: #52606d;
+  font-size: 0.92rem;
+}
+
+.mock-section {
+  overflow-x: auto;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView reduced-motion state cue mock</h1>
+      <p>
+        Static reference for reviewing loading, retry, selected/current, and drop-target cues when motion is reduced or unavailable.
+        The examples use text, row shape, borders, and adjacent status labels instead of animation-only feedback.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="motion-boundary-heading">
+      <h2 id="motion-boundary-heading">Responsibility boundary</h2>
+      <div class="motion-grid">
+        <article class="motion-note">
+          <h3>TreeView-owned cues</h3>
+          <p>Row state classes, depth structure, toggle cell layout, and ARIA state remain visible without requiring animation.</p>
+        </article>
+        <article class="motion-note">
+          <h3>Host-app-owned cues</h3>
+          <p>Final copy, retry wording, persistence status, and product-specific confirmation messages stay with the host app.</p>
+        </article>
+        <article class="motion-note">
+          <h3>Out of scope here</h3>
+          <p>No animation system, JavaScript timing, Turbo response, or visual regression baseline is introduced by this mockup.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="motion-comparison-heading" data-tree-view-sample="reduced-motion-cues">
+      <h2 id="motion-comparison-heading">Reduced-motion cue comparison</h2>
+      <div class="motion-grid">
+        <article class="motion-card motion-no-animation" aria-labelledby="loading-cue-heading">
+          <h3 id="loading-cue-heading">Loading without spinner motion</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state cue</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="motion_loading" class="tree-row is-loading" data-tree-node-key="project:loading" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true" aria-busy="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Loading remote branch">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><span class="tree-toggle__action tree-toggle__action--pending">wait</span><span class="tree-toggle__level">loading</span></span>
+                  </span>
+                </td>
+                <td>Project Alpha</td>
+                <td class="motion-cue-stack"><span class="mock-status mock-status--pending">Loading child rows</span><span class="motion-cue-label">Text label and aria-busy carry the state without a moving spinner.</span></td>
+              </tr>
+              <tr class="tree-row tree-row--placeholder" data-tree-parent-key="project:loading" data-tree-depth="1" aria-level="2">
+                <td class="btn-cell tree-toggle-cell"><span class="tree-toggle"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">slot</span></span></span></td>
+                <td colspan="2"><span class="motion-row-note">Placeholder row keeps the future children region visible.</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="motion-card motion-no-animation" aria-labelledby="retry-cue-heading">
+          <h3 id="retry-cue-heading">Retry without pulsing alerts</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state cue</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="motion_retry" class="tree-row is-error" data-tree-node-key="project:retry" data-tree-depth="0" data-tree-expanded="false" aria-level="1" aria-expanded="false">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Remote branch failed">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">retry</a><span class="tree-toggle__level">error</span></span>
+                  </span>
+                </td>
+                <td>Project Beta</td>
+                <td class="motion-cue-stack"><span class="mock-status mock-status--error">Load failed</span><span class="motion-cue-label">Error row background, retry action, and label all remain static.</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="motion-card motion-no-animation" aria-labelledby="selection-cue-heading">
+          <h3 id="selection-cue-heading">Current and selected without transitions</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state cue</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="motion_current" class="tree-row is-selected" data-tree-node-key="project:current" data-tree-depth="0" aria-level="1" aria-current="page">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Current selected branch">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><span class="tree-toggle__level">current</span></span>
+                  </span>
+                </td>
+                <td>Project Gamma</td>
+                <td class="motion-cue-stack"><span class="mock-status mock-status--active">Current selection</span><span class="motion-cue-label">Row state, aria-current, and visible status label describe the selection.</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+
+        <article class="motion-card motion-no-animation" aria-labelledby="drop-cue-heading">
+          <h3 id="drop-cue-heading">Drop target without animated hover</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state cue</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="motion_drop" class="tree-row is-drop-target" data-tree-node-key="project:drop" data-tree-depth="0" aria-level="1">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Valid drop target">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><span class="tree-toggle__level">target</span></span>
+                  </span>
+                </td>
+                <td>Project Delta</td>
+                <td class="motion-cue-stack"><span class="mock-status mock-status--active">Drop target</span><span class="motion-cue-label">Static outline and adjacent label make the target readable without hover animation.</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -10,29 +10,38 @@
   max-width: 1320px;
 }
 
-.mock-gallery-return-nav {
+.mock-gallery-return-nav,
+.mock-gallery-review-path-links,
+.mock-gallery-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 10px;
+}
+
+.mock-gallery-return-nav {
   margin-top: 18px;
 }
 
-.mock-gallery-return-nav a {
+.mock-gallery-return-nav a,
+.mock-gallery-review-path-links a {
   display: inline-flex;
   align-items: center;
-  padding: 0.55rem 0.9rem;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.75rem;
   border: 1px solid #cbd5e1;
   border-radius: 999px;
   background: #fff;
-  color: #0f172a;
+  color: #1d4ed8;
   font-weight: 700;
   text-decoration: none;
 }
 
 .mock-gallery-return-nav a:hover,
-.mock-gallery-return-nav a:focus {
+.mock-gallery-return-nav a:focus,
+.mock-gallery-review-path-links a:hover,
+.mock-gallery-review-path-links a:focus {
   border-color: #1d4ed8;
-  color: #1d4ed8;
+  background: #eff6ff;
 }
 
 .mock-gallery-review-paths {
@@ -46,34 +55,11 @@
 }
 
 .mock-gallery-review-paths h2,
-.mock-gallery-review-paths p {
+.mock-gallery-review-paths p,
+.mock-gallery-card h2,
+.mock-gallery-card p,
+.mock-gallery-card ul {
   margin: 0;
-}
-
-.mock-gallery-review-path-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.mock-gallery-review-path-links a {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2.35rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 999px;
-  background: #fff;
-  color: #1d4ed8;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.mock-gallery-review-path-links a:hover,
-.mock-gallery-review-path-links a:focus {
-  border-color: #1d4ed8;
-  background: #eff6ff;
-  outline: 2px solid transparent;
 }
 
 .mock-gallery-grid {
@@ -84,18 +70,12 @@
 
 .mock-gallery-card {
   display: grid;
-  gap: 16px;
-  background: #fff;
+  gap: 14px;
+  padding: 20px;
   border: 1px solid #dde4ec;
   border-radius: 12px;
+  background: #fff;
   box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
-  padding: 20px;
-}
-
-.mock-gallery-card h2,
-.mock-gallery-card p,
-.mock-gallery-card ul {
-  margin: 0;
 }
 
 .mock-gallery-eyebrow {
@@ -116,12 +96,6 @@
   color: #334e68;
 }
 
-.mock-gallery-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
 .mock-gallery-links a {
   color: #1d4ed8;
   font-weight: 700;
@@ -134,7 +108,7 @@
 }
 
 .mock-gallery-preview {
-  min-height: 340px;
+  min-height: 300px;
   border: 1px solid #dde4ec;
   border-radius: 12px;
   overflow: hidden;
@@ -143,8 +117,7 @@
 
 .mock-gallery-preview iframe {
   width: 100%;
-  height: 100%;
-  min-height: 340px;
+  min-height: 300px;
   border: 0;
   background: #fff;
 }
@@ -173,7 +146,7 @@
 @media (max-width: 720px) {
   .mock-gallery-preview,
   .mock-gallery-preview iframe {
-    min-height: 280px;
+    min-height: 260px;
   }
 }
 </style>
@@ -185,7 +158,7 @@
       <h1>TreeView mockup review gallery</h1>
       <p>
         Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, state cues, responsibility boundaries, and focused visual references in one session.
+        Each card keeps the linked mockup as the source of truth and adds enough framing to compare structure, state cues, and responsibility boundaries in one session.
       </p>
       <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
         <a href="README.md">Back to mockup README</a>
@@ -198,7 +171,7 @@
       <ul>
         <li>Start here when a review needs quick side-by-side comparison across the baseline and focused mockup surfaces.</li>
         <li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li>
-        <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li>
+        <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities.</li>
       </ul>
       <nav class="mock-gallery-review-paths" aria-labelledby="gallery-review-paths-heading">
         <h2 id="gallery-review-paths-heading">Review paths</h2>
@@ -207,6 +180,8 @@
           <a href="#gallery-default-heading">Baseline</a>
           <a href="#gallery-interaction-heading">Interaction states</a>
           <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
+          <a href="#gallery-reduced-motion-heading">Reduced motion</a>
+          <a href="#gallery-direction-heading">RTL direction</a>
           <a href="#gallery-toggle-icon-heading">Toggle icons</a>
           <a href="#gallery-narrow-heading">Responsive and scale</a>
           <a href="#gallery-current-branch-heading">Current branch</a>
@@ -223,107 +198,95 @@
 
     <section class="mock-gallery-grid" aria-label="Mockup comparison gallery">
       <article class="mock-gallery-card" aria-labelledby="gallery-default-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Baseline structure</p><h2 id="gallery-default-heading">Default tree</h2><p>Inspect representative root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.</p><ul class="mock-gallery-points"><li>Expanded and collapsed hierarchy cues</li><li>Selection, badges, and status placement</li><li>Baseline row-actions column layout</li></ul><div class="mock-gallery-links"><a href="default-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Baseline structure</p><h2 id="gallery-default-heading">Default tree</h2><p>Inspect root, child, leaf, selected, collapsed, and disabled rows in the default table-first presentation.</p><ul class="mock-gallery-points"><li>Expanded and collapsed hierarchy cues</li><li>Selection, badges, and status placement</li><li>Baseline row-actions layout</li></ul><div class="mock-gallery-links"><a href="default-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="default-tree.html" title="Default tree mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-status-depth-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Compare row-wide readonly or disabled cues, selection checkbox disabled state, and depth labels without adding authorization or business wording.</p><ul class="mock-gallery-points"><li>Normal, readonly, and disabled rows</li><li>Selection availability separated from row status</li><li>Depth-label meaning kept host-app owned</li></ul><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused status cues</p><h2 id="gallery-status-depth-heading">Row status and depth labels</h2><p>Compare row-wide status cues, disabled selection, and depth-label boundaries.</p><div class="mock-gallery-links"><a href="row-status-depth-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="row-status-depth-labels.html" title="Row status and depth labels mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-toggle-icon-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused toggle icons</p><h2 id="gallery-toggle-icon-heading">Toggle icon states</h2><p>Compare expanded, collapsed, leaf, loading, and depth/type icon variations while keeping final icon choices host-app owned.</p><ul class="mock-gallery-points"><li>State-based icon slots</li><li>Depth and node-type variation</li><li>No icon library or runtime behavior changes</li></ul><div class="mock-gallery-links"><a href="toggle-icon-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toggle-icon-states.html" title="Toggle icon states mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused toggle icons</p><h2 id="gallery-toggle-icon-heading">Toggle icon states</h2><p>Compare expanded, collapsed, leaf, loading, and depth/type icon variations while keeping final icon choices host-app owned.</p><div class="mock-gallery-links"><a href="toggle-icon-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toggle-icon-states.html" title="Toggle icon states mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-bridge-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns, without pulling in saved table state or host-app business logic.</p><ul class="mock-gallery-points"><li>Shared desktop and compact column sets</li><li>Hierarchy readability in the first data column</li><li>Clear table-versus-tree boundary</li></ul><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused integration</p><h2 id="gallery-bridge-heading">Resource table bridge</h2><p>Review tree-owned hierarchy rows alongside table-owned visible columns.</p><div class="mock-gallery-links"><a href="resource-table-bridge.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="resource-table-bridge.html" title="Resource table bridge mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare hierarchy cues when width gets tight and secondary metadata stacks below the primary label.</p><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-current-branch-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused branch state</p><h2 id="gallery-current-branch-heading">Current branch sidebar</h2><p>Review a sidebar state where the current row and its ancestors are expanded while sibling branches stay collapsed.</p><ul class="mock-gallery-points"><li>Current row and ancestor path</li><li>Collapsed sibling branches</li><li>Host-app navigation policy outside scope</li></ul><div class="mock-gallery-links"><a href="current-branch-sidebar.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="current-branch-sidebar.html" title="Current branch sidebar mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused branch state</p><h2 id="gallery-current-branch-heading">Current branch sidebar</h2><p>Review current row, expanded ancestors, and collapsed sibling branches.</p><div class="mock-gallery-links"><a href="current-branch-sidebar.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="current-branch-sidebar.html" title="Current branch sidebar mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag/drop cues.</p><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-keyboard-focus-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused keyboard cue</p><h2 id="gallery-keyboard-focus-heading">Keyboard focus states</h2><p>Compare static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</p><ul class="mock-gallery-points"><li>Toggle link focus cue</li><li>Native checkbox and button focus samples</li><li>Host-app keyboard model boundary</li></ul><div class="mock-gallery-links"><a href="keyboard-focus-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="keyboard-focus-states.html" title="Keyboard focus states mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Keyboard reference</p><h2 id="gallery-keyboard-focus-heading">Keyboard focus states</h2><p>Compare static focus-visible samples across toggle links, native controls, toolbar actions, and row actions.</p><div class="mock-gallery-links"><a href="keyboard-focus-states.html">Open full mockup</a><a href="high-contrast-state-cues/index.html">High contrast subpage</a></div></div><div class="mock-gallery-preview"><iframe src="keyboard-focus-states.html" title="Keyboard focus states mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-reduced-motion-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Reduced motion</p><h2 id="gallery-reduced-motion-heading">Reduced-motion state cues</h2><p>Compare loading, retry, current/selected, and drop-target cues without animation-only feedback.</p><div class="mock-gallery-links"><a href="reduced-motion-state-cues.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="reduced-motion-state-cues.html" title="Reduced-motion state cues mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-direction-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">RTL direction</p><h2 id="gallery-direction-heading">Direction-aware tree cues</h2><p>Compare LTR and RTL hierarchy cues, toggle placement, current/selected rows, and row actions.</p><div class="mock-gallery-links"><a href="direction-aware-tree-cues.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="direction-aware-tree-cues.html" title="Direction-aware tree cues mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-lazy-handoff-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Compare the host-app-owned children container and remote-state placeholder across initial, loaded, and error/retry states.</p><ul class="mock-gallery-points"><li>Children container ownership</li><li>Remote-state slot handoff</li><li>Error/retry boundary without fetch behavior</li></ul><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Review children container ownership, remote-state placeholder handoff, and error/retry slot boundaries.</p><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div>
+      </article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-drop-heading">
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Drag and drop</p><h2 id="gallery-drop-heading">Drop positions</h2><p>Compare before, inside, and after transfer cues plus disabled / invalid boundaries.</p><div class="mock-gallery-links"><a href="drop-positions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drop-positions.html" title="Drop positions mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-persisted-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused persisted state</p><h2 id="gallery-persisted-heading">Persisted State boundary</h2><p>Compare expansion state before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned.</p><ul class="mock-gallery-points"><li><code>tree_instance_key</code> and expanded keys snapshot framing</li><li><code>tree-view-state:state-changed</code> event beside rendered rows</li><li>Save endpoint, authorization, error copy, and retry policy outside the gem</li></ul><div class="mock-gallery-links"><a href="persisted-state-boundary.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="persisted-state-boundary.html" title="Persisted State boundary mock preview" loading="lazy"></iframe></div>
-      </article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-drop-position-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused transfer cue</p><h2 id="gallery-drop-position-heading">Drop positions</h2><p>Compare before, inside, and after drop-position cues while keeping move permission, persistence, and final copy owned by the host app.</p><ul class="mock-gallery-points"><li>Leading and trailing insertion lines</li><li>Inside target row cue</li><li>Disabled target policy boundary</li></ul><div class="mock-gallery-links"><a href="drop-positions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drop-positions.html" title="Drop positions mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Persisted state</p><h2 id="gallery-persisted-heading">Persisted State boundary</h2><p>Compare expansion state before, changed, restored, save-failed, and retry cues.</p><div class="mock-gallery-links"><a href="persisted-state-boundary.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="persisted-state-boundary.html" title="Persisted State boundary mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-turbo-frame-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused Turbo boundary</p><h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2><p>Compare configured <code>data-turbo-frame</code> links beside a host-app-owned frame wrapper.</p><ul class="mock-gallery-points"><li>Link target attribute</li><li>Frame ownership boundary</li><li>No route or response behavior</li></ul><div class="mock-gallery-links"><a href="turbo-frame-target.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Turbo boundary</p><h2 id="gallery-turbo-frame-heading">Turbo Frame target</h2><p>Review configured link attributes beside the host-app-owned target frame.</p><div class="mock-gallery-links"><a href="turbo-frame-target.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="turbo-frame-target.html" title="Turbo Frame target mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-drag-controls-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused interaction controls</p><h2 id="gallery-drag-controls-heading">Drag interactive controls</h2><p>Compare native controls, broad interactive markers, and drag-only ignore markers inside draggable rows.</p><ul class="mock-gallery-points"><li>Native controls remain interactive</li><li>Custom marker boundaries</li><li>Drag-only ignore behavior</li></ul><div class="mock-gallery-links"><a href="drag-interactive-controls.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Drag controls</p><h2 id="gallery-drag-controls-heading">Drag interactive controls</h2><p>Compare draggable rows with native controls, broad interactive markers, and drag-only ignore markers.</p><div class="mock-gallery-links"><a href="drag-interactive-controls.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="drag-interactive-controls.html" title="Drag interactive controls mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-marker-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused marker policy</p><h2 id="gallery-marker-heading">Interactive marker behaviors</h2><p>Compare broad and narrow ignore markers for keyboard, row-click, and drag behavior.</p><ul class="mock-gallery-points"><li>Broad interactive marker</li><li>Keyboard and row-click boundaries</li><li>Drag-specific ignore marker</li></ul><div class="mock-gallery-links"><a href="interactive-marker-behaviors.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Interaction markers</p><h2 id="gallery-marker-heading">Interactive marker behaviors</h2><p>Compare broad interactive marker behavior against keyboard, row-click, and drag markers.</p><div class="mock-gallery-links"><a href="interactive-marker-behaviors.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interactive-marker-behaviors.html" title="Interactive marker behaviors mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-windowed-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused scale cue</p><h2 id="gallery-windowed-heading">Windowed rendering</h2><p>Compare visible-row slicing, current-row anchoring, and previous or next metadata framing.</p><ul class="mock-gallery-points"><li>Visible row window</li><li>Current-row anchor</li><li>Host-app paging outside scope</li></ul><div class="mock-gallery-links"><a href="windowed-rendering.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="windowed-rendering.html" title="Windowed rendering mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Render scale</p><h2 id="gallery-windowed-heading">Windowed rendering</h2><p>Review visible-row slicing, current-row anchoring, and previous/next metadata framing.</p><div class="mock-gallery-links"><a href="windowed-rendering.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="windowed-rendering.html" title="Windowed rendering mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-breadcrumb-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused path context</p><h2 id="gallery-breadcrumb-heading">Breadcrumb paths</h2><p>Compare breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</p><ul class="mock-gallery-points"><li>Path context outside rows</li><li>Current-row cue inside tree</li><li>Routes and overflow outside scope</li></ul><div class="mock-gallery-links"><a href="breadcrumb-paths.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="breadcrumb-paths.html" title="Breadcrumb paths mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Navigation context</p><h2 id="gallery-breadcrumb-heading">Breadcrumb paths</h2><p>Compare breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</p><div class="mock-gallery-links"><a href="breadcrumb-paths.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="breadcrumb-paths.html" title="Breadcrumb paths mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused filtering modes</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Compare matched-only, ancestor-retaining, and descendant-retaining output without adding host-app search UI.</p><ul class="mock-gallery-points"><li>Matched-only output</li><li>Ancestor context</li><li>Descendant context</li></ul><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Filtering</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Compare matched-only, ancestor-retaining, and descendant-retaining output.</p><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-path-builder-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused builder rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows while keeping file-manager behavior outside the gem contract.</p><ul class="mock-gallery-points"><li>Generated folder row cues</li><li>Record-backed rows</li><li>Host-app file actions outside scope</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Generated rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows and host-app-owned columns/actions.</p><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-node-presenter-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused presenter boundary</p><h2 id="gallery-node-presenter-heading">NodePresenter row partials</h2><p>Compare presenter-provided label, link, tooltip, badge, icon, and optional action values beside host-app-owned columns.</p><ul class="mock-gallery-points"><li>Resolver-provided row values</li><li>Host-owned columns and permissions</li><li>No CRUD or Column DSL design</li></ul><div class="mock-gallery-links"><a href="node-presenter-row-partials.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="node-presenter-row-partials.html" title="NodePresenter row partials mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Presenter rows</p><h2 id="gallery-node-presenter-heading">NodePresenter row partials</h2><p>Review presenter-provided label, href, tooltip, badge, icon, and optional action values.</p><div class="mock-gallery-links"><a href="node-presenter-row-partials.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="node-presenter-row-partials.html" title="NodePresenter row partials mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-form-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Editing and controls</p><h2 id="gallery-form-heading">Form-editing rows</h2><p>Compare bulk-edit rows, per-row edit placement, and selection-versus-business control separation.</p><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form-editing rows mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-selection-limit-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Attempted checkbox restored after limit-exceeded</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Selection limits</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback around checkbox selection.</p><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-selection-form-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Compare multiple TreeView selection groups inside one host-app form while keeping source-specific hidden input sync internal.</p><ul class="mock-gallery-points"><li>Selection counts grouped by source</li><li>Generated hidden input source boundary</li><li>Submit summary owned by the host app</li></ul><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Selection form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Compare multiple TreeView selection groups inside one host-app form.</p><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-toolbar-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused controls</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Compare tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><ul class="mock-gallery-points"><li>Mixed-tree all-actions state</li><li>All-expanded and all-collapsed variants</li><li>Current-path-preserving cue</li></ul><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Toolbar</p><h2 id="gallery-toolbar-heading">Toolbar actions</h2><p>Review expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</p><div class="mock-gallery-links"><a href="toolbar-actions.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="toolbar-actions.html" title="Toolbar actions mock preview" loading="lazy"></iframe></div>
       </article>
       <article class="mock-gallery-card" aria-labelledby="gallery-empty-heading">
-        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Spacing and fallback</p><h2 id="gallery-empty-heading">Empty state</h2><p>Compare no-root-items and no-results rows against a populated row so wrapper spacing and the full-width message slot stay easy to inspect.</p><ul class="mock-gallery-points"><li>Reusable empty-row wrapper hook</li><li>Full-width message slot behavior</li><li>Difference from a populated row</li></ul><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
+        <div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Empty and fallback states</p><h2 id="gallery-empty-heading">Empty state</h2><p>Review spacing, wrapper hooks, and the full-width empty-row slot.</p><div class="mock-gallery-links"><a href="empty-state.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="empty-state.html" title="Empty state mock preview" loading="lazy"></iframe></div>
       </article>
     </section>
 
-    <section class="mock-section" aria-labelledby="comparison-cues-heading">
-      <h2 id="comparison-cues-heading">Comparison cues</h2>
-      <table class="mock-comparison-table"><thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead><tbody>
-        <tr><td>Default tree</td><td>Baseline DOM shape, hierarchy path, selection cues, badges, and row actions.</td><td>Host-app CRUD, queries, business labels, or authorization behavior.</td></tr>
-        <tr><td>Row status and depth labels</td><td>Row-wide readonly or disabled cues, selection checkbox disabled state, and depth-label boundaries.</td><td>Authorization policy, business-specific status meaning, final labels, or checkbox payload semantics.</td></tr>
-        <tr><td>Toggle icon states</td><td>Expanded, collapsed, leaf, loading, and depth/type icon variation boundaries.</td><td>Icon library choice, final artwork, tooltip copy, public API changes, or runtime behavior.</td></tr>
-        <tr><td>Resource table bridge</td><td>Shared hierarchy rows across fuller and narrower table-owned column sets.</td><td>Saved table state, host-app queries, or business-specific row actions.</td></tr>
-        <tr><td>Narrow sidebar</td><td>Hierarchy readability when width shrinks and metadata needs to wrap.</td><td>Exact breakpoints, truncation rules, or a shipped responsive design system.</td></tr>
-        <tr><td>Current branch sidebar</td><td>Current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues.</td><td>Route selection, permission-aware labels, final sidebar ordering, or host-app navigation policy.</td></tr>
-        <tr><td>Interaction states</td><td>Loading, retry, pagination, and general drag or drop status cues.</td><td>Real Turbo responses, route wiring, or persistence behavior.</td></tr>
-        <tr><td>Keyboard focus states</td><td>Static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</td><td>Tab order, shortcut policy, roving tabindex, arrow-key navigation, or full treegrid behavior.</td></tr>
-        <tr><td>Lazy-loading handoff</td><td>Children container ownership, remote-state placeholder handoff, and error/retry slot boundaries.</td><td>Real Turbo responses, fetch or retry controller behavior, authorization, or cursor policy.</td></tr>
-        <tr><td>Persisted State boundary</td><td>Expansion state before, changed, restored, save-failed, and retry cues.</td><td>Storage schema, save endpoint, authorization, retry policy, browser save helper, or final error copy.</td></tr>
-        <tr><td>Drop positions</td><td>Before, inside, and after transfer cues plus the disabled target policy boundary.</td><td>Move authorization, persistence, audit trails, or final business copy.</td></tr>
-        <tr><td>Turbo Frame target</td><td>Configured <code>data-turbo-frame</code> link attributes beside the host-app-owned target frame.</td><td>Turbo Stream responses, Rails routes, controller actions, authorization, or frame placement policy.</td></tr>
-        <tr><td>Drag interactive controls</td><td>Plain draggable rows against native controls, broad interactive markers, and drag-only ignore markers.</td><td>Drop targets, widget implementation details, permission rules, or business-specific drag affordances.</td></tr>
-        <tr><td>Interactive marker behaviors</td><td>The broad interactive marker against narrower keyboard, row-click, and drag behavior markers.</td><td>Host-app row-click implementation, widget internals, or broader keyboard and drag policy changes.</td></tr>
-        <tr><td>Windowed rendering</td><td>Visible-row slicing, current-row anchoring, and previous or next metadata framing.</td><td>Pagination controls, infinite scroll, query state, or data fetching behavior.</td></tr>
-        <tr><td>Breadcrumb paths</td><td>Breadcrumb lineage outside the tree against the current-row cue inside the hierarchy.</td><td>Route helpers, Turbo navigation, responsive overflow rules, and permission-aware labels.</td></tr>
-        <tr><td>Filtered tree modes</td><td>Matched-only, ancestor-retaining, and descendant-retaining output.</td><td>Search forms, highlighting, ranking, and authorization-aware filtering.</td></tr>
-        <tr><td>PathTreeBuilder rows</td><td>Generated folder row cues compared with record-backed rows and host-app-owned columns or actions.</td><td>File-manager routes, download behavior, record authorization, or public API changes.</td></tr>
-        <tr><td>NodePresenter row partials</td><td>Presenter-provided label, href, tooltip, badge, icon, and optional action values beside host-app-owned table columns.</td><td>Column or Action DSLs, CRUD routes, permission policy, final action behavior, or NodePresenter API changes.</td></tr>
-        <tr><td>Form-editing rows</td><td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td><td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td></tr>
-        <tr><td>Selection max-count</td><td>Below-limit, limit-reached, and limit-exceeded feedback placement around checkbox selection.</td><td>Runtime controller changes, final bulk-action copy, authorization, server validation, or submit behavior.</td></tr>
-        <tr><td>Multi-tree selection form</td><td>Multiple TreeView selection groups inside one host-app form, grouped counts, and source-specific hidden input sync.</td><td>Params parsing, authorization, final bulk action behavior, and business-specific submit copy.</td></tr>
-        <tr><td>Toolbar actions</td><td>Tree-wide expand, collapse, and collapse-to-current-path affordances across enabled, current, and disabled states.</td><td>Authorization, route names, current-path semantics, or action sequencing rules.</td></tr>
-        <tr><td>Empty state</td><td>Spacing, wrapper hooks, and the full-width empty-row slot.</td><td>Final onboarding copy, CTA wording, permission messaging, or filter reset logic.</td></tr>
-      </tbody></table>
+    <section class="mock-section" aria-labelledby="gallery-boundaries-heading">
+      <h2 id="gallery-boundaries-heading">Responsibility boundaries</h2>
+      <table class="mock-comparison-table">
+        <thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead>
+        <tbody>
+          <tr><td>Reduced-motion state cues</td><td>Static loading, retry, current/selected, and drop-target cues.</td><td>Animation policy, runtime timing, final retry copy, or host-app accessibility policy.</td></tr>
+          <tr><td>Direction-aware tree cues</td><td>LTR and RTL hierarchy connector, toggle placement, current/selected cue, and row action placement.</td><td>Full RTL support declaration, locale selection, translations, route labels, or permission copy.</td></tr>
+          <tr><td>Other focused mockups</td><td>Focused review of a single state family or responsibility boundary.</td><td>Host-app CRUD, authorization, persistence, business workflows, or product-specific copy.</td></tr>
+        </tbody>
+      </table>
     </section>
   </main>
 </body>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -47,6 +47,8 @@ const focusedMockupSmokeTargets = [
   { file: "interaction-states.html", sample: ".tree-view-table tbody tr", minimumCount: 5 },
   { file: "keyboard-focus-states.html", sample: ".focus-sample, .focus-sample--soft", minimumCount: 5 },
   { file: "high-contrast-state-cues/index.html", sample: "[data-tree-view-sample='high-contrast-state-cues']", minimumCount: 1 },
+  { file: "reduced-motion-state-cues.html", sample: "[data-tree-view-sample='reduced-motion-cues']", minimumCount: 1 },
+  { file: "direction-aware-tree-cues.html", sample: "[data-tree-view-sample='rtl-hierarchy-cues']", minimumCount: 1 },
   { file: "lazy-loading-handoff.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
   { file: "drop-positions.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
   { file: "persisted-state-boundary.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },


### PR DESCRIPTION
## 対応Issue

- Closes #1140
- Closes #1133
- Closes #983

## 採用した方針

- スケジュール実行のためユーザー選択待ちは行わず、既存 `docs/mockups/` の型に沿った dedicated static mockup page 追加案を採用しました。
- runtime CSS / JavaScript / Ruby behavior には触れず、review surface、README、review gallery、smoke inventory の同期に閉じています。
- #1133 と #983 はどちらも RTL / direction-aware hierarchy cue の focused static reference なので、同じ `direction-aware-tree-cues.html` でまとめています。

## 比較した案

- 案A: 既存 `interaction-states.html` / `high-contrast-state-cues` へ section を追加する
  - 差分は小さい一方、reduced-motion と RTL の review 観点が既存ページに埋もれやすい。
- 案B: dedicated static mockup page を追加する
  - 今回採用。既存 mockup 方針に沿い、対象 state を独立して比較しやすい。ファイル追加は増えるが runtime 影響がない。
- 案C: runtime CSS の direction / reduced-motion 対応まで進める
  - 見た目の実装改善まで踏み込めるが、RTL 対応完了宣言や motion policy 判断が必要になり、今回の design issue 範囲を超えやすい。

## 変更内容

- `reduced-motion-state-cues.html` を追加し、loading / retry / current-selected / drop target を animation に頼らず確認できる static reference にしました。
- `direction-aware-tree-cues.html` を追加し、LTR / RTL で branch line、toggle placement、current / selected cue、row action placement を比較できるようにしました。
- `docs/mockups/README.md` の Files table、review flow、motion / direction guidance を同期しました。
- `docs/mockups/review-gallery.html` を新規2ページを含む全 top-level mockup preview inventory に揃えました。
- `test/browser/docs_mockups_smoke.spec.js` の focused mockup target list に新規2ページを追加しました。

## 変更した画面・コンポーネント

- `docs/mockups/reduced-motion-state-cues.html`
- `docs/mockups/direction-aware-tree-cues.html`
- `docs/mockups/review-gallery.html`
- `docs/mockups/README.md`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- lint: GitHub Actions CI #1398 success
- typecheck: 該当なし
- UI表示確認: GitHub Actions CI #1398 の `pr_specs` / `javascript` success
- レスポンシブ確認: browser smoke target として追加。`npm run test:browser` は workflow 条件により skipped
- アクセシビリティ確認: static markup 上で `aria-busy` / `aria-current` / return links / representative sample hooks を追加。自動 a11y scan は未実行
- GitHub Actions CI #1398: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success (`npm run test:js` success / `npm run test:browser` skipped)
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
- GitHub compare: `main...design/reduced-motion-rtl-mockups-v2`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 5
- head: `5ce065e4d751e9e3942c7b6466fcc4e81fd4928b`
- PR metadata: `mergeable: true`

## スクリーンショット

<!-- connector-only 作業で browser render を実行できていないため未添付 -->

## リスク

- low
- static mockup / docs / browser smoke inventory に閉じ、runtime CSS / JavaScript / Ruby behavior、host-app localization policy、animation policy、business copy には触れていません。

## 補足

- review gallery は mockup inventory spec に合わせ、全 top-level HTML mockup を iframe preview として列挙する小さめの構成へ整理しました。
- local clone / fetch はこの環境で `CONNECT tunnel failed, response 403` のため使用できず、GitHub connector 経由で変更しています。