### PR TITLE
gem package contents guard に主要 docs entrypoint を追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -4,7 +4,8 @@
 require "rubygems/package"
 
 # Keep representative English and Japanese files in this list so package
-# verification covers the bilingual locale and release docs shipped by the gem.
+# verification covers the bilingual locale, public API, docs entrypoints,
+# and release docs shipped by the gem.
 REQUIRED_PACKAGED_PATHS = %w[
   app/helpers/tree_view_helper.rb
   app/helpers/tree_view_helper/support.rb
@@ -30,6 +31,10 @@ REQUIRED_PACKAGED_PATHS = %w[
   config/public_api_manifest.yml
   config/locales/tree_view.toolbar.en.yml
   config/locales/tree_view.toolbar.ja.yml
+  README.md
+  docs/README.md
+  docs/en/public-api.md
+  docs/ja/public-api.md
   docs/en/release.md
   docs/ja/release.md
 ].freeze


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1191

## Issue ごとの完了内容

- #1191: `script/check_gem_package_contents.rb` の representative package guard に、利用者が gem 内で参照する主要 docs entrypoint を追加しました。
- 追加対象は `README.md`、`docs/README.md`、`docs/en/public-api.md`、`docs/ja/public-api.md` に絞り、`docs/**/*` 全量の固定リスト化には広げていません。

## 変更内容

- `REQUIRED_PACKAGED_PATHS` に主要 docs entrypoint 4件を追加
- comment を、locale / public API / docs entrypoint / release docs の代表 guard であることが分かるように更新

## 改善カテゴリ

- test / package guard
- CI / gem package verification
- 小さな保守性改善

## 既存仕様への影響

- runtime Ruby / JavaScript、public API surface、docs content、release workflow、CI job name は変更していません。
- gemspec は既に `docs/**/*` と `README.md` を含めているため、今回の変更は packaged file guard の代表パス追加に閉じています。

## 実施した確認内容

- GitHub compare: `main...quality/1191-docs-entrypoint-package-guard`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local `ruby script/check_gem_package_contents.rb`: 未実行
  - この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions の `gem_package` / related checks を確認します。

## リスク評価

- risk: low
- package-sensitive path の representative guard 追加のみです。docs 内容や public API contract は変更していません。

## 補足事項

- #413 は今回も npm registry が `403 Forbidden` で、Issue 本文の実装制約どおり停止コメントを残しました。