### PR TITLE
Public API docs の helper entrypoint list を同期する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -39,6 +39,11 @@ Host apps may use these entry points directly:
 - `tree_view_rows(render_state)`
 - `tree_view_rows(render_state, window: { offset:, limit: })`
 - `tree_view_window(render_state, offset:, limit:)`
+- `tree_node_dom_id(item_or_id, ui: @tree_ui)`
+- `tree_children_container_dom_id(item_or_id, ui: @tree_ui)`
+- `tree_remote_state_placeholder_dom_id(item_or_id, ui: @tree_ui)`
+- `tree_remote_state_placeholder_attributes(item_or_id, state: nil, ui: @tree_ui)`
+- `tree_selection_value(item, tree, builder = nil)`
 - `tree_view_breadcrumb(tree, item, ...)`
 - `tree_view_toolbar(render_state, ...)`
 - `tree_view_toolbar_supported_actions`

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -39,6 +39,11 @@ host app が直接使ってよい主な入口は以下です。
 - `tree_view_rows(render_state)`
 - `tree_view_rows(render_state, window: { offset:, limit: })`
 - `tree_view_window(render_state, offset:, limit:)`
+- `tree_node_dom_id(item_or_id, ui: @tree_ui)`
+- `tree_children_container_dom_id(item_or_id, ui: @tree_ui)`
+- `tree_remote_state_placeholder_dom_id(item_or_id, ui: @tree_ui)`
+- `tree_remote_state_placeholder_attributes(item_or_id, state: nil, ui: @tree_ui)`
+- `tree_selection_value(item, tree, builder = nil)`
 - `tree_view_breadcrumb(tree, item, ...)`
 - `tree_view_toolbar(render_state, ...)`
 - `tree_view_toolbar_supported_actions`


### PR DESCRIPTION
## 対応 Issue

Closes #1305

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- 英日 `docs/*/public-api.md` の冒頭 `Stable public entry points` / `安定した公開入口` に、manifest-backed public helper surface のうち未掲載だった helper を追加しました。
- 追加対象は、同じページの `Public helper surface` では既に説明済みで、`config/public_api_manifest.yml` の `helper_methods` にも載っている helper に限定しています。

追加した helper:

- `tree_node_dom_id(item_or_id, ui: @tree_ui)`
- `tree_children_container_dom_id(item_or_id, ui: @tree_ui)`
- `tree_remote_state_placeholder_dom_id(item_or_id, state: nil, ui: @tree_ui)`
- `tree_remote_state_placeholder_attributes(item_or_id, state: nil, ui: @tree_ui)`
- `tree_selection_value(item, tree, builder = nil)`

## 根拠

- current `config/public_api_manifest.yml` は上記 helper を `helper_methods` として machine-readable public contract に含めています。
- 英日 `public-api.md` の `Public helper surface` 本文では上記 helper を documented public helper として説明済みでした。
- ただし冒頭の stable entrypoint list だけが未追従で、同一ページ内で一覧性にずれがありました。

## 非目標

- `config/public_api_manifest.yml` の変更
- helper API、戻り値、DOM ID、selection payload、lazy-loading behavior の変更
- API contract の新規追加
- specs / CI / runtime Ruby / JavaScript の変更

## 確認内容

- GitHub compare: `main...docs/public-api-helper-entrypoints`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 10 / deletions: 0
- GitHub Actions CI #1589: success
- PR metadata: `mergeable:true`
- docs-only 変更のため local test / lint は未実行です。

## リスク

low。既存 manifest と同一ページ本文で既に public helper とされている内容を、冒頭一覧へ同期するだけです。runtime behavior や public contract 自体は変更していません。