### PR TITLE
Render log level docs を root docs index へ追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@
 - [日本語Children Pagination](ja/children-pagination.md): direct children が多すぎる親nodeで、lazy loading と server-side child paging を組み合わせる入口。
 - [English Windowed Rendering](en/windowed-rendering.md): render visible rows by offset and limit while host apps keep query and paging ownership.
 - [日本語Windowed Rendering](ja/windowed-rendering.md): offset / limit で visible rows を描画し、query や paging は host app が所有する前提の入口。
+- [English Render log level](en/render-log-level.md): configure TreeView helper-rendered partial log verbosity without changing the host app's global Rails logger level.
+- [日本語Render log level](ja/render-log-level.md): host app 全体の Rails logger level を変えずに、TreeView helper-rendered partial log の出力を調整する入口。
 - [English direction-aware styling boundary](en/direction-aware-styling.md): host-app override guidance for RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing.
 - [日本語Direction-aware styling boundary](ja/direction-aware-styling.md): RTL、writing direction、current-row cue、hierarchy connector、toggle spacing の host-app override guidance。
 - [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure and interaction states. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.


### PR DESCRIPTION
## 対応 Issue

Closes #1320

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/README.md` の Recommended entry points に Render log level の英日導線を追加しました。
- root `README.md` の Quick Start と Key documents、`docs/en/README.md` / `docs/ja/README.md` には既に Render log level への導線があるため、今回の差分は root docs index の同期に限定しています。

## 根拠

- `README.md` は TreeView helper-rendered partial log silencing と `render_log_level` の設定例を説明しています。
- `docs/en/render-log-level.md` / `docs/ja/render-log-level.md` は accepted values と `nil` boundary を説明しています。
- root `docs/README.md` だけが cross-language entry point として未追従でした。

## 非目標

- render log behavior の変更
- `TreeView::Configuration` public constant 判断
- `render_log_level` accepted values の manifest 化
- docs 全体の再編
- #1321 の docs-entrypoint test guard

## 確認内容

- GitHub compare: `main...docs/1320-render-log-docs-index`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/README.md`)
  - additions: 2 / deletions: 0
- PR metadata: `mergeable:true`
- GitHub Actions CI #1627: success
- docs-only 変更のため local test / lint は未実行です。

## リスク

low。既存の英日 render-log docs への導線追加のみで、runtime behavior や public API contract は変更していません。