### PR TITLE
Cookbook に Breadcrumb helper の実践パターンを追加する

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -15,8 +15,38 @@ For API details, see:
 - [Selection](selection.md)
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
+- [Breadcrumb](breadcrumb.md)
 - [Localized names](localized-names.md)
 - [Toggle icon customization](toggle-icons.md)
+
+## Add a breadcrumb for the current item
+
+Use [Breadcrumb](breadcrumb.md) when the page already has a records-mode tree and a current item, and the UI needs a compact path from the root to that item. TreeView looks up the ancestor path with `tree.path_for(item)` and renders the standard breadcrumb markup through `tree_view_breadcrumb`.
+
+```erb
+<%= tree_view_breadcrumb(
+  @tree,
+  @document,
+  label_builder: ->(item) { item.name },
+  path_builder: ->(item) { document_path(item) }
+) %>
+```
+
+The current item is rendered as a current label, not a link. Keep route helpers, authorization, the current item choice, and layout placement in the host app. Use `path_builder:` for normal linked ancestors and omit it when the breadcrumb should render plain labels.
+
+When the host app needs custom wrappers, conditional copy, per-level authorization messaging, or markup that the helper options do not cover, build from the path directly instead of stretching the helper.
+
+```erb
+<% @tree.path_for(@document).each do |item| %>
+  <% if can?(:read, item) %>
+    <%= link_to item.name, document_path(item) %>
+  <% else %>
+    <span><%= item.name %></span>
+  <% end %>
+<% end %>
+```
+
+TreeView owns path lookup in records mode and the bundled helper option surface. The host app owns routes, authorization, where the breadcrumb appears, and any Turbo or analytics behavior attached to custom attributes.
 
 ## Row customization quick guide
 

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -15,8 +15,38 @@ cookbook は、個別APIの詳細仕様ではなく、host appでよく使う構
 - [Selection](selection.md)
 - [Lazy Loading](lazy-loading.md)
 - [Windowed Rendering](windowed-rendering.md)
+- [Breadcrumb](breadcrumb.md)
 - [Localized names](localized-names.md)
 - [toggle icon のカスタマイズ](toggle-icons.md)
+
+## 現在itemのbreadcrumbを追加する
+
+records mode のtreeと現在itemがあり、rootからそのitemまでの短いpathをUIに出したい場合は [Breadcrumb](breadcrumb.md) を使います。TreeView は `tree.path_for(item)` で祖先pathを解決し、`tree_view_breadcrumb` で標準的なbreadcrumb markupを描画します。
+
+```erb
+<%= tree_view_breadcrumb(
+  @tree,
+  @document,
+  label_builder: ->(item) { item.name },
+  path_builder: ->(item) { document_path(item) }
+) %>
+```
+
+現在itemはlinkではなくcurrent labelとして描画されます。route helper、authorization、現在itemの決定、layout上の配置はhost app側で扱います。通常のancestor linkには `path_builder:` を使い、breadcrumbをplain labelだけで出したい場合は省略します。
+
+独自wrapper、条件付きcopy、階層ごとのauthorization message、helper optionでは表現しきれないmarkupが必要な場合は、bundled helperを広げず、pathを直接使ってhost app側で描画します。
+
+```erb
+<% @tree.path_for(@document).each do |item| %>
+  <% if can?(:read, item) %>
+    <%= link_to item.name, document_path(item) %>
+  <% else %>
+    <span><%= item.name %></span>
+  <% end %>
+<% end %>
+```
+
+TreeView は records mode のpath lookupとbundled helper option surfaceを担当します。route、authorization、breadcrumbを置く場所、追加属性に紐づくTurbo / analytics behaviorはhost app側の責務です。
 
 ## 行customization quick guide
 


### PR DESCRIPTION
## 対応 Issue

Closes #1375

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- `docs/en/cookbook.md` と `docs/ja/cookbook.md` の API details list に Breadcrumb guide への導線を追加しました。
- Cookbook に current item の breadcrumb 実践パターンを追加しました。
- `tree_view_breadcrumb(tree, item, ...)` を使う通常パターンと、custom wrapper / conditional markup が必要な場合に `tree.path_for(item)` から host app 側で直接描画する境界を明記しました。

## 根拠

- `docs/en/breadcrumb.md` / `docs/ja/breadcrumb.md` は `tree_view_breadcrumb`、`label_builder`、`path_builder`、HTML attribute hooks、host-app-owned route / authorization / layout placement boundary を説明しています。
- Cookbook は既存 API composition の実践例を集める文書ですが、Breadcrumb helper の実践パターンと導線がありませんでした。
- Planner handoff では root README / docs index / mockup / smoke guard へ広げず、Cookbook 内の practical composition に閉じる方針でした。

## 非目標

- runtime Ruby / JavaScript の変更
- Breadcrumb helper API の変更
- public API manifest の変更
- mockup HTML/CSS の変更
- root README / docs index / entrypoint smoke の変更
- route / authorization / Turbo navigation policy の新規決定

## 確認内容

- latest main: `024df0b80f979ff78fa2a4ab420b90a01c43923b`
- head: `a42d75253eb5e989ccde0cfd68bbe4d25462fb3c`
- GitHub compare: `main...docs/1375-cookbook-breadcrumb-pattern`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 (`docs/en/cookbook.md`, `docs/ja/cookbook.md`)
  - additions: 60 / deletions: 0
- PR metadata: `mergeable:true`
- GitHub Actions CI #1697: success
  - `changes` / `lint` / `pr_specs`: success
  - `javascript`: docs-only / non-mockup skip path で success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip path で success
  - `ruby_matrix` / `rails_matrix` / `gem_package`: workflow 条件で skipped
- `docs/en|ja/breadcrumb.md` の責務境界とリンクパスを目視確認しました。
- local test / lint は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions を確認証跡にしています。

## リスク

low。Cookbook の実践パターン追加のみで、実装や公開 API 契約は変更していません。