### PR TITLE
PersistedState.from の入力境界を spec で固定する

### DIFF
--- a/spec/lib/tree_view/persisted_state_spec.rb
+++ b/spec/lib/tree_view/persisted_state_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe TreeView::PersistedState do
     expect(state.expanded_keys).to eq([1, 2])
   end
 
+  it "returns existing persisted state instances unchanged" do
+    state = described_class.new(tree_instance_key: "documents", expanded_keys: [1, 2])
+
+    expect(described_class.from(state)).to equal(state)
+  end
+
+  it "rejects non hash-like values" do
+    expect do
+      described_class.from("documents")
+    end.to raise_error(ArgumentError, /Hash-like/)
+  end
+
   it "returns nil from nil" do
     expect(described_class.from(nil)).to be_nil
   end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1334

## Issue ごとの完了内容

- #1334: `TreeView::PersistedState.from(value)` が既存 `PersistedState` instance をそのまま返す境界を representative spec で固定しました。
- #1334: non Hash-like input が `ArgumentError` を投げ、message の重要 fragment `Hash-like` を含むことを representative spec で固定しました。

## 変更内容

- `spec/lib/tree_view/persisted_state_spec.rb`
  - existing instance path の `equal` identity guard を追加
  - non Hash-like input の error guard を追加

## 改善カテゴリ

- test
- regression guard
- maintenance

## 既存仕様への影響はないこと

- runtime code、public API manifest、StateStore API、generator / migration、storage lifecycle、docs は変更していません。
- 既存の `from(nil)` / Hash-like input の spec と重複しすぎない代表境界だけを追加しています。

## 実施した確認内容

- GitHub compare: `main...quality/1334-persisted-state-from-boundary`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`spec/lib/tree_view/persisted_state_spec.rb`)
- PR metadata: `mergeable: true`
- GitHub Actions CI `#1651`: success
- connector 経由で更新後の spec 内容を確認しました。
- local RSpec は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions を確認しました。

## リスク評価

- low
- spec-only で現行挙動を固定するだけです。

## 補足事項

- #1325 の manifest-backed method surface 判断は吸収していません。
- #1327 / PR #1333 の docs-only lane とも分けています。