### PR TITLE
StateStore の failure boundary spec を追加する

### DIFF
--- a/spec/lib/tree_view/state_store_failure_boundary_spec.rb
+++ b/spec/lib/tree_view/state_store_failure_boundary_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe TreeView::StateStore do
+  let(:model) { double("persisted state model") }
+  let(:store) { described_class.new(model: model) }
+
+  it "propagates backing model save failures" do
+    error_class = Class.new(StandardError)
+    error = error_class.new("database unavailable")
+    record = double("persisted state record")
+
+    allow(record).to receive(:expanded_keys=).with(["node-1"])
+    allow(record).to receive(:save!).and_raise(error)
+    allow(model).to receive(:find_or_initialize_by)
+      .with(owner: :user, tree_instance_key: "documents")
+      .and_return(record)
+
+    expect do
+      store.save!(owner: :user, tree_instance_key: "documents", expanded_keys: ["node-1"])
+    end.to raise_error(error_class, "database unavailable")
+  end
+
+  it "coerces expanded keys before attempting to save" do
+    record = double("persisted state record", expanded_keys: ["node-1"])
+
+    allow(record).to receive(:expanded_keys=).with(["node-1"])
+    allow(record).to receive(:save!).and_return(true)
+    allow(model).to receive(:find_or_initialize_by)
+      .with(owner: :user, tree_instance_key: "documents")
+      .and_return(record)
+
+    state = store.save!(owner: :user, tree_instance_key: "documents", expanded_keys: "node-1")
+
+    expect(state).to be_a(TreeView::PersistedState)
+    expect(state.tree_instance_key).to eq("documents")
+    expect(state.expanded_keys).to eq(["node-1"])
+  end
+
+  it "propagates backing model destroy failures" do
+    error_class = Class.new(StandardError)
+    error = error_class.new("destroy failed")
+    record = double("persisted state record")
+
+    allow(record).to receive(:destroy!).and_raise(error)
+    allow(model).to receive(:find_by)
+      .with(owner: :user, tree_instance_key: "documents")
+      .and_return(record)
+
+    expect do
+      store.clear!(owner: :user, tree_instance_key: "documents")
+    end.to raise_error(error_class, "destroy failed")
+  end
+
+  it "treats clearing a missing record as an empty persisted state" do
+    allow(model).to receive(:find_by)
+      .with(owner: :user, tree_instance_key: "documents")
+      .and_return(nil)
+
+    state = store.clear!(owner: :user, tree_instance_key: "documents")
+
+    expect(state).to be_a(TreeView::PersistedState)
+    expect(state.tree_instance_key).to eq("documents")
+    expect(state.expanded_keys).to eq([])
+  end
+end


### PR DESCRIPTION
## 対応 Issue
- Closes #1238

## Issue ごとの完了内容
- #1238: `TreeView::StateStore#save!` が backing model の `save!` failure を握りつぶさないことを代表 spec で固定しました。
- #1238: `TreeView::StateStore#clear!` が backing model の `destroy!` failure を握りつぶさないことを代表 spec で固定しました。
- #1238: record が存在しない `clear!` が empty `TreeView::PersistedState` を返す no-op 境界を spec で固定しました。
- #1238: `expanded_keys` が保存前に `Array(...)` 相当で配列化され、戻り値の `PersistedState` と矛盾しないことを確認しました。

## 変更内容
- `spec/lib/tree_view/state_store_failure_boundary_spec.rb` を追加し、StateStore の failure boundary と missing-record clear no-op を確認する regression spec を追加しました。
- runtime code、public API、migration、controller、authorization、host-app retry UI は変更していません。

## 改善カテゴリ
- test
- error handling boundary guard

## 既存仕様への影響
- なし。実装変更はなく、既存の failure propagation / no-op contract を spec で固定するだけです。

## 実施した確認内容
- GitHub connector で main との差分が追加 spec 1 ファイルのみであることを確認しました。
- この実行環境では GitHub HTTPS clone が `CONNECT tunnel failed, response 403` で失敗したため、`bundle exec rspec spec/lib/tree_view/state_store_failure_boundary_spec.rb` はローカル実行できていません。GitHub Actions の結果で確認します。

## リスク評価
- low。test-only 変更で、runtime 挙動は変わりません。

## 補足事項
- storage adapter abstraction、migration schema、controller concern、authorization、host-app retry / notification UI には広げていません。