### PR TITLE
Windowed Rendering docs の API 名を実装に揃える

### DIFF
--- a/docs/en/windowed-rendering.md
+++ b/docs/en/windowed-rendering.md
@@ -45,8 +45,8 @@ Main metadata:
 | `total_count` | Visible row count before windowing. |
 | `before_count` | Number of visible rows before the current window. |
 | `after_count` | Number of visible rows after the current window. |
-| `has_previous?` | Whether a previous window exists. |
-| `has_next?` | Whether a next window exists. |
+| `previous?` | Whether a previous window exists. |
+| `next?` | Whether a next window exists. |
 | `previous_offset` | Offset to pass back when rendering the previous window, or `nil` when there is no previous window. |
 | `next_offset` | Offset to pass forward when rendering the next window, or `nil` when there is no next window. |
 
@@ -67,8 +67,8 @@ window = tree_view_window(@render_state, offset: params.fetch(:tree_offset, 0).t
   (<%= window.before_count %> before, <%= window.after_count %> after)
 </p>
 
-<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.has_previous? %>
-<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.has_next? %>
+<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.previous? %>
+<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.next? %>
 ```
 
 The label text, route helper, parameter name, disabled-button treatment, and whether this appears as links, buttons, or a Turbo Frame toolbar are all host-app decisions.
@@ -118,8 +118,8 @@ end
 ```
 
 ```erb
-<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.has_previous? %>
-<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.has_next? %>
+<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.previous? %>
+<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.next? %>
 ```
 
 `tree_offset` is only an example key. The host app owns route design, param names, and which interactions must preserve the offset.

--- a/docs/ja/windowed-rendering.md
+++ b/docs/ja/windowed-rendering.md
@@ -45,8 +45,8 @@ window = tree_view_window(@render_state, offset: 0, limit: 50)
 | `total_count` | window適用前のvisible row数。 |
 | `before_count` | 現在のwindowより前にあるvisible row数。 |
 | `after_count` | 現在のwindowより後ろに残るvisible row数。 |
-| `has_previous?` | 前のwindowが存在するか。 |
-| `has_next?` | 次のwindowが存在するか。 |
+| `previous?` | 前のwindowが存在するか。 |
+| `next?` | 次のwindowが存在するか。 |
 | `previous_offset` | 前のwindowを描画するときに渡すoffset。前のwindowがない場合は `nil`。 |
 | `next_offset` | 次のwindowを描画するときに渡すoffset。次のwindowがない場合は `nil`。 |
 
@@ -67,8 +67,8 @@ window = tree_view_window(@render_state, offset: params.fetch(:tree_offset, 0).t
   （前に <%= window.before_count %> 件、後ろに <%= window.after_count %> 件）
 </p>
 
-<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.has_previous? %>
-<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.has_next? %>
+<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.previous? %>
+<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.next? %>
 ```
 
 表示文言、route helper、param 名、disabled button の扱い、リンク・ボタン・Turbo Frame toolbar のどれで出すかはすべて host app 側で決めます。
@@ -118,8 +118,8 @@ end
 ```
 
 ```erb
-<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.has_previous? %>
-<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.has_next? %>
+<%= link_to "Previous", documents_path(tree_offset: window.previous_offset) if window.previous? %>
+<%= link_to "Next", documents_path(tree_offset: window.next_offset) if window.next? %>
 ```
 
 `tree_offset` はあくまで例です。param 名、route 設計、どの interaction で offset を保つかは host app 側で決めます。


### PR DESCRIPTION
## 対応 Issue

Closes #1247

## Issue ごとの完了内容

- #1247: `TreeView::RenderWindow` の実APIである `previous?` / `next?` に、英日 Windowed Rendering docs の metadata table と ERB examples を揃えました。
- #1247: `has_previous?` / `has_next?` alias は追加せず、public API surface を増やさない docs/API drift 解消に閉じました。

## 変更内容

- `docs/en/windowed-rendering.md`
  - metadata table と pagination examples を `previous?` / `next?` に更新
- `docs/ja/windowed-rendering.md`
  - 同じ API 名を日本語 docs 側にも同期

## 改善カテゴリ

- docs 改善
- API docs drift 修正

## 既存仕様への影響

- runtime Ruby behavior、RenderWindow pagination behavior、offset / limit slicing、host-app pagination UI、public API alias 追加は変更していません。
- 実装済み API 名へ docs を合わせるだけです。

## 実施した確認

- GitHub compare: `main...quality/1247-windowed-rendering-api-docs`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
- `lib/tree_view/render_window.rb` と `spec/lib/tree_view/render_window_spec.rb` を確認し、実装と既存specが `previous?` / `next?` を使っていることを確認しました。
- GitHub Actions `CI #1615`: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - `pr_rails_matrix`: success
- local RSpec / docs check は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` になるため、GitHub Actions で確認しました。

## リスク評価

- risk: low
- docs-only 変更で、実行時挙動や公開APIは変更していません。