### PR TITLE
windowed rendering の helper / boundary guard を追加する

### DIFF
--- a/spec/helpers/tree_view_window_rows_helper_spec.rb
+++ b/spec/helpers/tree_view_window_rows_helper_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+TreeViewWindowRowsHelperSpecNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+RSpec.describe "tree_view_rows window option" do
+  let(:ui_config) do
+    TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "item_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "item_button_box_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "item_show_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
+    )
+  end
+
+  let(:helper_host_class) do
+    Class.new do
+      include TreeViewHelper
+
+      attr_reader :render_calls
+
+      def initialize(tree_ui: nil)
+        @tree_ui = tree_ui
+        @render_calls = []
+      end
+
+      def render(**options)
+        render_calls << options
+        options
+      end
+    end
+  end
+
+  let(:nodes) do
+    [
+      TreeViewWindowRowsHelperSpecNode.new(id: 1, parent_item_id: nil, name: "Root"),
+      TreeViewWindowRowsHelperSpecNode.new(id: 2, parent_item_id: 1, name: "Child A"),
+      TreeViewWindowRowsHelperSpecNode.new(id: 3, parent_item_id: 1, name: "Child B")
+    ]
+  end
+  let(:tree) { TreeView::Tree.new(records: nodes, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) }) }
+
+  def build_render_state(tree:, ui_config:, empty_message: nil)
+    render_state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "items/tree_columns",
+      ui_config: ui_config
+    )
+    render_state.define_singleton_method(:empty_message) { empty_message }
+    render_state
+  end
+
+  it "renders hash window options through the window row partial" do
+    helper = helper_host_class.new(tree_ui: ui_config)
+    render_state = build_render_state(tree: tree, ui_config: ui_config)
+
+    result = helper.tree_view_rows(render_state, window: {offset: 1, limit: 2})
+
+    expect(result[:partial]).to eq("tree_view/tree_window_row")
+    expect(result[:as]).to eq(:visible_row)
+    expect(result[:collection].map(&:node_key)).to eq([2, 3])
+    expect(result[:locals].fetch(:render_context).render_state).to eq(render_state)
+    expect(helper.render_calls).to contain_exactly(result)
+  end
+
+  it "accepts a prebuilt RenderWindow instance" do
+    helper = helper_host_class.new(tree_ui: ui_config)
+    render_state = build_render_state(tree: tree, ui_config: ui_config)
+    window = helper.tree_view_window(render_state, offset: 0, limit: 1)
+
+    result = helper.tree_view_rows(render_state, window: window)
+
+    expect(result[:partial]).to eq("tree_view/tree_window_row")
+    expect(result[:collection]).to eq(window.rows)
+    expect(result[:collection].map(&:node_key)).to eq([1])
+  end
+
+  it "raises a clear error for unsupported window objects" do
+    helper = helper_host_class.new(tree_ui: ui_config)
+    render_state = build_render_state(tree: tree, ui_config: ui_config)
+
+    expect do
+      helper.tree_view_rows(render_state, window: Object.new)
+    end.to raise_error(ArgumentError, /window must be a TreeView::RenderWindow or Hash-like object/)
+  end
+
+  it "renders the empty row partial for empty windows with an empty message" do
+    helper = helper_host_class.new(tree_ui: ui_config)
+    render_state = build_render_state(tree: tree, ui_config: ui_config, empty_message: "No matching nodes")
+
+    result = helper.tree_view_rows(render_state, window: {offset: 20, limit: 5})
+
+    expect(result).to eq(
+      partial: "tree_view/tree_empty_row",
+      locals: {empty_message: "No matching nodes"}
+    )
+  end
+end

