### PR TITLE
release:check に CHANGELOG section 形状 guard を追加する

### DIFF
--- a/lib/tree_view/release_check.rb
+++ b/lib/tree_view/release_check.rb
@@ -11,6 +11,7 @@ module TreeView
     GEMSPEC_PATH = "tree_view.gemspec"
     CHANGELOG_PATH = "CHANGELOG.md"
     RELEASE_DOC_PATHS = %w[docs/en/release.md docs/ja/release.md].freeze
+    CHANGELOG_CATEGORY_HEADINGS = %w[Added Changed Fixed Deprecated Removed Security Documentation].freeze
 
     class Failure < StandardError; end
 
@@ -66,10 +67,34 @@ module TreeView
       end
 
       def ensure_changelog_has_release_section!
+        source = read(CHANGELOG_PATH)
         header = /^##\s+#{Regexp.escape(version)}\s+-\s+\d{4}-\d{2}-\d{2}$/
-        return if read(CHANGELOG_PATH).match?(header)
+        match = source.match(header)
+        raise Failure, "#{CHANGELOG_PATH} must include a dated section for #{version}" unless match
 
-        raise Failure, "#{CHANGELOG_PATH} must include a dated section for #{version}"
+        section = release_section_after(source, match.end(0))
+        ensure_changelog_release_section_has_category!(section)
+        ensure_changelog_release_section_has_body!(section)
+      end
+
+      def release_section_after(source, offset)
+        source[offset..].to_s.split(/^##\s+/, 2).first.to_s
+      end
+
+      def ensure_changelog_release_section_has_category!(section)
+        allowed = CHANGELOG_CATEGORY_HEADINGS.map { |heading| Regexp.escape(heading) }.join("|")
+        return if section.match?(/^###\s+(?:#{allowed})\s*$/)
+
+        raise Failure, "#{CHANGELOG_PATH} release section for #{version} must include at least one category heading: #{CHANGELOG_CATEGORY_HEADINGS.join(", ")}"
+      end
+
+      def ensure_changelog_release_section_has_body!(section)
+        body = section.lines.reject do |line|
+          line.strip.empty? || line.start_with?("###", "<!--", "-->")
+        end.join
+        return unless body.strip.empty?
+
+        raise Failure, "#{CHANGELOG_PATH} release section for #{version} must include release notes under a category heading"
       end
 
       def ensure_release_docs_reference_checklist!

--- a/spec/release_check_spec.rb
+++ b/spec/release_check_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TreeView::ReleaseCheck::Runner do
     run_command("git", "commit", "-q", "-m", "Initial fixture", chdir: root)
   end
 
-  def with_fixture_root(version: "0.1.0", changelog_version: version, include_release_check: true)
+  def with_fixture_root(version: "0.1.0", changelog_version: version, changelog_body: nil, include_release_check: true)
     Dir.mktmpdir do |root|
       write_file(root, "lib/tree_view/version.rb", <<~RUBY)
         # frozen_string_literal: true
@@ -63,10 +63,17 @@ RSpec.describe TreeView::ReleaseCheck::Runner do
         end
       RUBY
 
+      changelog_body ||= <<~MD
+        ### Fixed
+
+        - Keep release notes visible for the release.
+      MD
       write_file(root, "CHANGELOG.md", <<~MD)
         # Changelog
 
         ## #{changelog_version} - 2026-05-07
+
+        #{changelog_body}
       MD
 
       release_body = +"# Release checklist\n\nCHANGELOG.md\n"
@@ -94,6 +101,28 @@ RSpec.describe TreeView::ReleaseCheck::Runner do
       expect { runner.validate_metadata! }.to raise_error(
         TreeView::ReleaseCheck::Failure,
         /CHANGELOG\.md must include a dated section for 0\.1\.0/
+      )
+    end
+  end
+
+  it "fails when the changelog release section has no allowed category heading" do
+    with_fixture_root(changelog_body: "- Keep release notes visible.\n") do |root|
+      runner = described_class.new(root: root, stdout: StringIO.new, verify_package: false)
+
+      expect { runner.validate_metadata! }.to raise_error(
+        TreeView::ReleaseCheck::Failure,
+        /category heading/
+      )
+    end
+  end
+
+  it "fails when the changelog release section has a category heading but no release notes" do
+    with_fixture_root(changelog_body: "### Documentation\n") do |root|
+      runner = described_class.new(root: root, stdout: StringIO.new, verify_package: false)
+
+      expect { runner.validate_metadata! }.to raise_error(
+        TreeView::ReleaseCheck::Failure,
+        /release notes/
       )
     end
   end


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1434

## Issue ごとの完了内容

- #1434: release:check が dated release section の存在だけでなく、許可された category heading と category 配下の本文を軽量に確認するようにしました。

## 変更内容

- `lib/tree_view/release_check.rb`
  - CHANGELOG release section に `Added` / `Changed` / `Fixed` / `Deprecated` / `Removed` / `Security` / `Documentation` の category heading が少なくとも1つあることを確認
  - category heading だけの空 release section を failure にする
- `spec/release_check_spec.rb`
  - 既存の release check spec に category ありの成功例、category なし、category だけで本文なしの代表 failure を追加

## 改善カテゴリ

- test
- devops
- release guard

## 既存仕様への影響はないこと

- version bump、tag 作成、gem publish、public API manifest schema、docs sync policy は変更していません。
- release 前チェックの validation を、既存 docs policy に沿った最小の CHANGELOG 形状確認へ広げただけです。

## 実施した確認内容

- GitHub compare: `main...quality/1434-release-changelog-shape`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 (`lib/tree_view/release_check.rb`, `spec/release_check_spec.rb`)
- local RSpec は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後に GitHub Actions を確認します。

## リスク評価

low。release:check のメタデータ検証だけに閉じた変更です。

## 補足事項

- #1433 の public API manifest docs sync policy、semantic versioning 判定、migration note 自動判定には広げていません。