### PR TITLE
Node version source の drift guard を追加する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -18,7 +18,7 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
-Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version.
+Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version. The Node version source drift spec keeps `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value aligned without changing the current install policy.
 
 Keep using `npm install` for now. The repository has a committed `package-lock.json`, but it is not yet refreshed in sync with `package.json`, so local setup and pull-request CI stay on `npm install` until that lockfile refresh is completed in a registry-enabled environment. See [Installation](installation.md) for the current CI and install-path summary.
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -18,7 +18,7 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
-ローカルの JavaScript 作業では Node 22 を使ってください。repository root の `.nvmrc` が CI の JavaScript lane とそろった、推奨 Node major version の source of truth です。
+ローカルの JavaScript 作業では Node 22 を使ってください。repository root の `.nvmrc` が CI の JavaScript lane とそろった、推奨 Node major version の source of truth です。Node version source drift spec は `.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` を同期確認し、現在の install policy は変更しません。
 
 現状は `npm install` を使い続けてください。repo には `package-lock.json` を commit していますが、まだ `package.json` と同期していないため、ローカルセットアップと Pull Request CI は、registry-enabled な環境で lockfile refresh が完了するまで `npm install` を前提にしています。現在の CI と install path の整理は [導入手順](installation.md) を参照してください。
 

--- a/spec/node_version_sources_spec.rb
+++ b/spec/node_version_sources_spec.rb
@@ -18,12 +18,12 @@ module NodeVersionSourcesSpec
 
   def package_engine_major
     engines = JSON.parse(read("package.json")).fetch("engines")
-    engines.fetch("node").match(/\A(?<major>\d+)/).fetch(:major)
+    engines.fetch("node").match(/\A(?<major>\d+)/)[:major]
   end
 
   def ci_node_major
     workflow = read(".github/workflows/ci.yml")
-    workflow.match(/node-version:\s*["']?(?<major>\d+)/).fetch(:major)
+    workflow.match(/node-version:\s*["']?(?<major>\d+)/)[:major]
   end
 
   def development_docs

--- a/spec/node_version_sources_spec.rb
+++ b/spec/node_version_sources_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "json"
+require "spec_helper"
+
+module NodeVersionSourcesSpec
+  ROOT = File.expand_path("..", __dir__)
+
+  module_function
+
+  def read(path)
+    File.read(File.join(ROOT, path))
+  end
+
+  def nvmrc_major
+    read(".nvmrc").strip
+  end
+
+  def package_engine_major
+    engines = JSON.parse(read("package.json")).fetch("engines")
+    engines.fetch("node").match(/\A(?<major>\d+)/).fetch(:major)
+  end
+
+  def ci_node_major
+    workflow = read(".github/workflows/ci.yml")
+    workflow.match(/node-version:\s*["']?(?<major>\d+)/).fetch(:major)
+  end
+
+  def development_docs
+    %w[docs/en/development.md docs/ja/development.md]
+  end
+end
+
+RSpec.describe "Node version source drift" do
+  it "keeps package and CI Node majors aligned with .nvmrc" do
+    expected_major = NodeVersionSourcesSpec.nvmrc_major
+
+    aggregate_failures do
+      expect(NodeVersionSourcesSpec.package_engine_major).to eq(expected_major),
+        "package.json engines.node must match .nvmrc major #{expected_major}"
+      expect(NodeVersionSourcesSpec.ci_node_major).to eq(expected_major),
+        ".github/workflows/ci.yml JavaScript node-version must match .nvmrc major #{expected_major}"
+    end
+  end
+
+  it "documents .nvmrc as the Node major source of truth" do
+    expected_major = NodeVersionSourcesSpec.nvmrc_major
+
+    aggregate_failures do
+      NodeVersionSourcesSpec.development_docs.each do |path|
+        content = NodeVersionSourcesSpec.read(path)
+
+        expect(content).to include(".nvmrc"), "#{path} should name .nvmrc as the Node source of truth"
+        expect(content).to include("Node #{expected_major}"), "#{path} should mention Node #{expected_major}"
+        expect(content).to include("package.json"), "#{path} should mention package.json metadata drift"
+        expect(content).to include("node-version"), "#{path} should mention workflow node-version drift"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 対応 Issue

Closes #1258

## Issue ごとの完了内容

- #1258: `.nvmrc` を Node major の source of truth として、`package.json` `engines.node` と CI workflow の `node-version` が同じ major を指すことを RSpec で検出できるようにしました。
- #1258: 英日 development docs に、drift guard が `.nvmrc` / package metadata / workflow node-version を同期確認することを追記しました。

## 変更内容

- `spec/node_version_sources_spec.rb` を追加
  - `.nvmrc` の major version を読み取る
  - `package.json` `engines.node` の major version と比較
  - `.github/workflows/ci.yml` の JavaScript lane `node-version` と比較
  - 英日 development docs が `.nvmrc`、Node major、`package.json`、`node-version` を説明していることを確認
- `docs/en/development.md` / `docs/ja/development.md`
  - Node 22 / `.nvmrc` の既存説明に、drift guard の対象を一文で追記

## 改善カテゴリ

- test
- devops / CI設定の drift guard
- docs sync

## 既存仕様への影響

- Node version は変更していません。
- `package-lock.json` refresh、dependency update、`npm install` / `npm ci` policy、Actions cache、Ruby / Rails matrix、workflow condition は変更していません。
- runtime Ruby / JavaScript behavior、public API、docs-only CI shortcut には触れていません。

## 実施した確認

- GitHub Actions CI #1567: success
- 初回 CI #1566 で `MatchData#fetch` による spec error を確認し、named capture の参照を `match[:major]` に修正しました。
- GitHub compare: `main...quality/1258-node-version-drift-guard`
  - `behind_by: 0`
  - changed files: 3
- 変更内容を connector 経由で再取得し、spec / docs の対象が Issue 範囲内であることを確認しました。
- ローカル `bundle exec rspec spec/node_version_sources_spec.rb` / `bundle exec standardrb` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions の結果で確認しました。

## リスク評価

- risk: low
- 設定値の読み取りと docs guard に閉じた変更です。失敗時はどの source が `.nvmrc` とずれたか分かる message にしています。

## 補足事項

- #413 の lockfile / `npm ci` 復帰作業は吸収していません。
- workflow 値を変更せず、既存の `pr_specs` / full RSpec 実行に自然に乗る guard として追加しています。