### PR TITLE
Host App Extension Points の冒頭一覧を reverse lookup と同期する

### DIFF
--- a/docs/en/host-app-extension-points.md
+++ b/docs/en/host-app-extension-points.md
@@ -9,6 +9,7 @@ TreeView keeps business-specific display and behavior in the host app. The gem e
 Main extension points:
 
 - `row_partial`
+- `row_actions_partial`
 - `row_class_builder`
 - `row_data_builder`
 - `badge_builder`
@@ -18,8 +19,12 @@ Main extension points:
 - `row_disabled_reason_builder`
 - transfer payload builders
 - selection builders
+- selection controller value attributes
+- interactive-control markers (`data-tree-view-interactive` and `data-tree-view-ignore-*`)
 - lazy loading path builders
 - Turbo path builders
+
+Use render-state selection builders for row payloads, disabled state, selected keys, and checkbox visibility. Use host-element selection controller value attributes to mirror or constrain already-rendered checkboxes, and use interactive-control markers when custom row controls should opt out of TreeView keyboard, row-click, or drag behavior.
 
 For focused naming decisions, including the compatibility status of `icon_builder`, see [Public Name Decisions](public-name-decisions.md).
 

--- a/docs/ja/host-app-extension-points.md
+++ b/docs/ja/host-app-extension-points.md
@@ -9,6 +9,7 @@ TreeView は、業務固有の表示や挙動を gem 内に持ち込まず、hos
 主な extension point:
 
 - `row_partial`
+- `row_actions_partial`
 - `row_class_builder`
 - `row_data_builder`
 - `badge_builder`
@@ -18,8 +19,12 @@ TreeView は、業務固有の表示や挙動を gem 内に持ち込まず、hos
 - `row_disabled_reason_builder`
 - transfer payload builders
 - selection builders
+- selection controller value attributes
+- interactive-control markers (`data-tree-view-interactive` と `data-tree-view-ignore-*`)
 - lazy loading path builders
 - Turbo path builders
+
+row ごとの payload、disabled state、selected keys、checkbox visibility は render-state 側の selection builders で設定します。描画済み checkbox の同期や制約は host-element の selection controller value attributes で設定し、custom row control を TreeView の keyboard / row-click / drag から外したい場合は interactive-control markers を使います。
 
 `icon_builder` の compatibility status を含む公開名の判断は [Public Name Decisions](public-name-decisions.md) を参照してください。
 


### PR DESCRIPTION
## 対応 Issue

Closes #1501

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/host-app-extension-points.md` の冒頭 `Main extension points` に `row_actions_partial`、selection controller value attributes、interactive-control markers を追加しました。
- `docs/ja/host-app-extension-points.md` に同等の導線を追加しました。
- selection builders と host-element selection controller value attributes の役割差、custom row control に interactive-control markers を使う境界を短く補足しました。

## 変更範囲

- `docs/en/host-app-extension-points.md`
- `docs/ja/host-app-extension-points.md`

## 確認内容

- current main `5675a04b91cfd74527a5bbf98fd1315278e521aa` から branch を作成し直しました。
- GitHub compare: `main...docs/1501-host-app-extension-overview`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only
- 冒頭 list が本文の reverse lookup table にある `row_actions_partial` / `data-tree-view-interactive` / `data-tree-view-ignore-*` / selection controller value attributes と矛盾しないことを確認しました。
- runtime Ruby / JavaScript、manifest、TypeScript declaration、mockup HTML/CSS は変更していません。
- local docs smoke は未実行です。実行環境から GitHub clone / raw fetch が 403 でブロックされたため、PR 作成後に GitHub Actions を確認します。

## リスク

low。既存 docs 本文にある hook / marker を冒頭 overview から見つけやすくするだけで、public surface 追加や runtime behavior 変更はありません。