### PR TITLE
transfer DataTransfer MIME type を public export に追加する

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -45,6 +45,11 @@ export const TreeViewTransferDropPositions = Object.freeze({
   after: "after"
 })
 
+export const TreeViewTransferDataMimeTypes = Object.freeze({
+  applicationJson: "application/json",
+  textPlain: "text/plain"
+})
+
 export const TreeViewControllerIdentifiers = Object.freeze({
   state: "tree-view-state",
   client: "tree-view-client",

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -86,6 +86,7 @@ javascript_package_root:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
     - TreeViewTransferDropPositions
+    - TreeViewTransferDataMimeTypes
     - TreeViewStateController
     - TreeViewClientController
     - TreeViewSelectionController
@@ -96,6 +97,9 @@ javascript_package_root:
     before: before
     inside: inside
     after: after
+  transfer_data_mime_types:
+    application_json: application/json
+    text_plain: text/plain
   controller_registrations:
     - key: state
       identifier: tree-view-state

--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -93,6 +93,8 @@ function onDrop(event) {
 }
 ```
 
+`application/json` is the primary TreeView transfer MIME type for host apps to read. TreeView also writes the same JSON payload to `text/plain` as a browser compatibility fallback. Host apps that want machine-readable strings can import `TreeViewTransferDataMimeTypes` from the package root and read `TreeViewTransferDataMimeTypes.applicationJson` first, then `TreeViewTransferDataMimeTypes.textPlain` only as fallback.
+
 Host apps can also listen for the public transfer events dispatched by the `tree-view-transfer` controller instead of reading controller internals directly.
 
 ```js

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -93,6 +93,8 @@ function onDrop(event) {
 }
 ```
 
+`application/json` は、host app が通常読む primary な TreeView transfer MIME type です。TreeView は browser compatibility fallback として、同じ JSON payload を `text/plain` にも書き込みます。machine-readable な文字列を使いたい host app は package root から `TreeViewTransferDataMimeTypes` を import し、まず `TreeViewTransferDataMimeTypes.applicationJson` を読み、必要な場合だけ `TreeViewTransferDataMimeTypes.textPlain` を fallback として使ってください。
+
 host appは controller 内部に直接依存せず、`tree-view-transfer` controller がdispatchする公開transfer eventをlistenできます。
 
 ```js

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -138,3 +138,10 @@ assert(
   "TreeViewTransferDropPositions export is out of sync"
 )
 assertFrozenObject(entrypointModule.TreeViewTransferDropPositions, "TreeViewTransferDropPositions")
+
+const expectedTransferDataMimeTypes = deepCamelizeKeys(javascriptPackageManifest.transfer_data_mime_types)
+assert(
+  JSON.stringify(entrypointModule.TreeViewTransferDataMimeTypes) === JSON.stringify(expectedTransferDataMimeTypes),
+  "TreeViewTransferDataMimeTypes export is out of sync"
+)
+assertFrozenObject(entrypointModule.TreeViewTransferDataMimeTypes, "TreeViewTransferDataMimeTypes")


### PR DESCRIPTION
DataTransfer の primary / fallback MIME type を manifest-backed な public JS surface として固定します。

## 対応 Issue

Closes #1177

## 変更内容

- package root export に `TreeViewTransferDataMimeTypes` を追加しました。
  - `applicationJson: "application/json"`
  - `textPlain: "text/plain"`
- `config/public_api_manifest.yml` に named export と `transfer_data_mime_types` key set を追加しました。
- `script/test_entrypoints.mjs` で manifest と export の値が同期し、export object が frozen であることを確認する smoke を追加しました。
- 英日 drag-and-drop docs に、host app が通常読む primary key は `application/json`、`text/plain` は browser compatibility fallback であることを追記しました。

## 受け入れ条件との対応

- `TreeViewTransferDataMimeTypes.applicationJson` / `.textPlain` を package root から参照できます。
- manifest の named export / MIME key set と entrypoint smoke が同期しています。
- docs で primary reader-facing key と fallback key の責務境界を説明しています。
- transfer event names、event detail keys、drop positions、payload shape、drag/drop runtime behavior は変更していません。

## 変更範囲

- `app/javascript/tree_view/index.js`
- `config/public_api_manifest.yml`
- `script/test_entrypoints.mjs`
- `docs/en/drag-and-drop.md`
- `docs/ja/drag-and-drop.md`

## 実施した確認

- GitHub compare: `main...feature/1177-transfer-mime-types`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 5
- GitHub Actions CI #1418: success
  - `pr_specs`: success
  - `changes`: success
  - `lint`: success
  - `gem_package`: success
  - `javascript`: success (`npm run test:js` success / browser smoke skipped by workflow condition)
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
- local `npm run test:entrypoints` / `npm test` / `npm run test:js` は未実行です。
  - この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク

- medium
- public package-root export と manifest contract の追加です。ただし既存 controller behavior と payload shape は変えず、既存実装済みの MIME key set を machine-readable に公開するだけに閉じています。

## 未対応・補足

- transfer payload shape、operation kind export、DOM data hook export、drag/drop behavior redesign、host-app authorization / business operation policy は Issue 範囲外として扱っています。