### PR TITLE
root README に direction-aware styling boundary 入口を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Key documents:
 | Children pagination | [Children Pagination](docs/en/children-pagination.md) | [Children Pagination](docs/ja/children-pagination.md) |
 | Tree identity and diagnostics | [Node keys](docs/en/node-keys.md) and [Tree diagnostics](docs/en/tree-diagnostics.md) | [Node key 設計](docs/ja/node-keys.md) and [Tree diagnostics](docs/ja/tree-diagnostics.md) |
 | Rendering scale and boundaries | [Render Scale](docs/en/render-scale.md), [Lazy Loading](docs/en/lazy-loading.md), [Windowed Rendering](docs/en/windowed-rendering.md), [Rendering Boundaries](docs/en/rendering-boundaries.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [Lazy Loading](docs/ja/lazy-loading.md), [Windowed Rendering](docs/ja/windowed-rendering.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
+| Direction-aware styling boundary | [Direction-aware styling boundary](docs/en/direction-aware-styling.md) | [Direction-aware styling boundary](docs/ja/direction-aware-styling.md) |
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
 | GraphAdapter | [GraphAdapter](docs/en/graph-adapter.md) | [GraphAdapter](docs/ja/graph-adapter.md) |
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #1208

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- root `README.md` の Key documents table に `Direction-aware styling boundary` の英日リンクを追加しました。
- `docs/README.md` と `docs/en|ja/README.md` に既にある direction-aware styling boundary 入口と揃えました。
- direction-aware styling は host-app override guidance / responsibility boundary として扱い、public styling hook 化や mockup / runtime / manifest 変更には広げていません。

## 根拠

- `docs/README.md` の Recommended entry points には英日 direction-aware styling boundary が既にあります。
- `docs/en/direction-aware-styling.md` / `docs/ja/direction-aware-styling.md` は current-row cue、hierarchy connector、toggle spacing などの host-app override guidance と future public hook criteria を説明しています。
- root `README.md` の Key documents table には同じ入口がありませんでした。

## 非目標

- direction-aware styling hook の public contract 化
- RTL / vertical writing support の実装
- direction-aware focused mockup の追加
- docs 本文、mockup HTML/CSS、public API manifest、runtime code の変更
- #1200 / #1201 の判断先取り

## 確認内容

- latest main refresh: `07c43b1e3f80866f6996452ce41f0fbb6e50a054` を親に README 差分だけを再適用しました。
- head: `79ebd887297c357f9e750b280281d2e12b2435be`
- GitHub compare: `main...docs/1208-readme-direction-aware-entrypoint`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`README.md`)
  - additions: 1 / deletions: 0
- GitHub Actions CI #1593: success
  - `changes` / `lint` / `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `gem_package` / full matrices: skipped by workflow conditions
- PR metadata: `mergeable:true`
- docs-only README 変更のため local test / lint は未実行です。

## リスク

- low
- root README の導線追加のみで、仕様・コード・公開契約は変更していません。