### PR TITLE
PathTreeBuilder node shape を public manifest に同期する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -31,6 +31,30 @@ public_constants:
   - PersistedState
   - StateStore
   - Diagnostics
+path_tree_builder_node_shapes:
+  folder_node:
+    constant: PathTreeBuilder::FolderNode
+    fields:
+      - key
+      - parent_key
+      - label
+      - path
+      - node_type
+    predicates:
+      - folder_node?
+      - record_node?
+  record_node:
+    constant: PathTreeBuilder::RecordNode
+    fields:
+      - key
+      - parent_key
+      - label
+      - path
+      - record
+      - node_type
+    predicates:
+      - folder_node?
+      - record_node?
 helper_methods:
   - tree_view_rows
   - tree_view_window

--- a/docs/en/path-tree-builder.md
+++ b/docs/en/path-tree-builder.md
@@ -30,6 +30,8 @@ The builder creates two public node shapes:
 | `TreeView::PathTreeBuilder::FolderNode` | `key`, `parent_key`, `label`, `path`, `node_type`, `folder_node?`, `record_node?` | Generated intermediate folders. |
 | `TreeView::PathTreeBuilder::RecordNode` | `key`, `parent_key`, `label`, `path`, `record`, `node_type`, `folder_node?`, `record_node?` | Leaf nodes wrapping host-app records. |
 
+These field and predicate sets are tracked in the public API manifest as the node shape contract. The manifest fixes the readable shape of generated nodes, not the folder key generation strategy, sort algorithm, file-manager behavior, or host-app row action design.
+
 `RecordNode#record` keeps the original object so the row partial can render application-specific columns, links, status, or actions.
 
 ## Rendering folder and record rows

--- a/docs/ja/path-tree-builder.md
+++ b/docs/ja/path-tree-builder.md
@@ -30,6 +30,8 @@ builder は以下の2種類の公開node形状を作ります。
 | `TreeView::PathTreeBuilder::FolderNode` | `key`, `parent_key`, `label`, `path`, `node_type`, `folder_node?`, `record_node?` | 生成された中間フォルダ。 |
 | `TreeView::PathTreeBuilder::RecordNode` | `key`, `parent_key`, `label`, `path`, `record`, `node_type`, `folder_node?`, `record_node?` | host app recordを包むleaf node。 |
 
+これらの field / predicate set は、node shape contract として public API manifest でも追跡されます。manifest が固定するのは生成 node の読み取り可能な形状であり、folder key generation strategy、sort algorithm、file-manager behavior、host app の row action design までは固定しません。
+
 `RecordNode#record` には元のobjectが残るため、row partial 側で application-specific な列、link、status、action を描画できます。
 
 ## folder row と record row を描画する

--- a/spec/public_api_path_tree_builder_contract_spec.rb
+++ b/spec/public_api_path_tree_builder_contract_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+PATH_TREE_BUILDER_PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+RSpec.describe "PathTreeBuilder public node shape contract" do
+  def manifest_node_shapes
+    @manifest_node_shapes ||= YAML.safe_load_file(PATH_TREE_BUILDER_PUBLIC_API_MANIFEST_PATH).fetch("path_tree_builder_node_shapes")
+  end
+
+  def node_shape_constant(shape)
+    case shape.fetch("constant")
+    when "PathTreeBuilder::FolderNode"
+      TreeView::PathTreeBuilder::FolderNode
+    when "PathTreeBuilder::RecordNode"
+      TreeView::PathTreeBuilder::RecordNode
+    else
+      raise "Unknown PathTreeBuilder node shape constant: #{shape.fetch("constant")}"
+    end
+  end
+
+  it "keeps manifest node fields aligned with FolderNode and RecordNode members" do
+    manifest_node_shapes.each do |shape_name, shape|
+      expect(shape.fetch("fields")).to eq(node_shape_constant(shape).members.map(&:to_s)),
+        "expected #{shape_name} fields to match the generated Struct members"
+    end
+  end
+
+  it "keeps manifest predicates available on both public node shapes" do
+    manifest_node_shapes.each do |shape_name, shape|
+      node_class = node_shape_constant(shape)
+
+      shape.fetch("predicates").each do |predicate_name|
+        expect(node_class.public_instance_methods).to include(predicate_name.to_sym),
+          "expected #{shape_name} to keep ##{predicate_name} public"
+      end
+    end
+  end
+
+  it "keeps FolderNode and RecordNode predicate behavior aligned with their public shapes" do
+    folder = TreeView::PathTreeBuilder::FolderNode.new(
+      key: "folder:guides",
+      parent_key: nil,
+      label: "guides",
+      path: "guides",
+      node_type: :folder
+    )
+    record = TreeView::PathTreeBuilder::RecordNode.new(
+      key: "record:1",
+      parent_key: "folder:guides",
+      label: "Install",
+      path: "guides/install.md",
+      record: Object.new,
+      node_type: :record
+    )
+
+    expect(folder.folder_node?).to be(true)
+    expect(folder.record_node?).to be(false)
+    expect(record.folder_node?).to be(false)
+    expect(record.record_node?).to be(true)
+  end
+end


### PR DESCRIPTION
PathTreeBuilder の generated node shape を manifest-backed contract として固定します。

## 対応 Issue

Closes #1275

## 変更内容

- `config/public_api_manifest.yml` に `path_tree_builder_node_shapes` section を追加しました。
- `FolderNode` / `RecordNode` の field set と public predicate set を manifest から読めるようにしました。
- `spec/public_api_path_tree_builder_contract_spec.rb` を追加し、manifest と actual `Struct.members` / predicate methods / predicate behavior を照合します。
- 英日 `docs/*/path-tree-builder.md` に、node shape は public contract として固定しつつ、folder key generation strategy、sort algorithm、file-manager behavior、host-app row action design までは固定しない境界を追記しました。

## 受け入れ条件との対応

- `FolderNode` は `key` / `parent_key` / `label` / `path` / `node_type` と `folder_node?` / `record_node?` を manifest-backed にしています。
- `RecordNode` は `key` / `parent_key` / `label` / `path` / `record` / `node_type` と `folder_node?` / `record_node?` を manifest-backed にしています。
- runtime API、constructor options、sort/key generation、generated tree behavior は変更していません。
- docs では node shape contract と、host app が所有する row action / file-manager behavior の境界を分けています。

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_api_path_tree_builder_contract_spec.rb`
- `docs/en/path-tree-builder.md`
- `docs/ja/path-tree-builder.md`

## 実施した確認

- GitHub compare: `main...feature/1275-path-tree-node-shape-contract`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4
- connector 経由で `PathTreeBuilder` の current Struct fields / predicates と docs を確認しました。
- local `bundle exec rspec spec/public_api_path_tree_builder_contract_spec.rb spec/lib/tree_view/path_tree_builder_spec.rb` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後に GitHub Actions を確認します。

## リスク

- medium
- public contract を強める変更ですが、既に docs が public node shapes として説明している surface を manifest / spec に同期するだけで、runtime behavior は変更していません。

## 未対応・補足

- `PathTreeBuilder` API、FolderNode / RecordNode の class redesign、public API manifest schema の全面再設計、PathTreeBuilder mockup、file-manager behavior、host-app row action design は扱っていません。