### PR TITLE
public JS events の no-detail 分類を manifest smoke で固定する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -162,6 +162,12 @@ javascript_package_root:
       drop: tree-view-transfer:drop
       invalid_payload: tree-view-transfer:invalid-payload
       invalid_transfer: tree-view-transfer:invalid-transfer
+  event_names_without_detail:
+    host_lifecycle:
+      - loading
+      - loaded
+      - error
+      - retry
   event_detail_keys:
     state:
       state_changed:

--- a/docs/en/js-events.md
+++ b/docs/en/js-events.md
@@ -105,7 +105,7 @@ Dispatched when retry is requested for a remote row.
 
 Host apps may dispatch these lifecycle events on a lazy-loading TreeView row so the remote-state controller can mark that row as loading, loaded, error, or retrying.
 
-These events do not define public `event.detail` fields in the manifest. Put row-specific remote-state data on the row attributes documented for lazy loading instead of relying on payload fields.
+These events intentionally do not define public `event.detail` fields. They are listed in `config/public_api_manifest.yml` under `event_names_without_detail` instead of `event_detail_keys`, so the entrypoint smoke can distinguish this policy from an accidental missing detail-key entry. Put row-specific remote-state data on the row attributes documented for lazy loading instead of relying on payload fields.
 
 ## Transfer events
 
@@ -186,5 +186,7 @@ element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStat
 ## Compatibility policy
 
 The machine-readable public API manifest mirrors the event names and representative required `event.detail` keys documented on this page so compatibility specs can detect drift; this page remains the primary contract. Host app tests may import `TreeViewEventDetailKeys` from the package root when they need a machine-readable list of documented detail key names without changing the event payload shape.
+
+Every public event name in the manifest must be classified either under `event_detail_keys` when it has documented detail fields or under `event_names_without_detail` when it intentionally exposes no public detail fields. The entrypoint smoke checks that classification so host lifecycle events do not look like missing `event.detail` coverage.
 
 The event names and documented `detail` fields above are public integration points. Additive fields may be added in minor releases. Removing events, renaming fields, or changing documented field meanings should be treated as a compatibility-impacting change and called out in the changelog.

--- a/docs/ja/js-events.md
+++ b/docs/ja/js-events.md
@@ -105,7 +105,7 @@ remote row のretryが要求されたときに発火します。
 
 host app は、lazy-loading TreeView row 上でこれらの lifecycle event を発火し、remote-state controller にその row を loading、loaded、error、retrying として扱わせることができます。
 
-これらの event は、manifest 上で公開 `event.detail` field を定義していません。payload field に依存せず、lazy loading docs で案内している row attribute に remote-state data を置いてください。
+これらの event は、意図的に公開 `event.detail` field を定義していません。`config/public_api_manifest.yml` では `event_detail_keys` ではなく `event_names_without_detail` に載せ、entrypoint smoke がこの方針と detail-key entry の追加漏れを区別できるようにしています。payload field に依存せず、lazy loading docs で案内している row attribute に remote-state data を置いてください。
 
 ## Transfer events
 
@@ -186,5 +186,7 @@ element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStat
 ## 互換性方針
 
 machine-readable public API manifest は、このページで文書化している event name と代表的な必須 `event.detail` key を写して drift を検知するための guard です。一次の契約は引き続きこのページです。host app の test が documented detail key 名の machine-readable な一覧を必要とする場合は、event payload shape を変えずに package root の `TreeViewEventDetailKeys` を import できます。
+
+manifest 上のすべての public event name は、documented detail field を持つ場合は `event_detail_keys`、意図的に公開 detail field を持たない場合は `event_names_without_detail` のどちらかに分類します。entrypoint smoke はこの分類を確認するため、host lifecycle events が `event.detail` coverage の追加漏れに見えないようになります。
 
 上記のevent nameとdocumented `detail` fieldsは公開integration pointです。minor releaseではfield追加は許容します。event削除、field rename、documented fieldの意味変更は互換性に影響する変更として扱い、changelogで明示してください。

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -170,8 +170,8 @@ function assertUniqueStringList(values, name) {
   const seenValues = new Set()
 
   values.forEach((value) => {
-    assert(typeof value === "string" && value.length > 0, `${name} contains a non-string detail key`)
-    assert(!seenValues.has(value), `${name} contains duplicate detail key: ${value}`)
+    assert(typeof value === "string" && value.length > 0, `${name} contains a non-string value`)
+    assert(!seenValues.has(value), `${name} contains duplicate value: ${value}`)
     seenValues.add(value)
   })
 }
@@ -187,6 +187,44 @@ function assertEventDetailKeysMatchEventNames(eventNames, eventDetailKeys) {
         `event_detail_keys.${group}.${eventKey} does not match an exported event name`
       )
       assertUniqueStringList(detailKeys, `event_detail_keys.${group}.${eventKey}`)
