### PR TITLE
Docs entrypoint smoke for rendering boundary and guide links

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -33,6 +33,12 @@ function assertRootSignal(feature, rootPattern, message) {
   assert(rootPattern.test(rootReadme), `${feature}: ${message}`)
 }
 
+function assertDocumentSignal(sourcePath, signalPattern, feature, message) {
+  const source = read(sourcePath)
+
+  assert(signalPattern.test(source), `${feature}: ${message}`)
+}
+
 const rootReadme = read("README.md")
 
 const foundationalEntrypoints = [
@@ -171,6 +177,38 @@ const featureEntrypoints = [
     ]
   },
   {
+    feature: "Rendering Boundaries",
+    rootPattern: /Rendering Boundaries|描画責務の境界/,
+    links: [
+      ["README.md", "docs/en/rendering-boundaries.md"],
+      ["README.md", "docs/ja/rendering-boundaries.md"],
+      ["docs/en/README.md", "rendering-boundaries.md"],
+      ["docs/ja/README.md", "rendering-boundaries.md"]
+    ],
+    signals: [
+      [
+        "docs/en/rendering-boundaries.md",
+        /row_partial[\s\S]*host app partial renders application-specific columns/,
+        "English rendering-boundaries docs no longer state the row_partial ownership boundary"
+      ],
+      [
+        "docs/en/rendering-boundaries.md",
+        /controller action, query, and Turbo Stream response[\s\S]*host app/,
+        "English rendering-boundaries docs no longer state the Turbo response ownership boundary"
+      ],
+      [
+        "docs/ja/rendering-boundaries.md",
+        /row_partial[\s\S]*host app partialが業務固有のcolumns/,
+        "Japanese rendering-boundaries docs no longer state the row_partial ownership boundary"
+      ],
+      [
+        "docs/ja/rendering-boundaries.md",
+        /controller action、query、Turbo Stream responseはhost app側の責務/,
+        "Japanese rendering-boundaries docs no longer state the Turbo response ownership boundary"
+      ]
+    ]
+  },
+  {
     feature: "Turbo Frame option",
     rootPattern: /Turbo Frame option/,
     links: [
@@ -228,9 +266,28 @@ const featureEntrypoints = [
   },
   {
     feature: "Breadcrumb helper",
+    rootPattern: /tree_view_breadcrumb|Breadcrumb helper/,
     links: [
+      ["README.md", "docs/en/breadcrumb.md"],
+      ["README.md", "docs/ja/breadcrumb.md"],
+      ["docs/README.md", "en/breadcrumb.md"],
+      ["docs/README.md", "ja/breadcrumb.md"],
       ["docs/en/README.md", "breadcrumb.md"],
       ["docs/ja/README.md", "breadcrumb.md"]
+    ]
+  },
+  {
+    feature: "Depth Labels",
+    links: [
+      ["docs/en/README.md", "depth-labels.md"],
+      ["docs/ja/README.md", "depth-labels.md"]
+    ]
+  },
+  {
+    feature: "Row Status",
+    links: [
+      ["docs/en/README.md", "row-status.md"],
+      ["docs/ja/README.md", "row-status.md"]
     ]
   },
   {
@@ -334,10 +391,13 @@ foundationalEntrypoints.forEach(({ feature, rootPattern, links }) => {
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
 })
 
-featureEntrypoints.forEach(({ feature, rootPattern, links }) => {
+featureEntrypoints.forEach(({ feature, rootPattern, links, signals = [] }) => {
   assertRootSignal(feature, rootPattern, "README.md no longer exposes the representative feature signal")
 
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+  signals.forEach(([sourcePath, signalPattern, message]) => {
+    assertDocumentSignal(sourcePath, signalPattern, feature, message)
+  })
 })
 
 maintainerEntrypoints.forEach(({ feature, links }) => {


### PR DESCRIPTION
## 対応 Issue

- Closes #1465
- Closes #1467

## Issue ごとの完了内容

- #1465: Breadcrumb / Depth Labels / Row Status の docs entrypoint smoke を強化し、README / docs index から該当 docs へのリンクが落ちた場合に検知できるようにしました。
- #1467: Rendering Boundaries docs の entrypoint と、`row_partial` / Turbo response ownership の責務境界シグナルを docs smoke で検知できるようにしました。

## 変更内容

- `script/test_docs_entrypoints.mjs` に docs 本文シグナル確認用の helper を追加しました。
- Rendering Boundaries、Depth Labels、Row Status、Breadcrumb helper の entrypoint/link checks を追加・補強しました。
- runtime code、UI、public API、DB、認可、状態遷移には触れていません。

## 改善カテゴリ

- docs smoke test
- regression guard
- small internal test helper整理

## 既存仕様への影響

既存仕様への影響はありません。docs entrypoint の検証を追加しただけで、runtime behavior と公開 API は変更していません。

## 実施した確認内容

- GitHub compare で `main` から behind 0 / ahead 1 を確認しました。
- 差分が `script/test_docs_entrypoints.mjs` のみに限定されていることを確認しました。
- ローカル checkout / test 実行は、この実行環境から GitHub への shell network が `CONNECT tunnel failed, response 403` で遮断されるため未実施です。CI で docs smoke を確認します。

## リスク評価

risk: low。docs smoke の対象追加のみで、失敗時も docs entrypoint 欠落を早期検知する方向の変更です。
