### PR TITLE
PersistedState / StateStore の public method contract を最新 main で固定する

### DIFF
--- a/spec/public_api_persisted_state_method_surface_spec.rb
+++ b/spec/public_api_persisted_state_method_surface_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+PersistedStateContractRecord = Struct.new(:owner, :tree_instance_key, :expanded_keys) do
+  def save!
+    true
+  end
+
+  def destroy!
+    PersistedStateContractModel.record = nil
+    true
+  end
+end
+
+class PersistedStateContractModel
+  class << self
+    attr_accessor :record
+
+    def find_by(owner:, tree_instance_key:)
+      return nil unless record
+      return record if record.owner == owner && record.tree_instance_key == tree_instance_key
+
+      nil
+    end
+
+    def find_or_initialize_by(owner:, tree_instance_key:)
+      self.record ||= PersistedStateContractRecord.new(owner, tree_instance_key, [])
+    end
+  end
+end
+
+RSpec.describe "Persisted state public method surface" do
+  before do
+    PersistedStateContractModel.record = nil
+  end
+
+  it "keeps PersistedState.from as the documented normalization entrypoint" do
+    expect(TreeView::PersistedState).to respond_to(:from)
+    expect(TreeView::PersistedState.method(:from).parameters).to eq([[:req, :value]])
+
+    state = TreeView::PersistedState.new(tree_instance_key: "documents:index", expanded_keys: ["node:1"])
+
+    expect(TreeView::PersistedState.from(state)).to equal(state)
+    expect(TreeView::PersistedState.from(nil)).to be_nil
+  end
+
+  it "keeps StateStore find, save, and clear keyword boundaries public" do
+    store = TreeView::StateStore.new(model: PersistedStateContractModel)
+
+    expect(store).to respond_to(:find)
+    expect(store).to respond_to(:save!)
+    expect(store).to respond_to(:clear!)
+    expect(store.method(:find).parameters).to eq([[:keyreq, :owner], [:keyreq, :tree_instance_key]])
+    expect(store.method(:save!).parameters).to eq([
+      [:keyreq, :owner],
+      [:keyreq, :tree_instance_key],
+      [:keyreq, :expanded_keys]
+    ])
+    expect(store.method(:clear!).parameters).to eq([[:keyreq, :owner], [:keyreq, :tree_instance_key]])
+  end
+
+  it "keeps representative StateStore return behavior available" do
+    store = TreeView::StateStore.new(model: PersistedStateContractModel)
+
+    saved_state = store.save!(
+      owner: :user,
+      tree_instance_key: "documents:index",
+      expanded_keys: ["node:1", "node:2"]
+    )
+
+    expect(saved_state).to be_a(TreeView::PersistedState)
+    expect(saved_state.tree_instance_key).to eq("documents:index")
+    expect(saved_state.expanded_keys).to eq(["node:1", "node:2"])
+    expect(store.find(owner: :user, tree_instance_key: "documents:index").expanded_keys).to eq(["node:1", "node:2"])
+  end
+
+  it "keeps StateStore clear idempotent for missing records" do
+    store = TreeView::StateStore.new(model: PersistedStateContractModel)
+
+    empty_state = store.clear!(owner: :user, tree_instance_key: "documents:index")
+
+    expect(empty_state).to be_a(TreeView::PersistedState)
+    expect(empty_state.tree_instance_key).to eq("documents:index")
+    expect(empty_state.expanded_keys).to eq([])
+  end
+end


### PR DESCRIPTION
PersistedState / StateStore の public method surface を、最新 main 上で manifest schema 変更なしの compatibility spec として固定します。

## 対応 Issue

Closes #1325
Supersedes #1356

## 変更内容

- `spec/public_api_persisted_state_method_surface_spec.rb` を追加しました。
- `TreeView::PersistedState.from(value)` が public normalization entrypoint として残ることを確認します。
- `TreeView::StateStore#find`, `#save!`, `#clear!` の keyword boundary を確認します。
- `save!` / `find` の代表 return behavior と、missing record に対する `clear!` の empty `PersistedState` boundary を確認します。

## 受け入れ条件との対応

- `PersistedState.from` と `StateStore#find/save!/clear!` の public method surface を focused spec で守る場所を明確にしました。
- `clear!` の missing record empty-state boundary を spec で固定しました。
- `PersistedState.from` の詳細 input boundary は既存 docs/spec と #1327 側に残し、この PR では method surface 全体の contract 整理に留めています。
- `config/public_api_manifest.yml` は constants contract のまま維持し、method-level manifest schema は追加していません。

## 変更範囲

- spec 追加のみ

runtime behavior、API 追加・rename・削除、manifest schema、generator、migration、owner injection、storage retention / cleanup policy、retry / locking / merge policy は変更していません。

## 実施した確認

- GitHub compare: `main...feature/1325-persisted-state-method-contract-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- 旧 PR #1356 は作成直後に main が 3 commit 進んだため、この PR を latest-main replacement として作成しています。
- local `bundle exec rspec spec/public_api_persisted_state_method_surface_spec.rb spec/lib/tree_view/state_store_spec.rb spec/lib/tree_view/persisted_state_spec.rb` は未実行です。
  - この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後に GitHub Actions を確認します。

## リスク

- medium
- public method surface を明確化する spec 追加ですが、既存 behavior を guard するだけで実装は変更していません。

## 未対応・補足

- `PersistedState.from` の Hash-like / invalid input boundary の追加整理は #1327 に残します。
- cleanup helper、retention policy、generated migration schema の扱いはこの PR では変更していません。