### PR TITLE
docs entrypoint smoke に責務境界とイベント逆引き導線の signal guard を追加する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -59,6 +59,12 @@ export declare const TreeViewEventDetailKeys: Readonly<{
   }>
 }>
 
+export declare const TreeViewRemoteStateValues: Readonly<{
+  loading: "loading"
+  loaded: "loaded"
+  error: "error"
+}>
+
 export declare const TreeViewTransferDropPositions: Readonly<{
   before: "before"
   inside: "inside"
@@ -71,6 +77,13 @@ export declare const TreeViewControllerIdentifiers: Readonly<{
   selection: "tree-view-selection"
   transfer: "tree-view-transfer"
   remoteState: "tree-view-remote-state"
+}>
+
+export declare const TreeViewSelectionDataHooks: Readonly<{
+  hiddenInputNameValue: "data-tree-view-selection-hidden-input-name-value"
+  maxCountValue: "data-tree-view-selection-max-count-value"
+  cascadeValue: "data-tree-view-selection-cascade-value"
+  indeterminateValue: "data-tree-view-selection-indeterminate-value"
 }>
 
 export declare function registerTreeViewControllers(application: Application): void

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run",
     "test:browser": "playwright test",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && npm run test:docs-entrypoints",
     "test:js": "npm run test:entrypoints && npm test && npm run test:browser"
   },

--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const signalGroups = [
+  {
+    feature: "FAQ host responsibility boundary",
+    files: [
+      ["docs/en/faq.md", ["host app", "authorization", "query"]],
+      ["docs/ja/faq.md", ["host app", "authorization", "query"]]
+    ]
+  },
+  {
+    feature: "Troubleshooting host responsibility boundary",
+    files: [
+      ["docs/en/troubleshooting.md", ["host app still owns routes", "authorization", "business actions"]],
+      ["docs/ja/troubleshooting.md", ["routes", "authorization", "query", "business action"]]
+    ]
+  },
+  {
+    feature: "Troubleshooting JavaScript event reverse lookup",
+    files: [
+      [
+        "docs/en/troubleshooting.md",
+        [
+          "tree-view-selection:invalid-payload",
+          "tree-view-remote-state:retry",
+          "js-events.md#tree-view-remote-stateretry"
+        ]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        [
+          "tree-view-selection:invalid-payload",
+          "tree-view-remote-state:retry",
+          "js-events.md#tree-view-remote-stateretry"
+        ]
+      ]
+    ]
+  }
+]
+
+signalGroups.forEach(({ feature, files }) => {
+  files.forEach(([sourcePath, signals]) => assertSignals(sourcePath, feature, signals))
+})

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -9,6 +9,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   module_methods
   configuration_options
   public_constants
+  path_tree_builder_node_shapes
   helper_methods
   helper_option_keys
   toolbar_actions


### PR DESCRIPTION
## 対応 Issue

- Closes #1423
- Closes #1426

## Issue ごとの完了内容

- #1423: FAQ / Troubleshooting にある host app responsibility boundary の代表的な signal が docs smoke で落ちないようにしました。
- #1426: Troubleshooting から JavaScript integration event の逆引き導線が消えないよう、selection / remote state の代表 event signal と `js-events.md` link を smoke 対象にしました。

## 変更内容

- `script/test_docs_entrypoint_signals.mjs` を追加し、既存の entrypoint link smoke とは別に docs 内の代表 signal を確認するようにしました。
- `npm run test:docs-entrypoints` に signal smoke を組み込みました。
- CI 初回実行で current-main の public API manifest / TypeScript declaration 同期ズレが先に検出されたため、runtime export / manifest 本体は変えずに以下を同期しました。
  - `TreeViewSelectionDataHooks` / `TreeViewRemoteStateValues` の package-root declaration 追加
  - `path_tree_builder_node_shapes` の manifest structure expected key 追加

## 改善カテゴリ

- test
- docs smoke
- regression guard
- type / spec sync

## 既存仕様への影響

- docs smoke script、package script、TypeScript declaration、manifest structure spec の同期のみです。
- runtime code、UI、API実装、DB、認可、外部サービス契約には触れていません。

## 実施した確認

- GitHub compare で差分が docs smoke と CI-discovered declaration/spec sync に限られることを確認しました。
- 初回 CI `#1768` は、追加した signal smoke 到達前に既存の public API declaration/spec drift で失敗しました。
- ローカル checkout はネットワーク制限で取得できなかったため、ローカルで `npm run test:docs-entrypoints` は未実行です。再実行後のCIで確認します。

## リスク評価

- risk: low
- smoke check と宣言/spec同期のみで、既存公開挙動への影響はありません。

## 補足

- #1423 と #1426 はどちらも docs entrypoint から代表的な品質導線が消えないようにする改善で、同じ smoke 実行単位にまとめるのが自然なため同一 PR にしています。
- CI発見事項は、runtime export / manifest に既に存在するsignalへ宣言・spec期待値を合わせるだけに限定しています。