### PR TITLE
gem package contents verifier に代表 mockup assets を追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -5,7 +5,7 @@ require "rubygems/package"
 
 # Keep representative English and Japanese files in this list so package
 # verification covers the bilingual locale, public API, docs entrypoints,
-# and release docs shipped by the gem.
+# release docs, and user-facing mockup entrypoints shipped by the gem.
 REQUIRED_PACKAGED_PATHS = %w[
   app/helpers/tree_view_helper.rb
   app/helpers/tree_view_helper/support.rb
@@ -34,6 +34,10 @@ REQUIRED_PACKAGED_PATHS = %w[
   CHANGELOG.md
   README.md
   docs/README.md
+  docs/mockups/README.md
+  docs/mockups/review-gallery.html
+  docs/mockups/default-tree.html
+  docs/mockups/default-tree.css
   docs/en/installation.md
   docs/ja/installation.md
   docs/en/public-api.md


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1448

## Issue ごとの完了内容

- #1448: gem package contents verifier が、README から直接辿る代表 mockup entrypoint と共有 CSS を packaged path として確認するようにしました。

## 変更内容

- `script/check_gem_package_contents.rb`
  - `REQUIRED_PACKAGED_PATHS` に以下を追加
    - `docs/mockups/README.md`
    - `docs/mockups/review-gallery.html`
    - `docs/mockups/default-tree.html`
    - `docs/mockups/default-tree.css`
  - verifier comment を、user-facing mockup entrypoints も package verification の代表対象であることが分かる表現に更新

## 改善カテゴリ

- test
- package verification
- docs/mockup inventory guard

## 既存仕様への影響はないこと

- package contents verifier の代表 path 追加のみです。
- mockup HTML/CSS、runtime Ruby / JavaScript、public API、UI behavior、DB、認可、外部サービス契約は変更していません。
- `tree_view.gemspec` の `docs/**/*` package policy と矛盾せず、README から直接辿る entrypoint に限定しています。

## 実施した確認内容

- Issue #1448 のラベルを個別確認しました。
  - `status:ready-for-agent`
  - `agent:planned`
  - `track:quality`
  - `risk:low`
- Branch freshness: latest `main` `134934da49996b5fc0905e6e982b4c81ee4685f2` から作成
- GitHub compare: `main...quality/1448-mockup-package-contents`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/check_gem_package_contents.rb`)
- connector-only 更新後にファイル内容を再取得し、final newline と対象 path を確認しました。
- local `gem build` / `script/check_gem_package_contents.rb` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後の GitHub Actions を確認します。

## リスク評価

low。packaging guard の代表 path 追加だけで、公開挙動は変わりません。

## 補足事項

- `docs/mockups` 全体の exhaustive manifest 化、visual redesign、screenshot / visual diff、gemspec glob 変更には広げていません。