### PR TITLE
entrypoint export smoke の差分診断を改善する

### DIFF
--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -69,6 +69,78 @@ function assert(condition, message) {
   if (!condition) throw new Error(message)
 }
 
+function formatValue(value) {
+  return JSON.stringify(value)
+}
+
+function valueType(value) {
+  if (Array.isArray(value)) return "array"
+  if (value === null) return "null"
+
+  return typeof value
+}
+
+function isPlainObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value)
+}
+
+function diffValues(expected, actual, path) {
+  if (Array.isArray(expected) || Array.isArray(actual)) {
+    if (!Array.isArray(expected) || !Array.isArray(actual)) {
+      return [`${path}: expected ${valueType(expected)}, actual ${valueType(actual)}`]
+    }
+
+    if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+      return [`${path}: expected ${formatValue(expected)}, actual ${formatValue(actual)}`]
+    }
+
+    return []
+  }
+
+  if (isPlainObject(expected) || isPlainObject(actual)) {
+    if (!isPlainObject(expected) || !isPlainObject(actual)) {
+      return [`${path}: expected ${valueType(expected)}, actual ${valueType(actual)}`]
+    }
+
+    const diffs = []
+    const expectedKeys = Object.keys(expected)
+    const actualKeys = Object.keys(actual)
+
+    expectedKeys
+      .filter((key) => !(key in actual))
+      .forEach((key) => diffs.push(`${path}.${key}: missing, expected ${formatValue(expected[key])}`))
+
+    actualKeys
+      .filter((key) => !(key in expected))
+      .forEach((key) => diffs.push(`${path}.${key}: extra, actual ${formatValue(actual[key])}`))
+
+    expectedKeys
+      .filter((key) => key in actual)
+      .forEach((key) => diffs.push(...diffValues(expected[key], actual[key], `${path}.${key}`)))
+
+    return diffs
+  }
+
+  if (expected !== actual) {
+    return [`${path}: expected ${formatValue(expected)}, actual ${formatValue(actual)}`]
+  }
+
+  return []
+}
+
+function assertDeepEqualExport(actual, expected, name) {
+  const diffs = diffValues(expected, actual, name)
+
+  assert(
+    diffs.length === 0,
+    [
+      `${name} export is out of sync`,
+      ...diffs.slice(0, 10),
+      ...(diffs.length > 10 ? [`...and ${diffs.length - 10} more differences`] : [])
+    ].join("\n")
+  )
+}
+
 function assertFrozenObject(value, name, { deep = false } = {}) {
   assert(Object.isFrozen(value), `${name} export is not frozen`)
 
@@ -175,23 +247,18 @@ assert(
 )
 
 const expectedEventNames = deepCamelizeKeys(javascriptPackageManifest.event_names)
-assert(
-  JSON.stringify(entrypointModule.TreeViewEventNames) === JSON.stringify(expectedEventNames),
-  "TreeViewEventNames export is out of sync"
-)
+assertDeepEqualExport(entrypointModule.TreeViewEventNames, expectedEventNames, "TreeViewEventNames")
 assertFrozenObject(entrypointModule.TreeViewEventNames, "TreeViewEventNames", { deep: true })
 
 const expectedEventDetailKeys = deepCamelizeKeys(javascriptPackageManifest.event_detail_keys)
-assert(
-  JSON.stringify(entrypointModule.TreeViewEventDetailKeys) === JSON.stringify(expectedEventDetailKeys),
-  "TreeViewEventDetailKeys export is out of sync"
-)
+assertDeepEqualExport(entrypointModule.TreeViewEventDetailKeys, expectedEventDetailKeys, "TreeViewEventDetailKeys")
 assertFrozenEventDetailKeys(entrypointModule.TreeViewEventDetailKeys, "TreeViewEventDetailKeys")
 assertEventDetailKeysMatchEventNames(entrypointModule.TreeViewEventNames, entrypointModule.TreeViewEventDetailKeys)
 
 const expectedTransferDropPositions = javascriptPackageManifest.transfer_drop_positions
-assert(
-  JSON.stringify(entrypointModule.TreeViewTransferDropPositions) === JSON.stringify(expectedTransferDropPositions),
-  "TreeViewTransferDropPositions export is out of sync"
+assertDeepEqualExport(
+  entrypointModule.TreeViewTransferDropPositions,
+  expectedTransferDropPositions,
+  "TreeViewTransferDropPositions"
 )
 assertFrozenObject(entrypointModule.TreeViewTransferDropPositions, "TreeViewTransferDropPositions")


### PR DESCRIPTION
## 対応 Issue
- Closes #1300

## Issue ごとの完了内容
- #1300: `TreeViewEventNames` / `TreeViewEventDetailKeys` / `TreeViewTransferDropPositions` の同期検査で、失敗時に missing / extra / expected / actual を含む差分を表示するようにしました。

## 変更内容
- `script/test_entrypoints.mjs` に公開 export 同期検査用の差分生成ヘルパーを追加しました。
- 対象 3 export の `JSON.stringify(...)` 一致判定を、同じ値比較を維持しつつ差分付き assertion に置き換えました。
- 差分が多い場合は先頭 10 件と残件数を表示し、CI ログが過度に長くならないようにしています。

## 改善カテゴリ
- test
- error handling / diagnostics

## 既存仕様への影響
- なし。公開 JS export、manifest、docs、API 契約、UI、DB、認可、状態遷移は変更していません。
- エントリポイント smoke が失敗したときのメッセージのみを改善しています。

## 実施した確認
- GitHub connector で `main...quality/1300-entrypoint-diff-diagnostics` の差分が `script/test_entrypoints.mjs` のみであることを確認しました。
- ローカル clone はこの環境から GitHub への git 接続が 403 で利用できないため、PR 作成後の GitHub Actions で `npm run test:entrypoints` を含む CI 結果を確認します。

## リスク評価
- risk: low
- テストスクリプト内の診断改善のみで、プロダクションコードや公開契約には触れていません。

## 補足事項
- Quality Fixer Agent の通常ルールに従い、review follow-up も確認しました。#1299 は branch refresh が必要な状態ですが、今回の変更とは共通原因が薄く、大きな docs/spec 差分を connector-only で安全に載せ直す範囲ではなかったため、この PR では #1300 の診断改善に絞っています。