### PR TITLE
TreeViewSelectionDataHooks の docs entrypoint smoke を追加する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -59,6 +59,12 @@ export declare const TreeViewEventDetailKeys: Readonly<{
   }>
 }>
 
+export declare const TreeViewRemoteStateValues: Readonly<{
+  loading: "loading"
+  loaded: "loaded"
+  error: "error"
+}>
+
 export declare const TreeViewTransferDropPositions: Readonly<{
   before: "before"
   inside: "inside"
@@ -71,6 +77,13 @@ export declare const TreeViewControllerIdentifiers: Readonly<{
   selection: "tree-view-selection"
   transfer: "tree-view-transfer"
   remoteState: "tree-view-remote-state"
+}>
+
+export declare const TreeViewSelectionDataHooks: Readonly<{
+  hiddenInputNameValue: "data-tree-view-selection-hidden-input-name-value"
+  maxCountValue: "data-tree-view-selection-max-count-value"
+  cascadeValue: "data-tree-view-selection-cascade-value"
+  indeterminateValue: "data-tree-view-selection-indeterminate-value"
 }>
 
 export declare function registerTreeViewControllers(application: Application): void

--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -33,6 +33,12 @@ function assertRootSignal(feature, rootPattern, message) {
   assert(rootPattern.test(rootReadme), `${feature}: ${message}`)
 }
 
+function assertFileSignal(sourcePath, pattern, feature, message) {
+  const source = read(sourcePath)
+
+  assert(pattern.test(source), `${feature}: ${message}`)
+}
+
 const rootReadme = read("README.md")
 
 const foundationalEntrypoints = [
@@ -188,6 +194,12 @@ const featureEntrypoints = [
       ["docs/README.md", "ja/selection.md"],
       ["docs/en/README.md", "selection.md"],
       ["docs/ja/README.md", "selection.md"]
+    ],
+    signals: [
+      ["docs/en/public-api.md", /TreeViewSelectionDataHooks[\s\S]*data-tree-view-selection-hidden-input-name-value/, "English public API docs no longer describe TreeViewSelectionDataHooks host-authored attributes"],
+      ["docs/ja/public-api.md", /TreeViewSelectionDataHooks[\s\S]*data-tree-view-selection-hidden-input-name-value/, "Japanese public API docs no longer describe TreeViewSelectionDataHooks host-authored attributes"],
+      ["docs/en/selection.md", /TreeViewSelectionDataHooks\.hiddenInputNameValue[\s\S]*data-tree-view-selection-hidden-input-name-value/, "English selection docs no longer connect TreeViewSelectionDataHooks with hidden input value attributes"],
+      ["docs/ja/selection.md", /TreeViewSelectionDataHooks\.hiddenInputNameValue[\s\S]*data-tree-view-selection-hidden-input-name-value/, "Japanese selection docs no longer connect TreeViewSelectionDataHooks with hidden input value attributes"]
     ]
   },
   {
@@ -308,10 +320,11 @@ foundationalEntrypoints.forEach(({ feature, rootPattern, links }) => {
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
 })
 
-featureEntrypoints.forEach(({ feature, rootPattern, links }) => {
+featureEntrypoints.forEach(({ feature, rootPattern, links, signals = [] }) => {
   assertRootSignal(feature, rootPattern, "README.md no longer exposes the representative feature signal")
 
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+  signals.forEach(([sourcePath, pattern, message]) => assertFileSignal(sourcePath, pattern, feature, message))
 })
 
 maintainerEntrypoints.forEach(({ feature, links }) => {

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -9,6 +9,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   module_methods
   configuration_options
   public_constants
+  path_tree_builder_node_shapes
   helper_methods
   helper_option_keys
   toolbar_actions


### PR DESCRIPTION
## 対応 Issue

Closes #1395
Closes #1397
Closes #1398

## 変更内容

- `script/test_docs_entrypoints.mjs` に docs本文の representative signal check を追加しました。
- 既存 Selection docs entrypoint smoke に、`TreeViewSelectionDataHooks` と `data-tree-view-selection-hidden-input-name-value` の presence check を追加しました。
- 英日 `public-api.md` と英日 `selection.md` の両方で、package-root export 名と host-authored selection value attribute の導線が落ちないことを確認します。
- CI の既存 entrypoint smoke で検出された `index.d.ts` の manifest export drift を、既存 runtime export に合わせて同期しました。
- CI の Ruby spec で検出された manifest top-level key expectation drift を、現在の `public_api_manifest.yml` に合わせて spec 側だけ同期しました。

## Issue ごとの完了内容

- #1395: `TreeViewSelectionDataHooks` の public docs presence を docs entrypoint smoke で guard しました。
- #1397: `path_tree_builder_node_shapes` を public API manifest structure spec の expected top-level key list に追加しました。
- #1398: `TreeViewSelectionDataHooks` と `TreeViewRemoteStateValues` の TypeScript declaration を既存 export / manifest と同期しました。

## 改善カテゴリ

- test
- type declaration sync
- docs drift guard
- maintenance

## 既存仕様への影響

runtime JavaScript、selection controller behavior、public export shape、manifest schema、browser mockup smoke は変更していません。`index.d.ts` は既に `index.js` と manifest に存在する export の宣言追加のみで、manifest structure spec は既存 `public_api_manifest.yml` のキー一覧に合わせたテスト更新のみです。

## 実施した確認

- GitHub compare: `main...quality/1395-selection-data-hooks-docs-smoke`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 3 (`script/test_docs_entrypoints.mjs`, `app/javascript/tree_view/index.d.ts`, `spec/public_api_manifest_structure_spec.rb`)
- 対象 docs (`docs/en|ja/public-api.md`, `docs/en|ja/selection.md`) に `TreeViewSelectionDataHooks` と代表 host-authored attribute signal があることを確認しました。
- 初回 CI #1731 は既存 entrypoint smoke で `TreeViewSelectionDataHooks` / `TreeViewRemoteStateValues` の TypeScript declaration 不足を検出したため、宣言を同期しました。
- 追加 CI #1733 は JavaScript checks が成功し、Ruby/Rails checks で manifest top-level key expectation drift を検出したため、spec を同期しました。
- GitHub Actions CI #1734: success
- local `npm run test:docs` / `npm run test:js` / `bundle exec rspec` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` になるため、GitHub Actions を確認証跡にしています。

## リスク評価

low。docs entrypoint smoke の assertion 追加、既存 export の TypeScript declaration 同期、既存 manifest に合わせた spec 更新のみで、実装挙動や公開 runtime API は変更していません。