### PR TITLE
feature: breadcrumb default class の責務境界を明文化する

### DIFF
--- a/docs/en/breadcrumb.md
+++ b/docs/en/breadcrumb.md
@@ -101,6 +101,8 @@ For markup changes that need custom wrappers, conditional authorization copy, or
 
 The option names in this table are also listed in `config/public_api_manifest.yml` under `helper_option_keys.tree_view_breadcrumb`. That manifest-backed list is a compatibility contract for the existing helper option surface; it does not add markup, route, or authorization behavior.
 
+The default class names rendered when those class options are omitted are bundled styling references, not machine-readable manifest contracts. Host apps that require stable class names across upgrades should pass the class options explicitly; TreeView keeps the documented customization keys public without promoting the current default class list into `config/public_api_manifest.yml`.
+
 ## Supported mode
 
 The breadcrumb helper expects a records-mode tree.

--- a/docs/ja/breadcrumb.md
+++ b/docs/ja/breadcrumb.md
@@ -101,6 +101,8 @@ TreeView は、これらの属性をbuilt-in classやaccessibility属性とmerge
 
 この表の option 名は、`config/public_api_manifest.yml` の `helper_option_keys.tree_view_breadcrumb` にも載っています。この manifest-backed list は既存 helper option surface の互換性 contract であり、markup、route、authorization behavior を追加するものではありません。
 
+class option を省略したときに描画される default class names は bundled styling reference であり、machine-readable manifest contract ではありません。upgrade をまたいで class name を強く固定したい host app は class option を明示してください。TreeView は documented customization keys を public に保ちますが、現在の default class list は `config/public_api_manifest.yml` には昇格しません。
+
 ## 対応mode
 
 breadcrumb helper は records mode のtreeを前提にします。


### PR DESCRIPTION
Breadcrumb default CSS class names を manifest-backed contract には昇格しない方針として、英日 docs に責務境界を追記します。

## 対応 Issue

Closes #1377

## 変更内容

- `docs/en/breadcrumb.md` に、default class names は bundled styling reference であり manifest contract ではないことを追記しました。
- `docs/ja/breadcrumb.md` に同じ責務境界を追記しました。
- host app が upgrade をまたいで class name を強く固定したい場合は、既存の class options を明示指定する方針を明文化しました。

## 受け入れ条件との対応

- Breadcrumb default class names を manifest-backed contract に含めない判断: docs に明記しました。
- class options と default class names の責務境界: 英日 breadcrumb docs から読み取れるようにしました。
- `config/public_api_manifest.yml` に default class list を追加していないこと: manifest は変更していません。
- visual mockup、markup structure、route behavior、authorization、CSS redesign への拡大なし: docs 2 ファイルの追記に限定しました。

## review follow-up

- #1382 merge 後に `behind_by:1` / `status:diverged` になっていたため、branch を latest `main` `ebef32e52d2bfbfa6375d1cc7a6e7aeec3bf9316` に載せ直しました。
- branch reset 時に PR が一時 close されたため reopen 済みです。
- `docs/en/breadcrumb.md` / `docs/ja/breadcrumb.md` の intended docs-only 差分だけを再適用しました。

## 変更範囲

- `docs/en/breadcrumb.md`
- `docs/ja/breadcrumb.md`

## 実施した確認

- latest head: `869e2dd3a5d11c4af5863757f58c56aba6b3bc9f`
- GitHub compare: `main...feature/1377-breadcrumb-default-class-boundary`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
  - additions: 4 / deletions: 0
- PR metadata: `mergeable:true`
- GitHub Actions `CI #1707`: success
  - `changes` / `lint` / `pr_specs`: success
  - docs-only skip lanes: Rails compatibility matrix / JavaScript browser checks / gem package
- ローカル test / lint は未実行です。この環境では GitHub HTTPS checkout / raw fetch が `CONNECT tunnel failed, response 403` で失敗するため、GitHub Actions で確認しました。

## リスク

medium。public contract の境界判断ですが、Planner handoff どおり manifest 昇格を避け、docs-only の責務整理に閉じています。

## 未対応・補足

- helper spec は追加していません。今回の first slice は docs-only で完了条件を満たすため、default class 出力の compatibility guard は後続で必要になった場合に分けます。
- default class names を public styling contract に含めない adopter-facing boundary 判断は human review に残します。