### PR TITLE
render_log_level accepted values contract を current main で再提案する

### DIFF
--- a/spec/public_api_render_log_level_contract_spec.rb
+++ b/spec/public_api_render_log_level_contract_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "logger"
+
+RSpec.describe "Render log level public contract" do
+  after do
+    TreeView.reset_configuration!
+  end
+
+  it "keeps documented render_log_level symbol values aligned with Configuration" do
+    expect(TreeView::Configuration::VALID_RENDER_LOG_LEVELS.keys).to eq(%i[debug info warn error fatal unknown])
+
+    TreeView::Configuration::VALID_RENDER_LOG_LEVELS.each_key do |level|
+      TreeView.configure do |config|
+        config.render_log_level = level
+      end
+
+      expect(TreeView.configuration.render_log_level).to eq(level)
+    end
+  end
+
+  it "normalizes Ruby Logger level constants to their public symbol values" do
+    expected_levels = {
+      Logger::DEBUG => :debug,
+      Logger::INFO => :info,
+      Logger::WARN => :warn,
+      Logger::ERROR => :error,
+      Logger::FATAL => :fatal,
+      Logger::UNKNOWN => :unknown
+    }
+
+    expected_levels.each do |logger_constant, expected_level|
+      TreeView.configure do |config|
+        config.render_log_level = logger_constant
+      end
+
+      expect(TreeView.configuration.render_log_level).to eq(expected_level)
+    end
+  end
+
+  it "keeps nil as the public boundary for disabling TreeView render log silencing" do
+    TreeView.configure do |config|
+      config.render_log_level = nil
+    end
+
+    expect(TreeView.configuration.render_log_level).to be_nil
+  end
+
+  it "rejects values outside the documented render log level contract" do
+    expect do
+      TreeView.configure do |config|
+        config.render_log_level = :verbose
+      end
+    end.to raise_error(TreeView::ConfigurationError, /render_log_level/)
+
+    expect do
+      TreeView.configure do |config|
+        config.render_log_level = Object.new
+      end
+    end.to raise_error(TreeView::ConfigurationError, /render_log_level/)
+  end
+end


### PR DESCRIPTION
`render_log_level` の accepted values を manifest schema ではなく focused compatibility spec で固定する変更を、current main から再提案します。

## 対応 Issue / PR

Closes #1322
Supersedes #1364

## 置き換え理由

PR #1364 は Issue #1322 の方向性には合っていましたが、review comment で latest main refresh と fresh CI が求められていました。

- 旧 compare: `main...feature/1322-render-log-level-contract` は `ahead_by:1` / `behind_by:88` / `status:diverged`
- この PR は current `main` (`8cae5497d7c37e7d4915bbf49c470d20fe656bd0`) から同じ spec-only diff を再適用しています。

## 変更内容

- `spec/public_api_render_log_level_contract_spec.rb` を追加しました。
- `TreeView::Configuration::VALID_RENDER_LOG_LEVELS` の公開 symbol set が `debug/info/warn/error/fatal/unknown` のままであることを確認します。
- Ruby `Logger` level constants が対応する symbol に normalize されることを確認します。
- `nil` が TreeView render log silencing を無効化する public boundary として維持されることを確認します。
- documented contract 外の値は `TreeView::ConfigurationError` になることを確認します。

## 受け入れ条件との対応

- `render_log_level` option key は引き続き `config/public_api_manifest.yml` の `configuration_options.tree_view_configure` で守り、manifest schema は広げていません。
- accepted values / Logger constants / `nil` boundary は focused compatibility spec で guard します。
- docs 本文は既に option key と accepted values の責務境界を説明しているため、追加変更しません。
- `initial_state` など他の configuration option value surface には広げていません。

## 変更範囲

- spec-only: `spec/public_api_render_log_level_contract_spec.rb`

runtime behavior、Rails logger policy、partial render silencing implementation、public API manifest schema、new configuration option、host app logging policy は変更していません。

## 確認内容

- GitHub compare: `main...feature/1322-render-log-level-contract-refresh`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local RSpec は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR 作成後に GitHub Actions を確認します。

## リスク

medium。runtime は変えませんが、`render_log_level` の symbol values、Logger constants、`nil` boundary、invalid value error を public contract として固定する spec 追加です。public configuration contract の採用判断は、CI green 後も human review に残します。