### PR TITLE
focused mockup の狭幅 overflow guard を最新 main で再提案する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
       mockups_changed: ${{ steps.detect.outputs.mockups_changed }}
+      browser_smoke_changed: ${{ steps.detect.outputs.browser_smoke_changed }}
       package_sensitive: ${{ steps.detect.outputs.package_sensitive }}
     steps:
       - uses: actions/checkout@v6
@@ -23,6 +24,7 @@ jobs:
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "mockups_changed=false" >> "$GITHUB_OUTPUT"
+            echo "browser_smoke_changed=false" >> "$GITHUB_OUTPUT"
             echo "package_sensitive=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -37,6 +39,7 @@ jobs:
 
           docs_only=true
           mockups_changed=false
+          browser_smoke_changed=false
           package_sensitive=false
           while IFS= read -r file; do
             [ -z "$file" ] && continue
@@ -55,6 +58,12 @@ jobs:
             esac
 
             case "$file" in
+              test/browser/*|test/browser/**)
+                browser_smoke_changed=true
+                ;;
+            esac
+
+            case "$file" in
               tree_view.gemspec|script/check_gem_package_contents.rb|.github/workflows/ci.yml|config/importmap.tree_view.rb|config/public_api_manifest.yml|lib/*|lib/**|app/helpers/*|app/helpers/**|app/views/*|app/views/**|app/assets/*|app/assets/**|app/javascript/*|app/javascript/**|config/locales/*|config/locales/**)
                 package_sensitive=true
                 ;;
@@ -65,6 +74,7 @@ jobs:
 
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
           echo "mockups_changed=$mockups_changed" >> "$GITHUB_OUTPUT"
+          echo "browser_smoke_changed=$browser_smoke_changed" >> "$GITHUB_OUTPUT"
           echo "package_sensitive=$package_sensitive" >> "$GITHUB_OUTPUT"
 
   lint:
@@ -171,22 +181,22 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true'
-        run: 'echo "Docs-only PR without mockup changes: skipping JavaScript browser and entrypoint checks."'
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true'
+        run: 'echo "Docs-only PR without mockup or browser-smoke changes: skipping JavaScript browser and entrypoint checks."'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
         uses: actions/checkout@v6
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
         run: npm install
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
         run: npx playwright install --with-deps chromium
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name == 'pull_request' && (needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true')
         run: npm run test:browser
 
   gem_package:

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -39,8 +39,12 @@ async function openMockup(page, file) {
   await expect(page.locator("main.mock-page")).toBeVisible()
 }
 
+async function documentHorizontalOverflow(page) {
+  return page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+}
+
 async function expectNoDocumentHorizontalOverflow(page) {
-  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+  const overflow = await documentHorizontalOverflow(page)
   expect(overflow).toBeLessThanOrEqual(1)
 }
 
@@ -74,6 +78,34 @@ const focusedMockupSmokeTargets = [
   { file: "selection-multi-tree-form.html", sample: ".mock-selection-group", minimumCount: 2 },
   { file: "empty-state.html", sample: "[data-tree-view-empty-state='true']", minimumCount: 2 }
 ]
+
+const narrowOverflowExpectedMockups = new Map([
+  ["default-tree.html", "wide baseline table columns are intentionally visible in the reference mockup"],
+  ["resource-table-bridge.html", "resource-table comparison keeps fuller columns visible for review"],
+  ["row-status-depth-labels.html", "status/depth table columns are intentionally preserved"],
+  ["toggle-icon-states.html", "toggle-state comparison uses a wide table matrix"],
+  ["interaction-states.html", "interaction-state table keeps multiple state columns visible"],
+  ["reduced-motion-state-cues.html", "state-cue comparison keeps the table matrix visible"],
+  ["keyboard-focus-states.html", "focus samples include multiple side-by-side controls"],
+  ["high-contrast-state-cues/index.html", "high-contrast state-cue panels stay side by side for comparison"],
+  ["direction-aware-cues/index.html", "direction-aware examples keep multiple writing directions visible for comparison"],
+  ["drop-positions.html", "drop-position comparison keeps before/inside/after states side by side"],
+  ["persisted-state-boundary.html", "persisted-state comparison keeps multiple state columns visible"],
+  ["turbo-frame-target.html", "Turbo Frame reference keeps target and row columns visible"],
+  ["drag-interactive-controls.html", "interactive-control rows keep native controls visible"],
+  ["interactive-marker-behaviors.html", "marker-behavior comparison keeps multiple controls visible"],
+  ["windowed-rendering.html", "window metadata columns are intentionally visible"],
+  ["breadcrumb-paths.html", "breadcrumb path examples keep long path segments inspectable"],
+  ["filtered-tree-modes.html", "filtered-mode comparison keeps mode columns visible"],
+  ["path-tree-builder-rows.html", "PathTreeBuilder examples keep generated path columns inspectable"],
+  ["node-presenter-row-partials.html", "NodePresenter partial examples keep host-owned columns visible"],
+  ["localized-row-labels.html", "localized label comparison keeps multilingual columns visible"],
+  ["form-editing-rows.html", "bulk-edit controls are intentionally visible in the reference"],
+  ["toolbar-actions.html", "toolbar action labels include long/localized stress cases"],
+  ["selection-max-count.html", "selection limit comparison keeps multiple state panels visible"],
+  ["selection-multi-tree-form.html", "multi-tree form comparison keeps source groups side by side"],
+  ["empty-state.html", "empty-state comparison keeps table wrappers inspectable"]
+])
 
 test.describe("docs mockup browser smoke", () => {
   test("review gallery loads representative navigation, previews, and local links", async ({ page }) => {
@@ -131,6 +163,19 @@ test.describe("docs mockup browser smoke", () => {
     expect(missingGalleryFiles).toEqual([])
   })
 
+  test("narrow overflow exceptions stay explicit and attached to focused smoke targets", () => {
+    const coveredFiles = focusedMockupSmokeTargets.map((mockup) => mockup.file)
+    const staleExceptions = [...narrowOverflowExpectedMockups.keys()].filter((file) => !coveredFiles.includes(file))
+    const uncheckedFiles = coveredFiles.filter((file) => !narrowOverflowExpectedMockups.has(file))
+
+    expect(staleExceptions).toEqual([])
+    expect(uncheckedFiles).toEqual([
+      "narrow-sidebar-tree.html",
+      "current-branch-sidebar.html",
+      "lazy-loading-handoff.html"
+    ])
+  })
+
   for (const mockup of focusedMockupSmokeTargets) {
     test(`${mockup.file} exposes its main heading, return link, and representative sample region`, async ({ page }) => {
       await openMockup(page, mockup.file)
@@ -140,6 +185,24 @@ test.describe("docs mockup browser smoke", () => {
       expect(await page.locator(mockup.sample).count()).toBeGreaterThanOrEqual(mockup.minimumCount)
     })
   }
+
+  test("non-exempt focused mockups avoid document-level horizontal overflow at narrow width", async ({ page }) => {
+    const overflowingMockups = []
+    const checkedMockups = focusedMockupSmokeTargets.filter((mockup) => !narrowOverflowExpectedMockups.has(mockup.file))
+
+    await page.setViewportSize({ width: 390, height: 900 })
+
+    for (const mockup of checkedMockups) {
+      await openMockup(page, mockup.file)
+      const overflow = await documentHorizontalOverflow(page)
+
+      if (overflow > 1) {
+        overflowingMockups.push(`${mockup.file} (${overflow}px)`)
+      }
+    }
+
+    expect(overflowingMockups).toEqual([])
+  })
 
   for (const viewport of [
     { name: "desktop", width: 1280, height: 900 },


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1168

Supersedes #1169

## Issue ごとの完了内容

- #1168
  - `focusedMockupSmokeTargets` に含まれる mockup を、narrow viewport `390x900` の overflow guard 対象または理由付き例外へ明示分類しました。
  - `narrow-sidebar-tree.html`、`current-branch-sidebar.html`、`lazy-loading-handoff.html` は document-level horizontal overflow がないことを browser smoke で確認します。
  - table/reference/matrix 型の mockup は、狭幅でも比較対象を横方向に保つ意図があるため `narrowOverflowExpectedMockups` に理由付きで固定しました。
  - 新しい focused mockup が追加された場合は、narrow guard 対象か理由付き例外かを明示しないと spec が落ちるようにしました。

## review / CI follow-up 対応

- #1169 の初回案では全 focused mockup を一律に no-overflow 対象にしましたが、CI で現行 mockup の多くが比較用に横幅を持つことが確認されました。
- Issue の完了条件にある「例外が必要な場合は、対象 file と許容理由が spec 上で読める」を採用し、redesign や大きな CSS 修正には広げていません。
- review comment の指摘に対応し、`test/browser/**` 変更時も CI の `javascript` job で `npm run test:browser` が明示 step として走るようにしました。

## 変更内容

- `test/browser/docs_mockups_smoke.spec.js`
  - document overflow を数値で取得する helper を追加
  - `narrowOverflowExpectedMockups` を追加し、例外 file と理由を spec 上に固定
  - 例外リストが focused smoke target とずれた場合に落ちる inventory guard を追加
  - 非例外 focused mockup の narrow viewport overflow smoke を追加
- `.github/workflows/ci.yml`
  - `browser_smoke_changed` detection を追加
  - `test/browser/**` 変更時も JavaScript setup と `npm run test:browser` の明示 step を実行

## 改善カテゴリ

- テスト追加・改善
- browser smoke / narrow viewport guard
- CI evidence / workflow maintenance

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、HTML mockup の見た目、DB、認可、外部サービス契約は変更していません。
- screenshot baseline / visual diff / mockup redesign には広げていません。
- CI job names は変更していません。

## 実施した確認内容

- head: `22896835bd8dde1d6d62134df94eb3887e85505b`
- GitHub Actions CI #1458: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `gem_package`: success
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
  - `javascript`: success
    - `npm run test:js`: success
    - `npm run test:browser`: success（明示 step として実行）
- PR metadata: `mergeable: true`
- local `npm run test:browser`: 未実行
  - この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク評価

- low
- spec-only guard と CI detection の小変更です。横スクロールを許容する mockup は明示的な理由付き例外にしているため、新規 mockup 追加時に guard 対象か例外かの判断が必要になります。

## 補足事項

- review comment で指摘された「`npm run test:browser` step が skipped のまま」という証跡不足は、CI #1458 の `javascript` job step 8 success で解消しています。