### PR TITLE
NodePresenter builder names を public manifest に追加する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -35,6 +35,16 @@ public_constants:
   - PersistedState
   - StateStore
   - Diagnostics
+node_presenter_builder_names:
+  - key
+  - label
+  - href
+  - tooltip
+  - row_class
+  - row_data
+  - icon
+  - badge
+  - actions
 helper_methods:
   - tree_view_rows
   - tree_view_window
@@ -208,5 +218,3 @@ javascript_package_root:
       invalid_payload:
         - value
         - row
-      invalid_transfer:
-        - value

--- a/docs/en/node-presenter-row-partials.md
+++ b/docs/en/node-presenter-row-partials.md
@@ -42,6 +42,10 @@ Host apps own product-specific rendering:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` and its builder names are part of the public compatibility contract. The machine-readable builder list lives in `config/public_api_manifest.yml` as `node_presenter_builder_names`, and compatibility specs check it against `TreeView::NodePresenter::BUILDER_NAMES`.
+
+That contract stabilizes the available builder names only. The meaning of returned labels, links, row data, action identifiers, badges, icons, and any authorization or formatting decisions remains host-app owned and is intentionally shown here as cookbook guidance.
+
 ## Example presenter
 
 ```ruby

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -176,6 +176,7 @@ Stable enough for host apps to use:
 
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
+- `TreeViewEventDetailKeys`
 - `TreeViewTransferDropPositions`
 - `TreeViewControllerIdentifiers`
 - exported controller classes
@@ -190,6 +191,7 @@ Stable enough for host apps to use:
 `registerTreeViewControllers(application)` registers the five controller exports above with the documented identifiers in the bundled entrypoint order.
 
 `TreeViewEventNames` exposes the documented event names as a machine-readable package-root export. Use it when wiring host-app listeners and you want to avoid hand-copying event-name strings such as `TreeViewEventNames.selection.change` or `TreeViewEventNames.transfer.drop`.
