### PR TITLE
selection data hook を package root export として最新 main で再提案する

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -76,6 +76,13 @@ export const TreeViewControllerIdentifiers = Object.freeze({
   remoteState: "tree-view-remote-state"
 })
 
+export const TreeViewSelectionDataHooks = Object.freeze({
+  hiddenInputNameValue: "data-tree-view-selection-hidden-input-name-value",
+  maxCountValue: "data-tree-view-selection-max-count-value",
+  cascadeValue: "data-tree-view-selection-cascade-value",
+  indeterminateValue: "data-tree-view-selection-indeterminate-value"
+})
+
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
   application.register("tree-view-client", TreeViewClientController)

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -104,6 +104,7 @@ javascript_package_root:
   named_exports:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
+    - TreeViewSelectionDataHooks
     - TreeViewTransferDropPositions
     - TreeViewStateController
     - TreeViewClientController
@@ -202,3 +203,8 @@ javascript_package_root:
         - row
       invalid_transfer:
         - value
+  selection_data_hooks:
+    hidden_input_name_value: data-tree-view-selection-hidden-input-name-value
+    max_count_value: data-tree-view-selection-max-count-value
+    cascade_value: data-tree-view-selection-cascade-value
+    indeterminate_value: data-tree-view-selection-indeterminate-value

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -169,6 +169,7 @@ Stable enough for host apps to use:
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
 - `TreeViewControllerIdentifiers`
+- `TreeViewSelectionDataHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -182,6 +183,7 @@ Stable enough for host apps to use:
 
 `TreeViewEventNames` exposes the documented event names as a machine-readable package-root export. Use it when wiring host-app listeners and you want to avoid hand-copying event-name strings such as `TreeViewEventNames.selection.change` or `TreeViewEventNames.transfer.drop`.
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
+`TreeViewSelectionDataHooks` exposes the documented `tree-view-selection` host-element value attribute names as a machine-readable object. Use it when JavaScript needs to author or query those host-owned attributes without hand-copying strings such as `TreeViewSelectionDataHooks.hiddenInputNameValue`.
 
 Within `TreeViewEventNames`, lazy-loading request lifecycle names live under `hostLifecycle`:
 
@@ -200,6 +202,13 @@ Documented keys on `TreeViewControllerIdentifiers`:
 - `transfer`
 - `remoteState`
 
+Documented keys on `TreeViewSelectionDataHooks`:
+
+- `hiddenInputNameValue`
+- `maxCountValue`
+- `cascadeValue`
+- `indeterminateValue`
+
 The `tree-view-selection` controller's documented host-element value attributes are also part of the stable host-app wiring surface:
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -207,9 +216,9 @@ The `tree-view-selection` controller's documented host-element value attributes 
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
+Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
-The machine-readable source of truth for the package-root JavaScript exports and bundled controller identifiers lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, and selection data hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 
 Internal by default:
 
@@ -229,12 +238,12 @@ Representative documented hooks are tracked where their feature behavior is expl
 | Hook area | Representative hooks | Contract boundary |
 |---|---|---|
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | TreeView-owned hooks documented in [Toolbar](toolbar.md). Use helper methods for supported actions and metadata instead of internal constants. |
-| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Stable host-element controller values documented in [Selection](selection.md). Row payloads and disabled decisions stay with `selection:` render-state builders. |
+| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Stable host-element controller values documented in [Selection](selection.md) and mirrored by `TreeViewSelectionDataHooks`. Row payloads and disabled decisions stay with `selection:` render-state builders. Generated hidden input marker attributes and source-id attributes are TreeView-managed internals. |
 | Lazy loading | `data-tree-remote-state`, remote placeholder IDs, lazy-loading lifecycle events | Stable placeholder and event hooks documented in [Lazy Loading](lazy-loading.md). Host apps still own request dispatch and response handling. |
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | Reusable baseline hooks documented in the [mockup inventory](../mockups/README.md). They describe the shipped empty-state reference pattern, not every internal row class. |
 | Interaction markers | marker row classes and `data-*` hooks shown in focused mockups | Reference hooks documented through [mockups](../mockups/README.md) for review and adoption. Promote any hook to a machine-readable contract in `config/public_api_manifest.yml` only when it needs compatibility checks. |
 
-This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
+This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, selection data hooks, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
 
 Undocumented CSS helper classes, data attributes, DOM structure details, and gem partial locals are implementation details.
 

--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -132,10 +132,19 @@ When the tree sits inside a normal HTML form, the same controller can mirror che
 
 With `data-tree-view-selection-hidden-input-name-value`, TreeView writes one hidden input per valid checked payload and keeps those inputs in sync on connect, change, submit, and manual refresh.
 
+If your host app already imports the package root, use `TreeViewSelectionDataHooks.hiddenInputNameValue` when you need to reference the host-authored attribute name from JavaScript without hand-copying the raw string.
+
+```js
+import { TreeViewSelectionDataHooks } from "tree_view"
+
+const hiddenInputNameAttribute = TreeViewSelectionDataHooks.hiddenInputNameValue
+```
+
 - The hidden input `name` stays host-app controlled.
 - Values are written as JSON strings, so `TreeView.parse_selection_params(params[:selected_nodes])` keeps working.
 - Disabled checkboxes and invalid JSON payloads are skipped, matching the existing event payload behavior.
 - If the tree is not inside a form, TreeView keeps dispatching selection events and does not create hidden inputs.
+- Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks.
 
 When one form contains multiple `tree-view-selection` controllers, TreeView tags each generated hidden input with `data-tree-view-selection-source-id` so one controller only removes and rewrites its own generated inputs. If the controller element already has `data-tree-view-selection-source-id`, TreeView reuses that value; otherwise it assigns a generated source id on connect. Use separate `data-tree-view-selection-hidden-input-name-value` names when the host app wants separate submitted params for each tree. Reuse a name only when the server-side action intentionally accepts one combined array.
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -169,6 +169,7 @@ host app が使ってよい入口:
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
 - `TreeViewControllerIdentifiers`
+- `TreeViewSelectionDataHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -182,6 +183,7 @@ host app が使ってよい入口:
 
 `TreeViewEventNames` は documented event names を machine-readable に参照するための package-root export です。host app 側で listener を配線するとき、`TreeViewEventNames.selection.change` や `TreeViewEventNames.transfer.drop` のように使うことで event name string の写経を避けられます。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
