### PR TITLE
downstream host app smoke の release evidence 境界を追加する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -80,6 +80,14 @@ Main-push CI checks:
 
 PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes full compatibility matrices, JavaScript coverage, and unconditional package verification.
 
+## Downstream host-app evidence
+
+TreeView release evidence lives in this repository: the public API manifest, package-root exports, public API and feature docs, mockup README / review gallery, browser smoke targets, and package verification are the upstream sources to review before tagging.
+
+Downstream Rails applications, such as `docs-portal`, should keep their own adoption smoke and rollback notes for app-specific flows such as sidebar trees, detail trees, persisted state, selection, window offsets, routes, permissions, icons, and business row actions. Treat those notes as host-app adoption evidence, not as TreeView's source of truth or a TreeView-only release requirement.
+
+When a downstream smoke fails, first classify whether the finding points to an upstream TreeView contract/package issue or to host-app wiring, query, route, authorization, copy, or rollback policy. Do not use a downstream pinned SHA, application-specific rollback note, or unmerged downstream pull request as the release-facing source of truth for TreeView behavior.
+
 ## Documentation
 
 When public usage or public options change, update related docs and CHANGELOG.

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -80,6 +80,14 @@ package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_
 
 merge前にPR CIを通します。release判定には、full compatibility matrices、JavaScript coverage、unconditional package verificationを含む、より広い `main` CIを使います。
 
+## downstream host app evidence
+
+TreeView の release evidence はこの repository 側にあります。tag を打つ前は、public API manifest、package-root export、public API docs / feature docs、mockup README / review gallery、browser smoke target、package verification を upstream の確認対象として扱います。
+
+docs-portal のような downstream Rails application は、sidebar tree、detail tree、persisted state、selection、window offset、route、permission、icon、business row action など、app 固有 flow の adoption smoke と rollback note を自分の docs に残してください。それらは host app 側の採用証跡であり、TreeView の source of truth や TreeView 単体 release の必須条件ではありません。
+
+downstream smoke が失敗した場合は、まず upstream TreeView の contract / package の問題なのか、host app 側の wiring、query、route、authorization、copy、rollback policy の問題なのかを分類します。downstream の pinned SHA、app 固有の rollback note、未merge の downstream PR を、TreeView の release-facing source of truth として扱わないでください。
+
 ## ドキュメント
 
 Public usageや公開optionを変えた場合は、関連docsとCHANGELOGを更新します。


### PR DESCRIPTION
## 対応 Issue

Closes #1150

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/en/release.md` / `docs/ja/release.md` に downstream host app evidence の節を追加しました。
- TreeView 側の release evidence は public API manifest、package-root exports、public API / feature docs、mockup README / review gallery、browser smoke、package verification を upstream source として扱うことを明記しました。
- docs-portal など downstream Rails app 側の sidebar/detail tree、persisted state、selection、window offset、route、permission、business row action は host-app adoption smoke / rollback note として分けました。
- downstream pinned SHA、app 固有 rollback note、未merge downstream PR を TreeView の release-facing source of truth として扱わない境界を追加しました。

## 根拠

- #1150 は downstream smoke と upstream evidence の混同を避ける docs-only release evidence lane です。
- current release docs は manifest / package verification / public API docs の release-facing trail を持っていますが、downstream host-app smoke との読み分けがありませんでした。
- 追記は release checklist の責務境界に閉じ、runtime code、manifest schema、mockup inventory、downstream CI 実行には触れていません。

## 非目標

- docs-portal の Gemfile bump
- TreeView manifest schema の変更
- event payload / controller behavior の変更
- mockup gallery redesign
- downstream CI を TreeView repo から実行する仕組みの導入

## 確認内容

- GitHub compare: `main...docs/1150-downstream-release-evidence`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 16 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- release checklist の説明追加のみで、実装や公開 API 契約は変更していません。