### PR TITLE
keyboard current-row mockup を最新 main で再提案する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -20,6 +20,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 | [interaction-states.html](interaction-states.html) | Lazy-loading, loading, error/retry, next-page, and drag/drop visual states. |
 | [reduced-motion-state-cues.html](reduced-motion-state-cues.html) | Focused low-motion reference for loading, retry, current/selected, and drop-target cues that remain readable without animation. |
 | [keyboard-focus-states.html](keyboard-focus-states.html) | Focused keyboard reference showing static focus-visible samples for toggle links, native controls, toolbar actions, and row actions without promising a full keyboard model. |
+| [keyboard-current-row/index.html](keyboard-current-row/index.html) | Focused keyboard reference comparing focus-visible cues, current-row styling, expansion state, and host-app-owned row actions in one tree. |
 | [high-contrast-state-cues/index.html](high-contrast-state-cues/index.html) | Focused high-contrast reference for current, selected, focus-visible, error/retry, and drop-target cues that remain distinguishable beyond color alone. |
 | [lazy-loading-handoff.html](lazy-loading-handoff.html) | Focused lazy-loading reference showing children container ownership, remote-state placeholder handoff, and error/retry slot boundaries. |
 | [drop-positions.html](drop-positions.html) | Focused comparison for before, inside, and after drop-position cues plus transfer disabled / invalid payload boundary states. |
@@ -52,25 +53,26 @@ They are **not** a complete Rails application and should not grow into host-app 
 8. Use [interaction-states.html](interaction-states.html) when review needs a focused pass on lazy loading, retry, pagination placeholders, or drag/drop states.
 9. Use [reduced-motion-state-cues.html](reduced-motion-state-cues.html) when review needs to compare loading, retry, current/selected, and drop-target cues that remain readable without animation.
 10. Use [keyboard-focus-states.html](keyboard-focus-states.html) when review needs to compare visible focus cues across toggle links, native controls, toolbar actions, and row actions without treating the mockup as a keyboard navigation contract.