--- a/spec/helpers/tree_view_window_rows_helper_spec.rb
+++ b/spec/helpers/tree_view_window_rows_helper_spec.rb
@@ -7,9 +7,9 @@ TreeViewWindowRowsHelperSpecNode = Struct.new(:id, :parent_item_id, :name, keywo
 RSpec.describe "tree_view_rows window option" do
   let(:ui_config) do
     TreeView::UiConfig.new(
-      node_dom_id_builder: ->(item_or_id) { "item_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      button_dom_id_builder: ->(item_or_id) { "item_button_box_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" },
-      show_button_dom_id_builder: ->(item_or_id) { "item_show_button_#{item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id}" }
+      node_dom_id_builder: ->(item_or_id) { dom_id_for(item_or_id, "item") },
+      button_dom_id_builder: ->(item_or_id) { dom_id_for(item_or_id, "item_button_box") },
+      show_button_dom_id_builder: ->(item_or_id) { dom_id_for(item_or_id, "item_show_button") }
     )
   end
 
@@ -38,7 +38,18 @@ RSpec.describe "tree_view_rows window option" do
       TreeViewWindowRowsHelperSpecNode.new(id: 3, parent_item_id: 1, name: "Child B")
     ]
   end
-  let(:tree) { TreeView::Tree.new(records: nodes, parent_id_method: :parent_item_id, sorter: ->(items, _tree) { items.sort_by(&:id) }) }
+  let(:tree) do
+    TreeView::Tree.new(
+      records: nodes,
+      parent_id_method: :parent_item_id,
+      sorter: ->(items, _tree) { items.sort_by(&:id) }
+    )
+  end
+
+  def dom_id_for(item_or_id, prefix)
+    identifier = item_or_id.respond_to?(:id) ? item_or_id.id : item_or_id
+    "#{prefix}_#{identifier}"
+  end
 
   def build_render_state(tree:, ui_config:, empty_message: nil)
     render_state = TreeView::RenderState.new(

--- a/spec/lib/tree_view/windowed_rendering_boundary_spec.rb
+++ b/spec/lib/tree_view/windowed_rendering_boundary_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+WindowedRenderingBoundarySpecNode = Struct.new(:id, :parent_item_id, :name, keyword_init: true)
+
+RSpec.describe "Windowed rendering boundary guards" do
+  let(:ui_config) { TreeView::UiConfigBuilder.new(context: Object.new, node_prefix: "node").build_static }
+
+  def build_chain(length)
+    (1..length).map do |id|
+      WindowedRenderingBoundarySpecNode.new(
+        id: id,
+        parent_item_id: (id == 1) ? nil : id - 1,
+        name: "node #{id}"
+      )
+    end
+  end
+
+  def build_wide_tree(child_count:, grandchildren_per_child:)
+    records = [WindowedRenderingBoundarySpecNode.new(id: 1, parent_item_id: nil, name: "root")]
+    next_id = 2
+
+    child_count.times do |child_index|
+      child_id = next_id
+      records << WindowedRenderingBoundarySpecNode.new(id: child_id, parent_item_id: 1, name: "child #{child_index}")
+      next_id += 1
+
+      grandchildren_per_child.times do |grandchild_index|
+        records << WindowedRenderingBoundarySpecNode.new(
+          id: next_id,
+          parent_item_id: child_id,
+          name: "grandchild #{child_index}-#{grandchild_index}"
+        )
+        next_id += 1
+      end
+    end
+
+    records
+  end
+
+  def build_tree(records)
+    TreeView::Tree.new(
+      records: records,
+      parent_id_method: :parent_item_id,
+      sorter: ->(items, _tree) { items.sort_by(&:id) }
+    )
+  end
+
+  def build_render_state(tree, **options)
+    TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      **options
+    )
+  end
+
+  it "keeps representative VisibleRows structures reproducible" do
+    cases = [
+      {
+        name: "collapsed root",
+        records: build_chain(4),
+        options: {initial_state: :collapsed},
+        expected_rows: [[1, 0, nil, false]]
+      },
+      {
+        name: "expanded deep chain",
+        records: build_chain(4),
+        options: {},
+        expected_rows: [[1, 0, nil, true], [2, 1, 1, true], [3, 2, 2, true], [4, 3, 3, false]]
+      },
+      {
+        name: "wide tree with expanded root only",
+        records: build_wide_tree(child_count: 3, grandchildren_per_child: 2),
+        options: {initial_state: :collapsed, expanded_keys: [1]},
+        expected_rows: [[1, 0, nil, true], [2, 1, 1, false], [5, 1, 1, false], [8, 1, 1, false]]
+      }
+    ]
+
+    cases.each do |test_case|
+      tree = build_tree(test_case.fetch(:records))
+      rows = TreeView::VisibleRows.new(
+        tree: tree,
+        root_items: tree.root_items,
+        render_state: build_render_state(tree, **test_case.fetch(:options))
+      ).to_a
+
+      aggregate_failures("#{test_case.fetch(:name)} records=#{test_case.fetch(:records).map(&:id).join(",")}") do
+        expect(rows.map { |row| [row.node_key, row.depth, row.parent_key, row.expanded?] }).to eq(test_case.fetch(:expected_rows))
+      end
+    end
+  end
+
+  it "keeps RenderWindow boundary metadata stable across representative offsets" do
+    rows = (1..8).to_a
+    cases = [
+      {
+        name: "first page",
+        offset: 0,
+        limit: 3,
+        window_rows: [1, 2, 3],
+        before_count: 0,
+        after_count: 5,
+        start_index: 0,
+        end_index: 3,
+        previous_offset: nil,
+        next_offset: 3,
+        previous: false,
+        next: true
+      },
+      {
+        name: "middle page",
+        offset: 3,
+        limit: 3,
+        window_rows: [4, 5, 6],
+        before_count: 3,
+        after_count: 2,
+        start_index: 3,
+        end_index: 6,
+        previous_offset: 0,
+        next_offset: 6,
+        previous: true,
+        next: true
+      },
+      {
+        name: "tail page",
+        offset: 6,
+        limit: 3,
+        window_rows: [7, 8],
+        before_count: 6,
+        after_count: 0,
+        start_index: 6,
+        end_index: 8,
+        previous_offset: 3,
+        next_offset: nil,
+        previous: true,
+        next: false
+      },
+      {
+        name: "beyond total count",
+        offset: 11,
+        limit: 3,
+        window_rows: [],
+        before_count: 8,
+        after_count: 0,
+        start_index: 8,
+        end_index: 0,
+        previous_offset: 8,
+        next_offset: nil,
+        previous: true,
+        next: false
+      },
+      {
+        name: "empty source",
+        source_rows: [],
+        offset: 0,
+        limit: 3,
+        window_rows: [],
+        before_count: 0,
+        after_count: 0,
+        start_index: 0,
+        end_index: 0,
+        previous_offset: nil,
+        next_offset: nil,
+        previous: false,
+        next: false
+      }
+    ]
+
+    cases.each do |test_case|
+      source_rows = test_case.fetch(:source_rows, rows)
+      window = TreeView::RenderWindow.new(source_rows, offset: test_case.fetch(:offset), limit: test_case.fetch(:limit))
+
+      aggregate_failures("#{test_case.fetch(:name)} offset=#{test_case.fetch(:offset)} limit=#{test_case.fetch(:limit)} total=#{source_rows.length}") do
+        expect(window.to_a).to eq(test_case.fetch(:window_rows))
+        expect(window.before_count).to eq(test_case.fetch(:before_count))
+        expect(window.after_count).to eq(test_case.fetch(:after_count))
+        expect(window.start_index).to eq(test_case.fetch(:start_index))
+        expect(window.end_index).to eq(test_case.fetch(:end_index))
+        expect(window.previous_offset).to eq(test_case.fetch(:previous_offset))
+        expect(window.next_offset).to eq(test_case.fetch(:next_offset))
+        expect(window.previous?).to eq(test_case.fetch(:previous))
+        expect(window.next?).to eq(test_case.fetch(:next))
+      end
+    end
+  end
+end

--- a/spec/lib/tree_view/windowed_rendering_boundary_spec.rb
+++ b/spec/lib/tree_view/windowed_rendering_boundary_spec.rb
@@ -63,19 +63,31 @@ RSpec.describe "Windowed rendering boundary guards" do
         name: "collapsed root",
         records: build_chain(4),
         options: {initial_state: :collapsed},
-        expected_rows: [[1, 0, nil, false]]
+        expected_rows: [
+          [1, 0, nil, false]
+        ]
       },
       {
         name: "expanded deep chain",
         records: build_chain(4),
         options: {},
-        expected_rows: [[1, 0, nil, true], [2, 1, 1, true], [3, 2, 2, true], [4, 3, 3, false]]
+        expected_rows: [
+          [1, 0, nil, true],
+          [2, 1, 1, true],
+          [3, 2, 2, true],
+          [4, 3, 3, false]
+        ]
       },
       {
         name: "wide tree with expanded root only",
         records: build_wide_tree(child_count: 3, grandchildren_per_child: 2),
         options: {initial_state: :collapsed, expanded_keys: [1]},
-        expected_rows: [[1, 0, nil, true], [2, 1, 1, false], [5, 1, 1, false], [8, 1, 1, false]]
+        expected_rows: [
+          [1, 0, nil, true],
+          [2, 1, 1, false],
+          [5, 1, 1, false],
+          [8, 1, 1, false]
+        ]
       }
     ]
 
