### PR TITLE
PersistedState.from の入力境界を英日 docs に追記する

### DIFF
--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -18,6 +18,19 @@ The host app remains responsible for storage ownership, authorization, save timi
 
 For a static visual reference of the save/restore handoff, see [Persisted State boundary mockup](../mockups/persisted-state-boundary.html). The mockup shows representative before, changed, restored, save-failed, and retry cues without turning storage, save endpoints, authorization, or retry policy into gem-owned behavior.
 
+## PersistedState.from normalization
+
+Use `TreeView::PersistedState.from(value)` when host-app integration code needs to normalize an optional persisted-state value before passing it into `RenderState`.
+
+`from` accepts only the current persisted-state boundary shapes:
+
+- `nil` returns `nil`, so callers can keep optional persisted state optional.
+- an existing `TreeView::PersistedState` instance is returned unchanged.
+- Hash-like input is read through `to_h`, symbolized, and converted from `tree_instance_key` / `expanded_keys` into a `TreeView::PersistedState` value object.
+- non Hash-like input raises `ArgumentError` with a `Hash-like` message fragment.
+
+This normalization boundary does not change `StateStore` persistence behavior, generator output, migration shape, storage lifecycle, or host-app authorization policy.
+
 ## Generator
 
 Use the generator to create model and migration templates.

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -18,6 +18,19 @@ TreeView gem が担当するのは以下です。
 
 保存・復元の受け渡しを静的な visual reference で確認したい場合は、[Persisted State boundary mockup](../mockups/persisted-state-boundary.html) を参照してください。この mockup は、保存前、変更後、復元後、保存失敗、retry の代表的な見え方を示しますが、storage、save endpoint、認可、retry policy を gem 側の責務として扱うものではありません。
 
+## PersistedState.from の正規化境界
+
+host app integration code が optional な persisted-state value を `RenderState` へ渡す前に正規化したい場合は、`TreeView::PersistedState.from(value)` を使えます。
+
+`from` が受け付けるのは、現在の persisted-state 境界で扱う次の形だけです。
+
+- `nil` は `nil` のまま返します。caller は optional persisted state を optional のまま扱えます。
+- 既存の `TreeView::PersistedState` instance は、その instance をそのまま返します。
+- Hash-like input は `to_h` で読み取り、key を symbol 化したうえで、`tree_instance_key` / `expanded_keys` から `TreeView::PersistedState` value object に変換します。
+- non Hash-like input は `ArgumentError` を投げ、message には `Hash-like` fragment が含まれます。
+
+この正規化境界は、`StateStore` の保存挙動、generator output、migration shape、storage lifecycle、host app の authorization policy を変更するものではありません。
+
 ## generator
 
 保存用modelとmigrationの雛形は generator で作成できます。


### PR DESCRIPTION
## 対応 Issue

Closes #1327

## 判定分類

- `docs-stale`
- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `docs/en/persisted-state.md` に `TreeView::PersistedState.from(value)` の normalization boundary を追加しました。
- `docs/ja/persisted-state.md` に同じ内容の日本語説明を追加しました。
- `nil`、既存 `TreeView::PersistedState` instance、Hash-like input、non Hash-like input の扱いを、現在の `lib/tree_view/persisted_state.rb` と Issue #1327 の記述に合わせています。

## 根拠

- `lib/tree_view/persisted_state.rb` の current implementation は `.from(nil)`、existing instance、`to_h` を持つ Hash-like input、non Hash-like input の `ArgumentError` を明確に分けています。
- 既存 persisted-state docs は `StateStore` / controller concern / storage lifecycle が中心で、`.from` の accepted input boundary が見つけにくい状態でした。

## 非目標

- `PersistedState.from` API redesign
- `StateStore` API / generator / migration / concern の変更
- storage lifecycle / cleanup helper の追加
- public API manifest schema の変更
- representative spec の追加

## 確認内容

- GitHub compare: `main...docs/1327-persisted-state-from-boundary`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 26 / deletions: 0
- PR metadata: `mergeable:true`
- GitHub Actions CI #1632: success
  - `changes` / `lint` / `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `ruby_matrix` / `rails_matrix` / `gem_package`: workflow 条件で skipped
- 追記箇所を connector 経由で再取得し、英日とも同じ input boundary を説明していることを確認しました。
- local test / lint は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions を確認証跡にしています。

## リスク

low。current code の説明追記だけで、runtime behavior や public contract の追加判断には触れていません。