### PR TITLE
Docs entrypoint smoke に Accessibility Semantics を追加する

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -238,6 +238,18 @@ const featureEntrypoints = [
     ]
   },
   {
+    feature: "Accessibility Semantics",
+    rootPattern: /Accessibility Semantics[\s\S]*ARIA|accessibility-oriented row semantics/i,
+    links: [
+      ["README.md", "docs/en/accessibility-semantics.md"],
+      ["README.md", "docs/ja/accessibility-semantics.md"],
+      ["docs/README.md", "en/accessibility-semantics.md"],
+      ["docs/README.md", "ja/accessibility-semantics.md"],
+      ["docs/en/README.md", "accessibility-semantics.md"],
+      ["docs/ja/README.md", "accessibility-semantics.md"]
+    ]
+  },
+  {
     feature: "Direction-aware styling boundary",
     rootPattern: /Direction-aware styling boundary/i,
     links: [


### PR DESCRIPTION
## 対応 Issue

- Closes #1318

## Issue ごとの完了内容

- #1318: `script/test_docs_entrypoints.mjs` の feature entrypoint smoke に Accessibility Semantics を追加し、README / docs index から英日両方の `accessibility-semantics.md` へ到達できることを検査するようにしました。

## 変更内容

- `script/test_docs_entrypoints.mjs` に `Accessibility Semantics` の代表 feature entrypoint を追加
- root README の代表 signal と、以下のリンク存在・ローカル対象存在を検査
  - `README.md` -> English / Japanese Accessibility Semantics
  - `docs/README.md` -> English / Japanese Accessibility Semantics
  - `docs/en/README.md` / `docs/ja/README.md` -> 各言語ページ

## 改善カテゴリ

- test
- docs drift guard
- 小さな内部整理

## 既存仕様への影響

- runtime、UI、API、DB、認可、状態遷移、外部サービス契約には触れていません。
- docs 本文も変更せず、既に存在する entrypoint を smoke test に追加するだけです。

## 実施した確認

- GitHub 上の current `main` から `script/test_docs_entrypoints.mjs` と関連 README / docs index を確認しました。
- compare で差分が `script/test_docs_entrypoints.mjs` のみ、`ahead_by: 1` / `behind_by: 0` であることを確認しました。
- この実行環境では GitHub の直接 checkout が `CONNECT tunnel failed, response 403` でブロックされるため、ローカルの `npm run test:docs` / `npm run test:js` は未実行です。PR CI で確認します。

## リスク評価

- risk: low
- 既存ドキュメントに対するリンク存在チェック追加のみのため、公開挙動への影響はありません。

## 補足事項

- #413 は npm registry へアクセスできる環境での lockfile refresh が必要なため、本PRには含めていません。
- #1313 は Playwright forced-colors smoke の別系統テストであり、本PRの docs entrypoint drift guard とは変更単位を分けています。