### PR TITLE
docs: PR overlap preflight checklist を追加する

### DIFF
--- a/docs/en/pr-overlap-preflight.md
+++ b/docs/en/pr-overlap-preflight.md
@@ -1,0 +1,37 @@
+# PR overlap preflight
+
+Use this checklist before opening a pull request, or immediately after creating one when the environment cannot inspect GitHub beforehand. It keeps duplicate close intent and high changed-file overlap visible without changing repository settings or blocking merges automatically.
+
+## What to compare
+
+1. Search open pull requests for the same `Closes #NNN`, `Fixes #NNN`, or `Refs #NNN` issue reference.
+2. Check whether another open pull request mentions the same parent issue, superseded pull request, or replacement branch.
+3. Compare changed files for the candidate pull request and the existing open pull request.
+4. Treat overlap as high when both pull requests touch the same public API manifest, TypeScript declaration, workflow, browser smoke, or shared docs inventory file.
+5. Record whether the new pull request is a duplicate, a stacked follow-up, a clean replacement, or an intentionally separate slice.
+
+## Connector-only handoff
+
+When a local checkout or GitHub CLI is unavailable, record the connector evidence instead:
+
+- existing open pull request number and title
+- overlapping issue references or closing keywords
+- changed filenames compared
+- whether the existing pull request is mergeable, stale, or already superseded
+- next action: stop new PR creation, comment on the existing PR, open a replacement, or ask a maintainer to choose
+
+## Stop conditions
+
+Stop the new pull request path when an existing open pull request already closes the same issue and touches the same files, unless the new branch is an explicit replacement or stacked follow-up. If the two pull requests both contain useful but conflicting changes, ask for maintainer direction instead of opening a third unlabelled implementation path.
+
+## Evidence template
+
+```markdown
+### PR overlap preflight
+
+- Checked issue references:
+- Existing PR candidates:
+- Changed-file overlap:
+- Classification: duplicate / stacked follow-up / replacement / separate slice
+- Action taken:
+```

--- a/docs/ja/pr-overlap-preflight.md
+++ b/docs/ja/pr-overlap-preflight.md
@@ -1,0 +1,37 @@
+# PR overlap preflight
+
+Pull Request を作成する前、または事前に GitHub を確認できない環境では作成直後に、この checklist を使います。同じ Issue を close する PR や changed files の大きな重複を見える状態にし、repository settings や merge block の自動化には踏み込みません。
+
+## 比較するもの
+
+1. 同じ `Closes #NNN`、`Fixes #NNN`、`Refs #NNN` を持つ open Pull Request を探します。
+2. 同じ parent Issue、superseded PR、replacement branch を扱っている open Pull Request がないか確認します。
+3. 新しい PR 候補と既存 open PR の changed files を比較します。
+4. public API manifest、TypeScript declaration、workflow、browser smoke、shared docs inventory file が重なる場合は high overlap として扱います。
+5. 新しい PR が duplicate、stacked follow-up、clean replacement、意図的に分けた slice のどれかを記録します。
+
+## connector-only handoff
+
+ローカル checkout や GitHub CLI が使えない場合は、connector で確認できた証拠を記録します。
+
+- 既存 open PR の番号と title
+- 重複する Issue reference または closing keyword
+- 比較した changed filenames
+- 既存 PR が mergeable / stale / superseded のどれか
+- 次の action: 新規 PR を止める、既存 PR にコメントする、replacement を作る、maintainer 判断へ回す
+
+## 停止条件
+
+既存 open PR が同じ Issue を close し、同じ files を触っている場合は、新規 PR 作成を止めます。ただし、新しい branch が明示的な replacement または stacked follow-up の場合は除きます。2つの PR がどちらも必要だが競合する場合は、3つ目の曖昧な実装 path を開かず、maintainer 判断を求めます。
+
+## 記録テンプレート
+
+```markdown
+### PR overlap preflight
+
+- Checked issue references:
+- Existing PR candidates:
+- Changed-file overlap:
+- Classification: duplicate / stacked follow-up / replacement / separate slice
+- Action taken:
+```


### PR DESCRIPTION
## 対応 Issue

Closes #1401

## Issue ごとの完了内容

- #1401: PR 作成前または作成直後に、同じ close intent と changed-file overlap を確認する lightweight checklist を英日 docs として追加しました。

## 変更内容

- `docs/en/pr-overlap-preflight.md` を追加
- `docs/ja/pr-overlap-preflight.md` を追加
- connector-only 環境でも記録できる evidence 項目を明記
- duplicate / stacked follow-up / replacement / separate slice の分類と停止条件を整理

## 改善カテゴリ

- docs
- dev workflow guard
- maintenance

## 既存仕様への影響

なし。GitHub settings、branch protection、CI workflow、runtime Ruby / JavaScript、public API、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- GitHub compare: `main...quality/1401-pr-overlap-preflight`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only
- local checkout / docs test は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` になるため、connector 上の差分確認に閉じています。

## リスク評価

low。手順 docs の追加のみで、自動ブロックや repository 設定変更には広げていません。