### PR TITLE
Root README から Selection docs へ直接辿れるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Key documents:
 | Installation | [Installation](docs/en/installation.md) | [導入手順](docs/ja/installation.md) |
 | Minimal usage | [Minimal usage](docs/en/minimal-usage.md) | [最小利用例](docs/ja/minimal-usage.md) |
 | Usage | [Usage](docs/en/usage.md) | [使い方](docs/ja/usage.md) |
+| Selection | [Selection](docs/en/selection.md) | [Selection](docs/ja/selection.md) |
 | Toolbar helper (`tree_view_toolbar`) | [Toolbar helper](docs/en/toolbar.md) | [Toolbar helper](docs/ja/toolbar.md) |
 | Turbo Frame option | [Turbo Frame option](docs/en/turbo-frame.md) | [Turbo Frame オプション](docs/ja/turbo-frame.md) |
 | Persisted State | [Persisted State](docs/en/persisted-state.md) | [Persisted State](docs/ja/persisted-state.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #1349

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- root `README.md` の `Key documents` table に Selection docs の direct entrypoint を追加しました。
- 英日 `docs/en/selection.md` / `docs/ja/selection.md` への導線だけを足し、selection guide 本文は変更していません。

## 根拠

- root README の Features は checkbox selection hooks を主要機能として案内しています。
- `docs/en/README.md` / `docs/ja/README.md` と docs entrypoint guard は Selection を主要 entrypoint として扱っています。
- root README の Key documents table には Selection 専用行がなく、初見導線が少し遠い状態でした。

## 非目標

- runtime Ruby / JavaScript の変更
- selection controller behavior の変更
- public API manifest の変更
- mockup HTML / CSS の変更
- Selection docs 本文の rewrite
- docs entrypoint smoke の追加

## 確認内容

- GitHub compare: `main...docs/1349-readme-selection-entrypoint`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`README.md`)
  - additions: 1 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗します。

## リスク

low。README の docs cross-link 追加のみで、実装や公開 API 契約は変更していません。