+`TreeViewEventDetailKeys` exposes the documented `event.detail` key lists as a machine-readable package-root export. Use it when host-app tests or listeners need to compare against the documented key names without changing the payload shape; the field meanings still live in [JavaScript event contract](js-events.md).
 `TreeViewTransferDropPositions` exposes the documented coarse drop-position values for transfer events: `before`, `inside`, and `after`. `TreeViewEventNames.transfer.*` names transfer events, `TreeViewEventDetailKeys.transfer.*` lists the documented `event.detail` keys, and `TreeViewTransferDropPositions` carries the position values described in [Drag and Drop](drag-and-drop.md#drop-behavior).
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
 

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -47,6 +47,8 @@ Host apps may use these entry points directly:
 
 Use `TreeView::ResourceTableRenderState.call` when another table layer already owns column inference and table state, and TreeView should only build the hierarchical render state. See [Resource table bridge](resource-table-bridge.md).
 
+`TreeView::NodePresenter` is a stable public constant. Its builder names are also manifest-backed public contract entries, tracked by `node_presenter_builder_names` in `config/public_api_manifest.yml` and checked against `TreeView::NodePresenter::BUILDER_NAMES`.
+
 ## Public error surface
 
 Host apps may rescue `TreeView::Error` to handle documented TreeView validation and configuration failures separately from unrelated application errors.
@@ -156,12 +158,15 @@ Host apps are expected to provide these pieces:
 - `row_partial`
 - Turbo mode path builders
 - optional Turbo Frame targets through `turbo_frame:`
+- `TreeView::NodePresenter` builder blocks for stable node-level values such as labels, hrefs, row data, icons, badges, and action identifiers
 - row class / data builders
 - row event payload builders
 - selection payload / disabled builders
 - hidden message / breadcrumb / depth label / row status builders
 - lazy loading path builders and remote-state handling
 - persisted state storage model
+
+`TreeView::NodePresenter` builder names are stable, manifest-backed extension points. The builder return values, table cell markup, action rendering, authorization, formatting, and product-specific workflows remain host-app responsibilities; the row partial cookbook shows one usage pattern rather than turning every rendered cell or action into TreeView API.
 
 ## JavaScript surface
 
@@ -239,7 +244,7 @@ Representative documented hooks are tracked where their feature behavior is expl
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | Reusable baseline hooks documented in the [mockup inventory](../mockups/README.md). They describe the shipped empty-state reference pattern, not every internal row class. |
 | Interaction markers | marker row classes and `data-*` hooks shown in focused mockups | Reference hooks documented through [mockups](../mockups/README.md) for review and adoption. Promote any hook to a machine-readable contract in `config/public_api_manifest.yml` only when it needs compatibility checks. |
 
-This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
+This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, NodePresenter builder names, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
 
 Undocumented CSS helper classes, data attributes, DOM structure details, and gem partial locals are implementation details.
 

--- a/docs/ja/node-presenter-row-partials.md
+++ b/docs/ja/node-presenter-row-partials.md
@@ -42,6 +42,10 @@ Host app が担当するもの:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` とその builder 名は public compatibility contract の一部です。machine-readable な builder list は `config/public_api_manifest.yml` の `node_presenter_builder_names` に置き、compatibility spec で `TreeView::NodePresenter::BUILDER_NAMES` と照合します。
+
+この contract が安定させるのは利用可能な builder 名です。返される label、link、row data、action identifier、badge、icon の意味や、authorization / formatting の判断は host app 側の責務であり、この guide では cookbook として例示します。
+
 ## presenter 例
 
 ```ruby

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -47,6 +47,8 @@ host app が直接使ってよい主な入口は以下です。
 
 `TreeView::ResourceTableRenderState.call` は、別の table layer が列推論や table state を持っていて、TreeView には階層 render state の組み立てだけを任せたい場合の公開入口です。詳細は [Resource table bridge](resource-table-bridge.md) を参照してください。
 
+`TreeView::NodePresenter` は安定した public constant です。builder 名も manifest-backed public contract として扱い、`config/public_api_manifest.yml` の `node_presenter_builder_names` で管理し、`TreeView::NodePresenter::BUILDER_NAMES` と照合します。
+
 ## Public error surface
 
 host app は `TreeView::Error` を rescue することで、documented された TreeView の validation / configuration failure を、他の application error と分けて扱えます。
@@ -156,12 +158,15 @@ host app が提供する主な拡張点は以下です。
 - `row_partial`
 - Turbo mode path builders
 - `turbo_frame:` による任意の Turbo Frame target
+- label、href、row data、icon、badge、action identifier など、安定した node-level value 用の `TreeView::NodePresenter` builder block
 - row class / data builders
 - row event payload builders
 - selection payload / disabled builders
 - hidden message / breadcrumb / depth label / row status builders
 - lazy loading path builders and remote-state handling
 - persisted state storage model
+
+`TreeView::NodePresenter` builder 名は stable で manifest-backed な extension point です。一方で、builder の戻り値、table cell markup、action rendering、authorization、formatting、product-specific workflow は引き続き host app 側の責務です。row partial cookbook は使い方の pattern を示すもので、描画される cell や action すべてを TreeView API に昇格するものではありません。
 
 ## JavaScript surface
 
@@ -239,7 +244,7 @@ host app が依存してよい browser-facing surface は、documented された
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | [mockup inventory](../mockups/README.md) で説明している reusable baseline hook です。shipped empty-state reference pattern を示すもので、すべての internal row class を公開するものではありません。 |
 | Interaction markers | focused mockup に出てくる marker row classes / `data-*` hooks | review / adoption 用の reference hook として [mockups](../mockups/README.md) で説明します。compatibility check が必要な hook だけを `config/public_api_manifest.yml` の machine-readable contract へ昇格してください。 |
 
-この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
+この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、NodePresenter builder names、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
 
 undocumented な CSS helper class、data attribute、DOM 構造詳細、gem partial 内部 locals は内部実装です。
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -176,6 +176,7 @@ host app が使ってよい入口:
 
 - `registerTreeViewControllers(application)`
 - `TreeViewEventNames`
+- `TreeViewEventDetailKeys`
 - `TreeViewTransferDropPositions`
 - `TreeViewControllerIdentifiers`
 - exported controller classes
@@ -190,6 +191,7 @@ host app が使ってよい入口:
 `registerTreeViewControllers(application)` は、上記 5 つの controller export を bundled entrypoint の documented identifier 順に登録します。
 
 `TreeViewEventNames` は documented event names を machine-readable に参照するための package-root export です。host app 側で listener を配線するとき、`TreeViewEventNames.selection.change` や `TreeViewEventNames.transfer.drop` のように使うことで event name string の写経を避けられます。
+`TreeViewEventDetailKeys` は documented `event.detail` key list を machine-readable に参照するための package-root export です。host app の test や listener が documented key name と照合したい場合に使えますが、payload shape 自体は変えません。各 field の意味は [JavaScript event contract](js-events.md) を正本にしてください。
 `TreeViewTransferDropPositions` は transfer event の粗い drop-position value として、`before`、`inside`、`after` を公開します。`TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented な `event.detail` key、`TreeViewTransferDropPositions` は [Drag and Drop](drag-and-drop.md#drop処理) で説明している position value を表します。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
 

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -161,6 +161,13 @@ RSpec.describe "Public API compatibility" do
     expect(builder).to respond_to(:build_client_side)
   end
 
+  it "keeps documented NodePresenter builder names aligned with the public manifest" do
+    manifest_names = public_api_manifest.fetch("node_presenter_builder_names")
+
+    expect(manifest_names).to eq(TreeView::NodePresenter::BUILDER_NAMES.map(&:to_s)),
+      "expected NodePresenter builder names to stay aligned with the manifest-backed public contract"
+  end
+
   it "keeps documented RenderState grouped option keys available" do
     public_api_manifest.fetch("grouped_option_keys").each do |group_name, manifest_keys|
       expected_keys = RENDER_STATE_GROUPED_OPTION_KEY_RESOLVERS.fetch(group_name).call


### PR DESCRIPTION
Superseded by a clean branch based on current `main`; keeping the same Issue scope and changes in the replacement PR.