### PR TITLE
英日 docs の page set parity 方針を明文化する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -37,6 +37,18 @@ Japanese remains the more complete canonical prose source when English wording l
 
 If a page outside the High lane changes first, do not block the docs PR automatically. Instead, leave a visible note in the changed page or PR and add the follow-up to the next bilingual maintenance sweep.
 
+## Page-set parity checks
+
+Use the page-set check as a lightweight inventory guard before adding, renaming, or removing prose docs under `docs/en/` or `docs/ja/`. The baseline expectation is that user-facing Markdown pages in those two language trees have a matching peer with the same filename.
+
+Exceptions are allowed when the mismatch is intentional and visible:
+
+- root-level maintenance assets such as this checklist, `docs/README.md`, and technical asset indexes stay outside the language-tree parity set
+- `docs/mockups/**` is a technical visual reference area and is tracked through its own README, review gallery, and browser smoke inventory instead of language-tree parity
+- a page may temporarily exist in one language first when the PR or changed page leaves a visible follow-up note and does not change the High-lane entry-point promise
+
+When a lightweight automated parity check exists, use it as a first pass only. It should flag missing peer filenames and documented exceptions; it should not judge translation quality, wording equivalence, or whether Japanese or English is the canonical prose source for a disputed behavior.
+
 ## When to update both Japanese and English docs
 
 Update both language trees when the change affects user-facing behavior, public options, responsibility boundaries, or guidance that a reader would reasonably expect to match across languages.


### PR DESCRIPTION
## 対応 Issue

Closes #1170

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/i18n-audit.md` に `Page-set parity checks` 節を追加しました。
- `docs/en/*.md` と `docs/ja/*.md` の user-facing Markdown page は同名 peer を持つ、という baseline expectation を明記しました。
- root-level maintenance asset、`docs/mockups/**`、一時的な片言語先行 page の例外条件を整理しました。
- automated parity check が入る場合も、翻訳品質や正誤判断ではなく missing peer filename と documented exception の first pass に留める境界を明記しました。

## 根拠

- 既存 `docs/i18n-audit.md` は日英同期方針と High / Follow-up lane を持っていますが、page set parity の対象と例外がまとまった形では書かれていませんでした。
- #1170 の受け入れ条件には、軽量 script / test を追加する案に加えて、導入しない場合の docs policy 明文化も含まれています。
- 今回はコード・CI・script には触れず、既存 docs policy の範囲で低リスクに明文化しています。

## 非目標

- parity script / test の追加
- `.github/workflows/**` や CI policy の変更
- translation quality / wording equivalence の自動判定
- docs index の全面 rewrite
- `docs/mockups/**` inventory check の再設計

## 確認内容

- GitHub compare: `main...docs/1170-i18n-page-set-policy`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 docs file
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 既存の bilingual maintenance policy を補足するだけで、実装・CI・公開 API・mockup inventory には触れていません。