### PR TITLE
Empty-state の troubleshooting 導線を追加する

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -99,6 +99,25 @@ Read next:
 - [Accessibility Semantics](accessibility-semantics.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## Empty or no-results rows are missing, cramped, or use the wrong copy
+
+Empty-state symptoms usually belong to the host app's page state, search or filter policy, and final product copy. TreeView provides a reusable empty-row wrapper and message slot, but it does not decide why the page is empty or what action the user should take next.
+
+Check these points.
+
+- Decide whether the screen has no root items, no matching results after filtering, or records hidden by permission policy. Those cases often need different copy or next actions.
+- If the default empty row is enough, style or target the documented wrapper hooks instead of replacing the partial: `data-tree-view-empty-state="true"`, `.tree-view-empty-row__content`, and `.tree-view-empty-row__message`.
+- Keep final empty copy, CTA text, filter reset behavior, permission messaging, and analytics in the host app.
+- If the empty row looks cramped or does not span the surrounding table, inspect the host app table wrapper, captions, columns, and resource-table bridge layout before changing TreeView internals.
+- Treat the static empty-state mockup as a visual reference for hooks and boundaries, not as a Rails controller, query, or demo-app implementation.
+
+Read next:
+
+- [Accessibility Semantics: Empty-state and hidden-count hooks](accessibility-semantics.md#empty-state-and-hidden-count-hooks)
+- [Usage](usage.md)
+- [empty-state mockup](../mockups/empty-state.html)
+- [Mockup Empty-state guidance](../mockups/README.md#empty-state-guidance)
+
 ## Tree rendering triggers repeated queries or high ActiveRecord time
 
 Treat this as a host-app data loading and row partial problem first. TreeView can traverse the tree and render rows, but it does not choose eager-loading, authorization, caching, or derived-value strategies for application records.

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -99,6 +99,25 @@ TreeView は row wrapper と共通 tree UI cell を担当し、`row_partial` の
 - [Accessibility Semantics](accessibility-semantics.md)
 - [Tree diagnostics](tree-diagnostics.md)
 
+## empty / no-results row が出ない、狭い、または copy が合わない
+
+empty-state の症状は、多くの場合 host app 側の page state、search / filter policy、最終的な product copy の問題です。TreeView は再利用可能な empty-row wrapper と message slot を提供しますが、なぜ空なのか、次にユーザーへ何を促すかは決めません。
+
+次を確認してください。
+
+- その画面が no root items なのか、filter 後の no matching results なのか、permission policy によって record が隠れているのかを分ける。多くの場合、それぞれ copy や次 action が変わります。
+- default empty row で十分な場合は、partial を置き換える前に documented wrapper hook を装飾・target してください: `data-tree-view-empty-state="true"`、`.tree-view-empty-row__content`、`.tree-view-empty-row__message`。
+- 最終的な empty copy、CTA text、filter reset behavior、permission messaging、analytics は host app 側に置く。
+- empty row が狭い、または周囲の table を横断していないように見える場合は、TreeView 内部を変える前に host app 側の table wrapper、caption、column、resource-table bridge layout を確認する。
+- static empty-state mockup は hook と責務境界の visual reference として扱い、Rails controller、query、demo app 実装として扱わない。
+
+次に読む文書:
+
+- [Accessibility Semantics](accessibility-semantics.md)
+- [使い方](usage.md)
+- [empty-state mockup](../mockups/empty-state.html)
+- [Mockup Empty-state guidance](../mockups/README.md#empty-state-guidance)
+
 ## tree rendering 中に query が繰り返される / ActiveRecord time が大きい
 
 まず host app 側の data loading と row partial の問題として切り分けます。TreeView は tree traversal と row rendering を担いますが、application record の eager loading、authorization、caching、derived value の作り方は決めません。


### PR DESCRIPTION
## 対応 Issue

Closes #1406

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更理由

`docs/mockups/empty-state.html` と `docs/mockups/README.md#empty-state-guidance` には empty-state の wrapper hook と host-app-owned copy boundary が既にあります。

一方で、英日 troubleshooting から no root items / no results / filter result empty の症状として戻る入口が薄かったため、既存 guidance へ辿れる症状別セクションを追加しました。

## 変更内容

- `docs/en/troubleshooting.md`
  - Empty / no-results rows の症状別セクションを追加
  - `data-tree-view-empty-state="true"`、`.tree-view-empty-row__content`、`.tree-view-empty-row__message` の使いどころを既存 guidance と同期
  - copy / CTA / filter reset / permission messaging は host app responsibility と明記
- `docs/ja/troubleshooting.md`
  - 英語版と同じ粒度で同期

## 変更しないこと

- runtime Ruby / JavaScript
- public API manifest
- empty-state helper / option
- mockup HTML / CSS
- host app の search / filter / permission policy

## 確認内容

- Issue #1406 と Planner handoff を確認
- current main `2718d579001ce960e25a5a303fa6c92bb5337ed6` から branch 作成
- GitHub compare: `main...docs/1406-empty-state-troubleshooting-v2`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs-only
  - additions: 38 / deletions: 0
- 追加リンク先が既存 docs / mockup path と一致することを確認

local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR 作成後に GitHub Actions を確認します。

## リスク

low。既存 empty-state guidance への troubleshooting 導線追加のみで、API や実装挙動は変更していません。