### PR TITLE
default-tree mockup に narrow first-scan section を追加する

### DIFF
--- a/docs/mockups/default-tree.html
+++ b/docs/mockups/default-tree.html
@@ -5,6 +5,34 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Default TreeView rendering mock</title>
 <link rel="stylesheet" href="default-tree.css">
+<style>
+  .mock-narrow-scan {
+    max-width: 25rem;
+    overflow-x: auto;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+  }
+
+  .mock-narrow-scan .tree-view-table {
+    min-width: 44rem;
+    margin: 0;
+  }
+
+  .mock-narrow-scan th,
+  .mock-narrow-scan td {
+    white-space: nowrap;
+  }
+
+  .mock-narrow-scan .tree-toggle__control {
+    gap: 0.35rem;
+  }
+
+  .mock-narrow-note {
+    max-width: 48rem;
+    color: #57606a;
+    font-size: 0.9rem;
+  }
+</style>
 </head>
 <body>
   <main class="mock-page">
@@ -138,6 +166,76 @@
       </table>
     </section>
 
+    <section class="mock-section" aria-labelledby="narrow-scan-heading">
+      <h2 id="narrow-scan-heading">Narrow first-scan row composition</h2>
+      <p class="mock-narrow-note">
+        A constrained frame keeps the checkbox, current-row cue, badge, and row action visible together for first-pass review.
+        Host applications still own final sidebar width, action-menu behavior, and responsive framing.
+      </p>
+      <div class="mock-narrow-scan" role="region" aria-label="Narrow TreeView first-scan example" tabindex="0">
+        <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+          <thead>
+            <tr>
+              <th scope="col">select</th>
+              <th scope="col">tree</th>
+              <th scope="col">name</th>
+              <th scope="col">status</th>
+              <th scope="col">actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="narrow_project_2" class="tree-row is-expanded is-selected" data-tree-node-key="project:2" data-tree-parent-key="project:1" data-tree-depth="1" data-tree-expanded="true" aria-level="2" aria-expanded="true" aria-selected="true" aria-current="page">
+              <td class="tree-selection-cell">
+                <input class="tree-selection-checkbox" id="narrow_project_2_selection" name="selected_nodes[]" type="checkbox" checked value='{"key":"project:2","id":2,"type":"Project"}' data-tree-selection-payload='{"key":"project:2","id":2,"type":"Project"}'>
+              </td>
+              <td class="btn-cell tree-toggle-cell" id="narrow_project_2_button">
+                <span class="tree-toggle" aria-label="Current child row expanded">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot has-line"></span>
+                    <span class="tree-toggle__branch-slot is-current is-middle"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a>
+                    <span class="tree-toggle__level">child</span>
+                  </span>
+                </span>
+                <span class="tree-node-marker" title="Folder">folder</span>
+                <span class="tree-depth-label">L1</span>
+                <span class="tree-node-badge tree-node-badge--info" title="Selected node">selected</span>
+              </td>
+              <td>Admin UI</td>
+              <td><span class="mock-status mock-status--active">active</span></td>
+              <td class="tree-row-actions"><button type="button">Open</button></td>
+            </tr>
+            <tr id="narrow_project_4" class="tree-row is-collapsed" data-tree-node-key="project:4" data-tree-parent-key="project:1" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false" aria-selected="false">
+              <td class="tree-selection-cell">
+                <input class="tree-selection-checkbox" id="narrow_project_4_selection" name="selected_nodes[]" type="checkbox" disabled title="Archived nodes cannot be selected" value='{"key":"project:4","id":4,"type":"Project"}' data-tree-selection-disabled-reason="Archived nodes cannot be selected" data-tree-selection-payload='{"key":"project:4","id":4,"type":"Project"}'>
+              </td>
+              <td class="btn-cell tree-toggle-cell" id="narrow_project_4_button">
+                <span class="tree-toggle" aria-label="Collapsed archived row with hidden descendants">
+                  <span class="tree-toggle__branches" aria-hidden="true">
+                    <span class="tree-toggle__branch-slot has-line"></span>
+                    <span class="tree-toggle__branch-slot is-current is-last"></span>
+                  </span>
+                  <span class="tree-toggle__control">
+                    <a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a>
+                    <span class="tree-toggle__level">child</span>
+                    <span class="tree-toggle__hidden-count" title="Hidden descendants">12</span>
+                  </span>
+                </span>
+                <span class="tree-node-marker" title="Archive">archive</span>
+                <span class="tree-depth-label">L1</span>
+                <span class="tree-node-badge tree-node-badge--warning" title="Archived subtree">archived</span>
+              </td>
+              <td>Legacy reports</td>
+              <td><span class="mock-status mock-status--archived">archived</span></td>
+              <td class="tree-row-actions"><button type="button" disabled>Open</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
     <section class="mock-section" aria-labelledby="notes-heading">
       <h2 id="notes-heading">What this mock covers</h2>
       <ul>
