### PR TITLE
test: docs entrypoint guard に Turbo Frame と direction-aware docs を追加する

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -167,6 +167,18 @@ const featureEntrypoints = [
     ]
   },
   {
+    feature: "Turbo Frame option",
+    rootPattern: /Turbo Frame option/,
+    links: [
+      ["README.md", "docs/en/turbo-frame.md"],
+      ["README.md", "docs/ja/turbo-frame.md"],
+      ["docs/README.md", "en/turbo-frame.md"],
+      ["docs/README.md", "ja/turbo-frame.md"],
+      ["docs/en/README.md", "turbo-frame.md"],
+      ["docs/ja/README.md", "turbo-frame.md"]
+    ]
+  },
+  {
     feature: "Selection",
     rootPattern: /checkbox selection|selection hooks/i,
     links: [
@@ -223,6 +235,18 @@ const featureEntrypoints = [
       ["docs/README.md", "ja/public-api.md"],
       ["docs/en/README.md", "js-events.md"],
       ["docs/ja/README.md", "js-events.md"]
+    ]
+  },
+  {
+    feature: "Direction-aware styling boundary",
+    rootPattern: /Direction-aware styling boundary/i,
+    links: [
+      ["README.md", "docs/en/direction-aware-styling.md"],
+      ["README.md", "docs/ja/direction-aware-styling.md"],
+      ["docs/README.md", "en/direction-aware-styling.md"],
+      ["docs/README.md", "ja/direction-aware-styling.md"],
+      ["docs/en/README.md", "direction-aware-styling.md"],
+      ["docs/ja/README.md", "direction-aware-styling.md"]
     ]
   },
   {


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1367
Closes #1368

## Issue ごとの完了内容

- #1367: Direction-aware styling boundary の docs 導線を `script/test_docs_entrypoints.mjs` の lightweight entrypoint guard に追加しました。
- #1368: Turbo Frame option の docs 導線を同じ guard に追加しました。

## 変更内容

- `script/test_docs_entrypoints.mjs` に以下の representative feature entry を追加しました。
  - `Turbo Frame option`
  - `Direction-aware styling boundary`
- root README、root docs index、英日 README の既存リンクを確認対象にしています。

## 改善カテゴリ

- test
- docs drift guard
- maintenance

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、docs本文、mockup HTML/CSS は変更していません。
- docs entrypoint の存在とリンク先だけを守る spec/script 変更です。

## 実施した確認内容

- Issue #1367 / #1368 の対象 label と受け入れ条件を確認しました。
- current `main` の README / docs index / language README に対象リンクが存在することを確認しました。
- GitHub compare: `main...quality/1367-1368-docs-entrypoint-guards`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_docs_entrypoints.mjs`)
- local `npm run test:docs-entrypoints` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR作成後に GitHub Actions を確認します。

## リスク評価

- risk: low
- docs entrypoint guard の対象追加のみです。リンク先や docs 本文の採用判断、runtime behavior、CI workflow には触れていません。

## 補足事項

- Direction-aware styling と Turbo Frame option はどちらも既に README/docs の導線が存在するため、今回の変更は drift detection の追加に閉じています。