### PR TITLE
state install generator setup contract を最新 main で再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -70,6 +70,17 @@ toolbar_actions:
   expand_all: expanded
   collapse_all: collapsed
   collapse_all_except_current_path: current_path
+setup_generators:
+  persisted_state_install:
+    name: tree_view:state:install
+    class_name: TreeView::Generators::State::InstallGenerator
+    optional_arguments:
+      - name: owner_model_name
+        banner: OWNER_MODEL
+    generated_paths:
+      - db/migrate/*_create_tree_view_states.rb
+      - app/models/tree_view_state.rb
+      - app/models/concerns/tree_view_state_owner.rb
 grouped_option_keys:
   initial_expansion:
     - default

--- a/docs/en/public-setup-surface.md
+++ b/docs/en/public-setup-surface.md
@@ -1,0 +1,18 @@
+# Public Setup Surface
+
+The persisted-state install generator is a public setup entrypoint:
+
+- `bin/rails generate tree_view:state:install`
+- `bin/rails generate tree_view:state:install User`
+
+The machine-readable setup-generator contract in `config/public_api_manifest.yml` tracks the generator name, the optional owner argument, and the generated destination paths.
+
+The generated destination paths are part of the setup surface:
+
+- `db/migrate/*_create_tree_view_states.rb`
+- `app/models/tree_view_state.rb`
+- `app/models/concerns/tree_view_state_owner.rb`
+
+This path-level contract does not freeze the migration schema or the generated file contents. Use the generator to create the persisted-state migration, model, and owner concern, then review the generated files in the host app.
+
+Storage ownership, authorization, save timing, controller actions, and UI wiring remain host-app responsibilities. See [Persisted State](persisted-state.md) for setup details.

--- a/docs/ja/public-setup-surface.md
+++ b/docs/ja/public-setup-surface.md
@@ -1,0 +1,18 @@
+# Public Setup Surface
+
+persisted-state install generator は public setup entrypoint です。
+
+- `bin/rails generate tree_view:state:install`
+- `bin/rails generate tree_view:state:install User`
+
+`config/public_api_manifest.yml` の machine-readable setup-generator contract は、generator 名、任意の owner 引数、生成先 path を追跡します。
+
+生成先 path は setup surface の一部です。
+
+- `db/migrate/*_create_tree_view_states.rb`
+- `app/models/tree_view_state.rb`
+- `app/models/concerns/tree_view_state_owner.rb`
+
+この path-level contract は、migration schema や生成ファイル内容そのものを固定するものではありません。この generator は persisted-state 用 migration、model、owner concern を作成する入口として使い、生成後のファイルは host app 側で確認してください。
+
+storage ownership、認可、保存タイミング、controller action、UI wiring は host app 側の責務です。詳しくは [Persisted State](persisted-state.md) を参照してください。

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -12,6 +12,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   helper_methods
   helper_option_keys
   toolbar_actions
+  setup_generators
   grouped_option_keys
   javascript_package_root
 ].freeze

--- a/spec/public_setup_generator_compatibility_spec.rb
+++ b/spec/public_setup_generator_compatibility_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+require "generators/tree_view/state/install_generator"
+
+PUBLIC_SETUP_GENERATOR_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+PUBLIC_SETUP_GENERATOR_PATH = File.expand_path("../lib/generators/tree_view/state/install_generator.rb", __dir__)
+
+RSpec.describe "Public setup generator compatibility" do
+  def public_api_manifest
+    @public_api_manifest ||= YAML.safe_load_file(PUBLIC_SETUP_GENERATOR_MANIFEST_PATH)
+  end
+
+  def state_install_generator_manifest
+    public_api_manifest.fetch("setup_generators").fetch("persisted_state_install")
+  end
+
+  def state_install_generator_source
+    @state_install_generator_source ||= File.read(PUBLIC_SETUP_GENERATOR_PATH)
+  end
+
+  it "keeps the persisted-state install generator in the public setup manifest" do
+    manifest = state_install_generator_manifest
+    generator = TreeView::Generators::State::InstallGenerator
+
+    expect(manifest.fetch("name")).to eq("tree_view:state:install")
+    expect(manifest.fetch("class_name")).to eq("TreeView::Generators::State::InstallGenerator")
+    expect(generator.namespace).to eq(manifest.fetch("name"))
+
+    owner_argument = generator.arguments.find { |argument| argument.name == "owner_model_name" }
+    expect(owner_argument).not_to be_nil
+    expect(owner_argument.required?).to be(false)
+    expect(owner_argument.banner).to eq("OWNER_MODEL")
+    expect(manifest.fetch("optional_arguments")).to eq([
+      {"name" => "owner_model_name", "banner" => "OWNER_MODEL"}
+    ])
+  end
+
+  it "keeps generated destination paths documented without freezing template contents" do
+    manifest_paths = state_install_generator_manifest.fetch("generated_paths")
+
+    expect(manifest_paths).to eq([
+      "db/migrate/*_create_tree_view_states.rb",
+      "app/models/tree_view_state.rb",
+      "app/models/concerns/tree_view_state_owner.rb"
+    ])
+
+    source = state_install_generator_source
+    expect(source).to include("create_tree_view_states.rb")
+    expect(source).to include("migration_number")
+    expect(source).to include("app/models/tree_view_state.rb")
+    expect(source).to include("app/models/concerns/tree_view_state_owner.rb")
+  end
+end


### PR DESCRIPTION
PR #1214 の CI failure / stale branch follow-up として、同じ intent を current `main` から clean replacement として載せ直します。

## 対応 Issue / PR

Closes #1186
Superseded by #1632
Supersedes #1214

## 変更内容

- `config/public_api_manifest.yml` に `setup_generators.persisted_state_install` を追加しました。
- `tree_view:state:install` の generator 名、class 名、任意 owner 引数、生成先 path を path-level contract として記録します。
- 英日 `public-setup-surface.md` を追加し、generated path は setup surface だが migration schema / template contents は固定しない境界を明記しました。
- `spec/public_setup_generator_compatibility_spec.rb` を追加しました。
- current `main` に既に存在する `spec/public_api_manifest_structure_spec.rb` の top-level key expectation に `setup_generators` を追加しました。

## Superseded

この PR は latest main refresh / fresh CI のため #1632 に置き換えました。レビュー / merge 判断は #1632 側で行ってください。