### PR TITLE
ResourceTableRenderState の API reference 入口を補う

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -224,6 +224,38 @@ window = TreeView::RenderWindow.new(
 | `has_previous?` | Whether a previous window exists. |
 | `has_next?` | Whether a next window exists. |
 
+## TreeView::ResourceTableRenderState
+
+Builds a `TreeView::RenderState` for table-oriented screens where another layer already owns column definitions or table state.
+
+```ruby
+render_state = TreeView::ResourceTableRenderState.call(
+  records: @projects,
+  context: view_context,
+  table_key: "projects_tree",
+  parent_id_method: :parent_project_id,
+  table_state: table_state,
+  columns: columns
+)
+```
+
+| Argument | Required | Description |
+|---|---:|---|
+| `records:` | yes | Records to turn into a tree-backed table body. |
+| `context:` | yes | View context used to build the default `UiConfig` when `ui_config:` is not provided. |
+| `row_partial:` | no | Row partial used for business columns. Default: `tree_view/resource_table_row`. |
+| `parent_id_method:` | no | Method name that returns the parent ID. Default: `:parent_id`. |
+| `id_method:` | no | Method name that returns the item ID. Default: `:id`. |
+| `table_key:` | no | Stable table key used for DOM/data hooks and as the default node prefix. |
+| `columns:` | no | Column definitions supplied by the host app or table layer. |
+| `table_state:` | no | Table state supplied by the host app or table layer. |
+| `ui_config:` | no | Prebuilt `TreeView::UiConfig` when the host app needs custom modes or path builders. |
+| `**render_options` | no | Additional `TreeView::RenderState` options such as selection, lazy loading, row status, or render scope. |
+
+The default row partial reads `table_state["visible_columns"]`, then `table_state[:visible_columns]`, and then falls back to `columns`. TreeView owns hierarchy, visible row order, render state, and row hooks; column inference, saved table preferences, filters, sorts, and table-wide state remain owned by the host app or table layer.
+
+See [Resource table bridge](resource-table-bridge.md) for integration examples and responsibility boundaries.
+
 ## TreeView::RenderState
 
 Screen-level rendering state.

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -224,6 +224,38 @@ window = TreeView::RenderWindow.new(
 | `has_previous?` | 前 window があるか。 |
 | `has_next?` | 次 window があるか。 |
 
+## TreeView::ResourceTableRenderState
+
+別 layer が column definitions や table state を持つ table-oriented screen 向けに、`TreeView::RenderState` を組み立てる bridge API です。
+
+```ruby
+render_state = TreeView::ResourceTableRenderState.call(
+  records: @projects,
+  context: view_context,
+  table_key: "projects_tree",
+  parent_id_method: :parent_project_id,
+  table_state: table_state,
+  columns: columns
+)
+```
+
+| 引数 | 必須 | 説明 |
+|---|---:|---|
+| `records:` | yes | tree-backed table body にする records。 |
+| `context:` | yes | `ui_config:` を指定しない場合に default `UiConfig` を作るための view context。 |
+| `row_partial:` | no | business columns を描画する row partial。既定値は `tree_view/resource_table_row`。 |
+| `parent_id_method:` | no | 親 ID を返す method 名。既定値は `:parent_id`。 |
+| `id_method:` | no | 自身の ID を返す method 名。既定値は `:id`。 |
+| `table_key:` | no | DOM / data hook と default node prefix に使う安定した table key。 |
+| `columns:` | no | host app または table layer が渡す column definitions。 |
+| `table_state:` | no | host app または table layer が渡す table state。 |
+| `ui_config:` | no | host app が custom mode や path builder を必要とする場合の prebuilt `TreeView::UiConfig`。 |
+| `**render_options` | no | selection、lazy loading、row status、render scope など追加の `TreeView::RenderState` options。 |
+
+既定の row partial は `table_state["visible_columns"]`、次に `table_state[:visible_columns]` を読み、最後に `columns` へ fallback します。TreeView は hierarchy、visible row order、render state、row hooks を所有します。column inference、saved table preferences、filter、sort、table-wide state は host app または table layer の責務です。
+
+連携例と責務境界は [Resource table bridge](resource-table-bridge.md) を参照してください。
+
 ## TreeView::RenderState
 
 画面単位の描画状態をまとめるオブジェクトです。


### PR DESCRIPTION
## 対応 Issue

Closes #945

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `docs/en/api.md` と `docs/ja/api.md` に `TreeView::ResourceTableRenderState` の dedicated API reference entry を追加しました。
- `call(records:, context:, row_partial:, parent_id_method:, id_method:, table_key:, columns:, table_state:, ui_config:, **render_options)` の代表引数を短く整理しました。
- 既定 row partial が `tree_view/resource_table_row` で、`table_state["visible_columns"]`、`table_state[:visible_columns]`、`columns` fallback を読むことを明記しました。
- TreeView が hierarchy / visible row order / render state / row hooks を所有し、column inference / saved table preferences / filter / sort / table-wide state は host app または table layer が所有する境界を補足しました。

## 根拠

- `README.md` と `config/public_api_manifest.yml` は `TreeView::ResourceTableRenderState` を public surface として扱っています。
- `lib/tree_view/resource_table_render_state.rb` は current `call` signature と `RenderState` への bridge behavior を持っています。
- `app/views/tree_view/_resource_table_row.html.erb` は `table_state["visible_columns"]` / `table_state[:visible_columns]` / `columns` fallback を実装しています。
- `docs/en|ja/resource-table-bridge.md` は詳細な連携例と責務境界を既に持っているため、API reference では入口と代表引数に閉じています。

## 非目標

- `ResourceTableRenderState` の API 変更
- `config/public_api_manifest.yml` の変更
- resource-table bridge guide の全面改稿
- Rails Table Preferences 側 docs の更新
- mockup HTML/CSS や runtime code の変更

## 確認内容

- GitHub compare: `main...docs/945-resource-table-api-reference`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - deletions: 0
- connector で更新後の日英 API reference section を読み返し、見出し、リンク、代表引数、責務境界が対応していることを確認しました。
- docs-only 変更のため local test / lint は未実行です。

## リスク

- low
- 実装済み public surface の API reference 導線追加のみで、runtime behavior や public manifest contract は変更していません。