### PR TITLE
FilteredTree を Public API の入口一覧に同期する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -26,6 +26,7 @@ Host apps may use these entry points directly:
 - `TreeView::ResourceTableRenderState.call`
 - `TreeView::VisibleRows`
 - `TreeView::RenderWindow`
+- `TreeView::FilteredTree`
 - `TreeView::UiConfig`
 - `TreeView::UiConfigBuilder`
 - `TreeView::GraphAdapter`

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -26,6 +26,7 @@ host app が直接使ってよい主な入口は以下です。
 - `TreeView::ResourceTableRenderState.call`
 - `TreeView::VisibleRows`
 - `TreeView::RenderWindow`
+- `TreeView::FilteredTree`
 - `TreeView::UiConfig`
 - `TreeView::UiConfigBuilder`
 - `TreeView::GraphAdapter`


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1338

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/public-api.md` の Stable public entry points に `TreeView::FilteredTree` を追加しました。
- `docs/ja/public-api.md` の安定した公開入口にも同じ項目を追加しました。

## 根拠

- current `config/public_api_manifest.yml` の `public_constants` には `FilteredTree` が含まれています。
- `docs/en/filtered-trees.md` / `docs/ja/filtered-trees.md` では、`TreeView::FilteredTree` が manifest-backed public constant であることを既に説明しています。
- public API docs の冒頭一覧だけがその current public surface に追従していませんでした。

## 非目標

- public API manifest の変更
- `TreeView::FilteredTree` の挙動変更
- filtered tree mode / traversal / rendering behavior の変更
- API docs 全体の再構成
- CHANGELOG / release docs 更新

## 確認内容

- GitHub compare: `main...docs/filtered-tree-public-api-entry`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs files
  - additions: 2 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。

## リスク

low。既存 manifest と既存 filtered-tree docs に合わせて、public API docs の入口一覧を補完するだけです。