### PR TITLE
Unreleased CHANGELOG を最近の docs / public surface 追加に同期する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added client-side-only expand/collapse mode that renders collapsed descendants into initial HTML and toggles rows in the browser with the bundled `tree-view-client` controller.
 - Added `TreeView::Diagnostics.run` as a consolidated diagnostics entrypoint for node keys, DOM IDs, orphans, and cycles.
 - Added `tree_children_container_dom_id`, `tree_remote_state_placeholder_dom_id`, and `tree_remote_state_placeholder_attributes` so host apps can reuse stable lazy-loading placeholder IDs and data attributes.
+- Added `toggle_icons` to the manifest-backed grouped option compatibility surface while keeping the existing RenderState option behavior unchanged.
 
 ### Changed
 
@@ -65,6 +66,10 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added toolbar disabled-action troubleshooting guidance in Japanese and English.
 - Added transfer disabled / invalid boundary states to the drop-position mockup and updated the mockup review guidance.
 - Added static mockup references for multi-tree selection forms, toggle icon states, and high-contrast state cues.
+- Added focused mockup references for RenderWindow boundary metadata and direction-aware visual cue boundaries.
+- Added direction-aware styling boundary docs for host-app-owned RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing overrides.
+- Added Decision guide guidance for choosing Static, Turbo, or Client-side toggle mode before tuning render depth or loading strategy.
+- Clarified docs index entry points for PathTreeBuilder, Children Pagination, and large-tree reading paths.
 - Clarified that `docs/mockups/README.md` is the source of truth for mockup technical asset inventory.
 
 ### Tests
@@ -85,6 +90,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added package-root frozen object contract coverage for public JavaScript object exports.
 - Improved entrypoint smoke diagnostics for Ruby manifest loader and JSON parse failures without changing public export assertions.
 - Added browser smoke coverage for representative docs mockup pages and the review gallery.
+- Added docs entrypoint guard coverage for keeping README feature links and docs index targets aligned.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue

Closes #976

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の Unreleased section を最近の merged `main` 内容に合わせて監査しました。
- `toggle_icons` の manifest-backed grouped option compatibility surface を `Added` に追記しました。
- Direction-aware styling boundary、RenderWindow boundary / direction-aware mockup references、toggle mode decision guide、PathTreeBuilder / Children Pagination など docs index entrypoint の追従を `Documentation` に追記しました。
- README feature / docs entrypoint guard を `Tests` に追記しました。

## 根拠

- current `main` には `docs/en|ja/direction-aware-styling.md`、toggle mode selection を含む `docs/en|ja/decision-guide.md`、PathTreeBuilder / Children Pagination を含む `docs/README.md` の entrypoint 補強、README feature と docs entrypoint の guard が入っています。
- `docs/i18n-audit.md` は user-visible documentation / public API / release-facing changes を CHANGELOG で確認する運用にしています。

## 非目標

- CHANGELOG format の全面変更
- release automation / version bump / tag 作成
- open PR の未merge内容の先書き
- runtime Ruby / JavaScript、manifest、spec、docs本文の変更

## 確認内容

- GitHub compare: `main...docs/976-unreleased-changelog-audit`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`CHANGELOG.md`)
- docs-only 変更のため local test / lint は未実行です。

## リスク

low。release-facing summary の追記のみで、仕様・コード・公開契約は変更していません。