### PR TITLE
public_api_manifest 構造 drift guard を最新 main で再提案する

### DIFF
--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "psych"
+require "yaml"
+
+PUBLIC_API_MANIFEST_STRUCTURE_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
+  module_methods
+  public_constants
+  helper_methods
+  toolbar_actions
+  grouped_option_keys
+  javascript_package_root
+].freeze
+
+RSpec.describe "Public API manifest structure" do
+  def manifest_source
+    @manifest_source ||= File.read(PUBLIC_API_MANIFEST_STRUCTURE_PATH)
+  end
+
+  def manifest
+    @manifest ||= YAML.safe_load(manifest_source)
+  end
+
+  def duplicate_mapping_keys(yaml_source)
+    document = Psych.parse(yaml_source)
+    duplicates = []
+
+    walk_yaml_node(document.root, [], duplicates)
+
+    duplicates
+  end
+
+  def walk_yaml_node(node, path, duplicates)
+    case node
+    when Psych::Nodes::Mapping
+      seen_keys = {}
+
+      node.children.each_slice(2) do |key_node, value_node|
+        key = key_node.value.to_s
+        key_path = (path + [key]).join(".")
+
+        duplicates << key_path if seen_keys[key]
+        seen_keys[key] = true
+
+        walk_yaml_node(value_node, path + [key], duplicates)
+      end
+    when Psych::Nodes::Sequence
+      node.children.each_with_index do |child, index|
+        walk_yaml_node(child, path + [index.to_s], duplicates)
+      end
+    end
+  end
+
+  it "keeps expected top-level sections explicit" do
+    expect(manifest.keys).to eq(PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS)
+  end
+
+  it "does not contain duplicate keys in any mapping" do
+    expect(duplicate_mapping_keys(manifest_source)).to eq([])
+  end
+
+  it "detects duplicate keys inside nested mappings" do
+    yaml = <<~YAML
+      javascript_package_root:
+        event_names:
+          state: {}
+          state: {}
+    YAML
+
+    expect(duplicate_mapping_keys(yaml)).to eq(["javascript_package_root.event_names.state"])
+  end
+
+  it "keeps grouped option key sections shaped as non-empty string lists" do
+    manifest.fetch("grouped_option_keys").each do |group_name, keys|
+      expect(group_name).to be_a(String)
+      expect(keys).to be_an(Array), "expected grouped_option_keys.#{group_name} to be an array"
+      expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
+      expect(keys).to all(be_a(String))
+    end
+  end
+
+  it "keeps JavaScript event names and detail keys in nested hash sections" do
+    javascript_manifest = manifest.fetch("javascript_package_root")
+
+    %w[event_names event_detail_keys].each do |section_name|
+      section = javascript_manifest.fetch(section_name)
+
+      expect(section).to be_a(Hash)
+      expect(section).not_to be_empty
+
+      section.each do |group_name, events|
+        expect(group_name).to be_a(String)
+        expect(events).to be_a(Hash), "expected #{section_name}.#{group_name} to map event names"
+        expect(events).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -7,8 +7,10 @@ require "yaml"
 PUBLIC_API_MANIFEST_STRUCTURE_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
 PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   module_methods
+  configuration_options
   public_constants
   helper_methods
+  helper_option_keys
   toolbar_actions
   grouped_option_keys
   javascript_package_root


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1126

Supersedes #1190

## Issue ごとの完了内容

- #1126: `config/public_api_manifest.yml` の top-level section、duplicate key、代表 nested shape を lightweight spec で固定します。
- 旧 PR #1190 の review follow-up として、最新 `main` から replacement branch を作り直しました。

## 変更内容

- `spec/public_api_manifest_structure_spec.rb` を追加しました。
- Psych AST で YAML mapping 内の duplicate key を検出します。
- expected top-level section、`grouped_option_keys` の non-empty string list shape、JavaScript event names / detail keys の nested hash shape を確認します。

## 改善カテゴリ

- test 追加
- public API manifest drift guard
- review follow-up / branch freshness recovery

## 既存仕様への影響

- runtime Ruby / JavaScript、public API surface、manifest schema、CI workflow、release workflow は変更していません。
- manifest の中身は変更せず、構造 drift を検出する spec-only 変更です。

## 実施した確認内容

- GitHub compare: `main...quality/1126-public-api-manifest-structure-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local RSpec / lint は未実行です。
  - この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- risk: low
- spec-only です。public surface の追加・削除・rename や manifest schema redesign には広げていません。

## 補足事項

- 旧 PR #1190 は current main から behind / diverged になったため、この PR を replacement として扱います。
- heavy schema validator や Node YAML parser は導入していません。