### PR TITLE
Diagnostics の public contract を manifest と spec で固定する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -81,6 +81,19 @@ grouped_option_keys:
     - row_disabled_builder
     - row_readonly_builder
     - row_disabled_reason_builder
+diagnostics:
+  accepted_checks:
+    - node_keys
+    - dom_ids
+    - orphans
+    - cycles
+  result_surface:
+    attributes:
+      - checks
+      - errors
+      - warnings
+    methods:
+      - success?
 javascript_package_root:
   named_exports:
     - registerTreeViewControllers

--- a/docs/en/tree-diagnostics.md
+++ b/docs/en/tree-diagnostics.md
@@ -74,6 +74,8 @@ end
 
 `Result#success?` only reflects collected errors. Orphan reports are warnings, so review `warnings` when filtered, imported, or permission-scoped data can leave records outside the rendered tree.
 
+The manifest-backed diagnostics contract covers the accepted check names and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
+
 ## Node key uniqueness
 
 Enable validation when building the tree to catch duplicate node keys early.

--- a/docs/ja/tree-diagnostics.md
+++ b/docs/ja/tree-diagnostics.md
@@ -74,6 +74,8 @@ end
 
 `Result#success?` は収集されたerrorsだけを見ます。orphan reportはwarningsとして返るため、filter、import、permission scopeによって描画対象外のrecordsが生じる可能性がある場合は `warnings` も確認してください。
 
+manifest-backed な diagnostics contract は、accepted check names と `Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
+
 ## node key uniqueness
 
 node keyの重複を検出したい場合は、tree作成時にvalidationを有効にします。

--- a/spec/public_api_diagnostics_compatibility_spec.rb
+++ b/spec/public_api_diagnostics_compatibility_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "Diagnostics public API compatibility" do
+  let(:manifest_path) { File.expand_path("../config/public_api_manifest.yml", __dir__) }
+  let(:diagnostics_manifest) { YAML.safe_load_file(manifest_path).fetch("diagnostics") }
+
+  it "keeps Diagnostics accepted checks aligned with the manifest" do
+    expect(diagnostics_manifest.fetch("accepted_checks")).to eq(TreeView::Diagnostics::DEFAULT_CHECKS.map(&:to_s))
+  end
+
+  it "keeps Diagnostics::Result reader surface aligned with the manifest" do
+    result = TreeView::Diagnostics::Result.new(checks: [], errors: [], warnings: [])
+
+    diagnostics_manifest.fetch("result_surface").fetch("attributes").each do |attribute_name|
+      expect(result).to respond_to(attribute_name.to_sym),
+        "expected TreeView::Diagnostics::Result##{attribute_name} to remain public"
+    end
+
+    diagnostics_manifest.fetch("result_surface").fetch("methods").each do |method_name|
+      expect(result).to respond_to(method_name.to_sym),
+        "expected TreeView::Diagnostics::Result##{method_name} to remain public"
+    end
+
+    expect(result.success?).to eq(true)
+
+    failed_result = TreeView::Diagnostics::Result.new(
+      checks: [:node_keys],
+      errors: [{check: :node_keys, message: "duplicate node key"}],
+      warnings: []
+    )
+
+    expect(failed_result.success?).to eq(false)
+  end
+end


### PR DESCRIPTION
Diagnostics の accepted checks と Result surface を manifest-backed contract として固定します。

## 対応 Issue

Closes #1227

## 変更内容

- `config/public_api_manifest.yml` に `diagnostics` section を追加しました。
  - accepted checks: `node_keys`, `dom_ids`, `orphans`, `cycles`
  - Result attributes: `checks`, `errors`, `warnings`
  - Result methods: `success?`
- `spec/public_api_diagnostics_compatibility_spec.rb` を追加し、manifest と runtime surface の drift を検出できるようにしました。
- `docs/en/tree-diagnostics.md` / `docs/ja/tree-diagnostics.md` に、manifest-backed contract の対象と非対象を短く同期しました。

## 受け入れ条件との対応

- Diagnostics accepted checks と Result surface を manifest-backed contract に含めました。
- `TreeView::Diagnostics::DEFAULT_CHECKS` と manifest の accepted checks を spec で照合します。
- `TreeView::Diagnostics::Result` の reader / method surface を spec で照合します。
- docs では accepted checks / Result surface を stable public contract として説明しつつ、error entry internals、warning detail shape、orphan warning semantics、cycle validation policy は manifest で固定しない境界を明記しました。

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_api_diagnostics_compatibility_spec.rb`
- `docs/en/tree-diagnostics.md`
- `docs/ja/tree-diagnostics.md`

Diagnostics の実行挙動、check 種別、Result runtime shape、orphan / cycle / error collection policy は変更していません。

## 実施した確認

- GitHub compare: `main...feature/1227-diagnostics-public-contract-current`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- local `bundle exec rspec spec/public_api_diagnostics_compatibility_spec.rb` は未実行です。
  - この環境では GitHub HTTPS checkout/fetch が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。
- PR 作成後に GitHub Actions を確認します。

## リスク

- medium
- public contract を強める変更ですが、accepted checks と Result reader surface の最小範囲に閉じ、diagnostics behavior や詳細 semantics は固定しすぎないようにしています。

## 未対応・補足

- `spec/public_api_compatibility_spec.rb` 本体の大規模再編は行っていません。
- #357 の diagnostics 拡張、heavy fuzz / property-based testing、check 種別追加は扱っていません。