### PR TITLE
release docs の packaged files list を英日検証対象に同期する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -152,10 +152,12 @@ Before release:
   - `config/importmap.tree_view.rb`
   - `config/public_api_manifest.yml`
   - `config/locales/tree_view.toolbar.en.yml`
+  - `config/locales/tree_view.toolbar.ja.yml`
   - `README.md`
   - `CHANGELOG.md`
   - `docs/**/*`
   - `docs/en/release.md`
+  - `docs/ja/release.md`
   - `LICENSE*`
 
 ## Repository

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -152,10 +152,12 @@ release前に確認すること:
   - `config/importmap.tree_view.rb`
   - `config/public_api_manifest.yml`
   - `config/locales/tree_view.toolbar.en.yml`
+  - `config/locales/tree_view.toolbar.ja.yml`
   - `README.md`
   - `CHANGELOG.md`
   - `docs/**/*`
   - `docs/en/release.md`
+  - `docs/ja/release.md`
   - `LICENSE*`
 
 ## Repository


### PR DESCRIPTION
## 対応 Issue

Closes #1221

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/release.md` の Gem package checklist に `config/locales/tree_view.toolbar.ja.yml` と `docs/ja/release.md` を追加しました。
- `docs/ja/release.md` も同じ代表 path を明示し、英日 toolbar locale / release docs が package verification 対象として読めるようにしました。

## 根拠

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATHS` は `config/locales/tree_view.toolbar.en.yml` / `config/locales/tree_view.toolbar.ja.yml` と `docs/en/release.md` / `docs/ja/release.md` を要求しています。
- 既存 release checklist は `docs/**/*` を包括的に載せていますが、代表確認対象として日本語 locale / 日本語 release docs が埋もれていました。

## 非目標

- `script/check_gem_package_contents.rb` の変更
- `tree_view.gemspec` / `.github/workflows/ci.yml` / `config/locales/**` の変更
- release automation、version bump、tag 作成、gem publish 手順の変更
- release docs 全体の rewrite

## 確認内容

- GitHub compare: `main...docs/1221-release-packaged-files-list`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 4 / deletions: 0
- docs-only checklist 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

low。release checklist の代表 path 明示のみで、package verification の実行条件や release 手順は変更していません。