### PR TITLE
docs i18n parity exception の運用ルールを明文化する

### DIFF
--- a/docs/i18n-audit.md
+++ b/docs/i18n-audit.md
@@ -47,6 +47,8 @@ Exceptions are allowed when the mismatch is intentional and visible:
 - `docs/mockups/**` is a technical visual reference area and is tracked through its own README, review gallery, and browser smoke inventory instead of language-tree parity
 - a page may temporarily exist in one language first when the PR or changed page leaves a visible follow-up note and does not change the High-lane entry-point promise
 
+Only add a parity exception when the mismatch is temporary, maintainer-only, or a technical asset that is intentionally outside user-facing prose coverage. Record the reason, affected language, and the planned review timing or removal condition wherever the exception is introduced, such as the PR description, the changed page, or the parity check's exception entry. Do not use exceptions to make one-language user-facing docs permanent; if a user-facing page must stay unmatched for more than one maintenance sweep, track the follow-up explicitly and revisit whether the docs map still promises the right coverage.
+
 When a lightweight automated parity check exists, use it as a first pass only. It should flag missing peer filenames and documented exceptions; it should not judge translation quality, wording equivalence, or whether Japanese or English is the canonical prose source for a disputed behavior.
 
 ## When to update both Japanese and English docs


### PR DESCRIPTION
## 対応 Issue

Closes #1354

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/i18n-audit.md` の Page-set parity checks に、parity exception を追加してよい条件と記録項目を追記しました。
- 例外は temporary / maintainer-only / technical asset に限り、理由、対象言語、review timing または removal condition を残す方針にしています。
- one-language user-facing docs を恒久許可しないことを明記しました。

## 根拠

- #1354 の Planner handoff は docs maintenance policy を主軸にし、checker behavior を緩めない docs / comment-only lane として整理しています。
- current `docs/README.md` は user-facing docs の bilingual 原則を説明しており、`docs/i18n-audit.md` が language-sync rules の保守場所です。
- current `script/test_docs_i18n_parity.mjs` は例外 map を持ちますが、今回は Docs Sync Agent の範囲を docs だけに閉じるため checker comment / behavior には触れていません。

## 非目標

- 翻訳作業
- parity checker の挙動変更
- `script/test_docs_i18n_parity.mjs` の変更
- 実際の parity exception 追加
- README / docs index の再構成

## 確認内容

- GitHub compare: `main...docs/1354-i18n-parity-exception-policy`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/i18n-audit.md`)
  - additions: 2 / deletions: 0
- docs-only 変更のため local test / lint は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗します。
- PR 作成後に GitHub Actions を確認します。

## リスク

low。保守ドキュメントの運用説明追加のみで、checker behavior、runtime Ruby / JavaScript、public API、mockup inventory には触れていません。