### PR TITLE
docs index に Children Pagination 入口を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@
 - [日本語Selection](ja/selection.md): checkbox selection hooks、disabled state、cascade、submitted value parsing の入口。
 - [English Lazy Loading](en/lazy-loading.md): load children on demand through host-app routes and TreeView remote-state hooks.
 - [日本語Lazy Loading](ja/lazy-loading.md): host app の route と TreeView remote-state hooks で子nodeを必要時に読み込む入口。
+- [English Children Pagination](en/children-pagination.md): combine lazy loading with server-side child paging when a parent has too many direct children to return at once.
+- [日本語Children Pagination](ja/children-pagination.md): direct children が多すぎる親nodeで、lazy loading と server-side child paging を組み合わせる入口。
 - [English Windowed Rendering](en/windowed-rendering.md): render visible rows by offset and limit while host apps keep query and paging ownership.
 - [日本語Windowed Rendering](ja/windowed-rendering.md): offset / limit で visible rows を描画し、query や paging は host app が所有する前提の入口。
 - [English direction-aware styling boundary](en/direction-aware-styling.md): host-app override guidance for RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing.


### PR DESCRIPTION
## 対応 Issue

Closes #1264

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/README.md` の Recommended entry points に Children Pagination の英日リンクを追加しました。
- Lazy Loading と Windowed Rendering の間に置き、large-tree / partial rendering の読書順で見つけやすくしました。
- `docs/en|ja/README.md` と root `README.md` に既にある Children Pagination 導線と揃えています。

## 根拠

- root `README.md` の Key documents table には Children Pagination 入口があります。
- `docs/en/README.md` / `docs/ja/README.md` の goal-based shortcuts は Render Scale / Lazy Loading / Windowed Rendering / Children Pagination を同じ large-tree reading path として並べています。
- `docs/README.md` だけが Lazy Loading / Windowed Rendering までで、Children Pagination への直接入口を持っていませんでした。

## 非目標

- children pagination guide 本文の rewrite
- lazy loading / windowed rendering API の変更
- server-side pagination helper の追加
- root README や language README の再構成
- mockup HTML/CSS、runtime Ruby / JavaScript、public API manifest の変更

## 確認内容

- base: `main` (`0ae49b4700fa332e26563cc2ba579857a9ae0845`)
- head: `61c6dc05f4fd7b70c9ffc775daa597779df34f27`
- GitHub compare: `main...docs/1264-children-pagination-docs-index`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/README.md`)
  - additions: 2 / deletions: 0
- PR metadata: `mergeable: true`
- GitHub Actions CI #1608: success
  - `changes` / `lint` / `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `gem_package` / full matrices: skipped by workflow conditions
- docs-only 変更のため local test / lint は未実行です。

## リスク

low。既存 docs への導線追加のみで、仕様・コード・公開契約は変更していません。