### PR TITLE
selection hidden input の disconnect cleanup を追加する

### DIFF
--- a/app/javascript/tree_view/selection_controller.js
+++ b/app/javascript/tree_view/selection_controller.js
@@ -9,6 +9,7 @@ export class TreeViewSelectionController extends Controller {
   }
 
   connect() {
+    this.hiddenInputSyncedForm = null
     this.updateIndeterminateStates()
     this.dispatchSelectionChanged()
   }
@@ -16,10 +17,11 @@ export class TreeViewSelectionController extends Controller {
   disconnect() {
     if (!this.hiddenInputSyncEnabled()) return
 
-    const form = this.hiddenInputForm()
+    const form = this.hiddenInputSyncedForm || this.hiddenInputForm()
     if (!form) return
 
     this.removeSyncedHiddenInputs(form)
+    this.hiddenInputSyncedForm = null
   }
 
   selectedPayloads() {
@@ -115,6 +117,7 @@ export class TreeViewSelectionController extends Controller {
     const form = this.hiddenInputForm()
     if (!form) return
 
+    this.hiddenInputSyncedForm = form
     this.removeSyncedHiddenInputs(form)
 
     payloads.forEach((payload) => {

--- a/app/javascript/tree_view/selection_controller.js
+++ b/app/javascript/tree_view/selection_controller.js
@@ -13,6 +13,15 @@ export class TreeViewSelectionController extends Controller {
     this.dispatchSelectionChanged()
   }
 
+  disconnect() {
+    if (!this.hiddenInputSyncEnabled()) return
+
+    const form = this.hiddenInputForm()
+    if (!form) return
+
+    this.removeSyncedHiddenInputs(form)
+  }
+
   selectedPayloads() {
     return this.selectedCheckboxes()
       .map((checkbox) => this.parsePayload(checkbox))

--- a/app/javascript/tree_view/selection_controller.test.js
+++ b/app/javascript/tree_view/selection_controller.test.js
@@ -7,9 +7,10 @@ const flush = async () => {
   await Promise.resolve()
 }
 
-const hiddenInputValues = (form) =>
+const hiddenInputs = (form) =>
   Array.from(form.querySelectorAll('input[type="hidden"][data-tree-view-selection-generated-hidden-input="true"]'))
-    .map((input) => input.value)
+
+const hiddenInputValues = (form) => hiddenInputs(form).map((input) => input.value)
 
 describe("TreeViewSelectionController", () => {
   let application
@@ -118,5 +119,83 @@ describe("TreeViewSelectionController", () => {
 
     const form = document.getElementById("bulk-form")
     expect(hiddenInputValues(form)).toEqual(['{"id":1}'])
+  })
+
+  it("removes only its own generated hidden inputs when disconnected", async () => {
+    document.body.innerHTML = `
+      <form id="bulk-form">
+        <table>
+          <tbody
+            id="first-selection"
+            data-controller="tree-view-selection"
+            data-tree-view-selection-hidden-input-name-value="selected_nodes[]">
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  checked
+                  value='{"id":1}'>
+              </td>
+            </tr>
+          </tbody>
+          <tbody
+            id="second-selection"
+            data-controller="tree-view-selection"
+            data-tree-view-selection-hidden-input-name-value="selected_nodes[]">
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  checked
+                  value='{"id":2}'>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    `
+
+    await flush()
+
+    const form = document.getElementById("bulk-form")
+    expect(hiddenInputValues(form)).toEqual(['{"id":1}', '{"id":2}'])
+
+    document.getElementById("first-selection").remove()
+    await flush()
+
+    expect(hiddenInputValues(form)).toEqual(['{"id":2}'])
+    expect(hiddenInputs(form)[0].dataset.treeViewSelectionSourceId).toBe(
+      document.getElementById("second-selection").dataset.treeViewSelectionSourceId
+    )
+  })
+
+  it("does not raise on disconnect when hidden input sync is disabled", async () => {
+    document.body.innerHTML = `
+      <form id="bulk-form">
+        <table>
+          <tbody id="selection" data-controller="tree-view-selection">
+            <tr data-tree-depth="0">
+              <td>
+                <input
+                  class="tree-selection-checkbox"
+                  type="checkbox"
+                  checked
+                  value='{"id":1}'>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    `
+
+    await flush()
+
+    const selection = document.getElementById("selection")
+    expect(() => selection.remove()).not.toThrow()
+    await flush()
+
+    expect(hiddenInputValues(document.getElementById("bulk-form"))).toEqual([])
   })
 })


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1143

## Issue ごとの完了内容

- #1143
  - `TreeViewSelectionController#disconnect` で、自分の source id で生成した hidden input だけを削除するようにしました。
  - DOM から controller 要素が外れた後でも cleanup できるよう、最後に hidden input を同期した form を保持します。
  - 同じ form に複数 selection controller がある場合、disconnect した controller の generated input だけが消え、他 controller の hidden input は残ることを JS unit test で確認します。
  - hidden input sync が無効な controller の disconnect では例外にならないことを確認します。

## 変更内容

- `app/javascript/tree_view/selection_controller.js`
  - `disconnect()` を追加し、既存の `removeSyncedHiddenInputs(form)` を lifecycle cleanup に再利用
  - `syncHiddenInputs()` 時に対象 form を記録し、DOM removal 後の `disconnect()` でも stale input を削除できるように整理
- `app/javascript/tree_view/selection_controller.test.js`
  - generated hidden input helper を少し整理
  - disconnect cleanup の代表ケースと sync disabled の no-op ケースを追加

## 改善カテゴリ

- lifecycle cleanup
- test 追加
- 小さな安定性改善

## 既存仕様への影響

- `tree-view-selection:change` / `selected` event payload、selection cascade、max-count、indeterminate behavior、server-side params parser は変更していません。
- hidden input sync の生成形式、input name、payload JSON、source id marker は変更していません。
- cleanup 対象は同じ source id の generated hidden input に限定しています。

## 実施した確認内容

- GitHub compare: `main...quality/1143-selection-hidden-input-cleanup`
  - changed files: 2
  - commits: 3
  - latest head: `707c00963bdb69dfe6c4e97d46b564314087f346`
- GitHub Actions
  - 初回 `CI #1426`: `javascript` job で disconnect 後の stale hidden input が残るケースを検出
  - 修正後 `CI #1427`: success
    - `changes`: success
    - `lint`: success
    - `pr_specs`: success
    - `javascript`: success
    - `gem_package`: success
    - representative `pr_rails_matrix` lanes: success
- local `npm run test:js` は未実行です。
  - この環境では GitHub HTTPS checkout / raw fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク評価

- risk: medium
- controller lifecycle に cleanup を足しますが、既存の source-id scoped removal helper を再利用しており、他 selection group の generated hidden input は削除しません。
- DOM removal 後の lifecycle でも stale input cleanup だけを行うため、公開 event / params contract には影響しません。

## 補足事項

- Turbo Frame lifecycle 全体の設計、hidden input sync API の rename / redesign、server-side selection params parser には広げていません。