### PR TITLE
Node version source drift guard を追加する

### DIFF
--- a/spec/node_version_source_drift_spec.rb
+++ b/spec/node_version_source_drift_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+
+RSpec.describe "Node version source drift" do
+  let(:repository_root) { Pathname.new(__dir__).join("..").expand_path }
+
+  def read_repository_file(path)
+    repository_root.join(path).read
+  end
+
+  it "keeps .nvmrc, package engines, and CI node-version on the same major" do
+    nvmrc_major = read_repository_file(".nvmrc").strip.delete_prefix("v").split(".").first
+    package_json = JSON.parse(read_repository_file("package.json"))
+    engine_major = package_json.fetch("engines").fetch("node").match(/\d+/)[0]
+    workflow_versions = read_repository_file(".github/workflows/ci.yml")
+      .scan(/node-version:\s*["']?(\d+)/)
+      .flatten
+      .uniq
+
+    expect(engine_major).to eq(nvmrc_major)
+    expect(workflow_versions).to eq([nvmrc_major])
+  end
+
+  it "keeps development docs aligned with the guarded source of truth" do
+    %w[docs/en/development.md docs/ja/development.md].each do |path|
+      content = read_repository_file(path)
+
+      expect(content).to include("Node 22")
+      expect(content).to include(".nvmrc")
+      expect(content).to include("package.json")
+      expect(content).to include("node-version")
+    end
+  end
+end


### PR DESCRIPTION
## 対応Issue

- Closes #1497

## Issueごとの完了内容

- #1497
  - `.nvmrc`、`package.json` の `engines.node`、`.github/workflows/ci.yml` の `node-version` が同じ major version を指すことを確認する repository-level spec を追加しました。
  - `docs/en/development.md` / `docs/ja/development.md` が、実際の guard 対象である `.nvmrc`、`package.json`、`node-version`、Node 22 を説明していることも同じ spec で確認します。

## 変更内容

- `spec/node_version_source_drift_spec.rb` を追加
- 既存 docs / workflow / package metadata / install policy は変更していません

## 改善カテゴリ

- test
- CI / devops drift guard
- docs consistency guard

## 既存仕様への影響

- なし。runtime、public API、UI、DB、認可、外部サービス契約には触れていません。
- Node major upgrade、dependency upgrade、`npm install` / `npm ci` 方針変更にも広げていません。

## 確認内容

- connector 上で `docs/en/development.md` / `docs/ja/development.md`、`.nvmrc` / `package.json` / workflow の前提を確認
- PR 前 compare: `main...quality/1497-node-version-drift-spec` は `behind_by: 0`、changed files は `spec/node_version_source_drift_spec.rb` のみ
- GitHub Actions CI run #1887: success
- ローカル実行は GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗する環境のため未実施。GitHub Actions で確認しました。

## リスク評価

- low
- 静的な drift guard spec の追加のみで、アプリ挙動には影響しません。

## 補足

- #413 の `package-lock.json` / `npm ci` 復帰作業とは分離しています。