@@ -145,6 +243,7 @@
         <li>Expanded and collapsed rows with hidden-count cues</li>
         <li>Selected and disabled checkbox states</li>
         <li>Badge, marker, and depth-label placement</li>
+        <li>Narrow first-scan composition for checkbox, current cue, badge, and row action placement</li>
         <li>Row data attributes, tree state attributes, and row-actions column placement</li>
       </ul>
     </section>


### PR DESCRIPTION
## 対応Issue

- Closes #1408

## 採用した方針

- スケジュール実行のためユーザー選択待ちは行わず、最も低リスクで既存 mockup 構成に沿う案を採用しました。
- 新しい top-level mockup は増やさず、既存の `docs/mockups/default-tree.html` に narrow first-scan 用の確認セクションを追加しました。
- これにより README / gallery / smoke 対象の追加を避けつつ、checkbox、current cue、badge、row action の初見確認ポイントを同一ページで見られるようにしています。

## 比較した案

- 案A: 既存 `default-tree.html` に narrow first-scan section を追加する。既存導線を保てて変更範囲が小さいため採用。
- 案B: narrow 専用の mockup HTML を新規追加する。比較しやすい一方で README / gallery / smoke 同期が必要になり、今回の低リスク範囲より変更が広がるため不採用。
- 案C: runtime CSS や component 側のレスポンシブ調整まで行う。実画面挙動に踏み込める一方で、Issue #1408 の static mockup 補強を超えるため不採用。

## 変更内容

- `default-tree.html` に狭い表示幅を想定した `Narrow first-scan row composition` section を追加しました。
- 代表的な selected/current row と collapsed/archived row を並べ、checkbox、current cue、badge、action column の並びをレビューしやすくしました。
- 横スクロール可能な constrained frame と補足文を追加し、host app 側が最終的な sidebar width / action menu / responsive framing を持つ前提を明記しました。
- `What this mock covers` に narrow first-scan composition の観点を追加しました。

## 変更した画面・コンポーネント

- `docs/mockups/default-tree.html`

## 確認内容

- lint: GitHub Actions `CI #1792 / lint` success
- typecheck: 型定義に影響しない static HTML 変更です。
- specs: GitHub Actions `CI #1792 / pr_specs` success
- UI表示確認: GitHub Actions `CI #1792 / javascript` success。`npm run test:browser` が実行されています。
- レスポンシブ確認: 手元の実ブラウザでは未確認。代替として static HTML fixture 上に constrained frame を追加し、狭い幅での確認観点を PR レビュー対象にしています。
- アクセシビリティ確認: source review で section heading、region label、tabindex、既存 aria 属性の維持を確認しました。
- 実ブラウザ確認の代替: static HTML fixture / QA handoff note と GitHub Actions browser smoke で補完しています。スクリーンショット確認は未実施です。
- base確認: PR 作成前後に `main...design/1408-default-tree-narrow-first-scan-v2` が `behind_by: 0`、変更ファイル 1件であることを確認しました。

## スクリーンショット

<!-- connector-only 作業のため未添付。必要に応じて `docs/mockups/default-tree.html` をブラウザで開いて確認してください。 -->

## リスク

- low

## 補足

- 既存の standard table structure は維持しています。
- 新規 mockup ファイルを増やしていないため、review gallery や mockup index への追加更新は行っていません。