### PR TITLE
Unreleased CHANGELOG を最近の docs / guard 追加に同期する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Breaking changes and required migration notes should be called out explicitly in
 - Strengthened pull request CI to run Ruby specs alongside Standard Ruby lint while keeping broader compatibility and release checks on `main`.
 - Split RenderState selection and lazy-loading normalization into internal configuration objects while keeping the public RenderState API compatible.
 
+### Fixed
+
+- Fixed stale generated selection hidden inputs when a selection controller disconnects after its element is removed, scoped to the controller's own source id.
+
 ### Documentation
 
 - Added localized names docs in Japanese and English.
@@ -62,8 +66,15 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added FAQ guidance for keyboard behavior and `treegrid` responsibility boundaries in Japanese and English.
 - Added a host-app extension hook reverse lookup table in Japanese and English.
 - Added toolbar disabled-action troubleshooting guidance in Japanese and English.
+- Added GraphAdapter troubleshooting guidance in Japanese and English for resolver shape, heterogeneous node keys, and diagnostics handoff.
+- Clarified the LocalizedNames public API boundary in Japanese and English so helper fallback behavior stays separate from host-app row rendering.
+- Added ResourceTableRenderState API reference entries in Japanese and English for the bridge call signature, row partial fallback, and table-layer responsibility boundary.
+- Added glossary entries in Japanese and English for integration-surface terms such as remote state, transfer payloads, drop position, resource-table bridge, windowed rendering, and children pagination.
+- Added Standard Ruby preflight guidance to the development docs for connector or GitHub API edits to Ruby files.
+- Documented the bilingual page-set parity policy for `docs/en` and `docs/ja`, including technical-asset and temporary single-language exceptions.
+- Added release checklist guidance in Japanese and English that separates upstream TreeView release evidence from downstream host-app adoption smoke and rollback notes.
 - Added transfer disabled / invalid boundary states to the drop-position mockup and updated the mockup review guidance.
-- Added static mockup references for multi-tree selection forms, toggle icon states, and high-contrast state cues.
+- Added static mockup references for multi-tree selection forms, toggle icon states, high-contrast state cues, reduced-motion state cues, and localized row labels.
 - Clarified that `docs/mockups/README.md` is the source of truth for mockup technical asset inventory.
 
 ### Tests
@@ -83,6 +94,9 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added JavaScript public event contract specs for selection, remote state, and transfer events.
 - Added package-root frozen object contract coverage for public JavaScript object exports.
 - Added browser smoke coverage for representative docs mockup pages and the review gallery.
+- Added transfer controller regression coverage for drop positions and invalid payload / transfer event boundaries.
+- Added selection hidden input disconnect cleanup coverage for multiple controllers and disabled sync.
+- Expanded package verification coverage for TreeViewHelper subfiles, the breadcrumb helper, representative Japanese toolbar locale, and Japanese release docs files.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue

Closes #976

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased` を latest `main` に再同期しました。
- `Documentation` には、main に merge 済みの最近の docs 追加を短く追記しました。
  - GraphAdapter troubleshooting
  - LocalizedNames public API boundary
  - ResourceTableRenderState API reference
  - integration-surface glossary
  - Standard Ruby preflight guidance
  - bilingual page-set parity policy
  - downstream host-app evidence boundary
  - reduced-motion / localized row labels mockup references
- `Fixed` には、selection controller disconnect 後の stale generated hidden input cleanup を追記しました。
- `Tests` には、transfer controller regression guard、selection hidden input cleanup coverage、package verification guard を追記しました。

## review follow-up

- 最新 review:changes-requested コメントを受け、branch を current `main` (`8357d64f98602da8b0cab9fc9cc2eb1397249615`) に合わせ直しました。
- #1182 / #1184 / #1185 の merge 後差分を再監査し、CHANGELOG 対象へ含めるべき test / docs / lifecycle cleanup を反映しました。
- 既存対応済みの #1178 / #1173 / #1172 由来の docs / package guard 追記も維持しています。
- open PR の未merge内容は先取りしていません。

## 根拠

- #976 は Unreleased CHANGELOG が最近の public API / docs / test guard 追加と矛盾しないか監査する docs-only release-maintenance laneです。
- current `CHANGELOG.md` には release-facing category policy と docs/test categories があり、今回の追記は既存分類に収めています。
- 追記対象は main に merge 済みの変更だけに限定し、runtime code、manifest schema、release automation は変更していません。

## 非目標

- CHANGELOG format の全面変更
- release automation / changelog generation
- Git tag / version bump / gem release
- 過去 release note の書き換え
- runtime code / public API manifest / CI workflow の変更

## 確認内容

- GitHub compare: `main...docs/976-changelog-public-surface-audit`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`CHANGELOG.md`)
  - additions: 15 / deletions: 1
- docs-only 変更のため local test / lint は未実行です。
- PR reopen 後に GitHub Actions を確認します。

## リスク

- low
- release-facing summary の追記のみで、runtime behavior や release workflow は変更していません。