### PR TITLE
docs entrypoint smoke に代表 signal guard を追加する

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -64,6 +64,23 @@ const foundationalEntrypoints = [
       ["docs/ja/README.md", "installation.md"],
       ["docs/ja/README.md", "minimal-usage.md"],
       ["docs/ja/README.md", "usage.md"]
+    ],
+    signals: [
+      [
+        "docs/en/minimal-usage.md",
+        /TreeView::Tree[\s\S]*TreeView::UiConfigBuilder[\s\S]*build_static[\s\S]*TreeView::RenderState[\s\S]*tree_view_rows\(@render_state\)[\s\S]*row_partial[\s\S]*minimal-usage-first-render\.html/,
+        "English minimal-usage docs no longer expose the minimal controller/view/row-partial path and first-render mockup link"
+      ],
+      [
+        "docs/ja/minimal-usage.md",
+        /TreeView::Tree[\s\S]*TreeView::UiConfigBuilder[\s\S]*build_static[\s\S]*TreeView::RenderState[\s\S]*tree_view_rows\(@render_state\)[\s\S]*row_partial[\s\S]*minimal-usage-first-render\.html/,
+        "Japanese minimal-usage docs no longer expose the minimal controller/view/row-partial path and first-render mockup link"
+      ],
+      [
+        "docs/mockups/minimal-usage-first-render.html",
+        /data-tree-view-sample="minimal-usage-first-render"[\s\S]*Included[\s\S]*Initial table wrapper[\s\S]*Excluded[\s\S]*Checkbox selection[\s\S]*badges[\s\S]*row actions[\s\S]*CRUD links[\s\S]*routes[\s\S]*seeded demo records/,
+        "minimal-usage-first-render mockup no longer states the first-render included/excluded boundary"
+      ]
     ]
   },
   {
@@ -339,6 +356,48 @@ const featureEntrypoints = [
       ["docs/en/README.md", "host-app-extension-points.md"],
       ["docs/ja/README.md", "drag-and-drop.md"],
       ["docs/ja/README.md", "host-app-extension-points.md"]
+    ],
+    signals: [
+      [
+        "docs/en/host-app-extension-points.md",
+        /row_partial[\s\S]*row_actions_partial[\s\S]*row_data_builder[\s\S]*row_event_payload_builder/,
+        "English host-app extension docs no longer expose the row extension surface reverse lookup"
+      ],
+      [
+        "docs/en/host-app-extension-points.md",
+        /data-tree-view-interactive[\s\S]*data-tree-view-ignore-keyboard[\s\S]*data-tree-view-ignore-row-click[\s\S]*data-tree-view-ignore-drag/,
+        "English host-app extension docs no longer expose the interactive marker boundary"
+      ],
+      [
+        "docs/en/host-app-extension-points.md",
+        /data-tree-view-selection-hidden-input-name-value[\s\S]*data-tree-view-selection-max-count-value[\s\S]*data-tree-view-selection-cascade-value[\s\S]*data-tree-view-selection-indeterminate-value/,
+        "English host-app extension docs no longer expose the selection controller value attributes"
+      ],
+      [
+        "docs/en/host-app-extension-points.md",
+        /TreeView::PersistedState[\s\S]*TreeView::StateStore[\s\S]*show_descendants_path_builder[\s\S]*load_children_path_builder/,
+        "English host-app extension docs no longer expose persisted-state and path-builder boundaries"
+      ],
+      [
+        "docs/ja/host-app-extension-points.md",
+        /row_partial[\s\S]*row_actions_partial[\s\S]*row_data_builder[\s\S]*row_event_payload_builder/,
+        "Japanese host-app extension docs no longer expose the row extension surface reverse lookup"
+      ],
+      [
+        "docs/ja/host-app-extension-points.md",
+        /data-tree-view-interactive[\s\S]*data-tree-view-ignore-keyboard[\s\S]*data-tree-view-ignore-row-click[\s\S]*data-tree-view-ignore-drag/,
+        "Japanese host-app extension docs no longer expose the interactive marker boundary"
+      ],
+      [
+        "docs/ja/host-app-extension-points.md",
+        /data-tree-view-selection-hidden-input-name-value[\s\S]*data-tree-view-selection-max-count-value[\s\S]*data-tree-view-selection-cascade-value[\s\S]*data-tree-view-selection-indeterminate-value/,
+        "Japanese host-app extension docs no longer expose the selection controller value attributes"
+      ],
+      [
+        "docs/ja/host-app-extension-points.md",
+        /TreeView::PersistedState[\s\S]*TreeView::StateStore[\s\S]*show_descendants_path_builder[\s\S]*load_children_path_builder/,
+        "Japanese host-app extension docs no longer expose persisted-state and path-builder boundaries"
+      ]
     ]
   },
   {
@@ -406,10 +465,13 @@ const maintainerEntrypoints = [
   }
 ]
 
-foundationalEntrypoints.forEach(({ feature, rootPattern, links }) => {
+foundationalEntrypoints.forEach(({ feature, rootPattern, links, signals = [] }) => {
   assertRootSignal(feature, rootPattern, "README.md no longer exposes the representative docs signal")
 
   links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+  signals.forEach(([sourcePath, signalPattern, message]) => {
+    assertDocumentSignal(sourcePath, signalPattern, feature, message)
+  })
 })
 
 featureEntrypoints.forEach(({ feature, rootPattern, links, signals = [] }) => {


### PR DESCRIPTION
## 対応 Issue

- Closes #1499
- Closes #1502

## Issue ごとの完了内容

- #1499: 英日 minimal usage docs が `TreeView::Tree` / `TreeView::UiConfigBuilder#build_static` / `TreeView::RenderState` / `tree_view_rows(@render_state)` / `row_partial` / `minimal-usage-first-render.html` link を保つことを docs entrypoint smoke で確認します。あわせて `minimal-usage-first-render.html` の Included / Excluded boundary signal も軽量に確認します。
- #1502: 英日 Host App Extension Points docs が row extension surface、interactive marker、selection controller values、persisted-state / path-builder boundary の代表 signal を保つことを docs entrypoint smoke で確認します。

## 変更内容

- `script/test_docs_entrypoints.mjs` の `First-time setup docs` entry に `signals` を追加しました。
- 同 script の `Drag and Drop / Host App Extension Points` entry に、reverse lookup の代表 signal を追加しました。
- `foundationalEntrypoints` 側でも既存の `signals` 形式を処理するようにしました。

## 改善カテゴリ

- test
- docs drift guard
- 小さな内部整理

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、UI仕様、docs 本文、mockup HTML は変更していません。
- docs smoke の検出範囲だけを追加するため、公開挙動への影響はありません。

## 確認内容

- connector-only preflight: `main` との差分は `script/test_docs_entrypoints.mjs` のみ、branch は `main` から `behind_by: 0` です。
- PR CI: success（CI run #1889 / workflow run `27082522565`）。
- ローカル確認は未実施です。実行環境から GitHub clone / raw fetch が 403 でブロックされたため、PR CI を確認しました。

## リスク評価

- risk: low
- signal は hook 名 / marker 名 / boundary 名に寄せ、docs 全文 snapshot や翻訳品質判定にはしていません。

## 補足

- #1499 と #1502 はどちらも docs entrypoint smoke に代表 signal を追加する同系列の quality guard なので、1つの変更単位にまとめています。