### PR TITLE
TreeView::Configuration を public API manifest に同期する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -122,15 +122,8 @@ javascript_package_root:
       limit_exceeded: tree-view-selection:limit-exceeded
       invalid_payload: tree-view-selection:invalid-payload
     remote_state:
-      change:
-        - row
-        - state
-        - childrenUrl
-        - nodeKey
-      retry:
-        - row
-        - childrenUrl
-        - nodeKey
+      change: tree-view-remote-state:change
+      retry: tree-view-remote-state:retry
     host_lifecycle:
       loading: tree-view:loading
       loaded: tree-view:loaded

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -14,6 +14,7 @@ public_constants:
   - DuplicateNodeKeyError
   - CycleDetectedError
   - InvalidRenderWindowError
+  - Configuration
   - LocalizedNames
   - Tree
   - RenderState
@@ -121,8 +122,15 @@ javascript_package_root:
       limit_exceeded: tree-view-selection:limit-exceeded
       invalid_payload: tree-view-selection:invalid-payload
     remote_state:
-      change: tree-view-remote-state:change
-      retry: tree-view-remote-state:retry
+      change:
+        - row
+        - state
+        - childrenUrl
+        - nodeKey
+      retry:
+        - row
+        - childrenUrl
+        - nodeKey
     host_lifecycle:
       loading: tree-view:loading
       loaded: tree-view:loaded


### PR DESCRIPTION
## 対応 Issue

Closes #969

## 変更内容

- `config/public_api_manifest.yml` の `public_constants` に `Configuration` を追加しました。
- current main の `docs/en/public-api.md` / `docs/ja/public-api.md` には、すでに Public option surface として `TreeView::Configuration` が記載されているため、docs 本文は重複更新していません。

## 受け入れ条件との対応

- `TreeView::Configuration` を public constant として扱う方針を machine-readable manifest に反映しました。
- public API docs は current main の既存記述で `TreeView::Configuration` を option surface として案内しています。
- runtime behavior、configuration semantics、new configuration option、render log behavior、DB、認可、JavaScript は変更していません。

## 改善カテゴリ

- docs-sync
- public API contract guard

## 既存仕様への影響

- なし。manifest の additive change のみです。

## 実施した確認

- GitHub compare: `main...feature/969-configuration-public-surface-refresh`
  - changed files: 1
- CI は PR 作成後に GitHub Actions で確認します。

## リスク

- medium
- public compatibility surface の additive change です。ただし既に `TreeView.configuration` の返り値として露出している class を manifest に同期するだけで、runtime 挙動は変更していません。

## 補足

- #1020 が current main に対して conflict していたため、同じ intent を現行 main 向けの置き換え PR として作成しています。