### PR TITLE
direction-aware hierarchy cue mockup を最新 main で再提案する

### DIFF
--- a/docs/mockups/direction-aware-tree-cues/index.html
+++ b/docs/mockups/direction-aware-tree-cues/index.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView direction-aware hierarchy cue mock</title>
+<link rel="stylesheet" href="../default-tree.css">
+<style>
+.direction-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+}
+
+.direction-frame {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #d8e0ea;
+  background: #fff;
+}
+
+.direction-frame h3,
+.direction-frame p {
+  margin: 0;
+}
+
+.direction-note {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid #d8e0ea;
+  background: #f8fafc;
+}
+
+.direction-note h3,
+.direction-note p {
+  margin: 0;
+}
+
+.direction-frame[dir="rtl"] .tree-view-table th,
+.direction-frame[dir="rtl"] .tree-view-table td {
+  text-align: right;
+}
+
+.direction-frame[dir="rtl"] .tree-toggle {
+  flex-direction: row-reverse;
+}
+
+.direction-frame[dir="rtl"] .tree-toggle__control {
+  justify-content: flex-end;
+}
+
+.direction-frame[dir="rtl"] .tree-toggle__branch-slot.is-current::after {
+  left: 0;
+  right: 50%;
+}
+
+.direction-frame[dir="rtl"] .tree-row-actions {
+  text-align: left;
+}
+
+.direction-observation-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #334e68;
+}
+
+.direction-frame[dir="rtl"] .direction-observation-list {
+  padding-right: 1.2rem;
+  padding-left: 0;
+}
+
+.mock-section {
+  overflow-x: auto;
+}
+</style>
+</head>
+<body>
+  <main class="mock-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>TreeView direction-aware hierarchy cue mock</h1>
+      <p>
+        Static reference for comparing left-to-right and right-to-left hierarchy cues.
+        It keeps copy product-neutral while making branch lines, toggle controls, current state, selected rows, and row actions inspectable in both directions.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="../review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="../README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="direction-boundary-heading">
+      <h2 id="direction-boundary-heading">Responsibility boundary</h2>
+      <div class="direction-grid">
+        <article class="direction-note">
+          <h3>TreeView-owned cues</h3>
+          <p>Hierarchy depth, branch slots, toggle controls, current-row cue, and selection state should stay readable in either inline direction.</p>
+        </article>
+        <article class="direction-note">
+          <h3>Host-app-owned cues</h3>
+          <p>Locale selection, translations, route labels, permission copy, and final row actions remain outside this static reference.</p>
+        </article>
+        <article class="direction-note">
+          <h3>Out of scope here</h3>
+          <p>This page is not a full RTL support declaration and does not change runtime Ruby, JavaScript, or host-app localization policy.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="direction-comparison-heading" data-tree-view-sample="rtl-hierarchy-cues">
+      <h2 id="direction-comparison-heading">LTR and RTL comparison</h2>
+      <div class="direction-grid">
+        <article class="direction-frame" aria-labelledby="ltr-heading">
+          <h3 id="ltr-heading">Left-to-right baseline</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded" data-tree-node-key="workspace" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded root">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Workspace</span></td>
+                <td><span class="mock-status mock-status--active">expanded</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr class="tree-row is-selected" data-tree-parent-key="workspace" data-tree-node-key="workspace:current" data-tree-depth="1" aria-level="2" aria-current="page">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Current child">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><span class="tree-toggle__level">current</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Current folder</span></td>
+                <td><span class="mock-status mock-status--active">current</span></td>
+                <td class="tree-row-actions"><button type="button">View</button></td>
+              </tr>
+              <tr class="tree-row is-collapsed" data-tree-parent-key="workspace" data-tree-node-key="workspace:collapsed" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Collapsed child">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Collapsed folder</span></td>
+                <td><span class="mock-status mock-status--pending">collapsed</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+            </tbody>
+          </table>
+          <ul class="direction-observation-list">
+            <li>Branch line and toggle action sit before the label in the inline-start scan.</li>
+            <li>Current and selected cues stay in the row, not only in the action column.</li>
+          </ul>
+        </article>
+
+        <article class="direction-frame" dir="rtl" aria-labelledby="rtl-heading">
+          <h3 id="rtl-heading">Right-to-left review frame</h3>
+          <table class="tree-view-table">
+            <thead>
+              <tr>
+                <th scope="col">tree</th>
+                <th scope="col">node</th>
+                <th scope="col">state</th>
+                <th scope="col">actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="tree-row is-expanded" data-tree-node-key="workspace-rtl" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Expanded root in RTL">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Workspace</span></td>
+                <td><span class="mock-status mock-status--active">expanded</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+              <tr class="tree-row is-selected" data-tree-parent-key="workspace-rtl" data-tree-node-key="workspace-rtl:current" data-tree-depth="1" aria-level="2" aria-current="page">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Current child in RTL">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                    <span class="tree-toggle__control"><span class="tree-toggle__level">current</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Current folder</span></td>
+                <td><span class="mock-status mock-status--active">current</span></td>
+                <td class="tree-row-actions"><button type="button">View</button></td>
+              </tr>
+              <tr class="tree-row is-collapsed" data-tree-parent-key="workspace-rtl" data-tree-node-key="workspace-rtl:collapsed" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Collapsed child in RTL">
+                    <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                    <span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span></span>
+                  </span>
+                </td>
+                <td><span class="mock-node-title">Collapsed folder</span></td>
+                <td><span class="mock-status mock-status--pending">collapsed</span></td>
+                <td class="tree-row-actions"><button type="button">Open</button></td>
+              </tr>
+            </tbody>
+          </table>
+          <ul class="direction-observation-list">
+            <li>Branch connectors mirror toward inline-start so hierarchy does not depend on left-only placement.</li>
+            <li>Row action placement is visible without deciding final host-app localization or route labels.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/browser/direction_aware_tree_cues_smoke.spec.js
+++ b/test/browser/direction_aware_tree_cues_smoke.spec.js
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const mockupsRoot = path.join(repoRoot, "docs/mockups")
+
+function mockupUrl(file) {
+  return pathToFileURL(path.join(mockupsRoot, file)).toString()
+}
+
+async function expectNoDocumentHorizontalOverflow(page) {
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+  expect(overflow).toBeLessThanOrEqual(1)
+}
+
+test.describe("direction-aware tree cues mockup", () => {
+  for (const viewport of [
+    { name: "desktop", width: 1280, height: 900 },
+    { name: "narrow", width: 390, height: 900 }
+  ]) {
+    test(`keeps LTR and RTL hierarchy cues readable at ${viewport.name} width`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+      await page.goto(mockupUrl("direction-aware-tree-cues/index.html"))
+
+      await expect(page.getByRole("heading", { name: "TreeView direction-aware hierarchy cue mock", level: 1 })).toBeVisible()
+      await expect(page.getByRole("heading", { name: "Left-to-right baseline" })).toBeVisible()
+      await expect(page.getByRole("heading", { name: "Right-to-left review frame" })).toBeVisible()
+      await expect(page.locator("[data-tree-view-sample='rtl-hierarchy-cues'] .direction-frame[dir='rtl'] .tree-row")).toHaveCount(3)
+      await expect(page.getByText("Branch connectors mirror toward inline-start")).toBeVisible()
+      await expectNoDocumentHorizontalOverflow(page)
+    })
+  }
+})


