### PR TITLE
mockup copy / language policy の例外記録を明確にする

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -87,6 +87,13 @@ They are **not** a complete Rails application and should not grow into host-app 
 - Final labels, localization, permission messaging, and business wording remain host-app responsibilities.
 - If a future mockup intentionally uses another language, document that exception here so reviewers know it is deliberate.
 
+Record deliberate copy or language exceptions in this list. Add a row when a mockup needs non-neutral copy, localized-style text, or another language for a review purpose; do not use this list to choose final host-app copy.
+
+| Mockup | Deliberate exception | Review reason |
+|---|---|---|
+| `toolbar-actions.html` | Long / localized-style toolbar labels | Stress wrapping, disabled state, and current-state cues without choosing final translations. |
+| `localized-row-labels.html` | Long localized-style row labels and metadata | Stress primary label wrapping, badge placement, attribute labels, secondary metadata, and tooltip cues without choosing final translations. |
+
 ## Selection form guidance
 
 - Use selection form mockups to compare visible counts, source separation, and generated hidden input boundaries at review time.


### PR DESCRIPTION
## Summary

Closes #1293

- Classification: `docs-sync`
- `docs/mockups/README.md` の Copy and language policy に、意図的な copy / language 例外を記録する運用を追記しました。
- 既存の `toolbar-actions.html` と `localized-row-labels.html` を、最終文言ではなくレビュー用ストレスケースとして表に整理しました。
- host app 側が最終 copy / localization / business wording を決める前提は変更していません。

## Scope

- Docs only: `docs/mockups/README.md`
- No mockup HTML changes
- No smoke / CI / implementation changes
- No new localization or product wording decision

## Verification

- Compared `main...docs/1293-mockup-language-exceptions`: `ahead_by: 1`, `behind_by: 0`
- Changed files: `docs/mockups/README.md` only

Risk: low. This records existing docs policy boundaries and deliberate mockup exceptions without changing behavior or final wording decisions.