### PR TITLE
Unreleased CHANGELOG を最新 main で再監査する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added client-side-only expand/collapse mode that renders collapsed descendants into initial HTML and toggles rows in the browser with the bundled `tree-view-client` controller.
 - Added `TreeView::Diagnostics.run` as a consolidated diagnostics entrypoint for node keys, DOM IDs, orphans, and cycles.
 - Added `tree_children_container_dom_id`, `tree_remote_state_placeholder_dom_id`, and `tree_remote_state_placeholder_attributes` so host apps can reuse stable lazy-loading placeholder IDs and data attributes.
+- Added `toggle_icons` to the manifest-backed grouped option compatibility surface while keeping the existing RenderState option behavior unchanged.
 
 ### Changed
 
@@ -65,6 +66,12 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added toolbar disabled-action troubleshooting guidance in Japanese and English.
 - Added transfer disabled / invalid boundary states to the drop-position mockup and updated the mockup review guidance.
 - Added static mockup references for multi-tree selection forms, toggle icon states, and high-contrast state cues.
+- Added focused mockup references for RenderWindow boundary metadata and direction-aware visual cue boundaries.
+- Added direction-aware styling boundary docs for host-app-owned RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing overrides.
+- Added Decision guide guidance for choosing Static, Turbo, or Client-side toggle mode before tuning render depth or loading strategy.
+- Clarified docs index entry points for PathTreeBuilder, Children Pagination, and large-tree reading paths.
+- Added docs index entry points for Accessibility Semantics so ARIA placement, keyboard boundaries, and automated check allowances are easier to find before review.
+- Corrected Windowed Rendering docs examples and metadata tables to use the implemented `TreeView::RenderWindow#previous?` / `#next?` API names.
 - Clarified that `docs/mockups/README.md` is the source of truth for mockup technical asset inventory.
 
 ### Tests
@@ -85,6 +92,7 @@ Breaking changes and required migration notes should be called out explicitly in
 - Added package-root frozen object contract coverage for public JavaScript object exports.
 - Improved entrypoint smoke diagnostics for Ruby manifest loader and JSON parse failures without changing public export assertions.
 - Added browser smoke coverage for representative docs mockup pages and the review gallery.
+- Added docs entrypoint guard coverage for keeping README feature links and docs index targets aligned.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue

Closes #976
Supersedes #1319

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の Unreleased section を latest `main` の merged docs / public surface / test guard 内容に合わせて再監査しました。
- `toggle_icons` の manifest-backed grouped option compatibility surface を `Added` に追記しました。
- Direction-aware styling boundary、RenderWindow boundary / direction-aware mockup references、toggle mode decision guide、PathTreeBuilder / Children Pagination など docs index entrypoint の追従を `Documentation` に追記しました。
- #1315 merge 後の Accessibility Semantics docs index entrypoint を `Documentation` に追記しました。
- #1317 merge 後の Windowed Rendering docs API name correction (`previous?` / `next?`) を `Documentation` に追記しました。
- README feature / docs entrypoint guard を `Tests` に追記しました。

## latest main refresh

#1319 は review 中に #1317 / #1315 が `main` に merge され、compare が `behind_by: 2` / `status: diverged` になりました。この PR は latest `main` (`9c60514f8a29b91e473a7f8b99d946748cd67887`) から clean replacement として作成しています。

## 受け入れ条件との対応

- 最近の public API / docs / test guard / visual mockup guidance と `CHANGELOG.md` の Unreleased section が矛盾しないようにしました。
- open PR の未merge内容は先取りしていません。
- #1315 / #1317 は merged main 内容として明示的に扱いました。
- release automation、changelog generation、version bump、tag 作成には広げていません。

## 変更範囲

- `CHANGELOG.md` のみ

## 実施した確認

- GitHub compare: `main...docs/976-unreleased-changelog-audit-v2`
  - latest `main` から作成
  - changed files: 1 (`CHANGELOG.md`)
- docs-only 変更のため local test / lint は未実行です。
- この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` になるため、connector 経由で変更しています。
- GitHub Actions は PR 作成後に確認します。

## リスク

low。release-facing summary の追記のみで、runtime behavior、manifest schema、CI workflow、release automation は変更していません。

## 未対応・補足

- #1319 は replacement のため close します。