+    })
+  })
+}
+
+function assertEventDetailCoverage(eventNames, eventDetailKeys, eventNamesWithoutDetail) {
+  assert(
+    eventNamesWithoutDetail && typeof eventNamesWithoutDetail === "object" && !Array.isArray(eventNamesWithoutDetail),
+    "event_names_without_detail must be an object"
+  )
+
+  Object.entries(eventNamesWithoutDetail).forEach(([group, eventKeys]) => {
+    assert(group in eventNames, `event_names_without_detail.${group} does not match an exported event group`)
+    assertUniqueStringList(eventKeys, `event_names_without_detail.${group}`)
+
+    eventKeys.forEach((eventKey) => {
+      assert(
+        eventKey in eventNames[group],
+        `event_names_without_detail.${group}.${eventKey} does not match an exported event name`
+      )
+      assert(
+        !(eventKey in (eventDetailKeys[group] || {})),
+        `event_names_without_detail.${group}.${eventKey} is also listed in event_detail_keys`
+      )
+    })
+  })
+
+  Object.entries(eventNames).forEach(([group, events]) => {
+    Object.keys(events).forEach((eventKey) => {
+      const hasDetailKeys = eventKey in (eventDetailKeys[group] || {})
+      const isMarkedWithoutDetail = (eventNamesWithoutDetail[group] || []).includes(eventKey)
+
+      assert(
+        hasDetailKeys || isMarkedWithoutDetail,
+        [
+          `event_names.${group}.${eventKey} is not classified for detail coverage`,
+          "List it under event_detail_keys when it has documented public detail fields, or under event_names_without_detail when it intentionally has no public detail fields."
+        ].join("\n")
+      )
     })
   })
 }
@@ -254,6 +292,13 @@ const expectedEventDetailKeys = deepCamelizeKeys(javascriptPackageManifest.event
 assertDeepEqualExport(entrypointModule.TreeViewEventDetailKeys, expectedEventDetailKeys, "TreeViewEventDetailKeys")
 assertFrozenEventDetailKeys(entrypointModule.TreeViewEventDetailKeys, "TreeViewEventDetailKeys")
 assertEventDetailKeysMatchEventNames(entrypointModule.TreeViewEventNames, entrypointModule.TreeViewEventDetailKeys)
+
+const expectedEventNamesWithoutDetail = deepCamelizeKeys(javascriptPackageManifest.event_names_without_detail)
+assertEventDetailCoverage(
+  entrypointModule.TreeViewEventNames,
+  entrypointModule.TreeViewEventDetailKeys,
+  expectedEventNamesWithoutDetail
+)
 
 const expectedTransferDropPositions = javascriptPackageManifest.transfer_drop_positions
 assertDeepEqualExport(


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1267

## Issue ごとの完了内容

- #1267: public JS event names を、documented `event.detail` keys を持つ event と、意図的に public detail fields を持たない event に manifest 上で分類できるようにしました。
- #1267: host lifecycle events (`tree-view:loading` / `loaded` / `error` / `retry`) は no-detail event として明示し、entrypoint smoke が accidental omission と intentional no-detail を区別できるようにしました。
- Review follow-up: stale/diverged になっていた branch を最新 `main` ベースへ更新し、recent manifest surfaces を巻き戻さない形で差分を再適用しました。

## 変更内容

- `config/public_api_manifest.yml`
  - `javascript_package_root.event_names_without_detail.host_lifecycle` を追加
- `script/test_entrypoints.mjs`
  - `event_names_without_detail` の group / event key が exported event names と一致することを確認
  - `event_detail_keys` と no-detail classification の重複を拒否
  - すべての public event name が `event_detail_keys` または `event_names_without_detail` のどちらかに分類されていることを確認
- `docs/en/js-events.md` / `docs/ja/js-events.md`
  - host lifecycle events が意図的に public detail fields を定義しないことを manifest policy と同期
  - compatibility policy に detail-keyed events / no-detail events の分類ルールを追記

## 改善カテゴリ

- test
- docs
- public API manifest drift guard
- review follow-up / branch refresh

## 既存仕様への影響

- runtime JavaScript、event names、event payload shape、`TreeViewEventDetailKeys` export shape は変更していません。
- host lifecycle events への new payload field 追加、event rename / removal、remote-state controller behavior 変更には広げていません。

## 実施した確認内容

- GitHub compare: `main...quality/1267-no-detail-events-manifest`
  - `behind_by: 0`
  - changed files: 4
- connector 経由で manifest / smoke / docs の差分を再取得して確認しました。
- local `npm run test:entrypoints` / `npm run test:js` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 更新後の GitHub Actions で確認します。

## リスク評価

- risk: medium
- manifest-backed public contract の表現を追加しますが、runtime behavior と exported event-detail object は変えていません。

## 補足事項

- no-detail classification は host lifecycle events に限定しています。remote-state / selection / transfer / state events の documented detail keys は従来どおり `event_detail_keys` で守ります。
- 以前の review comment で挙げた public contract policy の人間確認ポイントは、この refresh では判断変更していません。