### PR TITLE
Public API docs に TreeViewEventDetailKeys export を明記する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -171,6 +171,7 @@ Stable enough for host apps to use:
 
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
+- `TreeViewEventDetailKeys`
 - `TreeViewTransferDropPositions`
 - `TreeViewControllerIdentifiers`
 - exported controller classes
@@ -185,6 +186,7 @@ Stable enough for host apps to use:
 `registerTreeViewControllers(application)` registers the five controller exports above with the documented identifiers in the bundled entrypoint order.
 
 `TreeViewEventNames` exposes the documented event names as a machine-readable package-root export. Use it when wiring host-app listeners and you want to avoid hand-copying event-name strings such as `TreeViewEventNames.selection.change` or `TreeViewEventNames.transfer.drop`.
+`TreeViewEventDetailKeys` exposes the documented `event.detail` key lists as a machine-readable package-root export. Use it when host-app tests or listeners need to compare against the documented key names without changing the payload shape; the field meanings still live in [JavaScript event contract](js-events.md).
 `TreeViewTransferDropPositions` exposes the documented coarse drop-position values for transfer events: `before`, `inside`, and `after`. `TreeViewEventNames.transfer.*` names transfer events, `TreeViewEventDetailKeys.transfer.*` lists the documented `event.detail` keys, and `TreeViewTransferDropPositions` carries the position values described in [Drag and Drop](drag-and-drop.md#drop-behavior).
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -171,6 +171,7 @@ host app が使ってよい入口:
 
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
+- `TreeViewEventDetailKeys`
 - `TreeViewTransferDropPositions`
 - `TreeViewControllerIdentifiers`
 - exported controller classes
@@ -185,6 +186,7 @@ host app が使ってよい入口:
 `registerTreeViewControllers(application)` は、上記 5 つの controller export を bundled entrypoint の documented identifier 順に登録します。
 
 `TreeViewEventNames` は documented event names を machine-readable に参照するための package-root export です。host app 側で listener を配線するとき、`TreeViewEventNames.selection.change` や `TreeViewEventNames.transfer.drop` のように使うことで event name string の写経を避けられます。
+`TreeViewEventDetailKeys` は documented `event.detail` key list を machine-readable に参照するための package-root export です。host app の test や listener が documented key name と照合したい場合に使えますが、payload shape 自体は変えません。各 field の意味は [JavaScript event contract](js-events.md) を正本にしてください。
 `TreeViewTransferDropPositions` は transfer event の粗い drop-position value として、`before`、`inside`、`after` を公開します。`TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented な `event.detail` key、`TreeViewTransferDropPositions` は [Drag and Drop](drag-and-drop.md#drop処理) で説明している position value を表します。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
 


### PR DESCRIPTION
## 対応 Issue

Closes #1252

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の JavaScript surface list に `TreeViewEventDetailKeys` を明示しました。
- `TreeViewEventNames` は event name、`TreeViewEventDetailKeys` は documented `event.detail` key list であることを短く説明しました。
- payload shape や field meaning の正本は `docs/en|ja/js-events.md` に残す責務境界を明記しました。

## 根拠

- `config/public_api_manifest.yml` は `TreeViewEventDetailKeys` を package-root named export として列挙しています。
- `script/test_entrypoints.mjs` は `TreeViewEventDetailKeys` と manifest の `event_detail_keys` の同期と freeze を確認しています。
- 既存 JavaScript event docs は `TreeViewEventDetailKeys` の用途を説明済みでしたが、Public API docs の stable JavaScript surface list では export 名が見つけにくい状態でした。

## 非目標

- `TreeViewEventDetailKeys` の実装変更
- event detail key の追加・削除・rename
- event payload shape の変更
- TypeScript declaration の追加
- Public API docs 全体の rewrite

## 確認内容

- GitHub compare: `main...docs/1252-event-detail-keys-public-api`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 4 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

low。既存の package-root export を Public API docs で見つけやすくするだけで、runtime JavaScript、manifest、entrypoint smoke、event contract は変更していません。