### PR TITLE
docs index に PathTreeBuilder 入口を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@
 - [日本語ReverseTree](ja/reverse-tree.md): matched recordを表示上のrootにし、ancestorをその下に並べるchild-to-parent pathの入口。
 - [English Filtered Trees](en/filtered-trees.md): render search or filter results as trees while keeping path-generated folders and child-to-parent paths separate.
 - [日本語Filtered Trees](ja/filtered-trees.md): 検索・絞り込み結果をtreeとして表示する入口。path生成folderやchild-to-parent pathとは使い分けます。
+- [English PathTreeBuilder](en/path-tree-builder.md): build generated folder rows and record rows from path-like record values.
+- [日本語PathTreeBuilder](ja/path-tree-builder.md): pathらしいrecord値から生成folder行とrecord行を作る入口。
 - [English FAQ](en/faq.md): quick answers about responsibility boundaries and common misunderstandings.
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.


### PR DESCRIPTION
## 対応 Issue

Closes #1274

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/README.md` の Recommended entry points に PathTreeBuilder の英日リンクを追加しました。
- GraphAdapter / ReverseTree / Filtered Trees と同じ特殊 tree surface の導線として、path-like record values から generated folder rows / record rows を作る入口だと分かる短い説明にしています。

## 根拠

- root `README.md` は feature list と Key documents table で PathTreeBuilder を案内しています。
- `docs/en/README.md` / `docs/ja/README.md` は document table と reading order から PathTreeBuilder へ辿れます。
- `docs/en/path-tree-builder.md` / `docs/ja/path-tree-builder.md` は generated folder nodes と record-backed rows の責務境界を説明済みです。
- `docs/README.md` の Recommended entry points だけが PathTreeBuilder への直接入口を持っていませんでした。

## 非目標

- PathTreeBuilder guide 本文の rewrite
- PathTreeBuilder API の変更
- generated folder row mockup の追加・変更
- root README や language README の再構成
- public API manifest、runtime Ruby、mockup HTML/CSS の変更

## 確認内容

- GitHub compare: `main...docs/1274-path-tree-builder-docs-index`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/README.md`)
  - additions: 2 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

low。既存 docs への導線追加のみで、仕様・コード・公開契約は変更していません。