### PR TITLE
installation docs と package guard の drift を検出する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -31,12 +31,33 @@ REQUIRED_PACKAGED_PATHS = %w[
   config/public_api_manifest.yml
   config/locales/tree_view.toolbar.en.yml
   config/locales/tree_view.toolbar.ja.yml
+  CHANGELOG.md
   README.md
   docs/README.md
   docs/en/public-api.md
   docs/ja/public-api.md
   docs/en/release.md
   docs/ja/release.md
+].freeze
+
+INSTALLATION_DOC_PATHS = %w[
+  docs/en/installation.md
+  docs/ja/installation.md
+].freeze
+
+INSTALLATION_REQUIRED_SIGNALS = [
+  "app/assets/stylesheets/tree_view.scss",
+  "app/helpers/tree_view_helper.rb",
+  "app/javascript/tree_view/**/*",
+  "app/views/tree_view/**/*",
+  "config/importmap.tree_view.rb",
+  "config/locales/**/*",
+  "config/public_api_manifest.yml",
+  "README.md",
+  "CHANGELOG.md",
+  "docs/**/*",
+  "@import \"tree_view\";",
+  "pin \"tree_view\", to: \"tree_view/index.js\""
 ].freeze
 
 root = File.expand_path("..", __dir__)
@@ -46,12 +67,34 @@ abort "No built gem found. Run `gem build tree_view.gemspec` first." unless gem_
 
 files = Gem::Package.new(gem_path).spec.files
 missing = REQUIRED_PACKAGED_PATHS.reject { |path| files.include?(path) }
+missing_installation_signals = INSTALLATION_DOC_PATHS.to_h do |path|
+  content = File.read(File.join(root, path))
+  [path, INSTALLATION_REQUIRED_SIGNALS.reject { |signal| content.include?(signal) }]
+end.reject { |_path, missing_signals| missing_signals.empty? }
 
-if missing.empty?
+importmap_path = File.join(root, "config/importmap.tree_view.rb")
+importmap_content = File.read(importmap_path)
+importmap_pin_missing = !importmap_content.include?("pin \"tree_view\", to: \"tree_view/index.js\"")
+
+if missing.empty? && missing_installation_signals.empty? && !importmap_pin_missing
   puts "Gem package contents verified: #{File.basename(gem_path)}"
 else
   warn "Gem package contents verification failed: #{File.basename(gem_path)}"
-  warn "Missing packaged files:"
-  missing.each { |path| warn "  - #{path}" }
+
+  unless missing.empty?
+    warn "Missing packaged files:"
+    missing.each { |path| warn "  - #{path}" }
+  end
+
+  missing_installation_signals.each do |path, signals|
+    warn "Missing installation docs signals in #{path}:"
+    signals.each { |signal| warn "  - #{signal}" }
+  end
+
+  if importmap_pin_missing
+    warn "Missing TreeView importmap pin in config/importmap.tree_view.rb:"
+    warn "  - pin \"tree_view\", to: \"tree_view/index.js\""
+  end
+
   abort "Gem package contents verification failed."
 end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1271
Closes #1272

## Issue ごとの完了内容

- #1271: installation docs の Packaged files section と package verification guard の代表 signal がずれた場合に検出できるようにしました。
- #1272: CSS import / importmap pin の代表導入経路について、packaged stylesheet / JavaScript / importmap file と `config/importmap.tree_view.rb` の pin を package check で確認するようにしました。

## 変更内容

- `script/check_gem_package_contents.rb`
  - required packaged paths に `CHANGELOG.md` を追加し、installation docs の Packaged files list と同期
  - 英日 installation docs に representative package family / CSS import / importmap pin signals が残っていることを確認
  - `config/importmap.tree_view.rb` に `pin "tree_view", to: "tree_view/index.js"` が残っていることを確認
  - 失敗時に missing packaged files / docs signals / importmap pin を分けて出すよう整理

## 改善カテゴリ

- test
- package verification
- docs drift guard
- CI / build guard

## 既存仕様への影響

- runtime Ruby / JavaScript、gemspec package glob、CSS、importmap API、host app integration behavior は変更していません。
- 既存 package checker の代表 guard を強めるだけです。

## 実施した確認内容

- GitHub compare: `main...quality/1271-package-installation-guards`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- ローカル `gem build` / package check は、この環境の GitHub HTTPS checkout 制限により未実行です。PR 作成後に GitHub Actions を確認します。

## リスク評価

- low
- package verification script の guard 追加に限定しています。full dummy app、release automation、Propshaft / Sprockets matrix には広げていません。