### PR TITLE
docs entrypoint と i18n page parity guard を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs",
+    "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && npm run test:docs-entrypoints",
     "test:js": "npm run test:entrypoints && npm test && npm run test:browser"
   },

--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -89,6 +89,16 @@ const featureEntrypoints = [
     ]
   },
   {
+    feature: "Render log level",
+    rootPattern: /render log silencing|render_log_level/i,
+    links: [
+      ["README.md", "docs/en/render-log-level.md"],
+      ["README.md", "docs/ja/render-log-level.md"],
+      ["docs/en/README.md", "render-log-level.md"],
+      ["docs/ja/README.md", "render-log-level.md"]
+    ]
+  },
+  {
     feature: "JavaScript controllers and events",
     rootPattern: /Register JavaScript controllers/,
     links: [

--- a/script/test_docs_i18n_parity.mjs
+++ b/script/test_docs_i18n_parity.mjs
@@ -1,0 +1,55 @@
+import { readdirSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+const parityExceptions = new Map([
+  // Keep intentional one-language Markdown pages visible here with a short reason.
+])
+
+function markdownPages(relativeDirectory) {
+  const absoluteDirectory = path.join(repoRoot, relativeDirectory)
+  const pages = []
+
+  readdirSync(absoluteDirectory, { withFileTypes: true }).forEach((entry) => {
+    const relativePath = path.join(relativeDirectory, entry.name)
+
+    if (entry.isDirectory()) {
+      markdownPages(relativePath).forEach((page) => pages.push(path.join(entry.name, page)))
+      return
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      pages.push(entry.name)
+    }
+  })
+
+  return pages.sort()
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function missingPeers(sourceLanguage, targetLanguage, sourcePages, targetPages) {
+  const targetSet = new Set(targetPages)
+
+  return sourcePages.filter((page) => {
+    const exceptionKey = `${sourceLanguage}:${page}`
+    return !targetSet.has(page) && !parityExceptions.has(exceptionKey)
+  }).map((page) => `${targetLanguage} missing ${page}`)
+}
+
+const englishPages = markdownPages("docs/en")
+const japanesePages = markdownPages("docs/ja")
+
+const failures = [
+  ...missingPeers("en", "ja", englishPages, japanesePages),
+  ...missingPeers("ja", "en", japanesePages, englishPages)
+]
+
+assert(
+  failures.length === 0,
+  `docs i18n page-set parity failed:\n${failures.map((failure) => `- ${failure}`).join("\n")}`
+)


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1326
Closes #1321

## Issue ごとの完了内容

- #1326: `docs/en` と `docs/ja` の Markdown page set parity を確認する lightweight Node script を追加しました。片側にだけ存在する page がある場合、missing side と filename を failure message に出します。
- #1321: `script/test_docs_entrypoints.mjs` に Render log level / `render_log_level` の representative README signal と英日 docs link guard を追加しました。

## 変更内容

- `script/test_docs_i18n_parity.mjs`
  - `docs/en` / `docs/ja` 配下の Markdown filename set を比較
  - `docs/README.md`、`docs/i18n-audit.md`、`docs/mockups/**` など language tree 外の technical assets は対象にしません
  - intentional mismatch 用の小さな allowlist 置き場を用意しました
- `package.json`
  - `npm run test:docs-i18n` を追加
  - `npm run test:docs-entrypoints` から docs entrypoint guard と i18n parity guard の両方を実行するようにしました
- `script/test_docs_entrypoints.mjs`
  - Render log level の root README signal と `README.md` / language README からの link を確認します

## 改善カテゴリ

- test
- docs inventory guard
- maintenance

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、configuration behavior、public API manifest schema、docs prose は変更していません。
- 翻訳品質、Markdown link checker、anchor checker、mockup inventory guard、CI workflow redesign には広げていません。

## 実施した確認内容

- GitHub compare: `main...quality/1326-docs-entrypoint-guards`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3
- GitHub Actions CI #1628: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success (`npm run test:js` completed; browser step skipped by docs-only policy)
  - representative Rails lanes 7.0 / 7.2 / 8.0: success
  - `gem_package` / full matrices: skipped by workflow conditions
- PR metadata: `mergeable: true`
- local `npm run test:docs-entrypoints` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions を確認証跡にしています。

## リスク評価

- risk: low
- lightweight docs inventory scripts の追加のみです。

## 補足事項

- #1326 は専用 script 推奨だったため、Render log level の entrypoint guard とは責務を分けて追加しました。
- #1321 は #1320 の docs navigation を前提にしすぎないよう、current `main` で既に存在する root README と language README のリンクを canonical にしています。