### PR DESCRIPTION
## 対応Issue

- Closes #1133
- Closes #983
- Supersedes #1159

## 採用した方針

- review follow-up として、古い #1159 branch を上書きせず、最新 `main` から replacement branch を作り直しました。
- #1159 の review 指摘に合わせ、`docs/mockups/review-gallery.html` の既存 card 詳細・comparison cues table は削らず、今回の PR では触っていません。
- top-level mockup inventory への影響を避けるため、direction-aware hierarchy cue は `high-contrast-state-cues/index.html` と同じ focused subpage 形式にしました。
- すでに current `main` に入っている `reduced-motion-state-cues.html` は保持し、追加差分は direction-aware hierarchy cue の focused page と browser smoke evidence に閉じています。

## 比較した案

- 案A: #1159 branch を force update して修正する
  - 不採用。古い branch は `behind_by > 0` / `mergeable:false` で、force update はレビュー履歴上も危険が高いです。
- 案B: current `main` から replacement PR を作る
  - 採用。既存 gallery guidance を保持し、review 指摘の information loss を避けられます。
- 案C: gallery / README inventory も同時に再同期する
  - 見送り。current `main` の gallery は詳細な comparison cues を持っており、今回の修正要求では削除を避けることを優先しました。
- 案D: top-level HTML ではなく focused subpage として追加する
  - 採用。既存 gallery を変更せず、専用 smoke で visual evidence を残せます。

## 変更内容

- `docs/mockups/direction-aware-tree-cues/index.html` を追加
  - LTR / RTL の hierarchy connector、toggle placement、current / selected cue、row action placement を比較できる static reference
  - full RTL support 宣言、locale policy、route labels、permission copy は host app responsibility として明記
- `test/browser/direction_aware_tree_cues_smoke.spec.js` を追加
  - desktop `1280x900` と narrow `390x900` で main heading、LTR/RTL frame、RTL row count、boundary copy、document horizontal overflow を確認

## 変更した画面・コンポーネント

- `docs/mockups/direction-aware-tree-cues/index.html`
- `test/browser/direction_aware_tree_cues_smoke.spec.js`

## 確認内容

- lint: PR の GitHub Actions で確認
- typecheck: 該当なし
- UI表示確認: browser smoke spec を追加し、desktop / narrow viewport の代表表示を CI で確認
- レスポンシブ確認: smoke spec で narrow `390x900` の horizontal overflow を確認
- アクセシビリティ確認: heading、return links、`dir="rtl"` frame、`aria-current`、`aria-expanded` を static markup 上で保持
- GitHub compare: `main...design/1133-direction-aware-tree-cues-refresh`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2

## スクリーンショット

<!-- connector-only 実行のため未添付。代替として browser smoke spec を追加しています。 -->

## リスク

- low
- static mockup と browser smoke spec の追加だけです。runtime Ruby / JavaScript behavior、public API、authorization、DB、host-app localization policy は変更していません。

## 補足

- #1159 で指摘された `review-gallery.html` の information loss は、この replacement PR では同ファイルを変更しないことで回避しています。
- `reduced-motion-state-cues.html` は current `main` に存在するため、この PR では重複して載せ直していません。