### PR TITLE
entrypoint smoke で manifest 未記載 export を検出する

### DIFF
--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -127,10 +127,20 @@ assert(
   "registerTreeViewControllers export is missing"
 )
 
+const documentedNamedExports = new Set(javascriptPackageManifest.named_exports)
 const missingNamedExports = javascriptPackageManifest.named_exports.filter((exportName) => !(exportName in entrypointModule))
 assert(
   missingNamedExports.length === 0,
   `named exports are out of sync: ${missingNamedExports.join(", ")}`
+)
+
+const undocumentedNamedExports = Object.keys(entrypointModule).filter((exportName) => !documentedNamedExports.has(exportName))
+assert(
+  undocumentedNamedExports.length === 0,
+  [
+    `entrypoint exports are missing from config/public_api_manifest.yml: ${undocumentedNamedExports.join(", ")}`,
+    "Add the export to javascript_package_root.named_exports and the relevant docs/smoke coverage, or stop exporting it from app/javascript/tree_view/index.js."
+  ].join("\n")
 )
 
 const expectedIdentifiers = Object.fromEntries(


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1251

## Issue ごとの完了内容

- #1251: package-root JavaScript entrypoint に manifest 未記載の named export が増えた場合、entrypoint smoke が失敗する guard を追加しました。

## 変更内容

- `script/test_entrypoints.mjs` に actual entrypoint exports -> `javascript_package_root.named_exports` の逆方向チェックを追加しました。
- 既存の manifest-listed export 欠落チェックは維持し、余剰 export がある場合は manifest / docs / smoke coverage を同期するか export を止めるよう failure message で案内します。

## 改善カテゴリ

- test 追加
- public JavaScript surface drift guard
- 小さな保守性改善

## 既存仕様への影響

- runtime JavaScript、public export、manifest schema、event payload、controller behavior は変更していません。
- `TreeViewEventNames` / `TreeViewEventDetailKeys` / controller identifiers など既存 contract はそのままです。

## 実施した確認内容

- GitHub compare: `main...quality/1251-entrypoint-extra-export-guard`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_entrypoints.mjs`)
- local `npm run test:entrypoints` / `npm run test:js` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。PR 作成後に GitHub Actions を確認します。

## リスク評価

- risk: low
- smoke check の追加のみです。今後 export を追加する PR は manifest/docs/smoke を同時更新する必要がありますが、現在の公開挙動は変わりません。