### PR TITLE
Public API docs に manifest の package 境界を明記する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -2,6 +2,12 @@
 
 This page describes which APIs host Rails apps may depend on directly, which parts are internal, and how compatibility is handled.
 
+## Public API manifest
+
+`config/public_api_manifest.yml` is a packaged audit artifact and compatibility contract. It records machine-readable public helper methods, grouped option keys, JavaScript package-root exports, controller identifiers, event surfaces, and selected documented hooks so specs, package checks, and entrypoint smoke checks can compare docs-facing contracts with current code.
+
+Host apps should not treat the manifest as a runtime configuration API. Use the documented Ruby classes, helpers, options, JavaScript exports, and feature guides instead. The manifest is included in the gem package so maintainers can catch missing files or contract drift during release verification; its schema may evolve as long as the documented public surface remains compatible.
+
 ## Stable public entry points
 
 Host apps may use these entry points directly:

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -2,6 +2,12 @@
 
 このページでは、host Rails app が直接使ってよい公開API、内部API、互換性方針を整理します。
 
+## Public API manifest
+
+`config/public_api_manifest.yml` は、gem package に含める audit artifact であり、互換性 contract です。公開 helper method、grouped option key、JavaScript package-root export、controller identifier、event surface、一部の documented hook を machine-readable に記録し、spec、package check、entrypoint smoke check が docs-facing contract と current code のずれを検出できるようにします。
+
+host app はこの manifest を runtime configuration API として扱わないでください。通常は documented Ruby class、helper、option、JavaScript export、feature guide を使います。manifest は release verification で file 欠落や contract drift を見つけるために package へ含める保守用 artifact であり、documented public surface の互換性を保つ限り schema は変わる可能性があります。
+
 ## 安定した公開入口
 
 host app が直接使ってよい主な入口は以下です。


### PR DESCRIPTION
## 対応 Issue

Closes #1149

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の冒頭に Public API manifest の境界説明を追加しました。
- `config/public_api_manifest.yml` を packaged audit artifact / compatibility contract として説明し、host app が runtime configuration API として読むものではないことを明記しました。
- manifest は release verification で file 欠落や contract drift を見つけるための保守用 artifact であり、通常利用は documented Ruby classes / helpers / options / JavaScript exports / feature guides に寄せる、と整理しました。

## 根拠

- `tree_view.gemspec` は `config/public_api_manifest.yml` を package 対象に含めています。
- `script/check_gem_package_contents.rb` と entrypoint smoke / compatibility specs は manifest を contract drift guard として扱っています。
- current Public API docs は manifest を machine-readable source of truth と説明していましたが、host app runtime API ではない境界が薄い状態でした。

## 非目標

- manifest schema redesign
- manifest を host app runtime API として正式化すること
- `tree_view.gemspec` / CI / package verification の変更
- public API docs 全体の rewrite
- #981 の close 判断

## 確認内容

- GitHub compare: `main...docs/1149-public-api-manifest-boundary`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- 既存 docs の責務境界を補足するだけで、runtime behavior、manifest schema、CI workflow、package verification は変更していません。