### PR TITLE
TypeScript declaration を最新 package-root export に同期する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -1,0 +1,76 @@
+import { Controller } from "@hotwired/stimulus"
+import type { Application } from "@hotwired/stimulus"
+
+export declare class TreeViewClientController extends Controller {}
+export declare class TreeViewRemoteStateController extends Controller {}
+export declare class TreeViewSelectionController extends Controller {}
+export declare class TreeViewStateController extends Controller {}
+export declare class TreeViewTransferController extends Controller {}
+
+export declare const TreeViewEventNames: Readonly<{
+  state: Readonly<{
+    stateChanged: "tree-view-state:state-changed"
+  }>
+  selection: Readonly<{
+    change: "tree-view-selection:change"
+    selected: "tree-view-selection:selected"
+    limitExceeded: "tree-view-selection:limit-exceeded"
+    invalidPayload: "tree-view-selection:invalid-payload"
+  }>
+  remoteState: Readonly<{
+    change: "tree-view-remote-state:change"
+    retry: "tree-view-remote-state:retry"
+  }>
+  hostLifecycle: Readonly<{
+    loading: "tree-view:loading"
+    loaded: "tree-view:loaded"
+    error: "tree-view:error"
+    retry: "tree-view:retry"
+  }>
+  transfer: Readonly<{
+    dragStart: "tree-view-transfer:drag-start"
+    dragOver: "tree-view-transfer:drag-over"
+    drop: "tree-view-transfer:drop"
+    invalidPayload: "tree-view-transfer:invalid-payload"
+    invalidTransfer: "tree-view-transfer:invalid-transfer"
+  }>
+}>
+
+export declare const TreeViewEventDetailKeys: Readonly<{
+  state: Readonly<{
+    stateChanged: readonly ["viewKey", "expandedKeys"]
+  }>
+  selection: Readonly<{
+    change: readonly ["selectedCount", "selectedValues", "selectedPayloads"]
+    selected: readonly ["payloads"]
+    limitExceeded: readonly ["maxCount", "attemptedCount", "attemptedChecked", "checkbox"]
+    invalidPayload: readonly ["value", "checkbox"]
+  }>
+  remoteState: Readonly<{
+    change: readonly ["row", "state", "childrenUrl", "nodeKey"]
+    retry: readonly ["row", "childrenUrl", "nodeKey"]
+  }>
+  transfer: Readonly<{
+    dragStart: readonly ["sourcePayload", "sourceRow"]
+    dragOver: readonly ["targetPayload", "targetRow", "position"]
+    drop: readonly ["sourcePayload", "targetPayload", "position", "targetRow"]
+    invalidPayload: readonly ["value", "row"]
+    invalidTransfer: readonly ["value"]
+  }>
+}>
+
+export declare const TreeViewTransferDropPositions: Readonly<{
+  before: "before"
+  inside: "inside"
+  after: "after"
+}>
+
+export declare const TreeViewControllerIdentifiers: Readonly<{
+  state: "tree-view-state"
+  client: "tree-view-client"
+  selection: "tree-view-selection"
+  transfer: "tree-view-transfer"
+  remoteState: "tree-view-remote-state"
+}>
+
+export declare function registerTreeViewControllers(application: Application): void

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
 
 function loadJavascriptPackageManifest() {
   const manifestJson = loadManifestJson()
@@ -48,6 +49,15 @@ function loadManifestJson() {
       { cause: error }
     )
   }
