### PR TITLE
Development docs の manifest sync policy を更新する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -55,7 +55,15 @@ Public API compatibility specs protect documented Ruby entry points, helper meth
 
 When an intentional breaking change is accepted, update the public API docs and the compatibility specs together so the documented contract and test coverage stay aligned.
 
-`config/public_api_manifest.yml` is the machine-readable source of truth for the public surface covered by compatibility checks. It currently tracks Ruby module methods, public constants, configuration options, helper names, helper option keys, toolbar action/state mapping, grouped option keys, JavaScript package-root named exports, controller registrations, public event names, and documented `event.detail` keys. When you add, rename, or remove one of those entries, update the manifest, keep `docs/en/public-api.md` and `docs/ja/public-api.md` aligned, check any README, usage page, feature doc, configuration option doc, or JavaScript event doc that names the same surface, add the user-facing note to `CHANGELOG.md` when the change materially affects adopters, and review `docs/en/release.md` / `docs/ja/release.md` when release notes or migration expectations need to change.
+`config/public_api_manifest.yml` is the machine-readable source of truth for the public surface covered by compatibility checks. It currently tracks Ruby module methods, public constants, configuration options, helper names, helper option keys, toolbar action/state mapping, grouped option keys, PathTreeBuilder node shapes, ResourceTableRenderState call keywords, RenderState callback builder keys, JavaScript package-root named exports, transfer drop positions, remote-state values, controller registrations, public event names, intentional no-detail event names, documented `event.detail` keys, and selection data hooks.
+
+When you add, rename, or remove one of those entries, keep the sync trail small and explicit:
+
+- Update the manifest and the owning compatibility spec, entrypoint smoke, or package guard that protects that surface.
+- Align `docs/en/public-api.md` and `docs/ja/public-api.md` when the surface is part of the documented public API.
+- Check any README, usage page, feature doc, configuration option doc, JavaScript event doc, mockup inventory, or release doc that names the same surface.
+- Record the user-facing effect in `CHANGELOG.md` when adopters need to notice it; use Documentation only for docs-only guidance changes that do not imply runtime behavior changes.
+- Review `docs/en/release.md` and `docs/ja/release.md` when the change affects release notes, migration expectations, package verification, or tag-time evidence.
 
 ## JavaScript browser smoke tests
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -55,7 +55,15 @@ Public API compatibility specsは、documented Ruby entry points、helper method
 
 意図的なbreaking changeを受け入れる場合は、public API docsとcompatibility specsを同時に更新し、documented contractとtest coverageを同期させます。
 
-`config/public_api_manifest.yml` は、compatibility checks が守る public surface の machine-readable source of truth です。現在は Ruby module methods、public constants、configuration options、helper names、helper option keys、toolbar action/state mapping、grouped option keys、JavaScript package-root named exports、controller registrations、public event names、documented `event.detail` keys を追跡しています。ここに entry を追加・rename・削除する場合は、manifest 自体を更新したうえで `docs/en/public-api.md` と `docs/ja/public-api.md` をそろえ、同じ surface を名前で案内している README / usage docs / feature docs / configuration option docs / JavaScript event docs を見直し、adopter に影響する変更なら利用者向けの変更点を `CHANGELOG.md` に残し、必要なら `docs/en/release.md` / `docs/ja/release.md` の release note や migration expectation も更新してください。
+`config/public_api_manifest.yml` は、compatibility checks が守る public surface の machine-readable source of truth です。現在は Ruby module methods、public constants、configuration options、helper names、helper option keys、toolbar action/state mapping、grouped option keys、PathTreeBuilder node shapes、ResourceTableRenderState call keywords、RenderState callback builder keys、JavaScript package-root named exports、transfer drop positions、remote-state values、controller registrations、public event names、intentional no-detail event names、documented `event.detail` keys、selection data hooks を追跡しています。
+
+これらの entry を追加・rename・削除する場合は、docs sync の導線を小さく明示します。
+
+- manifest と、その surface を守る compatibility spec、entrypoint smoke、package guard のいずれかを同期する
+- documented public API に含まれる surface なら `docs/en/public-api.md` と `docs/ja/public-api.md` をそろえる
+- 同じ surface を名前で案内している README、usage page、feature doc、configuration option doc、JavaScript event doc、mockup inventory、release doc を確認する
+- adopter が気づく必要のある変更は `CHANGELOG.md` に user-facing effect として残す。runtime behavior を変えない docs-only guidance だけなら Documentation として扱う
+- release notes、migration expectation、package verification、tag-time evidence に影響する場合は `docs/en/release.md` と `docs/ja/release.md` を見直す
 
 ## JavaScript browser smoke tests
 


### PR DESCRIPTION
## 対応 Issue

Closes #1433

## 変更理由

`config/public_api_manifest.yml` の追跡対象が、従来の Ruby / helper / JavaScript export / event detail keys から、PathTreeBuilder node shapes、ResourceTableRenderState call keywords、RenderState callback builder keys、remote-state values、no-detail events、selection data hooks などへ広がっています。

一方で `docs/en|ja/development.md` の Public API compatibility specs 節は古いカテゴリ一覧と単文の確認導線に留まっていたため、manifest-backed contract 変更時にどの docs / CHANGELOG / release docs を確認するかを短く整理します。

## 変更内容

- `docs/en/development.md`
  - current manifest の主要カテゴリ一覧へ追従
  - manifest entry 追加・rename・削除時の docs sync trail を bullet list 化
- `docs/ja/development.md`
  - 英語側と同じ粒度で日本語側も同期

## 判定分類

- `docs-stale`
- `docs-sync`

## 確認内容

- GitHub compare: `main...docs/1433-manifest-doc-sync-policy`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only
- `config/public_api_manifest.yml`、`docs/en|ja/public-api.md`、`docs/en|ja/release.md`、`CHANGELOG.md` を確認し、今回の変更は docs wording の同期だけに閉じています。
- runtime Ruby / JavaScript、public API manifest、compatibility spec、package verifier、release task は変更していません。
- local checkout / local markdown check は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR 作成後に GitHub Actions を確認します。

## リスク

low。maintainer docs の確認導線整理のみで、public surface や release policy の新規判断には踏み込んでいません。