+`TreeViewSelectionDataHooks` は、documented された `tree-view-selection` host-element value attribute names を machine-readable object として公開します。JavaScript が host-owned attribute を author / query するとき、`TreeViewSelectionDataHooks.hiddenInputNameValue` のように使うことで string の写経を避けられます。
 
 `TreeViewEventNames` のうち、lazy-loading の request lifecycle 名は `hostLifecycle` にまとめています。
 
@@ -200,6 +202,13 @@ host app が使ってよい入口:
 - `transfer`
 - `remoteState`
 
+`TreeViewSelectionDataHooks` の documented key:
+
+- `hiddenInputNameValue`
+- `maxCountValue`
+- `cascadeValue`
+- `indeterminateValue`
+
 `tree-view-selection` controller の documented host-element value attribute も、stable な host-app wiring surface の一部です。
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -207,9 +216,9 @@ host app が使ってよい入口:
 - `data-tree-view-selection-cascade-value`
 - `data-tree-view-selection-indeterminate-value`
 
-これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
+これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する内部寄りの属性であり、host app が authoring する public hook ではありません。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
-package-root の JavaScript export と bundled controller identifier の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+package-root の JavaScript export、bundled controller identifier、selection data hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 
 内部扱い:
 
@@ -229,12 +238,12 @@ host app が依存してよい browser-facing surface は、documented された
 | hook area | 代表 hook | contract boundary |
 |---|---|---|
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | [Toolbar](toolbar.md) で説明している TreeView-owned hook です。supported action や metadata は internal constant ではなく helper method から取得してください。 |
-| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | [Selection](selection.md) で説明している stable host-element controller value です。row payload や disabled 判定は `selection:` render-state builder 側に残ります。 |
+| Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | [Selection](selection.md) で説明している stable host-element controller value であり、`TreeViewSelectionDataHooks` からも参照できます。row payload や disabled 判定は `selection:` render-state builder 側に残ります。generated hidden input marker attribute と source-id attribute は TreeView-managed internal です。 |
 | Lazy loading | `data-tree-remote-state`, remote placeholder ID, lazy-loading lifecycle events | [Lazy Loading](lazy-loading.md) で説明している stable placeholder / event hook です。request dispatch と response handling は引き続き host app 側の責務です。 |
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | [mockup inventory](../mockups/README.md) で説明している reusable baseline hook です。shipped empty-state reference pattern を示すもので、すべての internal row class を公開するものではありません。 |
 | Interaction markers | focused mockup に出てくる marker row classes / `data-*` hooks | review / adoption 用の reference hook として [mockups](../mockups/README.md) で説明します。compatibility check が必要な hook だけを `config/public_api_manifest.yml` の machine-readable contract へ昇格してください。 |
 
