### PR TITLE
mockup 変更時の browser smoke 重複実行を避ける

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
         run: npx playwright install --with-deps chromium
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.mockups_changed == 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed == 'true'
         run: npm run test:browser
 
   gem_package:


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1233

## Issue ごとの完了内容

- #1233: docs-only mockup PR では standalone `npm run test:browser` を維持します。
- #1233: non-docs PR では `npm run test:js` に含まれる browser smoke と standalone `npm run test:browser` が重複しないようにしました。
- #1233: job name や branch protection surface は変更していません。

## 変更内容

- `.github/workflows/ci.yml` の standalone browser smoke step を、docs-only mockup PR のみに限定しました。
- non-docs PR / workflow変更PR / test変更PR は従来どおり `npm run test:js` を通り、その中で browser smoke が実行されます。

## 改善カテゴリ

- CI 改善
- devops cleanup

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、docs/mockups の内容、package verification、Rails matrix は変更していません。
- `npm install` / `npm ci` 方針にも触れていません。

## 実施した確認内容

- GitHub compare: `main...quality/1233-browser-smoke-dedupe`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- ローカル workflow 実行は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後の GitHub Actions で確認します。

## リスク評価

- risk: low
- workflow condition の限定変更です。docs-only mockup では standalone browser smoke が残り、non-docs PR では `test:js` 内の browser smoke を利用します。