### PR TITLE
docs index に direction-aware styling guide の入口を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,8 @@
 - [日本語Lazy Loading](ja/lazy-loading.md): host app の route と TreeView remote-state hooks で子nodeを必要時に読み込む入口。
 - [English Windowed Rendering](en/windowed-rendering.md): render visible rows by offset and limit while host apps keep query and paging ownership.
 - [日本語Windowed Rendering](ja/windowed-rendering.md): offset / limit で visible rows を描画し、query や paging は host app が所有する前提の入口。
+- [English direction-aware styling boundary](en/direction-aware-styling.md): host-app override guidance for RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing.
+- [日本語Direction-aware styling boundary](ja/direction-aware-styling.md): RTL、writing direction、current-row cue、hierarchy connector、toggle spacing の host-app override guidance。
 - [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure and interaction states. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
 - [English demo application boundary](en/demo-application-boundary.md): decide when to use static mockups versus a real Rails demo app, without adding private or unavailable demo links.
 - [日本語Demo application boundary](ja/demo-application-boundary.md): static mockup と real Rails demo app の役割分担、未公開 demo link を増やさない方針。


### PR DESCRIPTION
## 対応 Issue

Closes #1195

## 判定分類

- `docs-sync`
- `docs-stale`

## 変更内容

- `docs/README.md` の Recommended entry points に、英日 `direction-aware-styling.md` への入口を追加しました。
- 言語別 README では既に Direction-aware styling boundary が案内されているため、root docs index からも目的別に辿れるようにしました。

## 根拠

- current `docs/en/direction-aware-styling.md` / `docs/ja/direction-aware-styling.md` は、RTL、writing direction、current-row cue、hierarchy connector、toggle spacing の host-app override guidance を説明しています。
- `docs/en/README.md` / `docs/ja/README.md` には同 guide への導線がありますが、root `docs/README.md` の目的別入口にはまだありませんでした。
- 未 merge の mockup PR や runtime CSS / JS behavior には触れていません。

## 変更範囲

- `docs/README.md` のみ

## 確認内容

- GitHub compare: `main...docs/direction-aware-entrypoint`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
  - additions: 2 / deletions: 0
- GitHub Actions CI #1436: success
- PR metadata: `mergeable: true`
- docs-only 変更のため local test / lint は未実行です。

## リスク

- low
- 既存 docs への入口追加のみで、仕様追加、未実装 mockup へのリンク、runtime behavior、public API contract は変更していません。