### PR TITLE
Transfer drop positions export を Public API / Drag and Drop docs に明記する

### DIFF
--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -114,6 +114,8 @@ The transfer controller exposes these reader-facing details:
 
 `position` is a TreeView-owned coarse cue for where the pointer sits inside the target row: the top third is `before`, the middle third is `inside`, and the bottom third is `after`. Treat it as input to host-app business rules, not as final authorization or persistence policy. For example, a host app may ignore `inside` for leaf-only trees, reject drops across projects, or translate `before` / `after` into an ordering update.
 
+Use the package-root `TreeViewTransferDropPositions` export when host-app JavaScript wants to avoid raw drop-position strings. `TreeViewEventNames.transfer.*` names the transfer events, `TreeViewEventDetailKeys.transfer.*` lists the documented detail keys, and `TreeViewTransferDropPositions` carries the coarse `before` / `inside` / `after` position values.
+
 ### Transfer operation and outcome boundary
 
 TreeView sets the browser transfer cue to `move` by using `DataTransfer.effectAllowed` on drag start and `DataTransfer.dropEffect` while hovering over a valid row. That cue only says the current TreeView helper is row-transfer oriented; it does not decide the host app's business operation.

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -168,6 +168,7 @@ Stable enough for host apps to use:
 
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
+- `TreeViewTransferDropPositions`
 - `TreeViewControllerIdentifiers`
 - exported controller classes
   - `TreeViewStateController`
@@ -181,6 +182,7 @@ Stable enough for host apps to use:
 `registerTreeViewControllers(application)` registers the five controller exports above with the documented identifiers in the bundled entrypoint order.
 
 `TreeViewEventNames` exposes the documented event names as a machine-readable package-root export. Use it when wiring host-app listeners and you want to avoid hand-copying event-name strings such as `TreeViewEventNames.selection.change` or `TreeViewEventNames.transfer.drop`.
+`TreeViewTransferDropPositions` exposes the documented coarse drop-position values for transfer events: `before`, `inside`, and `after`. `TreeViewEventNames.transfer.*` names transfer events, `TreeViewEventDetailKeys.transfer.*` lists the documented `event.detail` keys, and `TreeViewTransferDropPositions` carries the position values described in [Drag and Drop](drag-and-drop.md#drop-behavior).
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
 
 Within `TreeViewEventNames`, lazy-loading request lifecycle names live under `hostLifecycle`:

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -114,6 +114,8 @@ transfer controller が読者向けに公開する主なdetailは次のとおり
 
 `position` は、target row内でpointerがどこにあるかを示すTreeView側の粗いcueです。上 1/3 は `before`、中央 1/3 は `inside`、下 1/3 は `after` になります。これはhost appの業務ルールへの入力として扱い、最終的な許可・保存方針として扱わないでください。たとえば、leaf-only treeでは `inside` を無視したり、projectをまたぐdropを拒否したり、`before` / `after` を並び順更新へ変換したりできます。
 
+host app の JavaScript で raw な drop-position string を写経したくない場合は、package-root の `TreeViewTransferDropPositions` export を使えます。`TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented detail key、`TreeViewTransferDropPositions` は粗い `before` / `inside` / `after` position value を表します。
+
 ### transfer operation と outcome の境界
 
 TreeView は drag start 時の `DataTransfer.effectAllowed` と、valid row 上で hover している間の `DataTransfer.dropEffect` を `move` に設定します。この cue は、現在の TreeView helper が row transfer 向けであることを示すだけで、host app の業務上の operation を決めるものではありません。

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -168,6 +168,7 @@ host app が使ってよい入口:
 
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
+- `TreeViewTransferDropPositions`
 - `TreeViewControllerIdentifiers`
 - exported controller classes
   - `TreeViewStateController`
@@ -181,6 +182,7 @@ host app が使ってよい入口:
 `registerTreeViewControllers(application)` は、上記 5 つの controller export を bundled entrypoint の documented identifier 順に登録します。
 
 `TreeViewEventNames` は documented event names を machine-readable に参照するための package-root export です。host app 側で listener を配線するとき、`TreeViewEventNames.selection.change` や `TreeViewEventNames.transfer.drop` のように使うことで event name string の写経を避けられます。
+`TreeViewTransferDropPositions` は transfer event の粗い drop-position value として、`before`、`inside`、`after` を公開します。`TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented な `event.detail` key、`TreeViewTransferDropPositions` は [Drag and Drop](drag-and-drop.md#drop処理) で説明している position value を表します。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
 
 `TreeViewEventNames` のうち、lazy-loading の request lifecycle 名は `hostLifecycle` にまとめています。


### PR DESCRIPTION
## 対応 Issue

Closes #1281

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の JavaScript surface list に `TreeViewTransferDropPositions` を明記しました。
- `TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented detail key、`TreeViewTransferDropPositions` は coarse drop-position value であることを短く説明しました。
- `docs/en/drag-and-drop.md` / `docs/ja/drag-and-drop.md` の `position` 説明から、raw string の代わりに package-root export を参照できることを追記しました。

## 根拠

- current `app/javascript/tree_view/index.js` は `TreeViewTransferDropPositions` を package-root export しています。
- `config/public_api_manifest.yml` は `javascript_package_root.transfer_drop_positions` として `before` / `inside` / `after` を持っています。
- `script/test_entrypoints.mjs` は export と manifest の同期・freeze を確認しています。
- 既存 Drag and Drop docs は `position` の意味を説明済みでしたが、host app が raw string を避けるための export 導線が薄い状態でした。

## 非目標

- new JavaScript export の追加
- `app/javascript/tree_view/index.js`、`config/public_api_manifest.yml`、`script/test_entrypoints.mjs` の変更
- transfer event payload shape の変更
- transfer operation kind / copy・move policy、DataTransfer MIME key、DOM data hook export lane の吸収
- drag/drop behavior、authorization、persistence、host-app drop target policy の変更

## 確認内容

- GitHub compare: `main...docs/1281-transfer-drop-positions-docs`
  - `ahead_by: 4`
  - `behind_by: 0`
  - changed files: 4 docs files
- docs-only 変更のため local test / lint は未実行です。
- PR 作成後に GitHub Actions を確認します。

## リスク

low。既存 export / manifest / entrypoint smoke で守られている surface の docs discoverability 補強に閉じています。