### PR TITLE
localized row labels の focused mockup を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -32,6 +32,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [path-tree-builder-rows.html](path-tree-builder-rows.html) | Focused PathTreeBuilder comparison for generated folder rows versus record-backed rows, keeping host-app columns/actions outside the gem contract. |
 | [node-presenter-row-partials.html](node-presenter-row-partials.html) | Focused NodePresenter row partial reference showing resolver-provided label, href, tooltip, badge, icon, and optional action beside host-app-owned columns and permissions. |
+| [localized-row-labels.html](localized-row-labels.html) | Focused localized and long translated row label reference showing primary label, type badge, attribute label, secondary metadata, and tooltip cues without choosing final host-app translations. |
 | [form-editing-rows.html](form-editing-rows.html) | Focused comparison for bulk-edit rows, per-row edit placement, and the boundary between TreeView selection checkboxes and host-app business controls. |
 | [selection-max-count.html](selection-max-count.html) | Focused selection max-count reference showing below-limit, limit-reached, and limit-exceeded feedback while keeping final action copy host-app owned. |
 | [selection-multi-tree-form.html](selection-multi-tree-form.html) | Focused multi-tree selection form reference showing source-specific selected counts, submit summary, empty state, and generated hidden input boundary as a review aid. |
@@ -49,7 +50,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 6. Use [toggle-icon-states.html](toggle-icon-states.html) when review needs to compare `toggle_icons:` expanded, collapsed, leaf, loading, and depth/type variation without selecting a final icon library.
 7. Use [resource-table-bridge.html](resource-table-bridge.html) when review needs a focused pass on table-owned columns plus TreeView-owned hierarchy cues.
 8. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
-9. Use [reduced-motion-state-cues.html](reduced-motion-state-cues.html) when review needs to compare loading, retry, current/selected, and drop-target cues without relying on animation.
+9. Use [reduced-motion-state-cues.html](reduced-motion-state-cues.html) when review needs to compare loading, retry, current/selected, and drop-target cues that remain readable without animation.
 10. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
 11. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
 12. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
@@ -63,12 +64,13 @@ They are **not** a complete Rails application and should not grow into host-app 
 20. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
 21. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
 22. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
-23. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-24. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-25. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
-26. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-27. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
-28. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+23. Use [localized-row-labels.html](localized-row-labels.html) when review needs to compare long localized row labels, type badges, attribute labels, secondary metadata, and tooltip cues without deciding final host-app translations.
+24. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+25. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+26. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
+27. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+28. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
+29. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 
@@ -79,6 +81,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 
 - Mockups use short, product-neutral English copy so reviewers can compare layout and state cues without language changes becoming visual noise.
 - `toolbar-actions.html` intentionally includes a narrow long/localized label stress case so reviewers can inspect wrapping and disabled/current cues without choosing final translations.
+- `localized-row-labels.html` intentionally uses long localized-style English labels to stress row wrapping, badge placement, attribute labels, secondary metadata, and tooltip cues without choosing final translations.
 - Final labels, localization, permission messaging, and business wording remain host-app responsibilities.
 - If a future mockup intentionally uses another language, document that exception here so reviewers know it is deliberate.
 

