### PR TITLE
README に default-tree 由来の代表 visual を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If you already know the symptom and want a faster reverse-lookup entry point, se
 
 If you want static visual references for baseline DOM structure and interaction states before wiring a host app, see [TreeView mockups](docs/mockups/README.md). Start with [review-gallery.html](docs/mockups/review-gallery.html) for the fastest first look, open [default-tree.html](docs/mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
 
+![Static TreeView mockup showing expanded and collapsed hierarchy rows with selection checkboxes, badges, and row actions.](docs/mockups/assets/readme-default-tree.svg)
+
+The image above is a single orientation asset derived from the `default-tree.html` baseline rows. Use the linked mockups for full static review paths and focused state comparisons.
+
 For the boundary between static mockups and a future real Rails demo app, see [Demo application boundary](docs/en/demo-application-boundary.md) / [日本語](docs/ja/demo-application-boundary.md). The public docs intentionally avoid direct demo repository links until a demo repository is public.
 
 ## Features

--- a/docs/mockups/assets/readme-default-tree.svg
+++ b/docs/mockups/assets/readme-default-tree.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="560" viewBox="0 0 1200 560" role="img" aria-labelledby="title desc">
+  <title id="title">Default TreeView rendering mock</title>
+  <desc id="desc">Static TreeView mockup showing expanded and collapsed hierarchy rows with selection checkboxes, badges, and row actions.</desc>
+  <rect width="1200" height="560" fill="#f7f9fb"/>
+  <rect x="24" y="24" width="1152" height="512" rx="16" fill="#ffffff" stroke="#dde4ec"/>
+  <g font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="48" y="64" font-size="14" font-weight="700" letter-spacing="1.1" fill="#52606d">TREE_VIEW-RAILS</text>
+    <text x="48" y="104" font-size="30" font-weight="760" fill="#102a43">Default TreeView rendering mock</text>
+    <text x="48" y="132" font-size="16" fill="#52606d">Table-first hierarchy rows with selection, expansion state, badges, and host-app-owned row actions.</text>
+
+    <rect x="40" y="142" width="1120" height="36" fill="#f1f5f9"/>
+    <text x="72" y="165" font-size="13" font-weight="700" letter-spacing="0.5" fill="#334e68">SELECT</text>
+    <text x="180" y="165" font-size="13" font-weight="700" letter-spacing="0.5" fill="#334e68">TREE</text>
+    <text x="650" y="165" font-size="13" font-weight="700" letter-spacing="0.5" fill="#334e68">NAME</text>
+    <text x="820" y="165" font-size="13" font-weight="700" letter-spacing="0.5" fill="#334e68">OWNER</text>
+    <text x="950" y="165" font-size="13" font-weight="700" letter-spacing="0.5" fill="#334e68">STATUS</text>
+    <text x="1080" y="165" font-size="13" font-weight="700" letter-spacing="0.5" fill="#334e68">ACTIONS</text>
+
+    <rect x="40" y="178" width="1120" height="68" fill="#ffffff"/>
+    <line x1="40" x2="1160" y1="246" y2="246" stroke="#e4e7eb"/>
+    <rect x="78" y="203" width="18" height="18" rx="4" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+    <line x1="190" y1="190" x2="190" y2="223" stroke="rgba(108,117,125,.48)"/>
+    <line x1="190" y1="209" x2="202" y2="209" stroke="rgba(108,117,125,.55)"/>
+    <rect x="212" y="200" width="49" height="24" rx="12" fill="#ffffff" stroke="#bcccdc"/>
+    <text x="236.5" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#1d4ed8">hide</text>
+    <rect x="266" y="200" width="44" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="288" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">root</text>
+    <rect x="322" y="200" width="62" height="24" rx="12" fill="#edf2f7"/>
+    <text x="353" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#334e68">folder</text>
+    <rect x="390" y="200" width="34" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="407" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">L0</text>
+    <rect x="436" y="200" width="34" height="24" rx="12" fill="#edf2f7"/>
+    <text x="453" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#334e68">3</text>
+    <text x="650" y="220" font-size="16" fill="#102a43">Product Platform</text>
+    <text x="820" y="220" font-size="16" fill="#334155">Team A</text>
+    <rect x="950" y="200" width="62" height="24" rx="12" fill="#e0f2fe"/>
+    <text x="981" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="#075985">active</text>
+    <rect x="1080" y="198" width="74" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+    <text x="1117" y="218" text-anchor="middle" font-size="14" fill="#1f2933">Edit</text>
+
+    <rect x="40" y="246" width="1120" height="68" fill="#eff6ff"/>
+    <line x1="40" x2="1160" y1="314" y2="314" stroke="#e4e7eb"/>
+    <rect x="78" y="271" width="18" height="18" rx="4" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+    <path d="M82 280 l4 4 l7 -8" fill="none" stroke="#2563eb" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="190" y1="258" x2="190" y2="291" stroke="rgba(108,117,125,.48)"/>
+    <line x1="214" y1="258" x2="214" y2="291" stroke="rgba(108,117,125,.48)"/>
+    <line x1="214" y1="277" x2="226" y2="277" stroke="rgba(108,117,125,.55)"/>
+    <rect x="236" y="268" width="49" height="24" rx="12" fill="#ffffff" stroke="#bcccdc"/>
+    <text x="260.5" y="284" text-anchor="middle" font-size="13" font-weight="700" fill="#1d4ed8">hide</text>
+    <rect x="290" y="268" width="48" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="314" y="284" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">child</text>
+    <rect x="348" y="268" width="62" height="24" rx="12" fill="#edf2f7"/>
+    <text x="379" y="284" text-anchor="middle" font-size="13" font-weight="700" fill="#334e68">folder</text>
+    <rect x="420" y="268" width="34" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="437" y="284" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">L1</text>
+    <rect x="466" y="268" width="78" height="24" rx="12" fill="#e0f2fe"/>
+    <text x="505" y="284" text-anchor="middle" font-size="13" font-weight="700" fill="#075985">selected</text>
+    <text x="650" y="288" font-size="16" fill="#102a43">Admin UI</text>
+    <text x="820" y="288" font-size="16" fill="#334155">Team B</text>
+    <rect x="950" y="268" width="62" height="24" rx="12" fill="#e0f2fe"/>
+    <text x="981" y="284" text-anchor="middle" font-size="13" font-weight="700" fill="#075985">active</text>
+    <rect x="1080" y="266" width="74" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+    <text x="1117" y="286" text-anchor="middle" font-size="14" fill="#1f2933">Open</text>
+
+    <rect x="40" y="314" width="1120" height="68" fill="#ffffff"/>
+    <line x1="40" x2="1160" y1="382" y2="382" stroke="#e4e7eb"/>
+    <rect x="78" y="339" width="18" height="18" rx="4" fill="#ffffff" stroke="#94a3b8" stroke-width="1.5"/>
+    <line x1="190" y1="326" x2="190" y2="359" stroke="rgba(108,117,125,.48)"/>
+    <line x1="214" y1="326" x2="214" y2="359" stroke="rgba(108,117,125,.48)"/>
+    <line x1="238" y1="326" x2="238" y2="345" stroke="rgba(108,117,125,.48)"/>
+    <line x1="238" y1="345" x2="250" y2="345" stroke="rgba(108,117,125,.55)"/>
+    <rect x="260" y="336" width="45" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="282.5" y="352" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">leaf</text>
+    <rect x="316" y="336" width="48" height="24" rx="12" fill="#edf2f7"/>
+    <text x="340" y="352" text-anchor="middle" font-size="13" font-weight="700" fill="#334e68">file</text>
+    <rect x="374" y="336" width="34" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="391" y="352" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">L2</text>
+    <text x="650" y="356" font-size="16" fill="#102a43">Settings page</text>
+    <text x="820" y="356" font-size="16" fill="#334155">Team B</text>
+    <rect x="950" y="336" width="56" height="24" rx="12" fill="#edf2f7"/>
+    <text x="978" y="352" text-anchor="middle" font-size="13" font-weight="700" fill="#334e68">ready</text>
+    <rect x="1080" y="334" width="74" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+    <text x="1117" y="354" text-anchor="middle" font-size="14" fill="#1f2933">Open</text>
+
+    <rect x="40" y="382" width="1120" height="68" fill="#fffaf0"/>
+    <line x1="40" x2="1160" y1="450" y2="450" stroke="#e4e7eb"/>
+    <rect x="78" y="407" width="18" height="18" rx="4" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+    <line x1="190" y1="394" x2="190" y2="427" stroke="rgba(108,117,125,.48)"/>
+    <line x1="214" y1="394" x2="214" y2="413" stroke="rgba(108,117,125,.48)"/>
+    <line x1="214" y1="413" x2="226" y2="413" stroke="rgba(108,117,125,.55)"/>
+    <rect x="236" y="404" width="49" height="24" rx="12" fill="#ffffff" stroke="#bcccdc"/>
+    <text x="260.5" y="420" text-anchor="middle" font-size="13" font-weight="700" fill="#1d4ed8">show</text>
+    <rect x="290" y="404" width="48" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="314" y="420" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">child</text>
+    <rect x="348" y="404" width="34" height="24" rx="12" fill="#e9ecef"/>
+    <text x="365" y="420" text-anchor="middle" font-size="13" font-weight="700" fill="#495057">12</text>
+    <rect x="390" y="404" width="63" height="24" rx="12" fill="#edf2f7"/>
+    <text x="421.5" y="420" text-anchor="middle" font-size="13" font-weight="700" fill="#334e68">archive</text>
+    <rect x="462" y="404" width="34" height="24" rx="12" fill="#f1f3f5"/>
+    <text x="479" y="420" text-anchor="middle" font-size="13" font-weight="700" fill="#6c757d">L1</text>
+    <rect x="510" y="404" width="78" height="24" rx="12" fill="#fef3c7"/>
+    <text x="549" y="420" text-anchor="middle" font-size="13" font-weight="700" fill="#92400e">archived</text>
+    <text x="650" y="424" font-size="16" fill="#102a43">Legacy reports</text>
+    <text x="820" y="424" font-size="16" fill="#334155">Team C</text>
+    <rect x="950" y="404" width="78" height="24" rx="12" fill="#fef3c7"/>
+    <text x="989" y="420" text-anchor="middle" font-size="13" font-weight="700" fill="#92400e">archived</text>
+    <rect x="1080" y="402" width="74" height="30" rx="8" fill="#f1f5f9" stroke="#cbd5e1"/>
+    <text x="1117" y="422" text-anchor="middle" font-size="14" fill="#9aa5b1">Open</text>
+  </g>
+</svg>

--- a/docs/mockups/readme-representative-visual-candidates.md
+++ b/docs/mockups/readme-representative-visual-candidates.md
@@ -2,16 +2,18 @@
 
 This note narrows the README screenshot or GIF source candidates before issue #360 adds an actual image asset.
 
-The source HTML/CSS mockups remain canonical. Do not add generated screenshots, GIFs, or GitHub-hosted image assets in this slice.
+The source HTML/CSS mockups remain canonical. The current first README image asset lives at `docs/mockups/assets/readme-default-tree.svg` and should stay traceable to the representative rows and state cues in `default-tree.html`.
 
 ## Candidate A: baseline tree screenshot
 
 - Source: `default-tree.html`
+- Selected README asset: `assets/readme-default-tree.svg`
 - Recommended state: first viewport showing the default hierarchy table, expanded and collapsed rows, selection checkboxes, row badges, depth labels, and row actions.
 - What it communicates: TreeView's baseline shape in one compact image. A new reader can understand that the gem renders table-first hierarchy rows while leaving business actions to the host app.
 - README placement: near the existing static visual reference paragraph in the introduction, before the feature list grows dense.
 - Alt text direction: "Static TreeView mockup showing expanded and collapsed hierarchy rows with selection checkboxes, badges, and row actions."
 - Weight concern: low. One focused screenshot is easier to scan than a gallery capture and does not imply every focused mockup is part of the README hero.
+- Refresh note: when `default-tree.html` changes the first-viewport representative rows, update the README asset in the same review so it still reflects the baseline table-first shape.
 - Caveat: it should not look like a complete file-manager product. Crop around the tree surface and keep host-app business copy out of the image.
 
 ## Candidate B: review gallery overview
@@ -30,7 +32,6 @@ Use Candidate A as the first README image candidate because it explains the prod
 
 ## Non-goals for this note
 
-- Adding screenshots, GIFs, or GitHub image assets.
-- Changing `README.md` image placement.
+- Adding multiple screenshots, GIFs, or GitHub-hosted image assets.
 - Redesigning `default-tree.html` or `review-gallery.html`.
-- Deciding final asset storage, capture tooling, or screenshot approval workflow.
+- Deciding a screenshot baseline platform or visual regression approval workflow.


### PR DESCRIPTION
## 対応Issue

- Closes #1447
- Related: #360

## Superseded

この PR は #1495 に supersede されました。

理由:

- current `main` から `behind_by: 3` / `status:diverged` になり、review comment で latest main 追従が必要でした。
- #1495 は latest main から clean replacement として同じ3ファイル差分だけを再適用しています。
- #1495 は `behind_by: 0` / `mergeable: true` / CI #1875 success です。

古い branch への追記ではなく #1495 をレビュー対象にしてください。