### PR TITLE
Clarify entrypoint manifest loader failures

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -71,7 +71,7 @@ A separate entrypoint smoke check loads `app/javascript/tree_view/index.js` dire
 npm run test:entrypoints
 ```
 
-That check keeps the documented controller exports and `registerTreeViewControllers` helper aligned with the importmap entrypoint.
+That check keeps the documented controller exports and `registerTreeViewControllers` helper aligned with the importmap entrypoint. It uses Ruby to load `config/public_api_manifest.yml` and print the `javascript_package_root` section as JSON before Node assertions run, so run it from the repository root with Ruby available when you are diagnosing manifest loader failures.
 
 Browser-level smoke tests run through Playwright with:
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -71,7 +71,7 @@ npm test
 npm run test:entrypoints
 ```
 
-このcheckで、documented controller exports と `registerTreeViewControllers` helper が importmap entrypoint とずれないようにします。
+このcheckで、documented controller exports と `registerTreeViewControllers` helper が importmap entrypoint とずれないようにします。Node 側の assertions を実行する前に Ruby で `config/public_api_manifest.yml` を読み、`javascript_package_root` section を JSON として出力します。manifest loader failure を調べる場合は、repository root から Ruby が使える状態で実行してください。
 
 Browser-level smoke testsはPlaywrightで実行します。
 

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -1,21 +1,53 @@
 import { execFileSync } from "node:child_process"
 
 function loadJavascriptPackageManifest() {
-  const manifestJson = execFileSync(
-    "ruby",
-    [
-      "-e",
-      [
-        'require "json"',
-        'require "yaml"',
-        'data = YAML.load_file("config/public_api_manifest.yml")',
-        'print JSON.generate(data.fetch("javascript_package_root"))'
-      ].join("; ")
-    ],
-    { encoding: "utf8" }
-  )
+  const manifestJson = loadManifestJson()
 
-  return JSON.parse(manifestJson)
+  try {
+    return JSON.parse(manifestJson)
+  } catch (error) {
+    throw new Error(
+      [
+        "Could not parse config/public_api_manifest.yml javascript_package_root as JSON.",
+        "The entrypoint smoke uses Ruby to load YAML and prints that manifest section as JSON before Node assertions run.",
+        `Parser error: ${error.message}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
+}
+
+function loadManifestJson() {
+  try {
+    return execFileSync(
+      "ruby",
+      [
+        "-e",
+        [
+          'require "json"',
+          'require "yaml"',
+          'data = YAML.load_file("config/public_api_manifest.yml")',
+          'print JSON.generate(data.fetch("javascript_package_root"))'
+        ].join("; ")
+      ],
+      { encoding: "utf8" }
+    )
+  } catch (error) {
+    const rubyOutput = [error.stdout, error.stderr]
+      .filter((output) => output && output.length > 0)
+      .join("\n")
+      .trim()
+    const detail = rubyOutput || error.message
+
+    throw new Error(
+      [
+        "Could not load config/public_api_manifest.yml for the entrypoint smoke.",
+        "Run this command from the repository root with Ruby available, or inspect the manifest YAML around javascript_package_root.",
+        `Ruby loader output: ${detail}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
 }
 
 function camelizeKey(value) {


### PR DESCRIPTION
## 対応 Issue

- Closes #1112

## Issue ごとの完了内容

- #1112: `script/test_entrypoints.mjs` の Ruby manifest loader failure を、Ruby 実行失敗と JSON parse failure に分けて読みやすいエラーにしました。
- #1112: 英日 development docs に、entrypoint smoke が Ruby で `config/public_api_manifest.yml` の `javascript_package_root` を読む前提を追記しました。

## 変更内容

- `script/test_entrypoints.mjs`
  - manifest JSON の取得を `loadManifestJson()` に分離
  - Ruby loader の stdout/stderr または例外 message を含む説明付きエラーを追加
  - JSON parse failure も manifest loader の境界が分かる説明付きエラーに変更
- `docs/en/development.md`
- `docs/ja/development.md`
  - `npm run test:entrypoints` の manifest loader 前提を明記

## 改善カテゴリ

- error handling
- docs
- test maintainability

## 既存仕様への影響

- public API / UI / DB / authorization / external service contract は変更していません。
- 成功時の entrypoint smoke assertions は既存どおりです。失敗時の診断メッセージだけを明確化しています。

## 実施した確認

- GitHub connector compare: `main...quality/1112-entrypoint-manifest-errors`
  - ahead_by: 3
  - behind_by: 0
  - changed files: 3
- ローカル clone / test は未実行です。この実行環境では GitHub HTTPS clone が `CONNECT tunnel failed, response 403` で使用できません。
- #413 については `npm view @playwright/test version` が registry `403 Forbidden` で失敗したため、lockfile refresh は停止し Issue にコメント済みです。

## リスク評価

- risk: low
- 成功経路の contract は変えず、failure diagnostics と docs のみの改善です。

## 補足事項

- #413 は registry-enabled environment が必要なため、この PR には含めていません。