### PR TITLE
installation docs を gem package verification の必須pathに含める

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -34,6 +34,8 @@ REQUIRED_PACKAGED_PATHS = %w[
   CHANGELOG.md
   README.md
   docs/README.md
+  docs/en/installation.md
+  docs/ja/installation.md
   docs/en/public-api.md
   docs/ja/public-api.md
   docs/en/release.md


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1331

## Issue ごとの完了内容

- #1331: `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATHS` に `docs/en/installation.md` と `docs/ja/installation.md` を追加しました。
- #1331: 既存の installation docs signal check はそのまま維持し、packaged-file existence check と docs signal check の責務を分けたままにしています。

## 変更内容

- `script/check_gem_package_contents.rb`
  - representative required packaged paths に英日 installation docs を追加

## 改善カテゴリ

- test
- package verification
- docs drift guard

## 既存仕様への影響はないこと

- runtime Ruby / JavaScript、gemspec glob、installation docs 本文、CI workflow、release automation、DB、認可、外部 API は変更していません。
- built gem contents verification の代表 path を2件増やすだけです。

## 実施した確認内容

- GitHub compare: `main...quality/1331-installation-docs-package-check`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- ローカル `bundle exec rake build` / package verification は未実行です。この環境では GitHub HTTPS access が `CONNECT tunnel failed, response 403` になるため、connector 経由で差分を作成しています。
- PR 作成後に GitHub Actions を確認します。

## リスク評価

- risk: low
- package verification script の required path 追加のみで、既存挙動は変更しません。

## 補足事項

- gemspec file list、installation docs rewrite、CI required check 名、release automation には広げていません。