### PR TITLE
public_api_manifest の構造 drift guard を追加する

### DIFF
--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "psych"
+require "yaml"
+
+RSpec.describe "Public API manifest structure" do
+  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+  EXPECTED_TOP_LEVEL_KEYS = %w[
+    module_methods
+    public_constants
+    helper_methods
+    toolbar_actions
+    grouped_option_keys
+    javascript_package_root
+  ].freeze
+
+  def manifest_source
+    @manifest_source ||= File.read(MANIFEST_PATH)
+  end
+
+  def manifest
+    @manifest ||= YAML.safe_load(manifest_source)
+  end
+
+  def duplicate_mapping_keys(yaml_source)
+    document = Psych.parse(yaml_source)
+    duplicates = []
+
+    walk_yaml_node(document.root, [], duplicates)
+
+    duplicates
+  end
+
+  def walk_yaml_node(node, path, duplicates)
+    case node
+    when Psych::Nodes::Mapping
+      seen_keys = {}
+
+      node.children.each_slice(2) do |key_node, value_node|
+        key = key_node.value.to_s
+        key_path = (path + [key]).join(".")
+
+        duplicates << key_path if seen_keys[key]
+        seen_keys[key] = true
+
+        walk_yaml_node(value_node, path + [key], duplicates)
+      end
+    when Psych::Nodes::Sequence
+      node.children.each_with_index do |child, index|
+        walk_yaml_node(child, path + [index.to_s], duplicates)
+      end
+    end
+  end
+
+  it "keeps expected top-level sections explicit" do
+    expect(manifest.keys).to eq(EXPECTED_TOP_LEVEL_KEYS)
+  end
+
+  it "does not contain duplicate keys in any mapping" do
+    expect(duplicate_mapping_keys(manifest_source)).to eq([])
+  end
+
+  it "detects duplicate keys inside nested mappings" do
+    yaml = <<~YAML
+      javascript_package_root:
+        event_names:
+          state: {}
+          state: {}
+    YAML
+
+    expect(duplicate_mapping_keys(yaml)).to eq(["javascript_package_root.event_names.state"])
+  end
+
+  it "keeps grouped option key sections shaped as non-empty string lists" do
+    manifest.fetch("grouped_option_keys").each do |group_name, keys|
+      expect(group_name).to be_a(String)
+      expect(keys).to be_an(Array), "expected grouped_option_keys.#{group_name} to be an array"
+      expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
+      expect(keys).to all(be_a(String))
+    end
+  end
+
+  it "keeps JavaScript event names and detail keys in nested hash sections" do
+    javascript_manifest = manifest.fetch("javascript_package_root")
+
+    %w[event_names event_detail_keys].each do |section_name|
+      section = javascript_manifest.fetch(section_name)
+
+      expect(section).to be_a(Hash)
+      expect(section).not_to be_empty
+
+      section.each do |group_name, events|
+        expect(group_name).to be_a(String)
+        expect(events).to be_a(Hash), "expected #{section_name}.#{group_name} to map event names"
+        expect(events).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -4,19 +4,19 @@ require "spec_helper"
 require "psych"
 require "yaml"
 
-RSpec.describe "Public API manifest structure" do
-  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
-  EXPECTED_TOP_LEVEL_KEYS = %w[
-    module_methods
-    public_constants
-    helper_methods
-    toolbar_actions
-    grouped_option_keys
-    javascript_package_root
-  ].freeze
+PUBLIC_API_MANIFEST_STRUCTURE_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
+  module_methods
+  public_constants
+  helper_methods
+  toolbar_actions
+  grouped_option_keys
+  javascript_package_root
+].freeze
 
+RSpec.describe "Public API manifest structure" do
   def manifest_source
-    @manifest_source ||= File.read(MANIFEST_PATH)
+    @manifest_source ||= File.read(PUBLIC_API_MANIFEST_STRUCTURE_PATH)
   end
 
   def manifest
@@ -54,7 +54,7 @@ RSpec.describe "Public API manifest structure" do
   end
 
   it "keeps expected top-level sections explicit" do
-    expect(manifest.keys).to eq(EXPECTED_TOP_LEVEL_KEYS)
+    expect(manifest.keys).to eq(PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS)
   end
 
   it "does not contain duplicate keys in any mapping" do


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1126

## Issue ごとの完了内容

- #1126
  - `config/public_api_manifest.yml` の top-level section を軽量 spec で固定しました。
  - YAML mapping 内の duplicate key を Psych AST で検出する helper と代表 fixture を追加しました。
  - `grouped_option_keys` と JavaScript event manifest の代表 nested shape を確認し、typo / shape drift を早く拾えるようにしました。

## 変更内容

- `spec/public_api_manifest_structure_spec.rb` を追加しました。
- manifest の public contract 内容自体は変更していません。
- `script/test_entrypoints.mjs` の JS export / event detail sync guard とは分け、manifest YAML 構造の guard に閉じています。

## 状態

Superseded by #1206.

この PR は current `main` から behind / diverged になったため、latest main から作り直した replacement PR #1206 にレビュー対象を移しました。