### PR TITLE
breadcrumb mockup の narrow long-label stress state を現行mainへ載せ直す

### DIFF
--- a/docs/mockups/breadcrumb-paths.html
+++ b/docs/mockups/breadcrumb-paths.html
@@ -46,6 +46,10 @@
   background: #fff;
 }
 
+.mock-breadcrumb-frame--narrow {
+  max-width: 390px;
+}
+
 .mock-breadcrumb-toolbar {
   display: grid;
   gap: 12px;
@@ -109,6 +113,10 @@
   list-style: none;
 }
 
+.mock-breadcrumb-path--stress {
+  gap: 0.45rem;
+}
+
 .mock-breadcrumb-path li {
   display: inline-flex;
   align-items: center;
@@ -145,6 +153,13 @@
 .mock-breadcrumb-pill--muted {
   border-style: dashed;
   color: #64748b;
+}
+
+.mock-breadcrumb-pill--stress {
+  align-items: flex-start;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .mock-breadcrumb-table {
@@ -441,6 +456,83 @@
           </div>
         </div>
       </div>
+
+      <div class="mock-breadcrumb-state">
+        <div class="mock-breadcrumb-state__header">
+          <p class="mock-breadcrumb-eyebrow">Mode C</p>
+          <h2>Long labels in a narrow breadcrumb frame</h2>
+          <p class="mock-breadcrumb-note">
+            Use this state when the review goal is to stress wrapping, separators, and the current breadcrumb cue in a compact host-app pane.
+          </p>
+        </div>
+
+        <div class="mock-breadcrumb-frame mock-breadcrumb-frame--narrow">
+          <div class="mock-breadcrumb-toolbar">
+            <p class="mock-breadcrumb-toolbar__title">Narrow path stress</p>
+            <div class="mock-breadcrumb-toolbar__meta" aria-label="Representative narrow path metadata">
+              <span class="mock-breadcrumb-chip">390px frame</span>
+              <span class="mock-breadcrumb-chip mock-breadcrumb-chip--secondary">long labels</span>
+            </div>
+          </div>
+          <div class="mock-breadcrumb-body">
+            <p class="mock-breadcrumb-callout">
+              This stress state keeps the path product-neutral. Final truncation, menus, breakpoint choices, and permission-aware labels remain host-app responsibilities.
+            </p>
+            <ol class="mock-breadcrumb-path mock-breadcrumb-path--stress" aria-label="Representative long breadcrumb path in a narrow frame">
+              <li><span class="mock-breadcrumb-pill mock-breadcrumb-pill--stress">Workspace operations and compliance area</span></li>
+              <li><span class="mock-breadcrumb-pill mock-breadcrumb-pill--stress">Regional implementation planning workspace</span></li>
+              <li><span class="mock-breadcrumb-pill mock-breadcrumb-pill--stress">Quarterly accessibility evidence package</span></li>
+              <li><span class="mock-breadcrumb-pill mock-breadcrumb-pill--stress mock-breadcrumb-pill--current" aria-current="page">Current review item with a deliberately long label</span></li>
+            </ol>
+            <table class="tree-view-table">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">name</th>
+                  <th scope="col">state</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-expanded" data-tree-node-key="narrow:1" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Narrow root row expanded">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control">
+                        <a class="tree-toggle__action" href="#">hide</a>
+                        <span class="tree-toggle__level">root</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-marker" title="Folder">folder</span>
+                    <span class="tree-depth-label">L0</span>
+                  </td>
+                  <td>Workspace operations</td>
+                  <td><span class="mock-status">ancestor</span></td>
+                </tr>
+                <tr class="tree-row is-window-current" data-tree-node-key="narrow:4" data-tree-parent-key="narrow:3" data-tree-depth="3" aria-level="4" aria-current="page">
+                  <td class="btn-cell tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Narrow current row">
+                      <span class="tree-toggle__branches" aria-hidden="true">
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot has-line"></span>
+                        <span class="tree-toggle__branch-slot is-current is-last"></span>
+                      </span>
+                      <span class="tree-toggle__control">
+                        <span class="tree-toggle__level">leaf</span>
+                      </span>
+                    </span>
+                    <span class="tree-node-marker" title="File">file</span>
+                    <span class="tree-depth-label">L3</span>
+                    <span class="tree-node-badge tree-node-badge--current">current row</span>
+                  </td>
+                  <td>Current review item with a deliberately long label</td>
+                  <td><span class="mock-status mock-status--active">current item</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section class="mock-section" aria-labelledby="breadcrumb-comparison-heading">
@@ -456,7 +548,7 @@
         <tbody>
           <tr>
             <td>Breadcrumb path</td>
-            <td>The lineage to the current item, including shallow and deep representative paths.</td>
+            <td>The lineage to the current item, including shallow, deep, and narrow long-label representative paths.</td>
             <td>Real route helpers, final labels, authorization-aware visibility, and Turbo navigation.</td>
           </tr>
           <tr>


### PR DESCRIPTION
## 対応Issue

- Closes #1372
- Supersedes #1412

## 採用した方針

- #1412 は current main から `behind_by: 16` / `status: diverged` になり、CI #1759 の `pr_specs` が public API manifest baseline drift で失敗していたため、latest main から replacement branch を作成しました。
- 差分は既存の `docs/mockups/breadcrumb-paths.html` への Mode C 追加 1 ファイルに閉じます。
- dedicated page / README / gallery inventory / runtime API には広げません。

## 比較した案

- 案A: 旧 #1412 branch を継続利用。stale かつ CI red のため未採用。
- 案B: latest main から replacement PR を作成。差分が小さく、CI drift を混ぜずにレビューできるため採用。
- 案C: dedicated mockup page を追加。inventory 増大とレビュー範囲拡大につながるため未採用。

## 変更内容

- `docs/mockups/breadcrumb-paths.html` に Mode C として 390px narrow frame、long breadcrumb labels、current row cue comparison を追加。
- stress 表示用に `mock-breadcrumb-frame--narrow`、`mock-breadcrumb-path--stress`、`mock-breadcrumb-pill--stress` を追加。
- comparison table の文言を shallow / deep / narrow long-label paths を含む説明へ更新。

## 変更した画面・コンポーネント

- Static mockup: `docs/mockups/breadcrumb-paths.html`

## 確認内容

- lint: GitHub Actions CI #1805 success。
- typecheck: 該当なし。
- UI表示確認: connector source review で Mode C の追加箇所を確認。
- レスポンシブ確認: source 上で 390px frame、`overflow-wrap: anywhere`、`white-space: normal` を確認。実ブラウザ screenshot は未取得。
- アクセシビリティ確認: `aria-label`、`aria-current`、tree row cue pattern を維持していることを source 上で確認。
- 実ブラウザ確認代替: static HTML fixture source review / browser smoke CI。
- CI: GitHub Actions CI #1805 success。
- PR 作成前 compare: `main...design/1372-breadcrumb-narrow-stress-current` は `behind_by: 0`、changed files は `docs/mockups/breadcrumb-paths.html` の 1 ファイルです。
- PR metadata: `mergeable: true`。

## スクリーンショット

<!-- connector-only 実行のため未添付 -->

## リスク

- low

## 補足

- #1412 は同じ intent の旧 PR ですが、latest main から `behind_by: 16` で CI red でした。baseline drift を design PR に混ぜないため、stack ではなく replacement としました。