### PR TITLE
ResourceTableRenderState manifest keyword guard を追加する

### DIFF
--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "psych"
+require "tree_view/resource_table_render_state"
 require "yaml"
 
 PUBLIC_API_MANIFEST_STRUCTURE_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
@@ -84,6 +85,30 @@ RSpec.describe "Public API manifest structure" do
       expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
       expect(keys).to all(be_a(String))
     end
+  end
+
+  it "keeps resource table render state keyword sections shaped as non-empty string lists" do
+    section = manifest.fetch("resource_table_render_state_call")
+
+    %w[required_keywords optional_keywords].each do |section_name|
+      keywords = section.fetch(section_name)
+
+      expect(keywords).to be_an(Array), "expected #{section_name} to be an array"
+      expect(keywords).not_to be_empty, "expected #{section_name} to list public keywords"
+      expect(keywords).to all(be_a(String))
+    end
+  end
+
+  it "keeps resource table render state keyword sections synchronized with the runtime call signature" do
+    section = manifest.fetch("resource_table_render_state_call")
+    parameters = TreeView::ResourceTableRenderState.method(:call).parameters
+    required_keywords = parameters.select { |kind, _name| kind == :keyreq }.map(&:last).map(&:to_s)
+    optional_keywords = parameters.select { |kind, _name| kind == :key }.map(&:last).map(&:to_s)
+
+    expect(section.fetch("required_keywords")).to eq(required_keywords)
+    expect(section.fetch("optional_keywords")).to eq(optional_keywords)
+    expect(parameters).to include([:keyrest, :render_options])
+    expect(section.fetch("render_options_contract")).to eq("render_state_pass_through")
   end
 
   it "keeps JavaScript event names and detail keys in nested hash sections" do

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -102,8 +102,9 @@ RSpec.describe "Public API manifest structure" do
   it "keeps resource table render state keyword sections synchronized with the runtime call signature" do
     section = manifest.fetch("resource_table_render_state_call")
     parameters = TreeView::ResourceTableRenderState.method(:call).parameters
-    required_keywords = parameters.select { |kind, _name| kind == :keyreq }.map(&:last).map(&:to_s)
-    optional_keywords = parameters.select { |kind, _name| kind == :key }.map(&:last).map(&:to_s)
+    parameters_by_kind = parameters.group_by(&:first)
+    required_keywords = parameters_by_kind.fetch(:keyreq, []).map(&:last).map(&:to_s)
+    optional_keywords = parameters_by_kind.fetch(:key, []).map(&:last).map(&:to_s)
 
     expect(section.fetch("required_keywords")).to eq(required_keywords)
     expect(section.fetch("optional_keywords")).to eq(optional_keywords)


### PR DESCRIPTION
## 対応 Issue

Closes #1439

## Issue ごとの完了内容

- #1439: `resource_table_render_state_call` manifest section の keyword shape を public API manifest spec で guard しました。

## 変更内容

- manifest の `required_keywords` / `optional_keywords` が空でない string list として維持されることを確認します。
- `TreeView::ResourceTableRenderState.call` の runtime keyword signature と manifest の keyword section が同期していることを確認します。
- `render_options` の keyrest と `render_state_pass_through` contract も合わせて固定しました。
- runtime 実装や public API manifest 本体は変更していません。

## 改善カテゴリ

- test
- public API manifest compatibility guard

## 既存仕様への影響

- spec-only の変更です。
- UI、API、DB、認可、状態遷移、外部サービス契約への影響はありません。

## 実施した確認内容

- Branch freshness: `main` から ahead 2 / behind 0 を確認しました。
- 差分対象: `spec/public_api_manifest_structure_spec.rb` のみであることを確認しました。
- GitHub Actions CI run #1807: success。
- local test/lint は、この実行環境から GitHub HTTPS checkout が 403 で制限されたため未実行です。

## リスク評価

- risk: low
- runtime signature と manifest の既存 shape を spec で固定するだけなので、公開挙動は変わりません。

## 補足事項

- connector-only の小変更として、final newline を維持した full-file update で反映しています。