### PR TITLE
docs index に Accessibility Semantics 入口を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
+- [English Accessibility Semantics](en/accessibility-semantics.md): table-first ARIA policy, keyboard helper boundary, and intentional automated-check allowances.
+- [日本語Accessibility Semantics](ja/accessibility-semantics.md): table-first ARIA 方針、keyboard helper の責務境界、自動 accessibility check の意図的な許容事項。
 - [English Selection](en/selection.md): checkbox selection hooks, disabled state, cascade behavior, and submitted value parsing.
 - [日本語Selection](ja/selection.md): checkbox selection hooks、disabled state、cascade、submitted value parsing の入口。
 - [English Lazy Loading](en/lazy-loading.md): load children on demand through host-app routes and TreeView remote-state hooks.


### PR DESCRIPTION
## 対応 Issue

Closes #1314

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/README.md` の Recommended entry points に Accessibility Semantics の英日リンクを追加しました。
- table-first ARIA policy、keyboard helper boundary、automated accessibility check の intentional allowances へ導入前・レビュー前に辿りやすくしました。
- root `README.md` の Key documents table と、既存の英日 `docs/*/accessibility-semantics.md` にある説明へ導線を揃えています。

## 根拠

- root `README.md` には accessibility-oriented row semantics と Accessibility Semantics 入口があります。
- `docs/en/accessibility-semantics.md` / `docs/ja/accessibility-semantics.md` は table-first accessibility policy、ARIA placement、keyboard helper の責務境界、automated accessibility check の許容事項を説明しています。
- `docs/README.md` の Recommended entry points だけが Accessibility Semantics への直接入口を持っていませんでした。

## 非目標

- ARIA semantics の変更
- keyboard helper behavior の変更
- accessibility docs 本文の rewrite
- automated accessibility smoke の追加
- mockup HTML/CSS、runtime Ruby / JavaScript、public API manifest の変更

## 確認内容

- base: `main` (`2c436cd35054ee0235f8cf10cab7b6c9b291c2ab`)
- head: `4681cfa955ff796fe208910e568e701de6d3d238`
- GitHub compare: `main...docs/1314-accessibility-semantics-docs-index`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/README.md`)
  - additions: 2 / deletions: 0
- PR metadata: `mergeable: true`
- GitHub Actions CI #1614: success
  - `changes` / `lint` / `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `gem_package` / full matrices: skipped by workflow conditions
- docs-only 変更のため local test / lint は未実行です。

## リスク

low。既存 docs への導線追加のみで、仕様・コード・公開契約は変更していません。