### PR TITLE
docs 日英ページセット parity spec を追加する

### DIFF
--- a/spec/docs_page_set_parity_spec.rb
+++ b/spec/docs_page_set_parity_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "spec_helper"
+
+module DocsPageSetParitySpec
+  ROOT = Pathname.new(File.expand_path("../docs", __dir__))
+  LANGUAGES = %w[en ja].freeze
+
+  DOCUMENTED_EXCEPTIONS = {
+    "en" => [].freeze,
+    "ja" => [].freeze
+  }.freeze
+
+  module_function
+
+  def markdown_pages(language)
+    Dir.glob(ROOT.join(language, "**/*.md")).map do |path|
+      Pathname.new(path).relative_path_from(ROOT.join(language)).to_s
+    end.sort
+  end
+
+  def exceptions_for(language)
+    DOCUMENTED_EXCEPTIONS.fetch(language)
+  end
+end
+
+RSpec.describe "documentation page-set parity" do
+  it "keeps English and Japanese Markdown page filenames aligned" do
+    english_pages = DocsPageSetParitySpec.markdown_pages("en")
+    japanese_pages = DocsPageSetParitySpec.markdown_pages("ja")
+
+    missing_in_japanese = english_pages - japanese_pages - DocsPageSetParitySpec.exceptions_for("ja")
+    missing_in_english = japanese_pages - english_pages - DocsPageSetParitySpec.exceptions_for("en")
+
+    aggregate_failures do
+      expect(missing_in_japanese).to eq([])
+      expect(missing_in_english).to eq([])
+    end
+  end
+
+  it "keeps documented parity exceptions tied to one-sided pages" do
+    english_pages = DocsPageSetParitySpec.markdown_pages("en")
+    japanese_pages = DocsPageSetParitySpec.markdown_pages("ja")
+
+    english_only_pages = english_pages - japanese_pages
+    japanese_only_pages = japanese_pages - english_pages
+
+    aggregate_failures do
+      expect(DocsPageSetParitySpec.exceptions_for("ja") - english_only_pages).to eq([])
+      expect(DocsPageSetParitySpec.exceptions_for("en") - japanese_only_pages).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1202

## Issue ごとの完了内容

- #1202: `docs/en/**/*.md` と `docs/ja/**/*.md` の相対ファイル名セットが一致しているかを確認する lightweight spec を追加しました。
- 例外リストは spec 内の `DOCUMENTED_EXCEPTIONS` に集約し、例外が現存する片側ページに対応していることも検証します。

## 変更内容

- `spec/docs_page_set_parity_spec.rb` を追加しました。
- `docs/en` / `docs/ja` の Markdown ファイル名のみを比較します。
- root-level docs、`docs/mockups/**`、翻訳品質、文言差分、どちらの言語を canonical とするかの判断には踏み込みません。

## 改善カテゴリ

- test 追加
- docs maintenance drift guard
- 小さな CI/spec ガード

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、UI、docs 本文、release workflow は変更していません。
- docs のページセット drift を検出する spec-only 変更です。

## 実施した確認内容

- GitHub compare: `main...quality/1202-docs-page-set-parity`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local RSpec / lint は未実行です。
  - この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- risk: low
- spec-only です。公開仕様や docs の内容判断には影響しません。

## 補足事項

- parity の対象は language tree 配下の Markdown ファイル名です。
- 一時的な片側追加が必要な場合は、Issue #1202 の範囲どおり、spec の例外リストへ明示的に追加する運用を想定しています。