### PR TITLE
Diagnostics public contract を current main で再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -140,6 +140,19 @@ grouped_option_keys:
     - row_disabled_builder
     - row_readonly_builder
     - row_disabled_reason_builder
+diagnostics:
+  accepted_checks:
+    - node_keys
+    - dom_ids
+    - orphans
+    - cycles
+  result_surface:
+    attributes:
+      - checks
+      - errors
+      - warnings
+    methods:
+      - success?
 resource_table_render_state_call:
   required_keywords:
     - records

--- a/docs/en/tree-diagnostics.md
+++ b/docs/en/tree-diagnostics.md
@@ -74,6 +74,8 @@ end
 
 `Result#success?` only reflects collected errors. Orphan reports are warnings, so review `warnings` when filtered, imported, or permission-scoped data can leave records outside the rendered tree.
 
+The manifest-backed diagnostics contract covers the accepted check names and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
+
 ## Node key uniqueness
 
 Enable validation when building the tree to catch duplicate node keys early.

--- a/docs/ja/tree-diagnostics.md
+++ b/docs/ja/tree-diagnostics.md
@@ -74,6 +74,8 @@ end
 
 `Result#success?` は収集されたerrorsだけを見ます。orphan reportはwarningsとして返るため、filter、import、permission scopeによって描画対象外のrecordsが生じる可能性がある場合は `warnings` も確認してください。
 
+manifest-backed な diagnostics contract は、accepted check names と `Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
+
 ## node key uniqueness
 
 node keyの重複を検出したい場合は、tree作成時にvalidationを有効にします。

--- a/spec/public_api_diagnostics_compatibility_spec.rb
+++ b/spec/public_api_diagnostics_compatibility_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "Diagnostics public API compatibility" do
+  let(:manifest_path) { File.expand_path("../config/public_api_manifest.yml", __dir__) }
+  let(:diagnostics_manifest) { YAML.safe_load_file(manifest_path).fetch("diagnostics") }
+
+  it "keeps Diagnostics accepted checks aligned with the manifest" do
+    expect(diagnostics_manifest.fetch("accepted_checks")).to eq(TreeView::Diagnostics::DEFAULT_CHECKS.map(&:to_s))
+  end
+
+  it "keeps Diagnostics::Result reader surface aligned with the manifest" do
+    result = TreeView::Diagnostics::Result.new(checks: [], errors: [], warnings: [])
+
+    diagnostics_manifest.fetch("result_surface").fetch("attributes").each do |attribute_name|
+      expect(result).to respond_to(attribute_name.to_sym),
+        "expected TreeView::Diagnostics::Result##{attribute_name} to remain public"
+    end
+
+    diagnostics_manifest.fetch("result_surface").fetch("methods").each do |method_name|
+      expect(result).to respond_to(method_name.to_sym),
+        "expected TreeView::Diagnostics::Result##{method_name} to remain public"
+    end
+
+    expect(result.success?).to eq(true)
+
+    failed_result = TreeView::Diagnostics::Result.new(
+      checks: [:node_keys],
+      errors: [{check: :node_keys, message: "duplicate node key"}],
+      warnings: []
+    )
+
+    expect(failed_result.success?).to eq(false)
+  end
+end

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -14,6 +14,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   helper_option_keys
   toolbar_actions
   grouped_option_keys
+  diagnostics
   resource_table_render_state_call
   render_state_callback_builder_keys
   javascript_package_root


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1227
Supersedes #1235

## 置き換え理由

PR #1235 が current `main` から大きく diverged し、`mergeable:false` になっていました。旧 branch の `config/public_api_manifest.yml` / public API docs / compatibility spec をそのまま載せ直すと、current main の public API manifest と docs inventory の更新を落とすリスクがあるため、current main から replacement branch を作成しました。

## 変更内容

- `config/public_api_manifest.yml` に `diagnostics` section を追加しました。
  - accepted checks: `node_keys`, `dom_ids`, `orphans`, `cycles`
  - Result attributes: `checks`, `errors`, `warnings`
  - Result methods: `success?`
- `spec/public_api_diagnostics_compatibility_spec.rb` を追加し、manifest と runtime surface の drift を検出できるようにしました。
- `spec/public_api_manifest_structure_spec.rb` に `diagnostics` top-level section を同期しました。
- `docs/en/tree-diagnostics.md` / `docs/ja/tree-diagnostics.md` に、manifest-backed contract の対象と非対象を短く同期しました。

## current main から保持した内容

current main の `path_tree_builder_node_shapes`、JavaScript package-root manifest entries、docs entrypoint smoke 関連の更新、PR overlap preflight docs などを保持しています。旧 #1235 branch の stale file 全文は戻していません。

## 既存仕様への影響

Diagnostics の実行挙動、check 種別、Result runtime shape、orphan / cycle / error collection policy は変更していません。accepted checks と Result reader surface を manifest-backed contract として固定するだけです。

## 確認内容

- GitHub compare: `main...feature/1227-diagnostics-public-contract-current-v2`
  - changed files: 5
  - `config/public_api_manifest.yml`
  - `spec/public_api_diagnostics_compatibility_spec.rb`
  - `spec/public_api_manifest_structure_spec.rb`
  - `docs/en/tree-diagnostics.md`
  - `docs/ja/tree-diagnostics.md`
- PR metadata: `mergeable:true`
- GitHub Actions CI #1800: success
- local checkout / local RSpec は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、connector 経由で変更しています。

## リスク

medium。public manifest contract を強める変更ですが、既存 documented / runtime surface の最小範囲に閉じ、diagnostics behavior や詳細 semantics は固定しすぎないようにしています。

## 未対応・補足

- #357 の diagnostics 拡張、heavy fuzz / property-based testing、check 種別追加は扱っていません。
- #1235 はこの PR で supersede し、コメント後に close 済みです。