### PR TITLE
Public API docs の signal smoke を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const manifest = read("config/public_api_manifest.yml")
+const publicApiDocs = [
+  ["docs/en/public-api.md", read("docs/en/public-api.md")],
+  ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
+]
+
+const callbackBuilderSignals = [
+  "render_state_callback_builder_keys",
+  "row_event_payload_builder",
+  "depth_label_builder",
+  "toggle_icon_builder"
+]
+
+const hostLifecycleSignals = [
+  "TreeViewEventNames.hostLifecycle",
+  "loading",
+  "loaded",
+  "error",
+  "retry",
+  "TreeViewEventNames.remoteState",
+  "TreeViewEventDetailKeys"
+]
+
+callbackBuilderSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest callback builder key surface")
+})
+
+assertIncludes(manifest, "event_names_without_detail", "public API manifest no-detail event surface")
+assertIncludes(manifest, "host_lifecycle", "public API manifest no-detail event surface")
+hostLifecycleSignals.slice(1, 5).forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest host lifecycle no-detail event names")
+})
+
+publicApiDocs.forEach(([relativePath, document]) => {
+  callbackBuilderSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} RenderState callback builder docs`)
+  })
+
+  assert(
+    /callback arity|return[- ]value|return value|callback arity|戻り値/.test(document),
+    `${relativePath}: RenderState callback builder docs no longer mention callback arity or return-value boundary`
+  )
+
+  hostLifecycleSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} host lifecycle event docs`)
+  })
+
+  assert(
+    /host app|host-app|host app 側|host-app 側/.test(document),
+    `${relativePath}: host lifecycle event docs no longer name the host-app ownership boundary`
+  )
+})


### PR DESCRIPTION
## 対応 Issue
- Closes #1474
- Closes #1475

## Issue ごとの完了内容
- #1474: RenderState callback builder keys が public API manifest と英日 docs に残ることを docs smoke signal として固定しました。
- #1475: no-detail host lifecycle events と related JavaScript surface が public API docs から落ちないことを guard しました。

## 変更内容
- `script/test_public_api_docs_signals.mjs` を追加し、public API manifest と英日 docs の重要 signal をまとめて検証するようにしました。
- `test:docs-entrypoints` に新しい smoke script を組み込み、既存 docs/i18n guard と同じ流れで実行されるようにしました。

## 改善カテゴリ
- test
- docs drift guard
- CI/docs smoke

## 既存仕様への影響
- runtime code は変更していません。
- 公開 API、UI、DB、認可、状態遷移、外部サービス契約への影響はありません。

## 実施した確認
- connector-only で main から branch が遅れていないことを確認しました。
- 差分が `package.json` と `script/test_public_api_docs_signals.mjs` に限定されていることを確認しました。
- この環境では npm registry が 403 で利用できないため、ローカル npm test は未実施です。PR CI で確認します。

## リスク評価
- risk: low
- docs smoke の追加のみで、既存挙動を変えない変更です。

## 補足
- #1474 と #1475 はどちらも public API docs の signal drift guard で、同じ script にまとめるのがレビューしやすい単位と判断しました。