### PR TITLE
Minimal usage の selection 例に form wiring 導線を追加する

### DIFF
--- a/docs/en/minimal-usage.md
+++ b/docs/en/minimal-usage.md
@@ -85,6 +85,8 @@ Set `selection.enabled` to `true` to enable checkbox selection.
 
 `visibility: :leaves` renders checkboxes only for leaf nodes.
 
+For regular form submits, continue with [Hidden input sync for regular form submit](selection.md#hidden-input-sync-for-regular-form-submit). When JavaScript needs to reference the controller data attribute, use `TreeViewSelectionDataHooks.hiddenInputNameValue` from the package root instead of copying the raw attribute string.
+
 See [Selection](selection.md) for details.
 
 ## Visual check

--- a/docs/ja/minimal-usage.md
+++ b/docs/ja/minimal-usage.md
@@ -85,6 +85,8 @@ end
 
 `visibility: :leaves` はleaf nodeだけにcheckboxを表示します。
 
+通常の form 送信で選択値を params に載せる場合は、次に [通常form送信用の hidden input 同期](selection.md#通常form送信用の-hidden-input-同期) を確認してください。JavaScript から controller の data attribute name を参照する場合は、raw string を写経せず package root の `TreeViewSelectionDataHooks.hiddenInputNameValue` を使えます。
+
 詳しくは [Selection](selection.md) を参照してください。
 
 ## 見た目の確認


### PR DESCRIPTION
## 対応 Issue

Closes #1489

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `docs/en/minimal-usage.md` の selection 例から、通常 form submit 用の hidden input sync 節へ直接辿れる導線を追加しました。
- `docs/ja/minimal-usage.md` に同等の導線を追加しました。
- JavaScript で controller data attribute name を参照する場合は、raw string ではなく package root の `TreeViewSelectionDataHooks.hiddenInputNameValue` を使えることを短く案内しました。

## 変更範囲

- `docs/en/minimal-usage.md`
- `docs/ja/minimal-usage.md`

## 確認内容

- Issue #1489 と関連 docs を確認し、runtime selection behavior / public export shape / public API manifest には触れず docs-only で完結できると判断しました。
- `docs/en/selection.md` に `Hidden input sync for regular form submit` があることを確認しました。
- `docs/ja/selection.md` に `通常form送信用の hidden input 同期` があることを確認しました。
- GitHub compare: `main...docs/1489-minimal-selection-wiring`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only

## リスク

low。既存 selection docs への導線追加のみで、runtime JavaScript、selection controller behavior、public API manifest、TypeScript declaration は変更していません。