### PR TITLE
toolbar action contract を最新 main で再提案する

### DIFF
--- a/docs/en/toolbar.md
+++ b/docs/en/toolbar.md
@@ -45,6 +45,12 @@ Supported actions:
 
 `collapse_all_except_current_path` is a host-app contract. TreeView only emits the toolbar action and state value.
 
+## Machine-readable contract
+
+The toolbar action/state mapping is also tracked in `config/public_api_manifest.yml` under `toolbar_actions`. The manifest maps each supported action name to the `toggle_all_path` state value used by the helper.
+
+Host apps should prefer `tree_view_toolbar_supported_actions`, `tree_view_toolbar_actions`, or `tree_view_toolbar_action_metadata` when building custom toolbar markup. The manifest exists for compatibility checks and integration audits; internal constants remain implementation details.
+
 ## Visual reference
 
 For a static comparison of expand-all, collapse-all, and current-path-preserving toolbar states, see [toolbar-actions.html](../mockups/toolbar-actions.html).

--- a/docs/ja/toolbar.md
+++ b/docs/ja/toolbar.md
@@ -45,6 +45,12 @@ tree_ui = TreeView::UiConfigBuilder.new(
 
 `collapse_all_except_current_path` はhost appとのcontractです。TreeViewはtoolbar actionとstate値を出すだけです。
 
+## machine-readable contract
+
+toolbar action と state の対応は `config/public_api_manifest.yml` の `toolbar_actions` でも管理します。この manifest は supported action name から、helper が `toggle_all_path` に渡す state value への mapping です。
+
+host app が独自 toolbar markup を組み立てる場合は、raw string を手書きするより `tree_view_toolbar_supported_actions`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` を使ってください。manifest は compatibility check と integration audit のための source of truth であり、internal constants は引き続き implementation detail です。
+
 ## Visual reference
 
 expand-all、collapse-all、current path を残す toolbar state を静的に見比べたい場合は [toolbar-actions.html](../mockups/toolbar-actions.html) を参照してください。

--- a/spec/public_api_toolbar_contract_spec.rb
+++ b/spec/public_api_toolbar_contract_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_view"
+require "action_view/helpers"
+require "yaml"
+
+RSpec.describe "Toolbar public API contract" do
+  let(:manifest) do
+    YAML.safe_load_file(File.expand_path("../config/public_api_manifest.yml", __dir__)).fetch("toolbar_actions")
+  end
+  let(:helper_class) do
+    Class.new do
+      include ActionView::Context
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::UrlHelper
+      include ActionView::Helpers::OutputSafetyHelper
+      include ActionView::Helpers::FormTagHelper
+      include TreeViewHelper
+    end
+  end
+  let(:helper) { helper_class.new }
+  let(:ui_config) do
+    TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" },
+      toggle_all_path_builder: ->(state) { "/tree?state=#{state}" }
+    )
+  end
+  let(:render_state) { instance_double(TreeView::RenderState, ui_config: ui_config) }
+
+  it "keeps supported toolbar actions aligned with the manifest" do
+    expect(helper.tree_view_toolbar_supported_actions.map(&:to_s)).to eq(manifest.keys)
+  end
+
+  it "keeps toolbar action states and action data aligned with the manifest" do
+    manifest.each do |action_name, state_name|
+      metadata = helper.tree_view_toolbar_action_metadata(render_state, action_name)
+
+      expect(metadata.fetch(:action).to_s).to eq(action_name)
+      expect(metadata.fetch(:state).to_s).to eq(state_name)
+      expect(metadata.fetch(:data).fetch(:tree_view_toolbar_action).to_s).to eq(action_name)
+      expect(metadata.fetch(:data)).not_to have_key(:tree_view_toolbar_disabled)
+    end
+  end
+
+  it "keeps disabled toolbar data hooks available for custom toolbar markup" do
+    static_ui_config = TreeView::UiConfig.new(
+      node_dom_id_builder: ->(item_or_id) { "node_#{item_or_id}" },
+      button_dom_id_builder: ->(item_or_id) { "button_#{item_or_id}" },
+      show_button_dom_id_builder: ->(item_or_id) { "show_button_#{item_or_id}" }
+    )
+    static_render_state = instance_double(TreeView::RenderState, ui_config: static_ui_config)
+
+    metadata = helper.tree_view_toolbar_action_metadata(static_render_state, :expand_all)
+
+    expect(metadata.fetch(:data)).to include(
+      tree_view_toolbar_action: :expand_all,
+      tree_view_toolbar_disabled: true
+    )
+  end
+end


### PR DESCRIPTION
## 対応 Issue / PR

- Closes #922
- Supersedes #953

## 変更内容

#953 が現在の `main` と conflict / diverged していたため、最新 `main` (`4d7733c1626ef98e6250072e3d9dda463de68190`) から同じ目的の差分を再適用しました。

現在の `main` には `config/public_api_manifest.yml` の `toolbar_actions` が action-to-state mapping として既に存在しているため、manifest の構造変更は行わず、最新形式に合わせて以下だけを追加しています。

- `spec/public_api_toolbar_contract_spec.rb` で manifest の action/state mapping と `tree_view_toolbar_*` helper metadata の整合を固定
- disabled toolbar metadata の `tree_view_toolbar_action` / `tree_view_toolbar_disabled` data hook を spec で固定
- `docs/en/toolbar.md` / `docs/ja/toolbar.md` に machine-readable contract と helper 経由利用の境界を追記

## 最新 main への追従で保持した内容

現在の `main` に入っている public API manifest の簡略 `toolbar_actions` mapping、JavaScript package-root contract、lazy-loading / transfer / configuration 関連の manifest 拡張を保持しています。

## 既存仕様への影響

runtime behavior、toolbar rendering、supported actions、path generation、labels、JavaScript controller、authorization、route / Turbo response は変更していません。spec と docs の contract 固定に限定しています。

## 確認

- GitHub compare: `main...feature/922-toolbar-public-contract-refresh`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- ローカル RSpec はこの環境の GitHub HTTPS 制限で実行不可のため、PR 作成後の GitHub Actions で確認します。

## リスク

medium。既存の toolbar action/state を manifest-backed contract として明示する変更です。public surface の追加ではなく、既存 helper behavior の互換性固定に留めています。