@@ -87,8 +99,12 @@ RSpec.describe "Windowed rendering boundary guards" do
         render_state: build_render_state(tree, **test_case.fetch(:options))
       ).to_a
 
-      aggregate_failures("#{test_case.fetch(:name)} records=#{test_case.fetch(:records).map(&:id).join(",")}") do
-        expect(rows.map { |row| [row.node_key, row.depth, row.parent_key, row.expanded?] }).to eq(test_case.fetch(:expected_rows))
+      aggregate_failures(visible_rows_case_description(test_case)) do
+        row_summaries = rows.map do |row|
+          [row.node_key, row.depth, row.parent_key, row.expanded?]
+        end
+
+        expect(row_summaries).to eq(test_case.fetch(:expected_rows))
       end
     end
   end
@@ -96,7 +112,7 @@ RSpec.describe "Windowed rendering boundary guards" do
   it "keeps RenderWindow boundary metadata stable across representative offsets" do
     rows = (1..8).to_a
     cases = [
-      {
+      render_window_case(
         name: "first page",
         offset: 0,
         limit: 3,
@@ -109,8 +125,8 @@ RSpec.describe "Windowed rendering boundary guards" do
         next_offset: 3,
         previous: false,
         next: true
-      },
-      {
+      ),
+      render_window_case(
         name: "middle page",
         offset: 3,
         limit: 3,
@@ -123,8 +139,8 @@ RSpec.describe "Windowed rendering boundary guards" do
         next_offset: 6,
         previous: true,
         next: true
-      },
-      {
+      ),
+      render_window_case(
         name: "tail page",
         offset: 6,
         limit: 3,
@@ -137,8 +153,8 @@ RSpec.describe "Windowed rendering boundary guards" do
         next_offset: nil,
         previous: true,
         next: false
-      },
-      {
+      ),
+      render_window_case(
         name: "beyond total count",
         offset: 11,
         limit: 3,
@@ -151,8 +167,8 @@ RSpec.describe "Windowed rendering boundary guards" do
         next_offset: nil,
         previous: true,
         next: false
-      },
-      {
+      ),
+      render_window_case(
         name: "empty source",
         source_rows: [],
         offset: 0,
@@ -166,14 +182,14 @@ RSpec.describe "Windowed rendering boundary guards" do
         next_offset: nil,
         previous: false,
         next: false
-      }
+      )
     ]
 
     cases.each do |test_case|
       source_rows = test_case.fetch(:source_rows, rows)
       window = TreeView::RenderWindow.new(source_rows, offset: test_case.fetch(:offset), limit: test_case.fetch(:limit))
 
