### PR TITLE
localized-row-labels mockup の CJK stress sample を最新 main で再提案する

### DIFF
--- a/docs/mockups/localized-row-labels.html
+++ b/docs/mockups/localized-row-labels.html
@@ -24,6 +24,7 @@
 .mock-localized-card { border: 1px solid #dde4ec; border-radius: 8px; background: #fff; padding: 14px; }
 .mock-localized-card h3, .mock-localized-card p { margin: 0; }
 .mock-localized-card h3 { margin-bottom: 0.45rem; }
+.mock-localized-language-note { display: inline-flex; align-items: center; width: fit-content; max-width: 100%; padding: 0.24rem 0.6rem; border: 1px solid #fed7aa; border-radius: 999px; background: #fff7ed; color: #9a3412; font-size: 0.8rem; font-weight: 800; overflow-wrap: anywhere; }
 @media (max-width: 760px) { .mock-localized-table { display: block; overflow-x: auto; } .mock-localized-table th, .mock-localized-table td { min-width: 10rem; } .mock-localized-table th:first-child, .mock-localized-table td:first-child { min-width: 18rem; } }
 </style>
 </head>
@@ -57,6 +58,25 @@
           <tr id="localized_node_3" class="tree-row is-collapsed" data-tree-node-key="localized:archive" data-tree-parent-key="localized:portfolio" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-expanded="false">
             <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Collapsed localized archive group"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#">show</a><span class="tree-toggle__level">child</span><span class="tree-toggle__hidden-count" title="Hidden localized descendants">6</span></span></span><span class="mock-localized-name"><span class="mock-localized-primary"><a href="#archive" title="Collapsed archive branch with localized long translated row label">Collapsed Archive Branch With Localized Long Translated Row Label</a><span class="mock-localized-type" title="Localized archive type">Translated archive type</span></span><span class="mock-localized-secondary">Hidden-count, badge, and secondary metadata remain scannable before final truncation decisions move to the host app.</span></span></td>
             <td><span class="mock-localized-attribute">Attribute label: Localized retention category</span></td><td><span class="mock-localized-secondary">Host app owns final policy wording, permission copy, and route labels.</span></td><td class="tree-row-actions"><a class="mock-localized-action" href="#archive-action">Inspect</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section mock-localized-frame" aria-labelledby="localized-cjk-heading">
+      <span class="mock-localized-language-note">Deliberate CJK width stress sample</span>
+      <h2 id="localized-cjk-heading">Japanese-width label stress sample</h2>
+      <p class="mock-localized-note">This section intentionally uses Japanese sample text to inspect CJK character width, badge placement, attribute labels, and tooltip cue proximity. It is not final product copy.</p>
+      <table class="tree-view-table mock-localized-table" lang="ja" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+        <thead><tr><th scope="col">tree node</th><th scope="col">attribute label</th><th scope="col">metadata / tooltip cue</th><th scope="col">row action</th></tr></thead>
+        <tbody>
+          <tr id="localized_cjk_node_1" class="tree-row is-expanded" data-tree-node-key="localized-cjk:contract" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Expanded CJK contract group"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#">hide</a><span class="tree-toggle__level">root</span></span></span><span class="mock-localized-name"><span class="mock-localized-primary"><a href="#cjk-contract" title="四半期契約レビューの地域別確認資料と承認経路一覧">四半期契約レビューの地域別確認資料と承認経路一覧</a><span class="mock-localized-type mock-localized-type--accent" title="CJK type badge">確認資料タイプ</span></span><span class="mock-localized-secondary">全角ラベルが複数行に折り返されても、階層 cue と type badge の位置関係を確認できる。</span></span></td>
+            <td><span class="mock-localized-attribute">属性ラベル: 最終確認ステージと担当部門</span></td><td><span class="mock-localized-tooltip-cue">tooltip cue: primary link title に全文を保持</span></td><td class="tree-row-actions"><a class="mock-localized-action" href="#cjk-contract-action">確認</a></td>
+          </tr>
+          <tr id="localized_cjk_node_2" class="tree-row is-selected" data-tree-node-key="localized-cjk:invoice" data-tree-parent-key="localized-cjk:contract" data-tree-depth="1" data-tree-expanded="false" aria-level="2" aria-current="page">
+            <td class="btn-cell tree-toggle-cell"><span class="tree-toggle" aria-label="Current CJK invoice row"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">child</span></span></span><span class="mock-localized-name"><span class="mock-localized-primary"><a href="#cjk-invoice" title="請求処理前の例外確認と長い部署名を含む行ラベル">請求処理前の例外確認と長い部署名を含む行ラベル</a><span class="tree-node-badge" title="Current row cue">current</span><span class="mock-localized-type" title="CJK localized type">承認待ち項目</span></span><span class="mock-localized-secondary">current cue、type badge、secondary metadata が host-app-owned columns へ流れ込まないことを確認する。</span></span></td>
+            <td><span class="mock-localized-attribute">属性ラベル: 連携先システムと確認期限</span></td><td><span class="mock-localized-secondary">Final translation、permission wording、business action labels remain host-app owned.</span></td><td class="tree-row-actions"><a class="mock-localized-action" href="#cjk-invoice-action">開く</a></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1389
Supersedes #1403
Supersedes #1468

## 置き換え理由

PR #1403 は #1389 の CJK / Japanese-width stress sample として方向性は合っていましたが、CI green 化のために `app/javascript/tree_view/index.d.ts` と `spec/public_api_manifest_structure_spec.rb` の drift sync が混ざり、review:changes-requested で #1396 相当の dedicated lane へ分離するよう求められました。

PR #1468 は current main から scoped replacement として作成し CI #1838 success まで確認しましたが、その直後に main がさらに進み `behind_by:1` になりました。この PR は latest `main` `2718d579001ce960e25a5a303fa6c92bb5337ed6` から再度 clean replacement branch を作成し、#1389 の mockup 1ファイル差分だけを再適用しています。

## 変更内容

- `docs/mockups/localized-row-labels.html`
  - deliberate CJK width stress sample section を追加
  - Japanese-width の長い primary label、type badge、attribute label、secondary metadata、tooltip cue を2行の representative rows で比較可能にしました
  - sample text が final product copy ではなく、CJK character width と cue placement の確認用であることを明記しました

## 受け入れ条件との対応

- 既存 mockup page 内の追加 section に閉じ、new dedicated page / gallery / smoke inventory には広げていません。
- runtime Ruby / JavaScript、I18n lookup behavior、final translation policy、public API manifest、TypeScript declaration は変更していません。
- #1385 の row action overflow / menu placement surface は別 lane として残しています。

## 変更範囲

- static mockup: `docs/mockups/localized-row-labels.html`

## 確認内容

- GitHub compare: `main...design/1389-localized-row-cjk-current-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`docs/mockups/localized-row-labels.html`)
- PR metadata: `mergeable: true`
- GitHub Actions CI #1840: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success (`npm run test:browser` success)
  - representative Rails compatibility lanes: docs-only skip / success
  - `gem_package`: skipped as docs-only
- connector 上で追加 section と representative rows を確認しました。
- 既存 `.mock-localized-table` の narrow overflow policy と既存 table layout に合わせています。
- section heading、table heading、row `aria-level` / `aria-expanded` / `aria-current` の既存 mockup pattern を維持しています。
- local checkout / local browser screenshot は GitHub HTTPS `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。static mockup の追加 section に限定した変更です。runtime behavior、public API implementation、DB、認可、外部 API には触れていません。

## 未対応・補足

- `index.d.ts` と `public_api_manifest_structure_spec.rb` の drift sync は #1396 相当の dedicated lane に分離し、この PR には含めていません。
- README の language exception table には既に `localized-row-labels.html` の localized-style exception があるため、この PR では既存 mockup page 内の CJK stress expansion に閉じています。