### PR TITLE
mockup copy policy の lightweight smoke を追加

### DIFF
--- a/spec/mockup_inventory_spec.rb
+++ b/spec/mockup_inventory_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe "mockup inventory" do
     File.read(audit_path)
   end
 
+  def mockup_copy_exception_rows
+    File.read(readme_path)
+      .lines
+      .grep(/\A\| `[^`]+\.html` \|/)
+      .to_h do |line|
+        _empty, mockup, exception, reason = line.split("|").map(&:strip)
+        [mockup.delete_prefix("`").delete_suffix("`"), {exception: exception, reason: reason}]
+      end
+  end
+
   it "keeps the mockup README inventory aligned with the actual asset set" do
     expect(readme_inventory).to eq(actual_mockup_assets - ["README.md"])
   end
@@ -55,5 +65,35 @@ RSpec.describe "mockup inventory" do
       "Focused subpage assets linked from the mockup README",
       "Update this technical-assets section only when the source-of-truth rule or asset-group responsibility changes"
     )
+  end
+
+  it "keeps the mockup copy and language exception policy visible" do
+    readme = File.read(readme_path)
+
+    expect(readme).to include(
+      "## Copy and language policy",
+      "Mockups use short, product-neutral English copy",
+      "Final labels, localization, permission messaging, and business wording remain host-app responsibilities",
+      "Record deliberate copy or language exceptions in this list",
+      "| Mockup | Deliberate exception | Review reason |"
+    )
+  end
+
+  it "keeps documented copy and language exceptions tied to review reasons" do
+    expect(mockup_copy_exception_rows).to include(
+      "toolbar-actions.html" => {
+        exception: "Long / localized-style toolbar labels",
+        reason: "Stress wrapping, disabled state, and current-state cues without choosing final translations."
+      },
+      "localized-row-labels.html" => {
+        exception: "Long localized-style row labels and metadata",
+        reason: "Stress primary label wrapping, badge placement, attribute labels, secondary metadata, and tooltip cues without choosing final translations."
+      }
+    )
+
+    mockup_copy_exception_rows.each do |mockup, metadata|
+      expect(metadata[:exception]).not_to be_empty, "#{mockup} must describe the deliberate exception"
+      expect(metadata[:reason]).not_to be_empty, "#{mockup} must keep a review reason"
+    end
   end
 end


### PR DESCRIPTION
## 対応 Issue

Closes #1481

## Issue ごとの完了内容

- #1481: `docs/mockups/README.md` の Copy and language policy と deliberate exception table が消えた場合に検出できるよう、既存の `spec/mockup_inventory_spec.rb` に代表 signal を追加しました。

## 変更内容

- `spec/mockup_inventory_spec.rb` に README の copy / language policy 見出し、product-neutral English 方針、host-app responsibility 境界、例外表ヘッダーの確認を追加
- `toolbar-actions.html` と `localized-row-labels.html` の deliberate exception / review reason が維持されていることを確認
- 例外表の各行に exception と review reason が残っていることを確認

## 改善カテゴリ

- test
- docs guard
- 小さな保守性改善

## 既存仕様への影響

- runtime code、mockup HTML/CSS、docs prose は変更していません。
- translation quality 判定、visual diff、mockup copy rewrite、host app の localization policy 決定には広げていません。

## 確認内容

- GitHub connector で `main` の最新 SHA を確認し、その SHA から branch を作成
- PR 前 compare で `behind_by: 0`、変更ファイルが `spec/mockup_inventory_spec.rb` のみであることを確認
- ローカル実行は、このコンテナに Ruby がないため未実施です。CI で `rspec` / lint を確認します。

## リスク評価

- `risk:low`
- 既存 README の代表文言に対する spec-only guard のため、公開挙動への影響はありません。

## 補足

- #413 は npm registry access が必要な lockfile / `npm ci` 系作業のため、この環境では引き続き着手していません。
- `rails_fields_kit` #1067 は未マージ PR #1005 / #1007 の public API 形に依存していたため、PR 作成せず `status:needs-human` に切り替え済みです。