### PR TITLE
docs/README から Toolbar / Breadcrumb helper へ辿れるようにする

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,10 @@
 - [日本語Demo application boundary](ja/demo-application-boundary.md): static mockup と real Rails demo app の役割分担、未公開 demo link を増やさない方針。
 - [English Turbo Frame option](en/turbo-frame.md): target TreeView Turbo toggle links at a host-app Turbo Frame without custom JavaScript.
 - [日本語Turbo Frame オプション](ja/turbo-frame.md): TreeView の Turbo toggle link を host app の Turbo Frame に向ける設定。
+- [English Toolbar helper](en/toolbar.md): render tree-wide expand, collapse, and collapse-to-current-path actions while host apps own final placement and copy.
+- [日本語Toolbar helper](ja/toolbar.md): tree全体のexpand / collapse / current pathへのcollapse actionを描画し、配置と文言はhost appが所有する入口。
+- [English Breadcrumb helper](en/breadcrumb.md): render ancestor path context for a current or target node without taking over host-app routing or navigation policy.
+- [日本語Breadcrumb helper](ja/breadcrumb.md): current nodeや対象nodeのancestor path contextを描画し、routeやnavigation policyはhost app側に残す入口。
 - [English Persisted State](en/persisted-state.md): save and restore TreeView expansion state through host-app-owned storage.
 - [日本語Persisted State](ja/persisted-state.md): TreeView の開閉状態を host app 側の保存先で保存・復元するための入口。
 - [English resource table bridge](en/resource-table-bridge.md): bridge TreeView row rendering with a separate table layer that owns columns and table state.


### PR DESCRIPTION
## 対応 Issue

Closes #1362

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/README.md` の Recommended entry points に Toolbar helper の英日 direct entrypoint を追加しました。
- 同じ場所に Breadcrumb helper の英日 direct entrypoint を追加しました。
- Toolbar は tree-wide expand/collapse action、Breadcrumb は ancestor path context として短く読み分けられるようにしています。

## 根拠

- root `README.md` と `docs/en/README.md` / `docs/ja/README.md` は Toolbar helper と Breadcrumb を user-facing docs として案内しています。
- cross-language index の `docs/README.md` だけ、Recommended entry points から Toolbar / Breadcrumb helper へ直接辿れない状態でした。
- 既存の英日 feature docs が current main に存在するため、入口追加だけで docs-only に閉じられます。

## 非目標

- `docs/en|ja/toolbar.md` / `docs/en|ja/breadcrumb.md` 本文の rewrite
- Host App Extension Points の reverse lookup 補強
- helper option surface / manifest / runtime behavior の変更
- mockup page の追加
- docs entrypoint smoke の追加

## 確認内容

- GitHub compare: `main...docs/1362-toolbar-breadcrumb-docs-index`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/README.md`)
  - additions: 4 / deletions: 0
- GitHub Actions CI #1681: success
  - success: `changes`, `lint`, `pr_specs`, `javascript`, `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0 docs-only lanes
  - skipped as expected for docs-only: `ruby_matrix`, `rails_matrix`, `gem_package`
- docs-only 変更のため local test / lint は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗します。

## リスク

low。root docs index のリンク追加のみで、runtime Ruby / JavaScript、helper API、public API manifest、mockup HTML/CSS には触れていません。