### PR TITLE
TreeViewHelper subfiles を package contents check に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -7,6 +7,17 @@ require "rubygems/package"
 # verification covers the bilingual locale and release docs shipped by the gem.
 REQUIRED_PACKAGED_PATHS = %w[
   app/helpers/tree_view_helper.rb
+  app/helpers/tree_view_helper/support.rb
+  app/helpers/tree_view_helper/rendering.rb
+  app/helpers/tree_view_helper/dom.rb
+  app/helpers/tree_view_helper/row_attributes.rb
+  app/helpers/tree_view_helper/selection.rb
+  app/helpers/tree_view_helper/transfer.rb
+  app/helpers/tree_view_helper/visuals.rb
+  app/helpers/tree_view_helper/render_scope.rb
+  app/helpers/tree_view_helper/lazy_loading.rb
+  app/helpers/tree_view_helper/toolbar.rb
+  app/helpers/tree_view_breadcrumb_helper.rb
   app/views/tree_view/_tree_row.html.erb
   app/assets/stylesheets/tree_view.scss
   app/javascript/tree_view/index.js


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1109

## Issue ごとの完了内容

- #1109
  - `TreeViewHelper` が `require_relative` している helper subfiles を `script/check_gem_package_contents.rb` の required packaged paths に追加しました。
  - 欠落時は既存の `Missing packaged files:` 出力に具体的な subfile path が出るため、root helper だけが package に残っている状態も検出できます。
  - toolbar / selection / lazy-loading / breadcrumb helper の runtime load 互換性を package verification 側で守る形にしました。

## 変更内容

- `script/check_gem_package_contents.rb`
  - `app/helpers/tree_view_helper/*.rb` の required subfiles を明示列挙
  - `app/helpers/tree_view_breadcrumb_helper.rb` を required path に追加

## 改善カテゴリ

- テスト追加・改善
- devops / package verification

## 既存仕様への影響

- runtime Ruby / JavaScript、public helper API、docs、gemspec、release workflow は変更していません。
- package contents verification の検出対象追加のみで、公開挙動は変わりません。

## 実施した確認内容

- GitHub compare: `main...quality/1109-helper-subfile-package-guard`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/check_gem_package_contents.rb`)
- ローカル `bundle exec rake build` / package check は未実行です。
  - この環境では GitHub HTTPS clone/fetch が `CONNECT tunnel failed, response 403` のため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- required path list への明示追加に閉じており、helper module 分割、自動導出、gemspec policy 再設計には広げていません。

## 補足事項

- helper subfile の追加・rename 時は、この required path list も更新対象になります。