### PR TITLE
transfer DataTransfer MIME type を最新 main で再提案する

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -68,6 +68,11 @@ export const TreeViewTransferDropPositions = Object.freeze({
   after: "after"
 })
 
+export const TreeViewTransferDataMimeTypes = Object.freeze({
+  applicationJson: "application/json",
+  textPlain: "text/plain"
+})
+
 export const TreeViewControllerIdentifiers = Object.freeze({
   state: "tree-view-state",
   client: "tree-view-client",

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -113,6 +113,7 @@ javascript_package_root:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
     - TreeViewTransferDropPositions
+    - TreeViewTransferDataMimeTypes
     - TreeViewStateController
     - TreeViewClientController
     - TreeViewSelectionController
@@ -124,6 +125,9 @@ javascript_package_root:
     before: before
     inside: inside
     after: after
+  transfer_data_mime_types:
+    application_json: application/json
+    text_plain: text/plain
   controller_registrations:
     - key: state
       identifier: tree-view-state

--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -93,6 +93,8 @@ function onDrop(event) {
 }
 ```
 
+`application/json` is the primary TreeView transfer MIME type for host apps to read. TreeView also writes the same JSON payload to `text/plain` as a browser compatibility fallback. Host apps that want machine-readable strings can import `TreeViewTransferDataMimeTypes` from the package root and read `TreeViewTransferDataMimeTypes.applicationJson` first, then `TreeViewTransferDataMimeTypes.textPlain` only as fallback.
+
 Host apps can also listen for the public transfer events dispatched by the `tree-view-transfer` controller instead of reading controller internals directly.
 
 ```js

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -93,6 +93,8 @@ function onDrop(event) {
 }
 ```
 
+`application/json` は、host app が通常読む primary な TreeView transfer MIME type です。TreeView は browser compatibility fallback として、同じ JSON payload を `text/plain` にも書き込みます。machine-readable な文字列を使いたい host app は package root から `TreeViewTransferDataMimeTypes` を import し、まず `TreeViewTransferDataMimeTypes.applicationJson` を読み、必要な場合だけ `TreeViewTransferDataMimeTypes.textPlain` を fallback として使ってください。
+
 host appは controller 内部に直接依存せず、`tree-view-transfer` controller がdispatchする公開transfer eventをlistenできます。
 
 ```js

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -195,3 +195,10 @@ assert(
   "TreeViewTransferDropPositions export is out of sync"
 )
 assertFrozenObject(entrypointModule.TreeViewTransferDropPositions, "TreeViewTransferDropPositions")
+
+const expectedTransferDataMimeTypes = deepCamelizeKeys(javascriptPackageManifest.transfer_data_mime_types)
+assert(
+  JSON.stringify(entrypointModule.TreeViewTransferDataMimeTypes) === JSON.stringify(expectedTransferDataMimeTypes),
+  "TreeViewTransferDataMimeTypes export is out of sync"
+)
+assertFrozenObject(entrypointModule.TreeViewTransferDataMimeTypes, "TreeViewTransferDataMimeTypes")


### PR DESCRIPTION
## 対応 Issue / PR

- Closes #1177
- Supersedes #1181

## 変更内容

PR #1181 が current `main` から `behind_by:77` / `status:diverged` / `mergeable:false` になっていたため、latest `main` から同じ intent を clean replacement として載せ直しました。

- package root export に `TreeViewTransferDataMimeTypes` を追加しました。
  - `applicationJson: "application/json"`
  - `textPlain: "text/plain"`
- `config/public_api_manifest.yml` に named export と `transfer_data_mime_types` key set を追加しました。
- `script/test_entrypoints.mjs` で manifest と export の値が同期し、export object が frozen であることを確認する smoke を追加しました。
- 英日 drag-and-drop docs に、host app が通常読む primary key は `application/json`、`text/plain` は browser compatibility fallback であることを追記しました。

## 最新 main への追従で保持した内容

current `main` の `TreeViewEventDetailKeys` export / manifest / entrypoint smoke / docs の追記を保持したまま、DataTransfer MIME type export だけを追加しています。旧 #1181 の branch 内容を丸ごと戻すのではなく、latest main の public JS surface を source of truth として再適用しました。

## 既存仕様への影響

- transfer payload shape、event names、event detail keys、drop positions、runtime drag/drop behavior は変更していません。
- 認可、DB、外部 API、migration、データ破壊、host-app authorization / business operation policy は変更していません。
- package-root public JS surface と manifest contract の additive expansion なので、#1181 と同じく human review 対象として残します。

## 確認

- GitHub compare: `main...feature/1177-transfer-mime-types-refresh`
  - changed files: 5
  - #1181 と同じ対象ファイルに限定
- PR metadata: `mergeable:true`
- GitHub Actions CI #1588: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `gem_package`: success
  - `javascript`: success
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
- local `npm run test:entrypoints` / `npm run test:js` は未実行です。この環境では GitHub HTTPS checkout / raw fetch が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions を確認証跡にしています。

## リスク

- risk: medium
- public package-root export と manifest contract の追加です。ただし既存 controller behavior と payload shape は変えず、既存実装済みの MIME key set を machine-readable に公開するだけに閉じています。

## 未対応・補足

- transfer payload shape、operation kind export、DOM data hook export、drag/drop behavior redesign、host-app authorization / business operation policy は Issue 範囲外として扱っています。
- #1181 はこの PR で supersede しました。