### PR TITLE
transfer controller の regression guard を追加する

### DIFF
--- a/app/javascript/tree_view/transfer_controller.test.js
+++ b/app/javascript/tree_view/transfer_controller.test.js
@@ -1,0 +1,98 @@
+import { Application } from "@hotwired/stimulus"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TreeViewTransferController } from "./index.js"
+
+function nextFrame() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("TreeViewTransferController", () => {
+  let application
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <table data-controller="tree-view-transfer">
+        <tbody>
+          <tr id="source-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:1"}'></tr>
+          <tr id="target-row" data-tree-depth="0" data-tree-transfer-payload='{"key":"project:2"}'></tr>
+        </tbody>
+      </table>
+    `
+
+    application = Application.start()
+    application.register("tree-view-transfer", TreeViewTransferController)
+    await nextFrame()
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  function controller() {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    return application.getControllerForElementAndIdentifier(element, "tree-view-transfer")
+  }
+
+  it("calculates before, inside, and after drop positions", () => {
+    const targetRow = document.querySelector("#target-row")
+    targetRow.getBoundingClientRect = () => ({ top: 10, height: 90 })
+
+    expect(controller().dropPosition({ clientY: 20 }, targetRow)).toBe("before")
+    expect(controller().dropPosition({ clientY: 55 }, targetRow)).toBe("inside")
+    expect(controller().dropPosition({ clientY: 95 }, targetRow)).toBe("after")
+  })
+
+  it("dispatches invalid-payload when a row payload is not valid JSON", () => {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    const targetRow = document.querySelector("#target-row")
+    const invalidPayloadSpy = vi.fn()
+    const dataTransfer = { dropEffect: null }
+    targetRow.dataset.treeTransferPayload = "not-json"
+    targetRow.getBoundingClientRect = () => ({ top: 0, height: 90 })
+    element.addEventListener("tree-view-transfer:invalid-payload", invalidPayloadSpy)
+
+    controller().over({
+      target: targetRow,
+      clientY: 45,
+      preventDefault: vi.fn(),
+      dataTransfer
+    })
+
+    expect(dataTransfer.dropEffect).toBe("move")
+    expect(invalidPayloadSpy).toHaveBeenCalledOnce()
+    expect(invalidPayloadSpy.mock.calls[0][0].detail).toMatchObject({
+      value: "not-json",
+      row: targetRow
+    })
+  })
+
+  it("dispatches invalid-transfer and keeps the drop event boundary intact", () => {
+    const element = document.querySelector("[data-controller='tree-view-transfer']")
+    const targetRow = document.querySelector("#target-row")
+    const invalidTransferSpy = vi.fn()
+    const dropSpy = vi.fn()
+    targetRow.getBoundingClientRect = () => ({ top: 0, height: 90 })
+    element.addEventListener("tree-view-transfer:invalid-transfer", invalidTransferSpy)
+    element.addEventListener("tree-view-transfer:drop", dropSpy)
+
+    controller().drop({
+      target: targetRow,
+      clientY: 80,
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        getData: (type) => (type === "application/json" ? "not-json" : "")
+      }
+    })
+
+    expect(invalidTransferSpy).toHaveBeenCalledOnce()
+    expect(invalidTransferSpy.mock.calls[0][0].detail).toEqual({ value: "not-json" })
+    expect(dropSpy).toHaveBeenCalledOnce()
+    expect(dropSpy.mock.calls[0][0].detail).toMatchObject({
+      sourcePayload: null,
+      targetPayload: { key: "project:2" },
+      position: "after",
+      targetRow
+    })
+  })
+})


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1175

## Issue ごとの完了内容

- #1175
  - `TreeViewTransferController#dropPosition` の `before` / `inside` / `after` 代表ケースを JS test で固定しました。
  - row payload JSON parse failure が `tree-view-transfer:invalid-payload` を dispatch する代表ケースを追加しました。
  - transferred JSON parse failure が `tree-view-transfer:invalid-transfer` を dispatch しつつ、既存の drop event boundary が維持されることを確認しました。

## 変更内容

- `app/javascript/tree_view/transfer_controller.test.js`
  - transfer controller 専用の Vitest regression guard を追加
  - Stimulus controller を実際に起動し、公開 event boundary を確認

## 改善カテゴリ

- test 追加
- public event boundary regression guard

## 既存仕様への影響

- runtime JavaScript、drag/drop behavior、host-app persistence、authorization、copy/move policy は変更していません。
- docs の drop position / invalid payload guidance と矛盾しない代表ケースだけを固定しています。

## 実施した確認内容

- GitHub compare: `main...quality/1175-transfer-regression-guard`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- GitHub Actions CI #1422: success
  - lint / pr_specs / gem_package / javascript (`npm run test:js`) / PR Rails compatibility 7.0・7.2・8.0: success
- local `npm test` は未実行です。
  - この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク評価

- risk: low
- test-only の変更です。公開挙動を変えず、既存 controller の representative edge behavior を固定するだけに留めています。