### PR TITLE
root README から demo application boundary へ導線を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ If you already know the symptom and want a faster reverse-lookup entry point, se
 
 If you want static visual references for baseline DOM structure and interaction states before wiring a host app, see [TreeView mockups](docs/mockups/README.md). Start with [review-gallery.html](docs/mockups/review-gallery.html) for the fastest first look, open [default-tree.html](docs/mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
 
+For the boundary between static mockups and a future real Rails demo app, see [Demo application boundary](docs/en/demo-application-boundary.md) / [日本語](docs/ja/demo-application-boundary.md). The public docs intentionally avoid direct demo repository links until a demo repository is public.
+
 ## Features
 
 - Build trees from parent-child records.


### PR DESCRIPTION
## 対応 Issue

Closes #1212

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- root `README.md` の mockup guidance 直後に、英日 `demo-application-boundary.md` への導線を追加しました。
- static mockups と将来の real Rails demo app の責務境界を短く示しました。
- demo repository が public になるまで public docs から direct demo repository link を追加しない方針を明記しました。

## 根拠

- root README は TreeView が complete file-manager application / CRUD / authorization / demo data / seeds を提供しないことを説明しています。
- `docs/en/demo-application-boundary.md` / `docs/ja/demo-application-boundary.md` は static mockups と real demo app の境界、public demo repository link を増やす条件を説明しています。
- root README の mockup guidance から、その境界 docs へ直接辿る導線がありませんでした。

## 非目標

- direct demo repository link の追加
- Rails demo app の追加
- CRUD / authorization / seed data examples の追加
- mockup HTML/CSS の変更
- docs navigation 全体の redesign

## 確認内容

- GitHub compare: `main...docs/1212-readme-demo-boundary`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`README.md`)
  - additions: 2 / deletions: 0
- docs-only README 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

- low
- root README の導線追加のみで、runtime code、mockup、公開 demo repository 判断、public API 契約は変更していません。