### PR TITLE
root README に Depth Labels / Row Status への導線を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Key documents:
 | Selection | [Selection](docs/en/selection.md) | [Selection](docs/ja/selection.md) |
 | Toolbar helper (`tree_view_toolbar`) | [Toolbar helper](docs/en/toolbar.md) | [Toolbar helper](docs/ja/toolbar.md) |
 | Breadcrumb helper (`tree_view_breadcrumb`) | [Breadcrumb helper](docs/en/breadcrumb.md) | [Breadcrumb helper](docs/ja/breadcrumb.md) |
+| Depth labels and row status | [Depth Labels](docs/en/depth-labels.md) and [Row Status](docs/en/row-status.md) | [Depth Labels](docs/ja/depth-labels.md) and [Row Status](docs/ja/row-status.md) |
 | Turbo Frame option | [Turbo Frame option](docs/en/turbo-frame.md) | [Turbo Frame オプション](docs/ja/turbo-frame.md) |
 | Persisted State | [Persisted State](docs/en/persisted-state.md) | [Persisted State](docs/ja/persisted-state.md) |
 | Localized names | [Localized names](docs/en/localized-names.md) | [ローカライズされた名前](docs/ja/localized-names.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #1492

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- root `README.md` の Key documents table に、Depth Labels / Row Status の英日リンクを 1 行追加しました。
- `docs/en|ja/README.md` で既に user-facing docs として列挙されている guide への入口を root README 側にも揃えました。

## 変更範囲

- `README.md` のみ

## 確認内容

- GitHub compare: `main...docs/1492-depth-row-status-readme`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`README.md`)
- `docs/en/README.md` / `docs/ja/README.md` に Depth Labels / Row Status が既に存在することを確認しました。
- `docs/en|ja/depth-labels.md` / `docs/en|ja/row-status.md` 本文、runtime helper、public API manifest、mockup inventory は変更していません。
- `script/test_docs_entrypoints.mjs` は Planner handoff の候補範囲にありましたが、Docs Sync Agent の docs-only 範囲外のためこの PR では触れていません。
- GitHub Actions CI #1876: success
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: docs-only skip path success
  - representative Rails lanes: docs-only skip path success
  - `gem_package`: skipped
- PR metadata: `mergeable:true`

## リスク

low。root README の docs entrypoint 追加のみです。