### PR TITLE
JavaScript package root の TypeScript declaration を追加する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -1,0 +1,53 @@
+import { Controller } from "@hotwired/stimulus"
+import type { Application } from "@hotwired/stimulus"
+
+export declare class TreeViewClientController extends Controller {}
+export declare class TreeViewRemoteStateController extends Controller {}
+export declare class TreeViewSelectionController extends Controller {}
+export declare class TreeViewStateController extends Controller {}
+export declare class TreeViewTransferController extends Controller {}
+
+export declare const TreeViewEventNames: Readonly<{
+  state: Readonly<{
+    stateChanged: "tree-view-state:state-changed"
+  }>
+  selection: Readonly<{
+    change: "tree-view-selection:change"
+    selected: "tree-view-selection:selected"
+    limitExceeded: "tree-view-selection:limit-exceeded"
+    invalidPayload: "tree-view-selection:invalid-payload"
+  }>
+  remoteState: Readonly<{
+    change: "tree-view-remote-state:change"
+    retry: "tree-view-remote-state:retry"
+  }>
+  hostLifecycle: Readonly<{
+    loading: "tree-view:loading"
+    loaded: "tree-view:loaded"
+    error: "tree-view:error"
+    retry: "tree-view:retry"
+  }>
+  transfer: Readonly<{
+    dragStart: "tree-view-transfer:drag-start"
+    dragOver: "tree-view-transfer:drag-over"
+    drop: "tree-view-transfer:drop"
+    invalidPayload: "tree-view-transfer:invalid-payload"
+    invalidTransfer: "tree-view-transfer:invalid-transfer"
+  }>
+}>
+
+export declare const TreeViewTransferDropPositions: Readonly<{
+  before: "before"
+  inside: "inside"
+  after: "after"
+}>
+
+export declare const TreeViewControllerIdentifiers: Readonly<{
+  state: "tree-view-state"
+  client: "tree-view-client"
+  selection: "tree-view-selection"
+  transfer: "tree-view-transfer"
+  remoteState: "tree-view-remote-state"
+}>
+
+export declare function registerTreeViewControllers(application: Application): void

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -164,6 +164,8 @@ Host apps are expected to provide these pieces:
 
 The public JavaScript entrypoint is `tree_view/index.js`.
 
+The adjacent `tree_view/index.d.ts` declaration mirrors that package-root entrypoint for TypeScript-aware bundlers and editor tooling. It is a compile-time aid only: importmap and plain ESM integrations still use `tree_view/index.js` at runtime, and the manifest-backed runtime export contract remains the source of truth.
+
 Stable enough for host apps to use:
 
 - `registerTreeViewControllers(application)`
@@ -210,6 +212,8 @@ The `tree-view-selection` controller's documented host-element value attributes 
 Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
 The machine-readable source of truth for the package-root JavaScript exports and bundled controller identifiers lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+
+The entrypoint smoke also compares the declaration's exported names with `javascript_package_root.named_exports`, so declaration drift is caught without turning controller private methods or event payload typing into a broader TypeScript API.
 
 Internal by default:
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -164,6 +164,8 @@ host app が提供する主な拡張点は以下です。
 
 公開 JavaScript entrypoint は `tree_view/index.js` です。
 
+隣接する `tree_view/index.d.ts` declaration は、この package-root entrypoint を TypeScript 対応 bundler や editor tooling から読みやすくするための補助です。これは compile-time aid に限られます。importmap や plain ESM の runtime integration は従来どおり `tree_view/index.js` を使い、manifest-backed runtime export contract が source of truth のままです。
+
 host app が使ってよい入口:
 
 - `registerTreeViewControllers(application)`
@@ -210,6 +212,8 @@ host app が使ってよい入口:
 これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
 package-root の JavaScript export と bundled controller identifier の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+
+entrypoint smoke は declaration の export 名も `javascript_package_root.named_exports` と照合します。これにより、controller private methods や event payload typing まで TypeScript API として広げずに、declaration drift だけを検知します。
 
 内部扱い:
 

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
 
 function loadJavascriptPackageManifest() {
   const manifestJson = loadManifestJson()
@@ -48,6 +49,15 @@ function loadManifestJson() {
       { cause: error }
     )
   }
+}
+
+function loadDeclarationExportNames() {
+  const declarationPath = new URL("../app/javascript/tree_view/index.d.ts", import.meta.url)
+  const declarationSource = readFileSync(declarationPath, "utf8")
+  const exportPattern = /^export\s+declare\s+(?:class|const|function)\s+([A-Za-z0-9_]+)/gm
+  const exportNames = [...declarationSource.matchAll(exportPattern)].map((match) => match[1])
+
+  return [...new Set(exportNames)]
 }
 
 function camelizeKey(value) {
@@ -123,6 +133,22 @@ const missingNamedExports = javascriptPackageManifest.named_exports.filter((expo
 assert(
   missingNamedExports.length === 0,
   `named exports are out of sync: ${missingNamedExports.join(", ")}`
+)
+
+const declarationExportNames = loadDeclarationExportNames()
+const missingDeclarationExports = javascriptPackageManifest.named_exports.filter(
+  (exportName) => !declarationExportNames.includes(exportName)
+)
+const undocumentedDeclarationExports = declarationExportNames.filter(
+  (exportName) => !javascriptPackageManifest.named_exports.includes(exportName)
+)
+assert(
+  missingDeclarationExports.length === 0,
+  `TypeScript declaration exports are missing manifest exports: ${missingDeclarationExports.join(", ")}`
+)
+assert(
+  undocumentedDeclarationExports.length === 0,
+  `TypeScript declaration exports are not listed in the manifest: ${undocumentedDeclarationExports.join(", ")}`
 )
 
 const expectedIdentifiers = Object.fromEntries(


### PR DESCRIPTION
TreeView の package-root JavaScript export に、TypeScript tooling 用の最小 declaration と manifest drift guard を追加します。

Closes #1179

## superseded

- Superseded by #1287
- この PR は current `main` から `behind_by:39` / `mergeable:false` になり、`TreeViewEventDetailKeys` を含む最新 package-root export / manifest と `.d.ts` が drift していました。
- #1287 は latest `main` から clean replacement として切り直しています。

## 変更内容

- `app/javascript/tree_view/index.d.ts` を追加し、`tree_view/index.js` の current package-root public exports に型定義を付けました。
- `registerTreeViewControllers(application)`、5つの controller class export、`TreeViewEventNames`、`TreeViewControllerIdentifiers`、`TreeViewTransferDropPositions` を current runtime export に合わせて定義しました。
- `script/test_entrypoints.mjs` で `.d.ts` の exported names と `config/public_api_manifest.yml` の `javascript_package_root.named_exports` を照合するようにしました。
- 英日 Public API docs に、`.d.ts` は TypeScript 対応 bundler / editor tooling 向けの compile-time aid であり、runtime contract は従来どおり `tree_view/index.js` と manifest-backed export contract に残ることを追記しました。

## 状態

- 旧 head CI #1462 は success でしたが、現在は stale / non-mergeable です。
- review / CI は replacement PR #1287 で継続します。