--- a/docs/mockups/localized-row-labels.html
+++ b/docs/mockups/localized-row-labels.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Localized row labels mock</title>
+<link rel="stylesheet" href="default-tree.css">
+<style>
+.mock-localized-note { margin: 0; color: #52606d; }
+.mock-localized-frame { display: grid; gap: 14px; }
+.mock-localized-table { table-layout: fixed; }
+.mock-localized-name { display: grid; gap: 0.35rem; min-width: 0; }
+.mock-localized-primary { display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem 0.5rem; min-width: 0; }
+.mock-localized-primary a { color: #1d4ed8; font-weight: 800; overflow-wrap: anywhere; text-decoration: none; }
+.mock-localized-primary a:hover, .mock-localized-primary a:focus { text-decoration: underline; }
+.mock-localized-type { display: inline-flex; align-items: center; max-width: 100%; padding: 0.15rem 0.45rem; border: 1px solid #cbd5e1; border-radius: 999px; background: #f8fafc; color: #334e68; font-size: 0.78rem; font-weight: 800; overflow-wrap: anywhere; }
+.mock-localized-type--accent { border-color: #bae6fd; background: #e0f2fe; color: #075985; }
+.mock-localized-attribute { display: inline-flex; max-width: 100%; color: #475569; font-size: 0.84rem; font-weight: 700; overflow-wrap: anywhere; }
+.mock-localized-secondary { color: #52606d; font-size: 0.86rem; line-height: 1.45; overflow-wrap: anywhere; }
+.mock-localized-tooltip-cue { color: #0f766e; font-size: 0.82rem; font-weight: 700; }
+.mock-localized-action { display: inline-flex; align-items: center; justify-content: center; min-height: 2.1rem; padding: 0.4rem 0.65rem; border: 1px solid #cbd5e1; border-radius: 8px; background: #fff; color: #1d4ed8; font-weight: 800; text-decoration: none; }
+.mock-localized-action:hover, .mock-localized-action:focus { border-color: #1d4ed8; outline: 2px solid transparent; }
+.mock-localized-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); gap: 14px; }
+.mock-localized-card { border: 1px solid #dde4ec; border-radius: 8px; background: #fff; padding: 14px; }
+.mock-localized-card h3, .mock-localized-card p { margin: 0; }
+.mock-localized-card h3 { margin-bottom: 0.45rem; }
+@media (max-width: 760px) { .mock-localized-table { display: block; overflow-x: auto; } .mock-localized-table th, .mock-localized-table td { min-width: 10rem; } .mock-localized-table th:first-child, .mock-localized-table td:first-child { min-width: 18rem; } }
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>Localized row labels mock</h1>
+      <p>Focused static reference for reviewing long localized row labels, type badges, attribute labels, secondary metadata, and tooltip cues without choosing final host-app translations.</p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section mock-localized-frame" aria-labelledby="localized-table-heading">
+      <h2 id="localized-table-heading">Long localized label stress sample</h2>
+      <p class="mock-localized-note">Rows use product-neutral, localized-style English copy. The goal is to inspect wrapping and cue placement, not to define final translations or truncation policy.</p>
+      <table class="tree-view-table mock-localized-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+        <thead><tr><th scope="col">tree node</th><th scope="col">localized attribute</th><th scope="col">secondary metadata</th><th scope="col">row action</th></tr></thead>
+        <tbody>
+          <tr id="localized_node_1" class="tree-row is-expanded" data-tree-node-key="localized:portfolio" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Expanded localized portfolio group"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span></span><span class="mock-localized-name"><span class="mock-localized-primary"><a href="#portfolio" title="Open Quarterly Planning Portfolio With Region-Specific Review Naming">Quarterly Planning Portfolio With Region-Specific Review Naming</a><span class="mock-localized-type mock-localized-type--accent" title="Localized node type label">Translated portfolio type</span></span><span class="mock-localized-secondary">Tooltip cue stays available while the primary label wraps before hiding hierarchy controls.</span></span></td>
+            <td><span class="mock-localized-attribute">Localized attribute: Responsible review group</span></td><td><span class="mock-localized-secondary">Secondary metadata wraps under the same row without replacing TreeView current or depth cues.</span></td><td class="tree-row-actions"><a class="mock-localized-action" href="#portfolio-action">Review</a></td>
+          </tr>
+          <tr id="localized_node_2" class="tree-row is-selected" data-tree-node-key="localized:budget" data-tree-parent-key="localized:portfolio" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-current="page">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Current localized budget row"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">child</span></span></span><span class="mock-localized-name"><span class="mock-localized-primary"><a href="#budget" title="Current target: International Budget Approval Label That Must Stay Readable">International Budget Approval Label That Must Stay Readable</a><span class="tree-node-badge" title="Current row cue">current</span><span class="mock-localized-type" title="Localized type badge">Translated document type</span></span><span class="mock-localized-secondary">Current cue remains adjacent to the label instead of drifting into host-owned columns.</span></span></td>
+            <td><span class="mock-localized-attribute">Attribute label: Last translated approval stage</span></td><td><span class="mock-localized-tooltip-cue">Tooltip cue: full localized label is available on the primary link.</span></td><td class="tree-row-actions"><a class="mock-localized-action" href="#budget-action">Open</a></td>
+          </tr>
+          <tr id="localized_node_3" class="tree-row is-collapsed" data-tree-node-key="localized:archive" data-tree-parent-key="localized:portfolio" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Collapsed localized archive group"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span><span class="tree-toggle__hidden-count" title="Hidden localized descendants">6</span></span></span><span class="mock-localized-name"><span class="mock-localized-primary"><a href="#archive" title="Collapsed archive branch with localized long translated row label">Collapsed Archive Branch With Localized Long Translated Row Label</a><span class="mock-localized-type" title="Localized archive type">Translated archive type</span></span><span class="mock-localized-secondary">Hidden-count, badge, and secondary metadata remain scannable before final truncation decisions move to the host app.</span></span></td>
+            <td><span class="mock-localized-attribute">Attribute label: Localized retention category</span></td><td><span class="mock-localized-secondary">Host app owns final policy wording, permission copy, and route labels.</span></td><td class="tree-row-actions"><a class="mock-localized-action" href="#archive-action">Inspect</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section mock-localized-cards" aria-labelledby="localized-boundary-heading">
+      <div class="mock-localized-card"><h2 id="localized-boundary-heading">TreeView-owned cues</h2><p>Hierarchy controls, current or selected state, depth labels, and toggle affordances must stay visible when labels wrap.</p></div>
+      <div class="mock-localized-card"><h3>Host-app-owned copy</h3><p>Final translations, truncation rules, tooltip text, permission copy, and business-specific labels remain outside this mockup.</p></div>
+      <div class="mock-localized-card"><h3>Review focus</h3><p>Inspect primary label wrapping, type badge placement, attribute label length, secondary metadata, and tooltip cue proximity.</p></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -6,155 +6,31 @@
 <title>TreeView mockup review gallery</title>
 <link rel="stylesheet" href="default-tree.css">
 <style>
-.mock-gallery-page {
-  max-width: 1320px;
-}
-
-.mock-gallery-return-nav,
-.mock-gallery-review-path-links,
-.mock-gallery-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.mock-gallery-return-nav {
-  margin-top: 18px;
-}
-
-.mock-gallery-return-nav a,
-.mock-gallery-review-path-links a {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2.35rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 999px;
-  background: #fff;
-  color: #1d4ed8;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.mock-gallery-return-nav a:first-child {
-  color: #0f172a;
-}
-
-.mock-gallery-return-nav a:hover,
-.mock-gallery-return-nav a:focus,
-.mock-gallery-review-path-links a:hover,
-.mock-gallery-review-path-links a:focus {
-  border-color: #1d4ed8;
-  background: #eff6ff;
-  outline: 2px solid transparent;
-}
-
-.mock-gallery-review-paths {
-  display: grid;
-  gap: 12px;
-  margin-top: 18px;
-  padding: 18px;
-  border: 1px solid #d8e0ea;
-  border-radius: 12px;
-  background: #f8fafc;
-}
-
-.mock-gallery-review-paths h2,
-.mock-gallery-review-paths p,
-.mock-gallery-card h2,
-.mock-gallery-card p,
-.mock-gallery-card ul {
-  margin: 0;
-}
-
-.mock-gallery-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 20px;
-}
-
-.mock-gallery-card {
-  display: grid;
-  gap: 16px;
-  background: #fff;
-  border: 1px solid #dde4ec;
-  border-radius: 12px;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
-  padding: 20px;
-}
-
-.mock-gallery-eyebrow {
-  color: #52606d;
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.mock-gallery-copy {
-  display: grid;
-  gap: 10px;
-}
-
-.mock-gallery-points {
-  padding-left: 1.2rem;
-  color: #334e68;
-}
-
-.mock-gallery-links a {
-  color: #1d4ed8;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.mock-gallery-links a:hover,
-.mock-gallery-links a:focus {
-  text-decoration: underline;
-}
-
-.mock-gallery-preview {
-  min-height: 340px;
-  border: 1px solid #dde4ec;
-  border-radius: 12px;
-  overflow: hidden;
-  background: #f8fafc;
-}
-
-.mock-gallery-preview iframe {
-  width: 100%;
-  height: 100%;
-  min-height: 340px;
-  border: 0;
-  background: #fff;
-}
-
-.mock-comparison-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.mock-comparison-table th,
-.mock-comparison-table td {
-  border-bottom: 1px solid #e4e7eb;
-  padding: 0.7rem 0.75rem;
-  text-align: left;
-  vertical-align: top;
-}
-
-.mock-comparison-table th {
-  background: #f1f5f9;
-  color: #334e68;
-  font-size: 0.82rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-@media (max-width: 720px) {
-  .mock-gallery-preview,
-  .mock-gallery-preview iframe {
-    min-height: 280px;
-  }
-}
+.mock-gallery-page { max-width: 1320px; }
+.mock-gallery-return-nav, .mock-gallery-review-path-links, .mock-gallery-links { display: flex; flex-wrap: wrap; gap: 12px; }
+.mock-gallery-return-nav { margin-top: 18px; }
+.mock-gallery-return-nav a, .mock-gallery-review-path-links a { display: inline-flex; align-items: center; border: 1px solid #cbd5e1; background: #fff; font-weight: 700; text-decoration: none; }
+.mock-gallery-return-nav a { padding: 0.55rem 0.9rem; border-radius: 999px; color: #0f172a; }
+.mock-gallery-return-nav a:hover, .mock-gallery-return-nav a:focus { border-color: #1d4ed8; color: #1d4ed8; }
+.mock-gallery-review-paths { display: grid; gap: 12px; margin-top: 18px; padding: 18px; border: 1px solid #d8e0ea; border-radius: 12px; background: #f8fafc; }
+.mock-gallery-review-paths h2, .mock-gallery-review-paths p { margin: 0; }
+.mock-gallery-review-path-links { gap: 10px; }
+.mock-gallery-review-path-links a { min-height: 2.35rem; padding: 0.5rem 0.75rem; border-radius: 999px; color: #1d4ed8; }
+.mock-gallery-review-path-links a:hover, .mock-gallery-review-path-links a:focus { border-color: #1d4ed8; background: #eff6ff; outline: 2px solid transparent; }
+.mock-gallery-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 20px; }
+.mock-gallery-card { display: grid; gap: 16px; background: #fff; border: 1px solid #dde4ec; border-radius: 12px; box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05); padding: 20px; }
+.mock-gallery-card h2, .mock-gallery-card p, .mock-gallery-card ul { margin: 0; }
+.mock-gallery-eyebrow { color: #52606d; font-size: 0.8rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+.mock-gallery-copy { display: grid; gap: 10px; }
+.mock-gallery-points { padding-left: 1.2rem; color: #334e68; }
+.mock-gallery-links a { color: #1d4ed8; font-weight: 700; text-decoration: none; }
+.mock-gallery-links a:hover, .mock-gallery-links a:focus { text-decoration: underline; }
+.mock-gallery-preview { min-height: 340px; border: 1px solid #dde4ec; border-radius: 12px; overflow: hidden; background: #f8fafc; }
+.mock-gallery-preview iframe { width: 100%; height: 100%; min-height: 340px; border: 0; background: #fff; }
+.mock-comparison-table { width: 100%; border-collapse: collapse; }
+.mock-comparison-table th, .mock-comparison-table td { border-bottom: 1px solid #e4e7eb; padding: 0.7rem 0.75rem; text-align: left; vertical-align: top; }
+.mock-comparison-table th { background: #f1f5f9; color: #334e68; font-size: 0.82rem; letter-spacing: 0.04em; text-transform: uppercase; }
+@media (max-width: 720px) { .mock-gallery-preview, .mock-gallery-preview iframe { min-height: 280px; } }
 </style>
 </head>
 <body>
@@ -162,42 +38,17 @@
     <header class="mock-header">
       <p class="mock-kicker">tree_view-rails</p>
       <h1>TreeView mockup review gallery</h1>
-      <p>
-        Static review hub for comparing the current TreeView mockup set without running a Rails app.
-        Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, state cues, responsibility boundaries, and focused visual references in one session.
-      </p>
-      <nav class="mock-gallery-return-nav" aria-label="Documentation entry points">
-        <a href="README.md">Back to mockup README</a>
-        <a href="../README.md">Open docs index</a>
-      </nav>
+      <p>Static review hub for comparing the current TreeView mockup set without running a Rails app. Each card keeps the existing mockup as the source of truth and adds just enough framing to compare baseline structure, state cues, responsibility boundaries, and focused visual references in one session.</p>
+      <nav class="mock-gallery-return-nav" aria-label="Documentation entry points"><a href="README.md">Back to mockup README</a><a href="../README.md">Open docs index</a></nav>
     </header>
 
     <section class="mock-section" aria-labelledby="gallery-usage-heading">
       <h2 id="gallery-usage-heading">How to use this gallery</h2>
-      <ul>
-        <li>Start here when a review needs quick side-by-side comparison across the baseline and focused mockup surfaces.</li>
-        <li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li>
-        <li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li>
-      </ul>
+      <ul><li>Start here when a review needs quick side-by-side comparison across the baseline and focused mockup surfaces.</li><li>Open the linked full mockup when you want the complete page context or longer notes for one state family.</li><li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li></ul>
       <nav class="mock-gallery-review-paths" aria-labelledby="gallery-review-paths-heading">
         <h2 id="gallery-review-paths-heading">Review paths</h2>
         <p>Jump to the first card in a state family, then continue through nearby cards for related comparisons.</p>
-        <div class="mock-gallery-review-path-links">
-          <a href="#gallery-default-heading">Baseline</a>
-          <a href="#gallery-interaction-heading">Interaction states</a>
-          <a href="#gallery-reduced-motion-heading">Low-motion cues</a>
-          <a href="#gallery-keyboard-focus-heading">Keyboard focus</a>
-          <a href="#gallery-toggle-icon-heading">Toggle icons</a>
-          <a href="#gallery-narrow-heading">Responsive and scale</a>
-          <a href="#gallery-current-branch-heading">Current branch</a>
-          <a href="#gallery-breadcrumb-heading">Navigation context</a>
-          <a href="#gallery-path-builder-heading">Generated rows</a>
-          <a href="#gallery-node-presenter-heading">Presenter row partials</a>
-          <a href="#gallery-form-heading">Editing and controls</a>
-          <a href="#gallery-selection-limit-heading">Selection limits</a>
-          <a href="#gallery-selection-form-heading">Selection form</a>
-          <a href="#gallery-empty-heading">Empty and fallback states</a>
-        </div>
+        <div class="mock-gallery-review-path-links"><a href="#gallery-default-heading">Baseline</a><a href="#gallery-interaction-heading">Interaction states</a><a href="#gallery-motion-heading">Low motion</a><a href="#gallery-keyboard-focus-heading">Keyboard focus</a><a href="#gallery-toggle-icon-heading">Toggle icons</a><a href="#gallery-narrow-heading">Responsive and scale</a><a href="#gallery-current-branch-heading">Current branch</a><a href="#gallery-breadcrumb-heading">Navigation context</a><a href="#gallery-path-builder-heading">Generated rows</a><a href="#gallery-node-presenter-heading">Presenter row partials</a><a href="#gallery-localized-heading">Localized labels</a><a href="#gallery-form-heading">Editing and controls</a><a href="#gallery-selection-limit-heading">Selection limits</a><a href="#gallery-selection-form-heading">Selection form</a><a href="#gallery-empty-heading">Empty and fallback states</a></div>
       </nav>
     </section>
 
@@ -209,7 +60,7 @@
       <article class="mock-gallery-card" aria-labelledby="gallery-narrow-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Responsive reference</p><h2 id="gallery-narrow-heading">Narrow sidebar</h2><p>Compare how hierarchy cues stay visible when width gets tight and secondary metadata needs to stack below the primary label.</p><ul class="mock-gallery-points"><li>22rem and 18rem representative frames</li><li>Current, archived, and loading cues</li><li>Compact actions without hiding the tree path</li></ul><div class="mock-gallery-links"><a href="narrow-sidebar-tree.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="narrow-sidebar-tree.html" title="Narrow sidebar tree mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-current-branch-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused branch state</p><h2 id="gallery-current-branch-heading">Current branch sidebar</h2><p>Review a sidebar state where the current row and its ancestors are expanded while sibling branches stay collapsed.</p><ul class="mock-gallery-points"><li>Current row and ancestor path</li><li>Collapsed sibling branches</li><li>Host-app navigation policy outside scope</li></ul><div class="mock-gallery-links"><a href="current-branch-sidebar.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="current-branch-sidebar.html" title="Current branch sidebar mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-interaction-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">State transitions</p><h2 id="gallery-interaction-heading">Interaction states</h2><p>Review lazy loading, retry, pagination, and general drag or drop cues without bringing in Turbo responses, controllers, or host-app behavior.</p><ul class="mock-gallery-points"><li>Loaded, loading, and retry rows</li><li>Children pagination placeholder rows</li><li>Dragging, valid drop, and blocked drop states</li></ul><div class="mock-gallery-links"><a href="interaction-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="interaction-states.html" title="Interaction states mock preview" loading="lazy"></iframe></div></article>
-      <article class="mock-gallery-card" aria-labelledby="gallery-reduced-motion-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Low-motion reference</p><h2 id="gallery-reduced-motion-heading">Low-motion state cues</h2><p>Compare loading, retry, current/selected, and drop-target states when animation is reduced or absent.</p><ul class="mock-gallery-points"><li>Text and status labels beside row states</li><li>Border and shape cues beyond color alone</li><li>No runtime animation or event contract changes</li></ul><div class="mock-gallery-links"><a href="reduced-motion-state-cues.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="reduced-motion-state-cues.html" title="Low-motion state cues mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-motion-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused low-motion cue</p><h2 id="gallery-motion-heading">Low-motion state cues</h2><p>Compare loading, retry, current/selected, and drop-target states that remain readable when motion is reduced.</p><ul class="mock-gallery-points"><li>Animation-independent loading and retry cues</li><li>Current and selected state pairing</li><li>Drop target feedback without visual regression baselines</li></ul><div class="mock-gallery-links"><a href="reduced-motion-state-cues.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="reduced-motion-state-cues.html" title="Low-motion state cues mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-keyboard-focus-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused keyboard cue</p><h2 id="gallery-keyboard-focus-heading">Keyboard focus states</h2><p>Compare static focus-visible samples across toggle links, checkboxes, toolbar actions, and row actions.</p><ul class="mock-gallery-points"><li>Toggle link focus cue</li><li>Native checkbox and button focus samples</li><li>Host-app keyboard model boundary</li></ul><div class="mock-gallery-links"><a href="keyboard-focus-states.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="keyboard-focus-states.html" title="Keyboard focus states mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-lazy-handoff-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused lazy loading</p><h2 id="gallery-lazy-handoff-heading">Lazy-loading handoff</h2><p>Compare the host-app-owned children container and remote-state placeholder across initial, loaded, and error/retry states.</p><ul class="mock-gallery-points"><li>Children container ownership</li><li>Remote-state slot handoff</li><li>Error/retry boundary without fetch behavior</li></ul><div class="mock-gallery-links"><a href="lazy-loading-handoff.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="lazy-loading-handoff.html" title="Lazy-loading handoff mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-persisted-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused persisted state</p><h2 id="gallery-persisted-heading">Persisted State boundary</h2><p>Compare expansion state before, changed, restored, save-failed, and retry cues while keeping storage and retry policy host-app owned.</p><ul class="mock-gallery-points"><li><code>tree_instance_key</code> and expanded keys snapshot framing</li><li><code>tree-view-state:state-changed</code> event beside rendered rows</li><li>Save endpoint, authorization, error copy, and retry policy outside the gem</li></ul><div class="mock-gallery-links"><a href="persisted-state-boundary.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="persisted-state-boundary.html" title="Persisted State boundary mock preview" loading="lazy"></iframe></div></article>
@@ -222,6 +73,7 @@
       <article class="mock-gallery-card" aria-labelledby="gallery-filtered-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused filtering modes</p><h2 id="gallery-filtered-heading">Filtered tree modes</h2><p>Compare matched-only, ancestor-retaining, and descendant-retaining output without adding host-app search UI.</p><ul class="mock-gallery-points"><li>Matched-only output</li><li>Ancestor context</li><li>Descendant context</li></ul><div class="mock-gallery-links"><a href="filtered-tree-modes.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="filtered-tree-modes.html" title="Filtered tree modes mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-path-builder-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused builder rows</p><h2 id="gallery-path-builder-heading">PathTreeBuilder rows</h2><p>Compare generated folder rows with record-backed rows while keeping file-manager behavior outside the gem contract.</p><ul class="mock-gallery-points"><li>Generated folder row cues</li><li>Record-backed rows</li><li>Host-app file actions outside scope</li></ul><div class="mock-gallery-links"><a href="path-tree-builder-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="path-tree-builder-rows.html" title="PathTreeBuilder rows mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-node-presenter-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused presenter boundary</p><h2 id="gallery-node-presenter-heading">NodePresenter row partials</h2><p>Compare presenter-provided label, link, tooltip, badge, icon, and optional action values beside host-app-owned columns.</p><ul class="mock-gallery-points"><li>Resolver-provided row values</li><li>Host-owned columns and permissions</li><li>No CRUD or Column DSL design</li></ul><div class="mock-gallery-links"><a href="node-presenter-row-partials.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="node-presenter-row-partials.html" title="NodePresenter row partials mock preview" loading="lazy"></iframe></div></article>
+      <article class="mock-gallery-card" aria-labelledby="gallery-localized-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Localized stress cue</p><h2 id="gallery-localized-heading">Localized row labels</h2><p>Compare long localized-style primary labels, type badges, attribute labels, secondary metadata, and tooltip cues without choosing final translations.</p><ul class="mock-gallery-points"><li>Long primary label wrapping</li><li>Badge and attribute label placement</li><li>Tooltip and host-app copy boundary</li></ul><div class="mock-gallery-links"><a href="localized-row-labels.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="localized-row-labels.html" title="Localized row labels mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-form-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused editing rows</p><h2 id="gallery-form-heading">Form editing rows</h2><p>Compare bulk edit rows, per-row edit placement, and selection-versus-business checkbox roles.</p><ul class="mock-gallery-points"><li>Bulk edit row placement</li><li>Editable fields inside rows</li><li>Per-row action placement</li></ul><div class="mock-gallery-links"><a href="form-editing-rows.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="form-editing-rows.html" title="Form editing rows mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-selection-limit-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection limit</p><h2 id="gallery-selection-limit-heading">Selection max-count</h2><p>Compare below-limit, limit-reached, and limit-exceeded feedback while keeping final messages and action policy host-app owned.</p><ul class="mock-gallery-points"><li>Selected count and max summary</li><li>Limit reached helper placement</li><li>Attempted checkbox restored after limit-exceeded</li></ul><div class="mock-gallery-links"><a href="selection-max-count.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-max-count.html" title="Selection max-count mock preview" loading="lazy"></iframe></div></article>
       <article class="mock-gallery-card" aria-labelledby="gallery-selection-form-heading"><div class="mock-gallery-copy"><p class="mock-gallery-eyebrow">Focused selection form</p><h2 id="gallery-selection-form-heading">Multi-tree selection form</h2><p>Compare multiple TreeView selection groups inside one host-app form while keeping source-specific hidden input sync internal.</p><ul class="mock-gallery-points"><li>Selection counts grouped by source</li><li>Generated hidden input source boundary</li><li>Submit summary owned by the host app</li></ul><div class="mock-gallery-links"><a href="selection-multi-tree-form.html">Open full mockup</a></div></div><div class="mock-gallery-preview"><iframe src="selection-multi-tree-form.html" title="Multi-tree selection form mock preview" loading="lazy"></iframe></div></article>
@@ -252,6 +104,7 @@
         <tr><td>Filtered tree modes</td><td>Matched-only, ancestor-retaining, and descendant-retaining output.</td><td>Search forms, highlighting, ranking, and authorization-aware filtering.</td></tr>
         <tr><td>PathTreeBuilder rows</td><td>Generated folder row cues compared with record-backed rows and host-app-owned columns or actions.</td><td>File-manager routes, download behavior, record authorization, or public API changes.</td></tr>
         <tr><td>NodePresenter row partials</td><td>Presenter-provided label, href, tooltip, badge, icon, and optional action values beside host-app-owned table columns.</td><td>Column or Action DSLs, CRUD routes, permission policy, final action behavior, or NodePresenter API changes.</td></tr>
+        <tr><td>Localized row labels</td><td>Long localized-style labels, type badges, attribute labels, secondary metadata, and tooltip cue proximity.</td><td>Final translations, truncation policy, host-app business labels, or localization completeness checks.</td></tr>
         <tr><td>Form-editing rows</td><td>Bulk edit rows, per-row edit placement, and selection-versus-business control separation.</td><td>Validation persistence, params parsing, Turbo replacement timing, and save workflows.</td></tr>
         <tr><td>Selection max-count</td><td>Below-limit, limit-reached, and limit-exceeded feedback placement around checkbox selection.</td><td>Runtime controller changes, final bulk-action copy, authorization, server validation, or submit behavior.</td></tr>
         <tr><td>Multi-tree selection form</td><td>Multiple TreeView selection groups inside one host-app form, grouped counts, and source-specific hidden input sync.</td><td>Params parsing, authorization, final bulk action behavior, and business-specific submit copy.</td></tr>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -59,6 +59,7 @@ const focusedMockupSmokeTargets = [
   { file: "filtered-tree-modes.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
   { file: "path-tree-builder-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
   { file: "node-presenter-row-partials.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
+  { file: "localized-row-labels.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },
   { file: "form-editing-rows.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
   { file: "toolbar-actions.html", sample: ".mock-toolbar-frame", minimumCount: 3 },
   { file: "selection-max-count.html", sample: ".mock-limit-state", minimumCount: 3 },
@@ -76,10 +77,12 @@ test.describe("docs mockup browser smoke", () => {
     await expect(page.getByRole("link", { name: "Interaction states" })).toHaveAttribute("href", "#gallery-interaction-heading")
     await expect(page.getByRole("link", { name: "Current branch" })).toHaveAttribute("href", "#gallery-current-branch-heading")
     await expect(page.getByRole("link", { name: "Presenter row partials" })).toHaveAttribute("href", "#gallery-node-presenter-heading")
+    await expect(page.getByRole("link", { name: "Localized labels" })).toHaveAttribute("href", "#gallery-localized-heading")
     await expect(page.getByRole("link", { name: "Selection form" })).toHaveAttribute("href", "#gallery-selection-form-heading")
     await expect(page.frameLocator("iframe[title='Default tree mock preview']").getByRole("heading", { name: "Default TreeView rendering mock", level: 1 })).toBeVisible()
     await expect(page.frameLocator("iframe[title='Current branch sidebar mock preview']").getByRole("heading", { name: "Current branch sidebar mock", level: 1 })).toBeVisible()
     await expect(page.frameLocator("iframe[title='NodePresenter row partials mock preview']").getByRole("heading", { name: "NodePresenter row partial mock", level: 1 })).toBeVisible()
+    await expect(page.frameLocator("iframe[title='Localized row labels mock preview']").getByRole("heading", { name: "Localized row labels mock", level: 1 })).toBeVisible()
     await expect(page.frameLocator("iframe[title='Multi-tree selection form mock preview']").getByRole("heading", { name: "TreeView multi-tree selection form mock", level: 1 })).toBeVisible()
 
     const linkedFiles = await page.locator("a[href]").evaluateAll((anchors) =>
@@ -96,6 +99,7 @@ test.describe("docs mockup browser smoke", () => {
     expect(linkedFiles).toContain("reduced-motion-state-cues.html")
     expect(linkedFiles).toContain("current-branch-sidebar.html")
     expect(linkedFiles).toContain("node-presenter-row-partials.html")
+    expect(linkedFiles).toContain("localized-row-labels.html")
     expect(linkedFiles).toContain("selection-multi-tree-form.html")
     expect(linkedFiles).toContain("empty-state.html")
     expect(missingLinks).toEqual([])


### PR DESCRIPTION
## 対応Issue

- Closes #1157

## 採用した方針

- スケジュール実行のためユーザー選択待ちは挟まず、Planner handoff の low-risk 方針に沿って dedicated static mockup page を追加しました。
- `localized-row-labels.html` を NodePresenter / narrow-width / toolbar long-label guidance の間をつなぐ visual review surface として扱い、runtime I18n behavior や translation completeness には広げていません。
- 作業中に current `main` へ #1153 reduced-motion mockup が入ったため、最新 main から `design/1157-localized-row-labels-current` を切り直し、reduced-motion の README / gallery / smoke inventory を保持したまま差分を載せ直しました。

## 比較した案

- 案A: 既存 `node-presenter-row-partials.html` に localized label section を足す
  - 変更量は小さいが、NodePresenter boundary と localized visual stress が混ざるため不採用。
- 案B: `narrow-sidebar-tree.html` に長い localized row を追加する
  - narrow width 確認には強いが、primary label / badge / attribute / tooltip cue の横断比較が弱くなるため不採用。
- 案C: dedicated `localized-row-labels.html` を追加する
  - 採用。Planner の指定どおり、focused page と README / gallery / browser smoke inventory の同期に閉じました。

## 変更内容

- `docs/mockups/localized-row-labels.html` を追加し、長い localized-style primary label、type badge、attribute label、secondary metadata、tooltip cue を比較できるようにしました。
- `docs/mockups/README.md` に Files table、review flow、copy/language policy の導線を追加しました。
- `docs/mockups/review-gallery.html` に localized labels の review path、card、comparison cue を追加しました。
- `test/browser/docs_mockups_smoke.spec.js` に new page と gallery preview の smoke expectation を追加しました。

## 変更した画面・コンポーネント

- `docs/mockups/localized-row-labels.html`
- `docs/mockups/README.md`
- `docs/mockups/review-gallery.html`
- `test/browser/docs_mockups_smoke.spec.js`

## 確認内容

- lint: GitHub Actions CI #1403 success（`lint` success）
- typecheck: 対象外（runtime code 変更なし）
- UI表示確認: GitHub compare で追加 page / gallery / README / smoke inventory の差分を確認
- レスポンシブ確認: `localized-row-labels.html` に narrow width 用の table overflow guard を追加。実ブラウザ目視は未実行
- アクセシビリティ確認: primary link の title、badge title、`aria-current`、hierarchy cue の保持を static markup で確認
- browser smoke: GitHub Actions CI #1403 success（`javascript` job の `npm run test:browser` success）
- GitHub Actions CI #1403: success
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
- PR metadata: `mergeable: true`
- GitHub compare: `main...design/1157-localized-row-labels-current`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4

## スクリーンショット

<!-- UI変更がある場合は添付 -->

未添付です。この実行環境では GitHub HTTPS checkout / raw download が `CONNECT tunnel failed, response 403` / raw 403 で失敗し、Playwright での実ブラウザ目視確認をローカル実行できませんでした。PR CI の `npm run test:browser` は success です。

## リスク

- low
- static mockup と review inventory の追加に閉じています。final translation wording、truncation policy、host-app business labels、LocalizedNames runtime behavior、public API manifest schema は変更していません。

## 補足

- 古い作業 branch `design/1157-localized-row-labels` は main が進んだためPR化していません。レビュー対象は current main から切った `design/1157-localized-row-labels-current` です。