### PR TITLE
TypeScript declaration の位置づけを Public API docs に補う

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -185,7 +185,7 @@ Host apps are expected to provide these pieces:
 
 ## JavaScript surface
 
-The public JavaScript entrypoint is `tree_view/index.js`.
+The public JavaScript entrypoint is `tree_view/index.js`. The bundled `app/javascript/tree_view/index.d.ts` declaration mirrors the package-root export names for TypeScript-aware tooling, but it does not change runtime behavior or add a separate public surface. Treat `tree_view/index.js`, `config/public_api_manifest.yml`, and the entrypoint smoke checks as the source of truth; the declaration is a compile-time aid for npm-style tooling, while importmap-only host apps do not need extra runtime setup for it.
 
 Stable enough for host apps to use:
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -185,7 +185,7 @@ host app が提供する主な拡張点は以下です。
 
 ## JavaScript surface
 
-公開 JavaScript entrypoint は `tree_view/index.js` です。
+公開 JavaScript entrypoint は `tree_view/index.js` です。bundled された `app/javascript/tree_view/index.d.ts` declaration は TypeScript 対応 tooling 用に package-root export 名を写すものですが、runtime behavior を変えたり、別の public surface を追加したりするものではありません。正本は `tree_view/index.js`、`config/public_api_manifest.yml`、entrypoint smoke check です。declaration は npm-style tooling 向けの compile-time aid であり、importmap-only の host app はこれに追加の runtime setup をする必要はありません。
 
 host app が使ってよい入口:
 


### PR DESCRIPTION
## 対応 Issue

Closes #1289

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更理由

PR #1287 が 2026-06-05 に merge 済みで、current main には `app/javascript/tree_view/index.d.ts` が存在します。一方で Public API docs の JavaScript surface では、`.d.ts` が runtime surface なのか compile-time aid なのかをまだ説明していませんでした。

## 変更内容

- `docs/en/public-api.md`
  - `tree_view/index.js` が runtime source of truth であることを維持しつつ、`index.d.ts` は TypeScript-aware tooling 向けの compile-time aid だと明記
  - source of truth は package-root export、`config/public_api_manifest.yml`、entrypoint smoke checks であることを追記
  - importmap-only host app では追加 runtime setup が不要な境界を追記
- `docs/ja/public-api.md`
  - 英語版と同じ粒度で同期

## 変更しないこと

- `app/javascript/tree_view/index.d.ts`
- `package.json` `types` field / package publish policy
- TypeScript compiler 導入
- event payload detailed typing
- runtime JavaScript behavior
- public API manifest
- package contents check / release docs (#1285)

## 確認内容

- current main `2718d579001ce960e25a5a303fa6c92bb5337ed6` から branch 作成
- PR #1287 が merged: true / merged_at: 2026-06-05T12:34:46Z であることを確認
- current main の `app/javascript/tree_view/index.d.ts` が存在することを確認
- GitHub compare: `main...docs/1289-typescript-declaration-docs`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs-only
    - `docs/en/public-api.md`
    - `docs/ja/public-api.md`

local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR 作成後に GitHub Actions を確認します。

## リスク

low。既存 implementation / declaration に対する Public API docs の追従のみで、runtime behavior や package metadata は変更していません。