### PR TITLE
Add RenderState toggle icon lookup specs

### DIFF
--- a/spec/lib/tree_view/render_state_toggle_icons_spec.rb
+++ b/spec/lib/tree_view/render_state_toggle_icons_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+RSpec.describe TreeView::RenderState, "toggle icon lookup" do
+  let(:node_class) { Struct.new(:id, :node_type, keyword_init: true) }
+  let(:tree) { instance_double(TreeView::Tree) }
+  let(:ui_config) { instance_double(TreeView::UiConfig) }
+
+  def build_state(toggle_icons)
+    described_class.new(
+      tree: tree,
+      root_items: [],
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      toggle_icons: toggle_icons
+    )
+  end
+
+  it "prefers node type icons before depth and state icons" do
+    state = build_state(
+      by_type: {
+        "folder" => {
+          "expanded" => {text: "folder-open"},
+          "collapsed" => {text: "folder-closed"}
+        }
+      },
+      by_depth: {
+        1 => {
+          expanded: {text: "depth-open"},
+          collapsed: {text: "depth-closed"}
+        }
+      },
+      by_state: {
+        expanded: {text: "state-open"},
+        collapsed: {text: "state-closed"}
+      }
+    )
+
+    folder = node_class.new(id: 1, node_type: :folder)
+
+    expect(state.toggle_icon_builder.call(folder, :expanded, {depth: 1})).to eq({text: "folder-open"})
+    expect(state.toggle_icon_builder.call(folder, "collapsed", {"depth" => 1})).to eq({text: "folder-closed"})
+  end
+
+  it "falls back from depth icons to state icons" do
+    state = build_state(
+      by_depth: {
+        "2" => {
+          expanded: {text: "depth-open"},
+          collapsed: {text: "depth-closed"}
+        }
+      },
+      by_state: {
+        "leaf" => {text: "state-leaf"},
+        "loading" => {text: "state-loading"}
+      }
+    )
+
+    node = node_class.new(id: 1)
+
+    expect(state.toggle_icon_builder.call(node, :expanded, {depth: 2})).to eq({text: "depth-open"})
+    expect(state.toggle_icon_builder.call(node, :leaf, {depth: 3})).to eq({text: "state-leaf"})
+    expect(state.toggle_icon_builder.call(node, "loading", {depth: nil})).to eq({text: "state-loading"})
+  end
+end


### PR DESCRIPTION
## 対応 Issue

- Closes #963

## Issue ごとの完了内容

- #963: `RenderState` の `toggle_icons:` lookup について、node type、depth、state fallback の代表ケースを spec で固定しました。

## 変更内容

- `spec/lib/tree_view/render_state_toggle_icons_spec.rb` を追加
- `by_type` が `by_depth` / `by_state` より優先されることを確認
- `by_depth` から `by_state` へ fallback することを確認
- string / symbol key の代表互換を spec に含めました

## 改善カテゴリ

- test
- regression guard

## 既存仕様への影響

- 実装コードは変更していません。
- 公開 API、UI、CI policy、DB、認可、外部サービス契約への変更はありません。
- 既存挙動を guard する spec 追加に閉じています。

## 実施した確認

- GitHub connector 経由で `lib/tree_view/render_state.rb` と既存 `spec/lib/tree_view/render_state_spec.rb` を確認
- CI: success (`CI` run #1662)
- ローカル clone はネットワーク制限で失敗しました
- このコンテナには Ruby がないため、ローカルで RSpec / Ruby 構文チェックは未実行です

## リスク評価

- risk: low
- spec 追加のみで、runtime behavior への影響はありません。

## 補足事項

- 同じ実行で確認した `tree_view-rails` #413 は `status:needs-human` のため実装対象から外しました。
- 他リポジトリの ready issue とは変更理由が異なるため、この PR には混ぜていません。