### PR TITLE
root README に large-tree strategy docs への入口を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Key documents:
 | Drag and drop | [Drag and Drop](docs/en/drag-and-drop.md) | [Drag and Drop](docs/ja/drag-and-drop.md) |
 | Children pagination | [Children Pagination](docs/en/children-pagination.md) | [Children Pagination](docs/ja/children-pagination.md) |
 | Tree identity and diagnostics | [Node keys](docs/en/node-keys.md) and [Tree diagnostics](docs/en/tree-diagnostics.md) | [Node key 設計](docs/ja/node-keys.md) and [Tree diagnostics](docs/ja/tree-diagnostics.md) |
-| Rendering scale and boundaries | [Render Scale](docs/en/render-scale.md), [Rendering Boundaries](docs/en/rendering-boundaries.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
+| Rendering scale and boundaries | [Render Scale](docs/en/render-scale.md), [Lazy Loading](docs/en/lazy-loading.md), [Windowed Rendering](docs/en/windowed-rendering.md), [Rendering Boundaries](docs/en/rendering-boundaries.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [Lazy Loading](docs/ja/lazy-loading.md), [Windowed Rendering](docs/ja/windowed-rendering.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
 | GraphAdapter | [GraphAdapter](docs/en/graph-adapter.md) | [GraphAdapter](docs/ja/graph-adapter.md) |
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #1246

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- root `README.md` の Key documents table にある `Rendering scale and boundaries` 行へ、`Lazy Loading` と `Windowed Rendering` の英日リンクを追加しました。
- 既存の `Render Scale`、`Rendering Boundaries`、`Render log level` の導線は維持しました。
- `Children Pagination` の既存行、docs/README.md、language README の entrypoint とは重複を増やしすぎない最小変更に留めています。

## 根拠

- root README の本文と Features は large-tree strategy として Render Scale / Lazy Loading / Children Pagination / host-app virtual scrolling を案内しています。
- docs/README.md と docs/en|ja/README.md では Lazy Loading / Windowed Rendering が既に recommended entry point として整理されています。
- root README の Key documents table では Lazy Loading / Windowed Rendering への直接入口が薄かったため、table から辿れるようにしました。

## 非目標

- large-tree strategy docs 本文の rewrite
- lazy-loading / windowed rendering API の変更
- virtual scrolling implementation の追加
- mockup HTML/CSS、public API manifest、CI の変更

## 確認内容

- GitHub compare: `main...docs/1246-readme-large-tree-entrypoints`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`README.md`)
  - additions: 1 / deletions: 1
- docs-only README 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

low。root README の導線補強のみで、仕様・コード・公開契約は変更していません。