+}
+
+function loadDeclarationExportNames() {
+  const declarationPath = new URL("../app/javascript/tree_view/index.d.ts", import.meta.url)
+  const declarationSource = readFileSync(declarationPath, "utf8")
+  const exportPattern = /^export\s+declare\s+(?:class|const|function)\s+([A-Za-z0-9_]+)/gm
+  const exportNames = [...declarationSource.matchAll(exportPattern)].map((match) => match[1])
+
+  return [...new Set(exportNames)]
 }
 
 function camelizeKey(value) {
@@ -141,6 +151,22 @@ assert(
     `entrypoint exports are missing from config/public_api_manifest.yml: ${undocumentedNamedExports.join(", ")}`,
     "Add the export to javascript_package_root.named_exports and the relevant docs/smoke coverage, or stop exporting it from app/javascript/tree_view/index.js."
   ].join("\n")
+)
+
+const declarationExportNames = loadDeclarationExportNames()
+const missingDeclarationExports = javascriptPackageManifest.named_exports.filter(
+  (exportName) => !declarationExportNames.includes(exportName)
+)
+const undocumentedDeclarationExports = declarationExportNames.filter(
+  (exportName) => !javascriptPackageManifest.named_exports.includes(exportName)
+)
+assert(
+  missingDeclarationExports.length === 0,
+  `TypeScript declaration exports are missing manifest exports: ${missingDeclarationExports.join(", ")}`
+)
+assert(
+  undocumentedDeclarationExports.length === 0,
+  `TypeScript declaration exports are not listed in the manifest: ${undocumentedDeclarationExports.join(", ")}`
 )
 
 const expectedIdentifiers = Object.fromEntries(


### PR DESCRIPTION
## 対応 Issue

Closes #1179

## supersede

- Supersedes #1205
- #1205 は旧 head の CI は green でしたが、current `main` から `behind_by:39` / `mergeable:false` になり、`TreeViewEventDetailKeys` を含む最新 package-root export / manifest へ `.d.ts` が追従していませんでした。
- この PR は latest `main` (`78195b74cc095e8a80dcbd266ddb442ff6410acd`) から clean replacement として切り直しています。

## 変更内容

- `app/javascript/tree_view/index.d.ts` を追加しました。
- current `app/javascript/tree_view/index.js` / `config/public_api_manifest.yml` の package-root named exports に合わせて、以下を declaration に含めています。
  - `registerTreeViewControllers(application)`
  - 5 つの controller class export
  - `TreeViewEventNames`
  - `TreeViewEventDetailKeys`
  - `TreeViewTransferDropPositions`
  - `TreeViewControllerIdentifiers`
- `script/test_entrypoints.mjs` に `.d.ts` の exported names と `javascript_package_root.named_exports` の同期 guard を追加しました。

## 採用した方針

- Reviewer 指摘に合わせ、旧PRの差分を latest `main` にそのまま載せ直すのではなく、current manifest / package-root export を source of truth として `.d.ts` を更新しました。
- TypeScript compiler 導入や event payload shape の詳細型 redesign には広げず、Planner handoff どおり export-name drift guard に閉じました。

## 比較した案

- 案A: 旧 PR #1205 branch を直接更新する
  - 未採用。branch が大きく diverged しており、差分なし状態や conflict を誘発しやすいためです。
- 案B: latest `main` から replacement PR を作る
  - 採用。current export surface に同期した差分だけを review できます。
- 案C: docs / event payload typing / package.json `types` まで広げる
  - 未採用。今回の follow-up は stale branch と declaration drift の解消が主目的で、npm package policy や詳細 payload typing の判断には広げません。

## 確認内容

- GitHub compare: `main...feature/1179-typescript-declaration-refresh`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
- connector 経由で以下を確認しました。
  - `.d.ts` が `TreeViewEventDetailKeys` を含む current named exports を持つこと
  - entrypoint smoke に declaration export-name guard が入っていること
- GitHub Actions CI #1560: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `gem_package`: success
  - `javascript`: success（`npm run test:js` success / browser smoke は workflow 条件で skipped）
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
  - `ruby_matrix` / `rails_matrix`: workflow 条件で skipped
- PR metadata: `mergeable:true`
- ローカル `npm run test:entrypoints` / `npm run test:js` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions を正としています。

## スクリーンショット

<!-- UI変更なし -->

## リスク

- medium
- runtime JavaScript、event payload shape、event name、controller behavior、public export の追加・rename・削除は変更していません。
- public JS developer surface に declaration を追加するため、最終的な採用判断は human review に残します。

## 補足

- 旧 PR #1205 の docs 追記は、巨大な public API ページの connector-only 全文置換リスクを避けるため、この replacement では差分に含めていません。current public API docs は runtime contract / manifest source of truth を既に説明しており、declaration 用の境界説明はこの PR 本文で明記しています。必要なら follow-up で docs-only に分けます。