-この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
+この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、selection data hook、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
 
 undocumented な CSS helper class、data attribute、DOM 構造詳細、gem partial 内部 locals は内部実装です。
 

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -132,10 +132,19 @@ tree が通常の HTML form の中にある場合、同じ controller で checke
 
 `data-tree-view-selection-hidden-input-name-value` を指定すると、TreeView は valid な checked payload ごとに hidden input を 1 つずつ生成し、connect / change / submit / manual refresh に追従して同期します。
 
+host app が package root をすでに import している場合、JavaScript から host-authored attribute name を参照するときは `TreeViewSelectionDataHooks.hiddenInputNameValue` を使うと raw string の写経を避けられます。
+
+```js
+import { TreeViewSelectionDataHooks } from "tree_view"
+
+const hiddenInputNameAttribute = TreeViewSelectionDataHooks.hiddenInputNameValue
+```
+
 - hidden input の `name` は host app 側で決められます。
 - value は JSON 文字列で書き込まれるため、`TreeView.parse_selection_params(params[:selected_nodes])` をそのまま使えます。
 - disabled checkbox と不正な JSON payload は既存 event と同じく skip されます。
 - tree が form の外にある場合は、selection event だけを dispatch し、hidden input は生成しません。
+- generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する内部寄りの属性であり、host app が authoring する public hook ではありません。
 
 1つの form に複数の `tree-view-selection` controller がある場合、TreeView は生成した hidden input に `data-tree-view-selection-source-id` を付けます。これにより、各 controller は自分が生成した hidden input だけを削除・再生成します。controller element に `data-tree-view-selection-source-id` がすでにある場合はその値を使い、なければ connect 時に自動生成します。tree ごとに別々の params として受け取りたい場合は、`data-tree-view-selection-hidden-input-name-value` に別々の名前を指定してください。同じ名前を使うのは、server-side action が1つの配列としてまとめて受け取る設計のときに限ります。
 

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -152,6 +152,13 @@ assert(
 )
 assertFrozenObject(entrypointModule.TreeViewControllerIdentifiers, "TreeViewControllerIdentifiers")
 
+const expectedSelectionDataHooks = deepCamelizeKeys(javascriptPackageManifest.selection_data_hooks)
+assert(
+  JSON.stringify(entrypointModule.TreeViewSelectionDataHooks) === JSON.stringify(expectedSelectionDataHooks),
+  "TreeViewSelectionDataHooks export is out of sync"
+)
+assertFrozenObject(entrypointModule.TreeViewSelectionDataHooks, "TreeViewSelectionDataHooks")
+
 const expectedRegistrations = javascriptPackageManifest.controller_registrations.map(({ identifier, export: exportName }) => {
   assert(exportName in entrypointModule, `${exportName} export is missing`)
   return [identifier, entrypointModule[exportName]]


### PR DESCRIPTION
## 対応 Issue / PR

- Closes #890
- Supersedes #908

## 変更内容

#908 が現在の `main` と conflict していたため、最新 `main` (`e5c9e546d79f5374c26dc04e27401cb5062bc1aa`) から同内容を再適用しました。

- `TreeViewSelectionDataHooks` を package root export として追加
- `config/public_api_manifest.yml` に selection data hook values を追加
- entrypoint smoke check で manifest との同期と frozen object を検証
- 英語 / 日本語 docs に公開 API と selection hook 境界を追記

## 既存仕様への影響

既存の controller behavior、attribute 名、render-state selection builders の責務は変更していません。host app が既存の raw attribute string を使い続ける動作にも影響しない、追加の公開 export と docs / contract 追跡です。

## 確認

- GitHub compare: `main...feature/890-selection-data-hooks-export-refresh` が `behind_by: 0`
- PR metadata: `mergeable: true`
- GitHub Actions: CI #1537 success
- 変更ファイルは #908 と同じ 7 ファイル

## リスク

低。公開済みの selection host-element value attribute names を machine-readable export として追加する変更で、既存 API の削除・rename・挙動変更はありません。