### PR TITLE
test: configuration options manifest contract を固定する

### DIFF
--- a/spec/public_api_configuration_options_spec.rb
+++ b/spec/public_api_configuration_options_spec.rb
@@ -3,9 +3,9 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "Public configuration option compatibility" do
-  PUBLIC_CONFIGURATION_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+PUBLIC_CONFIGURATION_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
 
+RSpec.describe "Public configuration option compatibility" do
   def configuration_option_keys
     YAML.safe_load_file(PUBLIC_CONFIGURATION_MANIFEST_PATH).fetch("configuration_options").fetch("tree_view_configure")
   end

--- a/spec/public_api_configuration_options_spec.rb
+++ b/spec/public_api_configuration_options_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "Public configuration option compatibility" do
+  PUBLIC_CONFIGURATION_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+  def configuration_option_keys
+    YAML.safe_load_file(PUBLIC_CONFIGURATION_MANIFEST_PATH).fetch("configuration_options").fetch("tree_view_configure")
+  end
+
+  after do
+    TreeView.reset_configuration!
+  end
+
+  it "keeps TreeView.configure options aligned with the public manifest" do
+    representative_values = {
+      "initial_state" => :collapsed,
+      "render_log_level" => :info
+    }
+
+    expect(configuration_option_keys).to eq(representative_values.keys)
+
+    configuration_option_keys.each do |option_name|
+      expect(TreeView.configuration).to respond_to(option_name),
+        "expected TreeView.configuration.#{option_name} to remain readable"
+      expect(TreeView.configuration).to respond_to("#{option_name}="),
+        "expected TreeView.configuration.#{option_name}= to remain writable"
+    end
+
+    TreeView.configure do |config|
+      configuration_option_keys.each do |option_name|
+        config.public_send("#{option_name}=", representative_values.fetch(option_name))
+      end
+    end
+
+    configuration_option_keys.each do |option_name|
+      expect(TreeView.configuration.public_send(option_name)).to eq(representative_values.fetch(option_name))
+    end
+  end
+end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1308

## Issue ごとの完了内容

- #1308: `configuration_options.tree_view_configure` を読み、`TreeView.configuration` の reader / writer surface と代表 `TreeView.configure` behavior が同期していることを spec で固定しました。

## 変更内容

- `spec/public_api_configuration_options_spec.rb` を追加
- manifest の `tree_view_configure` key set を source of truth として読み込み
- `initial_state` / `render_log_level` の reader / writer availability と代表 configure value を確認
- 各 example 後に `TreeView.reset_configuration!` で状態を戻すようにしました
- review follow-up: StandardRB の定数定義位置指摘に合わせ、manifest path constant を top-level へ移動しました

## 改善カテゴリ

- test
- public API manifest drift guard

## 既存仕様への影響はないこと

- `TreeView::Configuration` runtime API、validation policy、manifest schema、docs は変更していません。
- 新 option 追加や behavior redesign には広げていません。

## 実施した確認内容

- GitHub compare: `main...quality/1308-config-manifest-spec`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 1 spec file
- GitHub Actions CI #1600: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
- 初回 CI #1599 は `Lint/ConstantDefinitionInBlock` で失敗し、follow-up commit で修正済みです。
- local `bundle exec rspec spec/public_api_configuration_options_spec.rb` は未実行です。local checkout は GitHub HTTPS 制限により `CONNECT tunnel failed, response 403` でした。

## リスク評価

- risk: low
- spec-only 追加で、公開挙動は変更しません。

## 補足事項

- #1309 の docs sync とは隣接しますが、Planner handoff どおり spec guard と docs-only sync は分けています。