### PR TITLE
minimal usage docs から first-render mockup へ導線を追加する

### DIFF
--- a/docs/en/minimal-usage.md
+++ b/docs/en/minimal-usage.md
@@ -87,6 +87,12 @@ Set `selection.enabled` to `true` to enable checkbox selection.
 
 See [Selection](selection.md) for details.
 
+## Visual check
+
+After wiring the controller, view, and row partial above, use [minimal-usage-first-render.html](../mockups/minimal-usage-first-render.html) to inspect the first visible output from this minimal setup.
+
+Use [default-tree.html](../mockups/default-tree.html) when you want the richer baseline with shared CSS, selection, badges, row actions, and expanded or collapsed states. The minimal first-render mockup stays close to this page's controller/view/row-partial example and does not add host-app CRUD, routes, seed data, or visual redesign requirements.
+
 ## Next steps
 
 - [Installation](installation.md)

--- a/docs/ja/minimal-usage.md
+++ b/docs/ja/minimal-usage.md
@@ -87,6 +87,12 @@ end
 
 詳しくは [Selection](selection.md) を参照してください。
 
+## 見た目の確認
+
+上の controller、view、row partial をつないだあと、[minimal-usage-first-render.html](../mockups/minimal-usage-first-render.html) でこの最小構成から最初に見える出力を確認できます。
+
+共有 CSS、selection、badge、row action、展開 / 折りたたみ状態を含む richer baseline を見たい場合は [default-tree.html](../mockups/default-tree.html) を使ってください。minimal first-render mockup は、このページの controller / view / row partial 例に近い確認用であり、host app の CRUD、route、seed data、visual redesign の要件は追加しません。
+
 ## 次に読むもの
 
 - [導入手順](installation.md)


### PR DESCRIPTION
## 対応 Issue

Closes #1417

## 変更理由

Quick Start / minimal usage の controller・view・row partial を読んだ直後に、最初に見える TreeView output を確認できる `minimal-usage-first-render.html` への導線が薄い状態でした。

`docs/mockups/README.md` では既に minimal first-render mockup と `default-tree.html` の役割が整理されているため、英日 minimal usage docs からその既存 static reference へ短く誘導します。

## 変更内容

- `docs/en/minimal-usage.md`
  - `Visual check` 節を追加
  - `minimal-usage-first-render.html` と `default-tree.html` の役割差を説明
- `docs/ja/minimal-usage.md`
  - 英語版と同じ粒度で `見た目の確認` 節を追加

## 判定分類

- `docs-missing`
- `docs-sync`

## 確認内容

- GitHub compare: `main...docs/1417-minimal-first-render-mockup`
  - `ahead_by:3`
  - `behind_by:0`
  - changed files: 2 docs-only
- `docs/mockups/README.md` の Files table / Recommended review flow を確認し、既存 mockup guidance と矛盾しない導線にしています。
- runtime Ruby / JavaScript、public API、mockup HTML/CSS、README hero / screenshot、demo Rails app は変更していません。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR 作成後に GitHub Actions を確認します。

## リスク

low。既存 static mockup へのリンク補強だけで、Quick Start の API 例や visual design は変更していません。