### PR TITLE
Troubleshooting に large tree / pagination 境界の入口を追加する

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -123,6 +123,45 @@ Read next:
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## Large trees render too much HTML or the app needs virtual scrolling
+
+Start by separating HTML output pressure from host-app data pressure. TreeView can limit what it renders, but it does not reduce database queries, implement scroll-position-driven virtualization, or choose the host app's pagination strategy.
+
+Check these points.
+
+- If the initial page opens too many nodes, limit initial expansion with `max_initial_depth` before adding pagination or custom JavaScript.
+- If the rendered descendants are deeper than the screen needs, use `max_render_depth` or `max_leaf_distance` to reduce the render scope.
+- If the data is already loaded but the HTML output is too large, use `TreeView::RenderWindow` or `tree_view_rows(..., window:)` to slice the currently visible rows.
+- If fetching or preparing every descendant is the expensive part, move to lazy loading so the host app fetches children only when the user asks.
+- If one parent can have many children, use children pagination in the host app and keep cursor, limit, ordering, authorization, and next-page detection there.
+- If the product requires scroll-position-driven virtual scrolling, implement that in the host app. TreeView's windowed rendering is an HTML-output slice, not a full virtual scroll engine.
+
+Read next:
+
+- [Render scale](render-scale.md)
+- [Windowed Rendering](windowed-rendering.md)
+- [Lazy Loading](lazy-loading.md)
+- [Children Pagination](children-pagination.md)
+
+## Children pagination placeholders or unloaded descendants behave unexpectedly
+
+Children pagination is a host-app pattern built on lazy loading. TreeView provides child URL hooks and row data, but the host app owns the page query, next-page placeholder, bulk-action intent, and server-side validation.
+
+Check these points.
+
+- If the next-page placeholder never appears, confirm the host app detected another page, rendered the placeholder where it wants the next request to start, and returned the expected Turbo Stream response.
+- If a loaded page appends but the old placeholder remains, inspect the host app's `children_more` replacement or removal target before changing TreeView row partials.
+- If checkbox selection, cascade, drag/drop, or bulk actions seem to ignore unloaded descendants, decide whether the action applies only to loaded DOM rows or to the full filtered child set.
+- Use DOM-submitted checkbox values only when the action is intentionally limited to loaded rows. Use a query-backed or server-side intent when the action should include unloaded children.
+- Keep ordering, cursor validation, authorization, move validation, and final user-facing copy in the host app.
+
+Read next:
+
+- [Children Pagination](children-pagination.md#selection-and-dragdrop-interactions)
+- [Lazy Loading](lazy-loading.md)
+- [Selection](selection.md)
+- [children-pagination-selection-boundary mockup](../mockups/children-pagination-selection-boundary.html)
+
 ## GraphAdapter rows look duplicated, incomplete, or shaped differently than expected
 
 GraphAdapter symptoms usually come from the host app's resolver output or node-key strategy. TreeView normalizes resolver results so it can render rows, but it does not decide traversal policy, authorization, cycle handling, or query planning for graph-like data.

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -123,6 +123,45 @@ tree を描画しているときの Rails log で次を確認します。
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## 大きな tree で HTML が重い / virtual scroll が欲しい
+
+まず HTML 出力量の問題と host app 側 data fetching の問題を分けてください。TreeView は描画対象を制限できますが、database query を減らすこと、scroll 位置に応じた DOM virtualization、host app の pagination strategy の選択は行いません。
+
+次を確認してください。
+
+- 初期表示で開く node が多すぎる場合は、pagination や custom JavaScript を足す前に `max_initial_depth` で初期展開を制限する。
+- 画面に必要な範囲より深い descendant が描画されている場合は、`max_render_depth` または `max_leaf_distance` で描画範囲を減らす。
+- data はすでに読み込まれていて HTML 出力量だけが大きい場合は、`TreeView::RenderWindow` または `tree_view_rows(..., window:)` で現在 visible な row を slice する。
+- 全 descendant の取得や準備が重い場合は lazy loading に移し、host app がユーザー操作時に children を取得する。
+- 1つの親に大量の children がある場合は host app 側で children pagination を使い、cursor、limit、ordering、authorization、次 page 判定を host app に置く。
+- product 要件として scroll 位置に応じた virtual scrolling が必要な場合は、host app 側で実装する。TreeView の windowed rendering は HTML 出力の slice であり、full virtual scroll engine ではありません。
+
+次に読む文書:
+
+- [Render scale](render-scale.md)
+- [Windowed Rendering](windowed-rendering.md)
+- [Lazy Loading](lazy-loading.md)
+- [Children Pagination](children-pagination.md)
+
+## children pagination の placeholder や unloaded descendants が想定どおりにならない
+
+children pagination は lazy loading の上に host app が作る pattern です。TreeView は children URL hook と row data を提供しますが、page query、next-page placeholder、bulk action intent、server-side validation は host app の責務です。
+
+次を確認してください。
+
+- next-page placeholder が出ない場合は、host app が次 page の存在を判定し、次の request を始めたい場所に placeholder を描画し、期待する Turbo Stream response を返しているか確認する。
+- loaded page は追加されるが古い placeholder が残る場合は、TreeView row partial を変える前に host app 側の `children_more` replacement または removal target を確認する。
+- checkbox selection、cascade、drag/drop、bulk action が unloaded descendants を無視しているように見える場合は、その action が loaded DOM rows だけに作用するのか、filtered child set 全体に作用するのかを決める。
+- DOM から送られる checkbox 値は、action を loaded rows に限定する場合だけ使う。unloaded children も含めるなら query-backed action または server-side intent を使う。
+- ordering、cursor validation、authorization、move validation、最終的なユーザー向け copy は host app 側に置く。
+
+次に読む文書:
+
+- [Children Pagination](children-pagination.md#selection--drag-drop-との相互作用)
+- [Lazy Loading](lazy-loading.md)
+- [Selection](selection.md)
+- [children-pagination-selection-boundary mockup](../mockups/children-pagination-selection-boundary.html)
+
 ## GraphAdapter の行が重複する / 足りない / 想定と違う形になる
 
 GraphAdapter で起きる症状は、多くの場合 host app 側の resolver 出力または node key strategy から来ます。TreeView は行を描画できるよう resolver 結果を正規化しますが、graph-like data の traversal policy、authorization、cycle handling、query planning は決めません。


### PR DESCRIPTION
## 対応 Issue

Closes #1410
Closes #1418

## 変更理由

大きな tree の利用時に、Render Scale / Windowed Rendering / Lazy Loading / Children Pagination の本文は揃っていますが、Troubleshooting から「HTML が重い」「virtual scroll が欲しい」「children pagination の placeholder や unloaded descendants の境界が分からない」といった症状で戻る入口が薄い状態でした。

#1410 と #1418 はどちらも large-tree 系の症状別導線で、同じ英日 troubleshooting への追記に閉じられるため 1 PR にまとめています。

## 変更内容

- `docs/en/troubleshooting.md`
  - large tree / virtual scroll 期待時の切り分け節を追加
  - children pagination placeholder / unloaded descendants の症状節を追加
- `docs/ja/troubleshooting.md`
  - 英語版と同じ責務境界・リンク粒度で同期

## 判定分類

- `docs-missing`
- `docs-sync`

## 確認内容

- GitHub compare: `main...docs/1410-1418-large-tree-troubleshooting`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 2 docs-only
- PR metadata: `mergeable:true`
- GitHub Actions CI #1826: success
- `docs/en|ja/render-scale.md` と `docs/en|ja/children-pagination.md` を確認し、今回の追記は既存 docs への症状別入口に限定しています。
- runtime Ruby / JavaScript、public API、server-side query strategy、mockup HTML/CSS は変更していません。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。docs-only の導線追加で、pagination algorithm や virtual scroll 実装を新規仕様化していません。