### PR TITLE
docs entrypoint guard に feature / maintainer docs を追加する

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -69,6 +69,41 @@ const featureEntrypoints = [
     ]
   },
   {
+    feature: "Filtered Trees",
+    rootPattern: /Filtered Trees/,
+    links: [
+      ["README.md", "docs/en/filtered-trees.md"],
+      ["README.md", "docs/ja/filtered-trees.md"],
+      ["docs/README.md", "en/filtered-trees.md"],
+      ["docs/README.md", "ja/filtered-trees.md"],
+      ["docs/en/README.md", "filtered-trees.md"],
+      ["docs/ja/README.md", "filtered-trees.md"]
+    ]
+  },
+  {
+    feature: "Render Scale strategy",
+    rootPattern: /Render Scale[\s\S]*Lazy Loading[\s\S]*Children Pagination/,
+    links: [
+      ["README.md", "docs/en/render-scale.md"],
+      ["README.md", "docs/en/lazy-loading.md"],
+      ["README.md", "docs/en/children-pagination.md"],
+      ["docs/README.md", "en/lazy-loading.md"],
+      ["docs/README.md", "ja/lazy-loading.md"],
+      ["docs/README.md", "en/windowed-rendering.md"],
+      ["docs/README.md", "ja/windowed-rendering.md"],
+      ["docs/README.md", "en/children-pagination.md"],
+      ["docs/README.md", "ja/children-pagination.md"],
+      ["docs/en/README.md", "render-scale.md"],
+      ["docs/en/README.md", "lazy-loading.md"],
+      ["docs/en/README.md", "windowed-rendering.md"],
+      ["docs/en/README.md", "children-pagination.md"],
+      ["docs/ja/README.md", "render-scale.md"],
+      ["docs/ja/README.md", "lazy-loading.md"],
+      ["docs/ja/README.md", "windowed-rendering.md"],
+      ["docs/ja/README.md", "children-pagination.md"]
+    ]
+  },
+  {
     feature: "Selection",
     rootPattern: /checkbox selection|selection hooks/i,
     links: [
@@ -121,8 +156,40 @@ const featureEntrypoints = [
   }
 ]
 
+const maintainerEntrypoints = [
+  {
+    feature: "Maintainer release docs",
+    links: [
+      ["docs/README.md", "en/release.md"],
+      ["docs/README.md", "ja/release.md"],
+      ["docs/en/README.md", "release.md"],
+      ["docs/ja/README.md", "release.md"],
+      ["docs/README.md", "../CHANGELOG.md"],
+      ["docs/en/README.md", "../../CHANGELOG.md"],
+      ["docs/ja/README.md", "../../CHANGELOG.md"]
+    ]
+  },
+  {
+    feature: "Maintainer development docs",
+    links: [
+      ["docs/README.md", "en/development.md"],
+      ["docs/README.md", "ja/development.md"],
+      ["docs/en/README.md", "development.md"],
+      ["docs/ja/README.md", "development.md"],
+      ["docs/README.md", "en/code-quality.md"],
+      ["docs/README.md", "ja/code-quality.md"],
+      ["docs/en/README.md", "code-quality.md"],
+      ["docs/ja/README.md", "code-quality.md"]
+    ]
+  }
+]
+
 featureEntrypoints.forEach(({ feature, rootPattern, links }) => {
   assert(rootPattern.test(rootReadme), `${feature}: README.md no longer exposes the representative feature signal`)
 
+  links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+})
+
+maintainerEntrypoints.forEach(({ feature, links }) => {
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
 })


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1340
Closes #1344

## Issue ごとの完了内容

- #1340: `script/test_docs_entrypoints.mjs` に Filtered Trees と Render Scale strategy の representative entrypoint guard を追加しました。
  - root README の feature signal を確認します。
  - root README / docs index / 英日 README から Filtered Trees、Render Scale、Lazy Loading、Windowed Rendering、Children Pagination へ辿れることを確認します。
- #1344: maintainer-facing docs entrypoint guard を追加しました。
  - `docs/README.md` と英日 README から Release checklist、CHANGELOG、Development、Code quality へ辿れることを確認します。
  - user-facing feature entrypoint guard とは別の `maintainerEntrypoints` として分けました。

## 変更内容

- `script/test_docs_entrypoints.mjs`
  - `featureEntrypoints` に `Filtered Trees` と `Render Scale strategy` を追加
  - `maintainerEntrypoints` を追加し、release / development / code-quality / changelog の代表導線を検査

## 改善カテゴリ

- test
- docs drift guard
- maintenance

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、docs本文、mockup HTML/CSS、CI workflow は変更していません。
- 既存の `npm run test:docs-entrypoints` で実行される lightweight link / source signal guard の対象追加だけです。

## 実施した確認内容

- Issue #1340 / #1344 の label が `status:ready-for-agent`、`track:quality`、`agent:planned`、`risk:low` であることを確認しました。
- GitHub compare: `main...quality/1340-1344-docs-entrypoint-guards`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- PR metadata: `mergeable: true`
- GitHub Actions `CI #1656`: success
  - `changes`, `lint`, `pr_specs`, `javascript`, and representative `pr_rails_matrix` lanes succeeded.
  - `rails_matrix`, `ruby_matrix`, and `gem_package` were skipped by workflow conditions.
- local `npm run test:docs-entrypoints` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更し、GitHub Actions で確認しました。

## リスク評価

- risk: low
- 既存 docs entrypoint smoke の対象を増やすだけで、公開挙動やドキュメント本文は変えていません。

## 補足事項

- #1318 は #1315 依存と明記されているため今回の束には含めていません。
- browser smoke / visual regression / Markdown 全文 link checker には広げていません。