### PR TITLE
test: GraphAdapter docs entrypoint smoke を root / language README へ広げる

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -97,8 +97,12 @@ const featureEntrypoints = [
     feature: "GraphAdapter",
     rootPattern: /Use `GraphAdapter`/,
     links: [
+      ["README.md", "docs/en/graph-adapter.md"],
+      ["README.md", "docs/ja/graph-adapter.md"],
       ["docs/README.md", "en/graph-adapter.md"],
-      ["docs/README.md", "ja/graph-adapter.md"]
+      ["docs/README.md", "ja/graph-adapter.md"],
+      ["docs/en/README.md", "graph-adapter.md"],
+      ["docs/ja/README.md", "graph-adapter.md"]
     ]
   },
   {


### PR DESCRIPTION
## 対応 Issue

Closes #1452

## Issue ごとの完了内容

- #1452: GraphAdapter guide の docs entrypoint smoke に root README と英日 README の direct link guard を追加しました。

## 変更内容

- `script/test_docs_entrypoints.mjs` の GraphAdapter entry を拡張しました。
- 既存の `docs/README.md` direct links に加えて、次の導線を guard します。
  - `README.md` -> `docs/en/graph-adapter.md`
  - `README.md` -> `docs/ja/graph-adapter.md`
  - `docs/en/README.md` -> `graph-adapter.md`
  - `docs/ja/README.md` -> `graph-adapter.md`

## 改善カテゴリ

- test
- docs drift guard

## 既存仕様への影響

GraphAdapter runtime、public API manifest、guide 本文、README 構成は変更していません。既存 link surface の regression guard に限定しています。

## 実施した確認

- GitHub compare: `main...quality/1452-graph-adapter-entrypoint-smoke`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR 作成後に GitHub Actions を確認します。

## リスク評価

low。既存 docs smoke の link list を小さく広げるだけです。