### PR TITLE
Decision guide に toggle mode 選択の入口を追加する

### DIFF
--- a/docs/en/decision-guide.md
+++ b/docs/en/decision-guide.md
@@ -9,6 +9,18 @@ TreeView APIs fall into two broad groups:
 
 Use render controls first when the data is already available. Use lazy loading or children pagination when fetching all children up front is the problem. Use host-app JavaScript when the problem is full scroll-position-driven DOM virtualization.
 
+## Choose the toggle mode first
+
+Before tuning render depth or loading strategy, decide how each tree should open and close rows.
+
+| Mode | Start with | Choose it when | Host app owns |
+|---|---|---|---|
+| Static | `UiConfigBuilder#build_static` | The tree is a read-only snapshot, or the screen should not open collapsed descendants in the browser. | Which records are included before rendering and whether another page/action changes the view. |
+| Turbo | `UiConfigBuilder#build_turbo` | Opening a row should call host-app routes and return a Turbo Stream response, or unloaded children must be fetched later. | `show_descendants_path_builder`, `hide_descendants_path_builder`, routes, authorization, controller actions, queries, and Turbo Stream responses. |
+| Client-side | `UiConfigBuilder#build_client_side` | All rows in the render scope can be emitted in the initial HTML and browser-local show/hide behavior is enough. | Initial HTML size, JavaScript registration, row scope, and any business action after the user opens rows. |
+
+Use Turbo mode for lazy loading or children pagination. Client-side mode can only reveal rows already present in the initial DOM, so it is not a replacement for server-side fetching. If toggle links already render but do not work, use [Troubleshooting](troubleshooting.md#toggle-links-do-not-expand-or-collapse) as the reverse-lookup entry point.
+
 ## Start from the use case
 
 | I want to... | Start with | Key options or APIs | Notes |
@@ -134,3 +146,4 @@ flowchart TD
 - [Drag and Drop](drag-and-drop.md)
 - [Persisted State](persisted-state.md)
 - [Tree diagnostics](tree-diagnostics.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/ja/decision-guide.md
+++ b/docs/ja/decision-guide.md
@@ -9,6 +9,18 @@ TreeViewのAPIは大きく分けると次の2種類です。
 
 データがすでに取得済みなら、まず描画制御を使います。全ての子要素を先に取得すること自体が問題なら、Lazy LoadingやChildren Paginationを使います。scroll位置に応じたDOM仮想化が問題なら、host app側のJavaScriptで実装します。
 
+## 先にtoggle modeを選ぶ
+
+render depthやloading strategyを細かく決める前に、そのtree instanceで行をどう開閉するかを決めます。
+
+| Mode | まず使うAPI | 向いている場面 | host appが担当すること |
+|---|---|---|---|
+| Static | `UiConfigBuilder#build_static` | treeをread-only snapshotとして見せたい、またはcollapsed descendantsをbrowser上で開かせない画面。 | 描画前にどのrecordsを含めるか、別画面や別actionでviewを切り替えるか。 |
+| Turbo | `UiConfigBuilder#build_turbo` | 行を開くとhost app routeへrequestし、Turbo Stream responseで差し替えたい場合。あとから子要素を取得する必要がある場合。 | `show_descendants_path_builder`、`hide_descendants_path_builder`、routes、authorization、controller actions、queries、Turbo Stream responses。 |
+| Client-side | `UiConfigBuilder#build_client_side` | render scope内の全行を初期HTMLに含められ、browser内のshow/hideだけで足りる場合。 | 初期HTML量、JavaScript登録、row scope、ユーザーが行を開いた後の業務action。 |
+
+Lazy LoadingやChildren PaginationにはTurbo modeを使います。Client-side modeは初期DOMに存在する行だけを表示できます。server-side fetchingの代替にはなりません。toggle linkは表示されているが動かない場合は、症状別の逆引きとして [Troubleshooting](troubleshooting.md#toggle-links-do-not-expand-or-collapse) を参照してください。
+
 ## やりたいことから選ぶ
 
 | やりたいこと | まず使うAPI | 主なoption / API | 補足 |


### PR DESCRIPTION
## 対応 Issue

Closes #1261

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/en/decision-guide.md` / `docs/ja/decision-guide.md` に toggle mode 選択の短い入口を追加しました。
- Static / Turbo / Client-side mode について、最初に見る API、向いている場面、host app が持つ責務を表で整理しました。
- Lazy Loading / Children Pagination は Turbo mode、Client-side mode は初期 DOM に存在する行だけを表示できる、という境界を明記しました。
- toggle link が既に表示されているが動かない場合の逆引きとして Troubleshooting へリンクしました。

## 根拠

- `docs/en|ja/usage.md` は `UiConfigBuilder#build_static` / `build_turbo` / `build_client_side` の挙動を説明しています。
- `docs/en|ja/troubleshooting.md` は症状発生後の mode 確認を案内しています。
- Issue #1261 は導入前に decision guide から mode selection を読める docs entrypoint 補強を求めています。

## 非目標

- `UiConfigBuilder` API の変更
- Turbo endpoint / route generator の追加
- client-side toggle behavior の変更
- troubleshooting docs 全体の rewrite
- focused mockup 追加 lane (#1260) の吸収

## 確認内容

- base: `main` (`0ae49b4700fa332e26563cc2ba579857a9ae0845`)
- head: `9e74083e6c611356a7be16d4c3be7fd108fc1e9e`
- GitHub compare: `main...docs/1261-toggle-mode-decision-guide`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 25 / deletions: 0
- PR metadata: `mergeable: true`
- GitHub Actions CI #1607: success
  - `changes` / `lint` / `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `gem_package` / full matrices: skipped by workflow conditions
- docs-only 変更のため local test / lint は未実行です。

## リスク

low。既存 Usage / Troubleshooting の mode boundary を decision guide の入口に戻すだけで、runtime Ruby / JavaScript、public API manifest、mockup HTML/CSS は変更していません。