### PR TITLE
Cookbook に lazy loading と children pagination の組み合わせ recipe を追加する

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -296,6 +296,47 @@ Use windowed rendering when many visible rows remain.
 
 Use lazy loading when children should be loaded only as needed.
 
+## Combine lazy loading with children pagination
+
+Use this pattern when a branch has many direct children and rendering all of them after the first expand would still be too large. Keep lazy loading responsible for the initial child endpoint and remote-state placeholders, then let the host app return one page of children plus a host-app-owned "Load more" row.
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document",
+  key_resolver: ->(item) { TreeView.node_key("document", item.id) }
+).build(
+  load_children_path_builder: ->(item, depth, scope) {
+    children_document_path(item, depth:, scope:, limit: 50, format: :turbo_stream)
+  }
+)
+```
+
+```erb
+<%= turbo_stream.replace tree_children_container_dom_id(@parent) do %>
+  <tbody id="<%= tree_children_container_dom_id(@parent) %>">
+    <%= tree_view_rows(@render_state) %>
+    <% if @next_cursor %>
+      <tr id="<%= dom_id(@parent, :children_more) %>">
+        <td colspan="6">
+          <%= link_to "Load more",
+            children_document_path(@parent, cursor: @next_cursor, limit: @limit, format: :turbo_stream),
+            data: { turbo_stream: true } %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+<% end %>
+
+<%= turbo_stream.replace tree_remote_state_placeholder_dom_id(@parent) do %>
+  <span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent, state: "loaded")) %>>loaded</span>
+<% end %>
+```
+
+TreeView provides `load_children_path_builder`, children container IDs, remote-state placeholder attributes, row rendering, and lazy-loading hooks. The host app owns the cursor or offset strategy, limit clamping, query ordering, authorization, `children_more` placement, retry copy, and Turbo Stream partial shape.
+
+For the full boundary and cursor details, read [Lazy Loading](lazy-loading.md), [Children Pagination](children-pagination.md), and [Render Scale](render-scale.md). Do not use this recipe as an infinite-scroll or virtual-scroll contract; those policies stay in the host app unless a separate feature changes them.
+
 ## Avoid an unopenable static collapsed tree
 
 `build_static` does not configure expand/collapse URLs. If static rendering is combined with `initial_expansion: { default: :collapsed }`, collapsed descendants are not rendered into the initial HTML and the user cannot open them from the browser.

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -296,6 +296,47 @@ render_state = TreeView::RenderState.new(
 
 子nodeを必要な分だけ読み込みたい場合は lazy loading を使います。
 
+## lazy loading と children pagination を組み合わせる
+
+1つのbranchに大量の直接childrenがあり、最初の展開後も全件描画すると大きすぎる場合に使います。lazy loading は最初のchildren endpointとremote-state placeholderをつなぎ、host app は1page分のchildrenとhost-app-ownedの「もっと見る」行を返します。
+
+```ruby
+tree_ui = TreeView::UiConfigBuilder.new(
+  context: view_context,
+  node_prefix: "document",
+  key_resolver: ->(item) { TreeView.node_key("document", item.id) }
+).build(
+  load_children_path_builder: ->(item, depth, scope) {
+    children_document_path(item, depth:, scope:, limit: 50, format: :turbo_stream)
+  }
+)
+```
+
+```erb
+<%= turbo_stream.replace tree_children_container_dom_id(@parent) do %>
+  <tbody id="<%= tree_children_container_dom_id(@parent) %>">
+    <%= tree_view_rows(@render_state) %>
+    <% if @next_cursor %>
+      <tr id="<%= dom_id(@parent, :children_more) %>">
+        <td colspan="6">
+          <%= link_to "もっと見る",
+            children_document_path(@parent, cursor: @next_cursor, limit: @limit, format: :turbo_stream),
+            data: { turbo_stream: true } %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+<% end %>
+
+<%= turbo_stream.replace tree_remote_state_placeholder_dom_id(@parent) do %>
+  <span <%= tag.attributes(tree_remote_state_placeholder_attributes(@parent, state: "loaded")) %>>loaded</span>
+<% end %>
+```
+
+TreeView は `load_children_path_builder`、children container ID、remote-state placeholder attributes、row rendering、lazy-loading hookを提供します。cursor / offset strategy、limit clamp、query ordering、authorization、`children_more` の配置、retry copy、Turbo Stream partial の形はhost app側で決めます。
+
+詳しい責務境界とcursor設計は [Lazy Loading](lazy-loading.md)、[Children Pagination](children-pagination.md)、[描画スケール](render-scale.md) を参照してください。この recipe を infinite scroll や virtual scroll の契約として扱わないでください。それらの方針は、別のfeatureで変えない限りhost app側の責務です。
+
 ## static collapsed tree が開けなくなる落とし穴を避ける
 
 `build_static` は開閉URLを設定しません。そのため static rendering と `initial_expansion: { default: :collapsed }` を組み合わせると、collapsed な子孫行は初期HTMLに描画されず、ユーザー操作では展開できません。


### PR DESCRIPTION
## 対応 Issue

Closes #779

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/en/cookbook.md` / `docs/ja/cookbook.md` に lazy loading と children pagination を組み合わせる実践 recipe を追加しました。
- `load_children_path_builder` で初回 children endpoint を接続し、host app が 1 page 分の children と `children_more` row を返す読み方を示しました。
- TreeView 側の責務を children container ID、remote-state placeholder attributes、row rendering、lazy-loading hook に限定し、cursor / offset strategy、limit clamp、query ordering、authorization、Turbo Stream partial shape は host app 側責務として明記しました。
- 詳細は既存の `lazy-loading.md`、`children-pagination.md`、`render-scale.md` に委譲しています。

## 根拠

- #779 は Cookbook に lazy loading + children pagination の combined recipe が薄いことを補う docs-only lane です。
- current `docs/en|ja/lazy-loading.md` と `docs/en|ja/children-pagination.md` は責務境界を既に持っているため、今回の変更は Cookbook の実践入口に閉じています。
- runtime code、helper API、mockup HTML/CSS、server-side pagination helper には触れていません。

## review follow-up

- 最新 `main` `f4997d7e65cde56dfa32393353f3499b3be64d91` を親に、Cookbook 差分だけを clean commit として再適用しました。
- head: `3267919cf1b081460a806bc1a66eac209a872245`
- PR が branch refresh 中に一時 close されたため、差分再適用後に reopen しています。

## 非目標

- server-side pagination helper の追加
- infinite scroll / virtual scrolling 実装
- lazy-loading controller behavior の変更
- feature guide 全体の再構成
- static mockup の追加

## 確認内容

- GitHub compare: `main...docs/779-lazy-loading-pagination-recipe`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 2 docs files (`docs/en/cookbook.md`, `docs/ja/cookbook.md`)
  - additions: 84 / deletions: 2
  - deletions は両 Cookbook 末尾の missing newline 正規化のみです。
- PR metadata: `mergeable: true`
- GitHub Actions CI #1679: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `gem_package` / full matrices: skipped by workflow conditions
- docs-only 変更のため local test / lint は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗します。

## リスク

- low
- 既存 docs の責務境界に沿った Cookbook 追記のみで、実装や公開 API 契約は変更していません。