### PR TITLE
README 用 representative visual 候補を整理する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -12,6 +12,7 @@ They are **not** a complete Rails application and should not grow into host-app 
 |---|---|
 | [review-gallery.html](review-gallery.html) | Single-surface comparison hub for the current baseline and focused mockup references, with review-path jump links, embedded previews, and links to each full page. |
 | [default-tree.html](default-tree.html) | Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS. |
+| [readme-representative-visual-candidates.md](readme-representative-visual-candidates.md) | Candidate note for choosing a future README screenshot or GIF source before adding generated assets in #360. |
 | [resource-table-bridge.html](resource-table-bridge.html) | Resource table bridge reference showing shared hierarchy rows across fuller and narrower visible column sets without host-app table logic. |
 | [narrow-sidebar-tree.html](narrow-sidebar-tree.html) | Narrow sidebar and small-width reference that keeps toggle controls, primary labels, and current or selection cues visible while secondary metadata wraps below. |
 | [current-branch-sidebar.html](current-branch-sidebar.html) | Current branch sidebar reference showing current row, expanded ancestors, collapsed sibling branches, and depth/toggle cues without host-app navigation policy. |

--- a/docs/mockups/readme-representative-visual-candidates.md
+++ b/docs/mockups/readme-representative-visual-candidates.md
@@ -1,0 +1,36 @@
+# README representative visual candidates
+
+This note narrows the README screenshot or GIF source candidates before issue #360 adds an actual image asset.
+
+The source HTML/CSS mockups remain canonical. Do not add generated screenshots, GIFs, or GitHub-hosted image assets in this slice.
+
+## Candidate A: baseline tree screenshot
+
+- Source: `default-tree.html`
+- Recommended state: first viewport showing the default hierarchy table, expanded and collapsed rows, selection checkboxes, row badges, depth labels, and row actions.
+- What it communicates: TreeView's baseline shape in one compact image. A new reader can understand that the gem renders table-first hierarchy rows while leaving business actions to the host app.
+- README placement: near the existing static visual reference paragraph in the introduction, before the feature list grows dense.
+- Alt text direction: "Static TreeView mockup showing expanded and collapsed hierarchy rows with selection checkboxes, badges, and row actions."
+- Weight concern: low. One focused screenshot is easier to scan than a gallery capture and does not imply every focused mockup is part of the README hero.
+- Caveat: it should not look like a complete file-manager product. Crop around the tree surface and keep host-app business copy out of the image.
+
+## Candidate B: review gallery overview
+
+- Source: `review-gallery.html`, preferably the gallery card or preview area that includes the default-tree reference plus a few focused state families.
+- Recommended state: side-by-side gallery overview that shows the breadth of focused mockups without opening every page.
+- What it communicates: the repository has a reviewable static mockup system for baseline output, state cues, accessibility references, and focused UX surfaces.
+- README placement: below the baseline TreeView explanation or in a short "Visual references" note, not as the primary hero image.
+- Alt text direction: "TreeView review gallery showing multiple static mockup previews for baseline rows and focused interaction states."
+- Weight concern: medium. The overview is useful for reviewers, but it may be visually busy for first-time README readers.
+- Caveat: the gallery image should not replace links to individual mockup pages. It is an orientation aid, not the source of truth for every state.
+
+## Recommendation
+
+Use Candidate A as the first README image candidate because it explains the product shape with the least visual noise. Keep Candidate B as a secondary option if #360 decides the README should emphasize the mockup review system rather than the rendered tree surface itself.
+
+## Non-goals for this note
+
+- Adding screenshots, GIFs, or GitHub image assets.
+- Changing `README.md` image placement.
+- Redesigning `default-tree.html` or `review-gallery.html`.
+- Deciding final asset storage, capture tooling, or screenshot approval workflow.


### PR DESCRIPTION
## 対応Issue

Closes #1294

## 採用した方針

- スケジュール実行のためユーザー選択待ちは行わず、Planner handoff の低リスクな候補選定 docs-only 方針を採用しました。
- 実画像生成、README への画像追加、GitHub assets 管理、mockup HTML/CSS redesign には広げず、#360 の前段になる decision note に閉じています。
- 候補メモを独立ファイルとして追加し、mockup inventory guard に合わせて `docs/mockups/README.md` の Files table にだけ同期しました。

## 比較した案

- 案A: `docs/mockups/README.md` へ直接 candidate matrix を追加する
  - 見送り。mockup inventory file の本文を重くせず、候補選定メモを独立して読めるようにするためです。
- 案B: `docs/mockups/readme-representative-visual-candidates.md` を追加し、Files table へ最小同期する
  - 採用。候補を1〜2案に絞りつつ、画像追加やREADME placement判断は #360 / follow-up に残せます。
- 案C: README に画像 placeholder や候補リンクを追加する
  - 見送り。Issue の非目標である README image placement へ近づくため、今回は候補選定に留めました。

## 変更内容

- `docs/mockups/readme-representative-visual-candidates.md` を追加しました。
- README 用 representative visual 候補を次の2案に絞りました。
  - Candidate A: `default-tree.html` の baseline tree screenshot
  - Candidate B: `review-gallery.html` の overview capture
- 各候補について、伝える feature、source mockup/state、README placement、alt text 方針、重さの懸念、注意点を整理しました。
- 推奨案として、初回 README image には Candidate A を優先し、mockup review system を強調したい場合に Candidate B を secondary option とする方針を明記しました。
- `docs/mockups/README.md` の Files table に新規候補メモを追加し、mockup inventory guard と同期しました。

## 変更した画面・コンポーネント

- `docs/mockups/readme-representative-visual-candidates.md`
- `docs/mockups/README.md`

## 確認内容

- lint: GitHub Actions CI #1625 success
- typecheck: 該当なし
- UI表示確認: 該当なし。画像やHTML/CSSは追加していません
- レスポンシブ確認: 該当なし
- アクセシビリティ確認: alt text 方針を候補ごとに記載
- pr_specs / mockup inventory guard: GitHub Actions CI #1625 success
- JavaScript / browser smoke: GitHub Actions CI #1625 success
- representative Rails lanes: docs-only skip path で success
- GitHub compare: `main...design/1294-readme-visual-candidates`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only
- PR metadata: `mergeable: true`
- head: `10c95333ea6cf48c16175a802d23b1e823bb416d`

## スクリーンショット

<!-- 画像追加を行わない Issue のため未添付 -->

## リスク

- low

## 補足

- 初回 CI #1623 は `mockup inventory` guard で失敗し、Files table を同期する追加コミットで解消しました。
- ローカル checkout / docs lint は、この環境の GitHub HTTPS 制限により未実行です。
- 実画像追加、README placement、asset storage、capture workflow は #360 または follow-up に残しています。