-11. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
-12. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
-13. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
-14. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
-15. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
-16. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
-17. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-18. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
-19. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
-20. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
-21. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
-22. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
-23. Use [localized-row-labels.html](localized-row-labels.html) when review needs to compare long localized row labels, type badges, attribute labels, secondary metadata, and tooltip cues without deciding final host-app translations.
-24. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
-25. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
-26. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
-27. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
-28. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
-29. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
+11. Use [keyboard-current-row/index.html](keyboard-current-row/index.html) when review needs to compare focus-visible cues beside `aria-current="page"`, expanded/collapsed rows, and host-app-owned row actions in the same tree.
+12. Use [high contrast state cues](high-contrast-state-cues/index.html) when review needs to compare current, selected, focus-visible, error/retry, and drop-target cues without relying on color alone.
+13. Use [lazy-loading-handoff.html](lazy-loading-handoff.html) when review needs to isolate children container ownership and remote-state slot handoff from the broader interaction-state page.
+14. Use [drop-positions.html](drop-positions.html) when review needs to compare before, inside, after, transfer disabled, and invalid transfer boundary cues without modeling host-app reorder rules or persistence.
+15. Use [persisted-state-boundary.html](persisted-state-boundary.html) when review needs to compare persisted expansion state before, changed, restored, save-failed, and retry cues without adding host-app persistence behavior.
+16. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
+17. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
+18. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
+19. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+20. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
+21. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
+22. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.
+23. Use [node-presenter-row-partials.html](node-presenter-row-partials.html) when review needs to compare NodePresenter-provided row partial values against host-app-owned columns, permissions, and final actions.
+24. Use [localized-row-labels.html](localized-row-labels.html) when review needs to compare long localized row labels, type badges, attribute labels, secondary metadata, and tooltip cues without deciding final host-app translations.
+25. Use [form-editing-rows.html](form-editing-rows.html) when review needs to compare bulk edit rows, per-row edit action placement, or selection-versus-business checkbox roles without adding a real save workflow.
+26. Use [selection-max-count.html](selection-max-count.html) when review needs to compare below-limit, limit-reached, and limit-exceeded selection feedback without adding runtime behavior or final bulk-action copy.
+27. Use [selection-multi-tree-form.html](selection-multi-tree-form.html) when review needs to compare multiple TreeView selection groups in one form, source-specific counts, and generated hidden input sync boundaries. Treat its hidden input rows as a review aid; [Selection](../en/selection.md#hidden-input-sync-for-regular-form-submit) is the contract for per-payload hidden input sync.
+28. Use [empty-state.html](empty-state.html) when review needs a focused pass on no-root-items or no-results rows, the reusable empty-row wrapper hook, or the host-app-owned copy boundary.
+29. Use [toolbar-actions.html](toolbar-actions.html) when review needs a focused pass on expand, collapse, collapse-to-current-path, or long/localized label wrapping affordances instead of row-by-row hierarchy layout.
+30. Keep host-app wording, permissions, routes, and business actions out of this directory even when the gallery highlights a gap.
 
 ## Automated smoke coverage
 
@@ -125,6 +127,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 ## Keyboard focus guidance
 
 - Use `keyboard-focus-states.html` to review static focus-visible cues across representative focus targets.
+- Use `keyboard-current-row/index.html` when the review needs to compare focus, current-row, expansion, and row-action cues together.
 - Use the [high contrast state cues](high-contrast-state-cues/index.html) focused subpage when the review question is whether state cues remain distinguishable without relying on color alone.
 - Keep tab order, shortcut keys, roving tabindex, and full treegrid keyboard behavior in the host app or a separate implementation issue.
 

--- a/docs/mockups/keyboard-current-row/index.html
+++ b/docs/mockups/keyboard-current-row/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeView keyboard focus and current-row mockup</title>
+<link rel="stylesheet" href="../default-tree.css">
+<style>
+.keyboard-current-page { max-width: 1180px; }
+.keyboard-current-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 18px; }
+.keyboard-current-summary__item { border: 1px solid #d8e0ea; border-radius: 8px; background: #fff; padding: 14px; }
+.keyboard-current-summary__item strong { display: block; margin-bottom: 0.35rem; color: #102a43; }
+.keyboard-current-layout { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr); gap: 20px; align-items: start; }
+.keyboard-current-demo { overflow-x: auto; border: 1px solid #d8e0ea; border-radius: 8px; background: #fff; }
+.keyboard-current-demo .tree-view { min-width: 820px; margin: 0; }
+.keyboard-current-focus { outline: 3px solid #2563eb; outline-offset: 3px; box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.16); }
+.keyboard-current-row { background: #eff6ff; }
+.keyboard-current-row .tree-leaf-label, .keyboard-current-row .tree-toggle__action { font-weight: 700; }
+.keyboard-current-note-list { display: grid; gap: 12px; }
+.keyboard-current-note { border: 1px solid #d8e0ea; border-radius: 8px; background: #f8fafc; padding: 14px; }
+.keyboard-current-note h3, .keyboard-current-note p { margin: 0; }
+.keyboard-current-note h3 { margin-bottom: 0.4rem; color: #102a43; }
+.keyboard-current-state-list { margin: 0; padding-left: 1.2rem; }
+.keyboard-current-action { display: inline-flex; align-items: center; min-height: 1.9rem; padding: 0.3rem 0.55rem; border: 1px solid #cbd5e1; border-radius: 8px; background: #fff; color: #1d4ed8; font: inherit; font-weight: 700; }
+.keyboard-current-action[data-tree-view-interactive]::after { content: "interactive"; margin-left: 0.45rem; color: #64748b; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; }
+@media (max-width: 760px) { .keyboard-current-layout { grid-template-columns: 1fr; } .keyboard-current-demo .tree-view { min-width: 720px; } }
+</style>
+</head>
+<body>
+  <main class="mock-page keyboard-current-page">
+    <header class="mock-header">
+      <p class="mock-kicker">focused mockup</p>
+      <h1>Keyboard focus and current-row cues</h1>
+      <p>Static reference for comparing focus-visible rings, the current-row cue, expanded or collapsed rows, and host-app-owned row actions in one scan. The page does not add keyboard behavior; it only keeps the visual states reviewable.</p>
+      <nav class="mock-page-nav" aria-label="Mockup navigation">
+        <a href="../review-gallery.html">Back to gallery</a>
+        <a href="../README.md">Mockup README</a>
+        <a href="../keyboard-focus-states.html">Focus-only reference</a>
+      </nav>
+      <div class="keyboard-current-summary" aria-label="Review summary">
+        <div class="keyboard-current-summary__item"><strong>TreeView-owned cues</strong>Expanded, collapsed, current row, and visible focus markers remain readable without changing public behavior.</div>
+        <div class="keyboard-current-summary__item"><strong>Host-app boundary</strong>Row actions and interactive controls stay marked as app-owned behavior, not a TreeView routing or permission contract.</div>
+        <div class="keyboard-current-summary__item"><strong>Static comparison</strong>Representative rings and current-row highlights are shown at once so review does not depend on live keyboard interaction.</div>
+      </div>
+    </header>
+
+    <section class="mock-section keyboard-current-layout" aria-labelledby="current-focus-heading">
+      <div>
+        <h2 id="current-focus-heading">Current row beside focused row</h2>
+        <div class="keyboard-current-demo">
+          <table class="tree-view" aria-label="Keyboard focus and current-row comparison">
+            <thead><tr><th scope="col">Node</th><th scope="col">Visual state</th><th scope="col">ARIA sample</th><th scope="col">Row action</th></tr></thead>
+            <tbody>
+              <tr class="tree-row tree-row--expanded"><td><a href="#" class="tree-toggle__action keyboard-current-focus" aria-expanded="true">Operations handbook</a></td><td><span class="tree-badge">Focused expanded parent</span></td><td><code>aria-expanded="true"</code></td><td><button type="button" class="keyboard-current-action" data-tree-view-interactive>Open</button></td></tr>
+              <tr class="tree-row tree-row--child keyboard-current-row" aria-current="page"><td><span class="tree-leaf-label">Release checklist</span></td><td><span class="tree-badge">Current row</span></td><td><code>aria-current="page"</code></td><td><button type="button" class="keyboard-current-action" data-tree-view-interactive>Preview</button></td></tr>
+              <tr class="tree-row tree-row--child tree-row--expanded keyboard-current-row" aria-current="page"><td><a href="#" class="tree-toggle__action keyboard-current-focus" aria-expanded="true">Incident response</a></td><td><span class="tree-badge">Current and focused</span></td><td><code>aria-current="page" aria-expanded="true"</code></td><td><button type="button" class="keyboard-current-action" data-tree-view-interactive>Assign</button></td></tr>
+              <tr class="tree-row tree-row--child tree-row--collapsed"><td><a href="#" class="tree-toggle__action" aria-expanded="false">Archived playbooks</a></td><td><span class="tree-muted">Collapsed sibling</span></td><td><code>aria-expanded="false"</code></td><td><button type="button" class="keyboard-current-action" data-tree-view-interactive>Open</button></td></tr>
+              <tr class="tree-row tree-row--leaf"><td><span class="tree-leaf-label">Postmortem template</span></td><td><span class="tree-muted">Leaf row with action focus</span></td><td><span class="tree-muted">No expansion attribute</span></td><td><button type="button" class="keyboard-current-action keyboard-current-focus" data-tree-view-interactive>Copy</button></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <aside class="keyboard-current-note-list" aria-label="Responsibility notes">
+        <div class="keyboard-current-note"><h3>Focus versus current</h3><p>The focus ring marks the active keyboard target. The current-row cue marks the app's current item. They can appear on different rows or on the same row.</p></div>
+        <div class="keyboard-current-note"><h3>Expanded and collapsed rows</h3><p>The mockup keeps expansion icons and state text visible so current or focus styling does not hide the hierarchy cue.</p></div>
+        <div class="keyboard-current-note"><h3>Interactive controls</h3><p>Buttons marked with <code>data-tree-view-interactive</code> represent host-app-owned actions. The mockup does not define routes, authorization, or final action copy.</p></div>
+      </aside>
+    </section>
+
+    <section class="mock-section" aria-labelledby="boundary-heading">
+      <h2 id="boundary-heading">Review boundaries</h2>
+      <ul class="keyboard-current-state-list">
+        <li>Use this page to compare focus-visible and current-row styling when both cues are present in the same tree.</li>
+        <li>Use <a href="../keyboard-focus-states.html">keyboard-focus-states.html</a> when review only needs representative focus targets without current-row context.</li>
+        <li>Keep tab order, arrow-key behavior, roving tabindex, routes, permissions, and business actions outside this static mockup.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -47,6 +47,7 @@ const focusedMockupSmokeTargets = [
   { file: "interaction-states.html", sample: ".tree-view-table tbody tr", minimumCount: 5 },
   { file: "reduced-motion-state-cues.html", sample: "[data-tree-view-sample='reduced-motion-state-cues'] .tree-view-table tbody tr", minimumCount: 5 },
   { file: "keyboard-focus-states.html", sample: ".focus-sample, .focus-sample--soft", minimumCount: 5 },
+  { file: "keyboard-current-row/index.html", sample: ".keyboard-current-row, .keyboard-current-focus", minimumCount: 3 },
   { file: "high-contrast-state-cues/index.html", sample: "[data-tree-view-sample='high-contrast-state-cues']", minimumCount: 1 },
   { file: "lazy-loading-handoff.html", sample: ".tree-view-table tbody tr", minimumCount: 4 },
   { file: "drop-positions.html", sample: ".tree-view-table tbody tr", minimumCount: 3 },


### PR DESCRIPTION
## 対応 Issue / PR

- Closes #736
- Supersedes #967

## 変更内容

#967 が現在の `main` と conflict / diverged していたため、最新 `main` (`4d7733c1626ef98e6250072e3d9dda463de68190`) から対象差分を再適用しました。

- `docs/mockups/keyboard-current-row/index.html` を追加
  - focus-visible cue と current-row cue が別行にある状態
  - focus-visible cue と `aria-current="page"` が同じ行に重なる状態
  - expanded / collapsed row の代表状態
  - `data-tree-view-interactive` 付き row action の host-app-owned 境界
- `docs/mockups/README.md` に file entry、review flow、keyboard focus guidance を追加

## 最新 main への追従で整理した内容

古い #967 branch には、その後 `main` 側で進んだ toggle icon / high contrast / node presenter / selection form などの mockup 導線差分も混ざっていました。今回は #736 の対象である `keyboard-current-row` に差分を絞り、既に最新 `main` にある他の mockup 導線は再編集していません。

## 既存仕様への影響

runtime JavaScript、ARIA behavior、keyboard navigation、Ruby helper、public API、route / authorization / business action は変更していません。static mockup と README 導線に限定しています。

## 確認

- GitHub compare: `main...design/736-keyboard-current-row-refresh`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- ローカル browser smoke はこの環境の GitHub HTTPS 制限で実行不可のため、PR 作成後の GitHub Actions で確認します。

## リスク

low。static mockup と docs link の追加のみです。review-gallery への再編集は、古いbranch由来の unrelated mockup 差分を混ぜないため、この置き換えPRでは行っていません。