-      aggregate_failures("#{test_case.fetch(:name)} offset=#{test_case.fetch(:offset)} limit=#{test_case.fetch(:limit)} total=#{source_rows.length}") do
+      aggregate_failures(render_window_case_description(test_case, total: source_rows.length)) do
         expect(window.to_a).to eq(test_case.fetch(:window_rows))
         expect(window.before_count).to eq(test_case.fetch(:before_count))
         expect(window.after_count).to eq(test_case.fetch(:after_count))
@@ -185,5 +201,17 @@ RSpec.describe "Windowed rendering boundary guards" do
         expect(window.next?).to eq(test_case.fetch(:next))
       end
     end
+  end
+
+  def visible_rows_case_description(test_case)
+    "#{test_case.fetch(:name)} records=#{test_case.fetch(:records).map(&:id).join(",")}"
+  end
+
+  def render_window_case(**options)
+    options
+  end
+
+  def render_window_case_description(test_case, total:)
+    "#{test_case.fetch(:name)} offset=#{test_case.fetch(:offset)} limit=#{test_case.fetch(:limit)} total=#{total}"
   end
 end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #824
Closes #1118

## Issue ごとの完了内容

- #824: `VisibleRows` の collapsed / expanded deep chain / wide tree の代表構造と、`RenderWindow` の first / middle / tail / beyond / empty source の境界 metadata を deterministic な spec で固定しました。
- #1118: `tree_view_rows(render_state, window:)` が Hash-like window option と prebuilt `TreeView::RenderWindow` を受け、window row partial / empty row partial へ渡す代表経路を helper-level spec で固定しました。unsupported window object の `ArgumentError` も確認します。

## 変更内容

- `spec/lib/tree_view/windowed_rendering_boundary_spec.rb` を追加
  - VisibleRows の代表 traversal を seed 相当の records / case name 付きで確認
  - RenderWindow の offset / limit / before/after / start/end / previous/next 境界を table-driven に確認
- `spec/helpers/tree_view_window_rows_helper_spec.rb` を追加
  - helper host の `render` 呼び出しを記録し、public helper entrypoint が期待する partial / collection / locals を渡すことを確認

## 改善カテゴリ

- test 追加
- helper-level regression guard
- windowed rendering boundary guard

## 既存仕様への影響

- runtime code、public API、helper behavior、partials、docs、mockups、DB、認可、外部 API は変更していません。
- `TreeView::RenderWindow` の pagination math は既存 spec に任せつつ、今回の spec では代表 boundary と helper integration に閉じています。

## 実施した確認内容

- GitHub compare: `main...quality/824-1118-render-window-guards`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 2 spec files only
- local RSpec / standardrb: 未実行
  - この実行環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗します。
  - この実行環境には Ruby がなく、`ruby -v` は `command not found` でした。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- risk: low
- spec-only の quality guard です。new dependency、property-based framework、windowed rendering API 変更、virtual scrolling、tree row partial redesign には広げていません。

## 補足事項

- #824 と #1118 はどちらも windowed rendering / RenderWindow 周辺の low-risk test guard で、同じ representative boundary を守るため1つのPRにまとめています。