### PR TITLE
docs entrypoint smoke に基礎導線と helper 導線を追加する

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -27,6 +27,12 @@ function assertRelativeLink(sourcePath, href, feature) {
   )
 }
 
+function assertRootSignal(feature, rootPattern, message) {
+  if (!rootPattern) return
+
+  assert(rootPattern.test(rootReadme), `${feature}: ${message}`)
+}
+
 const rootReadme = read("README.md")
 
 const foundationalEntrypoints = [
@@ -184,7 +190,6 @@ const featureEntrypoints = [
   },
   {
     feature: "Breadcrumb helper",
-    rootPattern: /TreeView::Breadcrumb|tree_view_breadcrumb|breadcrumb/i,
     links: [
       ["docs/en/README.md", "breadcrumb.md"],
       ["docs/ja/README.md", "breadcrumb.md"]
@@ -262,13 +267,13 @@ const maintainerEntrypoints = [
 ]
 
 foundationalEntrypoints.forEach(({ feature, rootPattern, links }) => {
-  assert(rootPattern.test(rootReadme), `${feature}: README.md no longer exposes the representative docs signal`)
+  assertRootSignal(feature, rootPattern, "README.md no longer exposes the representative docs signal")
 
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
 })
 
 featureEntrypoints.forEach(({ feature, rootPattern, links }) => {
-  assert(rootPattern.test(rootReadme), `${feature}: README.md no longer exposes the representative feature signal`)
+  assertRootSignal(feature, rootPattern, "README.md no longer exposes the representative feature signal")
 
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
 })

--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -29,6 +29,63 @@ function assertRelativeLink(sourcePath, href, feature) {
 
 const rootReadme = read("README.md")
 
+const foundationalEntrypoints = [
+  {
+    feature: "First-time setup docs",
+    rootPattern: /Installation[\s\S]*Minimal usage[\s\S]*Usage/,
+    links: [
+      ["README.md", "docs/en/installation.md"],
+      ["README.md", "docs/ja/installation.md"],
+      ["README.md", "docs/en/minimal-usage.md"],
+      ["README.md", "docs/ja/minimal-usage.md"],
+      ["README.md", "docs/en/usage.md"],
+      ["README.md", "docs/ja/usage.md"],
+      ["docs/README.md", "en/installation.md"],
+      ["docs/README.md", "ja/installation.md"],
+      ["docs/README.md", "en/minimal-usage.md"],
+      ["docs/README.md", "ja/minimal-usage.md"],
+      ["docs/README.md", "en/usage.md"],
+      ["docs/README.md", "ja/usage.md"],
+      ["docs/en/README.md", "installation.md"],
+      ["docs/en/README.md", "minimal-usage.md"],
+      ["docs/en/README.md", "usage.md"],
+      ["docs/ja/README.md", "installation.md"],
+      ["docs/ja/README.md", "minimal-usage.md"],
+      ["docs/ja/README.md", "usage.md"]
+    ]
+  },
+  {
+    feature: "Decision guide docs",
+    rootPattern: /Decision guide|API判断ガイド/,
+    links: [
+      ["README.md", "docs/en/decision-guide.md"],
+      ["README.md", "docs/ja/decision-guide.md"],
+      ["docs/README.md", "en/decision-guide.md"],
+      ["docs/README.md", "ja/decision-guide.md"],
+      ["docs/en/README.md", "decision-guide.md"],
+      ["docs/ja/README.md", "decision-guide.md"]
+    ]
+  },
+  {
+    feature: "FAQ and troubleshooting docs",
+    rootPattern: /FAQ[\s\S]*Troubleshooting|Troubleshooting[\s\S]*FAQ/,
+    links: [
+      ["README.md", "docs/en/faq.md"],
+      ["README.md", "docs/ja/faq.md"],
+      ["README.md", "docs/en/troubleshooting.md"],
+      ["README.md", "docs/ja/troubleshooting.md"],
+      ["docs/README.md", "en/faq.md"],
+      ["docs/README.md", "ja/faq.md"],
+      ["docs/README.md", "en/troubleshooting.md"],
+      ["docs/README.md", "ja/troubleshooting.md"],
+      ["docs/en/README.md", "faq.md"],
+      ["docs/en/README.md", "troubleshooting.md"],
+      ["docs/ja/README.md", "faq.md"],
+      ["docs/ja/README.md", "troubleshooting.md"]
+    ]
+  }
+]
+
 const featureEntrypoints = [
   {
     feature: "GraphAdapter",
@@ -107,10 +164,30 @@ const featureEntrypoints = [
     feature: "Selection",
     rootPattern: /checkbox selection|selection hooks/i,
     links: [
+      ["README.md", "docs/en/selection.md"],
+      ["README.md", "docs/ja/selection.md"],
       ["docs/README.md", "en/selection.md"],
       ["docs/README.md", "ja/selection.md"],
       ["docs/en/README.md", "selection.md"],
       ["docs/ja/README.md", "selection.md"]
+    ]
+  },
+  {
+    feature: "Toolbar helper",
+    rootPattern: /tree_view_toolbar|Toolbar helper/,
+    links: [
+      ["README.md", "docs/en/toolbar.md"],
+      ["README.md", "docs/ja/toolbar.md"],
+      ["docs/en/README.md", "toolbar.md"],
+      ["docs/ja/README.md", "toolbar.md"]
+    ]
+  },
+  {
+    feature: "Breadcrumb helper",
+    rootPattern: /TreeView::Breadcrumb|tree_view_breadcrumb|breadcrumb/i,
+    links: [
+      ["docs/en/README.md", "breadcrumb.md"],
+      ["docs/ja/README.md", "breadcrumb.md"]
     ]
   },
   {
@@ -183,6 +260,12 @@ const maintainerEntrypoints = [
     ]
   }
 ]
+
+foundationalEntrypoints.forEach(({ feature, rootPattern, links }) => {
+  assert(rootPattern.test(rootReadme), `${feature}: README.md no longer exposes the representative docs signal`)
+
+  links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+})
 
 featureEntrypoints.forEach(({ feature, rootPattern, links }) => {
   assert(rootPattern.test(rootReadme), `${feature}: README.md no longer exposes the representative feature signal`)


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1350
Closes #1353
Closes #1363

## Issue ごとの完了内容

- #1350: Selection entrypoint guard に root `README.md` から英日 Selection docs への direct link を追加しました。
- #1353: 初回導入、Decision guide、FAQ / Troubleshooting の基礎 docs 導線を `test_docs_entrypoints` で確認するようにしました。
- #1363: Toolbar helper と Breadcrumb helper の docs entrypoint guard を追加しました。Breadcrumb は current main で言語別 README が正本導線のため、root README signal は強制していません。

## 変更内容

- `script/test_docs_entrypoints.mjs`
  - `foundationalEntrypoints` を追加し、first-time setup / decision / FAQ / troubleshooting の代表リンクを確認
  - Selection の root README direct link を既存 feature guard に追加
  - Toolbar helper / Breadcrumb helper の代表 docs links を追加
  - root README signal がない entry でもリンク存在を確認できるよう、root signal assertion を optional 化

## 改善カテゴリ

- test
- docs drift guard
- maintenance

## 既存仕様への影響

- runtime Ruby / JavaScript behavior、public API manifest、docs 本文、mockup HTML/CSS は変更していません。
- Markdown 全文 link checker や docs navigation redesign には広げていません。

## 実施した確認内容

- GitHub compare: `main...quality/1350-1353-1363-docs-entrypoints`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 1 (`script/test_docs_entrypoints.mjs`)
- local `npm run test:docs-entrypoints` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後の GitHub Actions で確認します。

## リスク評価

- risk: low
- 既存 docs entrypoint smoke の対象リンクを増やすだけで、挙動変更はありません。

## 補足事項

- #1362 が未反映のため、Toolbar / Breadcrumb について root `docs/README.md` の direct entrypoint は今回の guard 対象に含めていません。current main に存在する root README / language README の導線だけを固定しています。