### PR TITLE
root docs index に初回導入導線を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@
 
 ## Recommended entry points
 
+- [English first-time setup](en/installation.md): install TreeView first, then continue to [Minimal usage](en/minimal-usage.md) and [Usage](en/usage.md) for the smallest working host-app wiring.
+- [日本語初回導入](ja/installation.md): まず TreeView を導入し、続けて [最小利用例](ja/minimal-usage.md) と [使い方](ja/usage.md) で host app の最小構成を確認します。
 - [English decision guide](en/decision-guide.md): choose APIs and options by use case, including when to use GraphAdapter adapter mode for heterogeneous or graph-like nodes.
 - [日本語API判断ガイド](ja/decision-guide.md): use caseからAPIやoptionを選ぶための入口。異種node混在やgraph-like nodeでGraphAdapter adapter modeを選ぶ場面も確認できます。
 - [English API overview: adapter mode](en/api-overview.md#adapter-mode): quick GraphAdapter entry point before moving to the full API reference or cookbook performance notes.


### PR DESCRIPTION
## 対応 Issue

Closes #1210

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/README.md` の Recommended entry points に初回導入向けの英日リンクを追加しました。
- English は `Installation` から `Minimal usage` / `Usage` へ進む導線、日本語は `導入手順` から `最小利用例` / `使い方` へ進む導線にしています。
- root `README.md` と `docs/en|ja/README.md` に既にある初回導入の読み順と揃えました。

## 根拠

- root `README.md` の Key documents table には `Installation` と `Minimal usage` が英日で載っています。
- `docs/en/README.md` / `docs/ja/README.md` の goal-based shortcuts には、初回導入向けに Installation / Minimal usage / Usage の導線があります。
- `docs/README.md` の Recommended entry points には、初回導入者向けの Installation / Minimal usage 入口がありませんでした。

## 非目標

- Installation / Minimal usage / Usage 本文の改稿
- Quick Start の再設計
- minimal usage static mockup lane (#1110) の吸収
- demo app / host app CRUD example の追加
- docs navigation 全体の redesign
- runtime code / mockup HTML/CSS の変更

## 確認内容

- GitHub compare: `main...docs/1210-root-docs-first-use-entrypoints`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/README.md`)
  - additions: 2 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- cross-language docs index の導線追加のみで、仕様・コード・公開契約は変更していません。