### PR TITLE
CHANGELOG に entrypoint smoke 診断改善を反映する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Clarified release checklist guidance for documented JavaScript wiring surfaces, including `data-tree-view-*` integration hooks and selection controller host-element value attributes, alongside machine-readable package-root exports.
 - Added migration guides in Japanese and English to summarize compatibility promises, deprecations, rename handling, and release-note expectations.
 - Clarified the CI policy split between pull request Ruby checks and broader `main` / release checks.
+- Clarified development docs for the Ruby-backed `npm run test:entrypoints` manifest loader path and setup expectations.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
@@ -82,6 +83,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added specs for RenderState internal configuration objects and the consolidated diagnostics entrypoint.
 - Added JavaScript public event contract specs for selection, remote state, and transfer events.
 - Added package-root frozen object contract coverage for public JavaScript object exports.
+- Improved entrypoint smoke diagnostics for Ruby manifest loader and JSON parse failures without changing public export assertions.
 - Added browser smoke coverage for representative docs mockup pages and the review gallery.
 
 ## 0.1.0 - 2026-05-07


### PR DESCRIPTION
## 対応 Issue

Refs #1112

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の Unreleased に、#1197 で merge 済みの entrypoint smoke manifest loader 診断改善を追記しました。
- Development docs 側の Ruby-backed `npm run test:entrypoints` manifest loader 前提の補足を Documentation に、Ruby loader / JSON parse failure の診断改善を Tests に分類しました。

## 根拠

- PR #1197 は `script/test_entrypoints.mjs` の失敗診断と英日 `docs/*/development.md` を更新して main に merge 済みです。
- current `CHANGELOG.md` にはこの release-facing maintenance change がまだ反映されていませんでした。
- 成功時の public export assertions、manifest schema、public API、runtime behavior は #1197 で変更されていないため、短い changelog 追記に閉じています。

## 非目標

- script / test / runtime / manifest / CI workflow の変更
- #413 の lockfile refresh
- release automation、version bump、tag 作成
- open PR の未merge内容の先取り

## 確認内容

- GitHub compare: `main...docs/1112-entrypoint-smoke-changelog`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`CHANGELOG.md`)
  - additions: 2 / deletions: 0
- PR metadata: `mergeable: true`
- GitHub Actions CI #1456: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `gem_package`: skipped
- docs-only / changelog-only 変更のため local test / lint は未実行です。

## リスク

- low
- release-facing summary の追記のみで、実装や公開 API 契約は変更していません。