### PR TITLE
Root README から Breadcrumb helper docs へ直接辿れるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Key documents:
 | Usage | [Usage](docs/en/usage.md) | [使い方](docs/ja/usage.md) |
 | Selection | [Selection](docs/en/selection.md) | [Selection](docs/ja/selection.md) |
 | Toolbar helper (`tree_view_toolbar`) | [Toolbar helper](docs/en/toolbar.md) | [Toolbar helper](docs/ja/toolbar.md) |
+| Breadcrumb helper (`tree_view_breadcrumb`) | [Breadcrumb helper](docs/en/breadcrumb.md) | [Breadcrumb helper](docs/ja/breadcrumb.md) |
 | Turbo Frame option | [Turbo Frame option](docs/en/turbo-frame.md) | [Turbo Frame オプション](docs/ja/turbo-frame.md) |
 | Persisted State | [Persisted State](docs/en/persisted-state.md) | [Persisted State](docs/ja/persisted-state.md) |
 | Localized names | [Localized names](docs/en/localized-names.md) | [ローカライズされた名前](docs/ja/localized-names.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #1371

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- root `README.md` の `Key documents` table に Breadcrumb helper の direct entrypoint を追加しました。
- 英日 `docs/en/breadcrumb.md` / `docs/ja/breadcrumb.md` への導線だけを足し、Breadcrumb helper docs 本文は変更していません。

## 根拠

- `tree_view_breadcrumb` は `config/public_api_manifest.yml` の `helper_methods` / `helper_option_keys.tree_view_breadcrumb` に public surface として載っています。
- `docs/README.md` と `docs/en|ja/README.md` には既に Breadcrumb helper 導線があります。
- root README の Key documents table には Toolbar helper などの helper docs はある一方、Breadcrumb helper への direct entrypoint がありませんでした。

## 非目標

- runtime Ruby / JavaScript の変更
- public API manifest の変更
- mockup HTML / CSS の変更
- Breadcrumb helper docs 本文の rewrite
- docs entrypoint smoke の追加

## 確認内容

- latest main: `79d6b050f5ee68444e8ecad622ecf61d4d7a0ed6`
- head: `8d612ee5572caf425cd5162fcfc1ba724474a5a9`
- GitHub compare: `main...docs/1371-readme-breadcrumb-entrypoint`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`README.md`)
  - additions: 1 / deletions: 0
- PR metadata: `mergeable:true`
- GitHub Actions CI #1693: success
  - `changes` / `lint` / `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `ruby_matrix` / `rails_matrix` / `gem_package`: workflow 条件で skipped
- Markdown link の相対パスが既存 docs と同じ形式であることを目視確認しました。
- local test / lint は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions を確認証跡にしています。

## リスク

low。README の docs cross-link 追加のみで、実装や公開 API 契約は変更していません。