### PR TITLE
localized-row-labels mockup の代表 signal を browser smoke で守る

### DIFF
--- a/test/browser/localized_row_labels_mockup_smoke.spec.js
+++ b/test/browser/localized_row_labels_mockup_smoke.spec.js
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const mockupsRoot = path.join(repoRoot, "docs/mockups")
+const localizedMockupPath = path.join(mockupsRoot, "localized-row-labels.html")
+const mockupsReadmePath = path.join(mockupsRoot, "README.md")
+
+function mockupUrl(file) {
+  return pathToFileURL(path.join(mockupsRoot, file)).toString()
+}
+
+function deliberateExceptionRowFor(readme, file) {
+  return readme
+    .split("## Selection form guidance", 2)[0]
+    .split("\n")
+    .find((line) => line.includes(`| \`${file}\``))
+}
+
+test.describe("localized row labels mockup smoke", () => {
+  test("keeps long localized label and metadata stress signals visible", async ({ page }) => {
+    await page.goto(mockupUrl("localized-row-labels.html"))
+
+    await expect(page.getByRole("heading", { name: "Localized row labels mock", level: 1 })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Long localized label stress sample", level: 2 })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Japanese-width label stress sample", level: 2 })).toBeVisible()
+    await expect(page.getByText("Quarterly Planning Portfolio With Region-Specific Review Naming")).toBeVisible()
+    await expect(page.getByText("International Budget Approval Label That Must Stay Readable")).toBeVisible()
+    await expect(page.getByText("Translated document type")).toBeVisible()
+    await expect(page.getByText("Attribute label: Last translated approval stage")).toBeVisible()
+    await expect(page.getByText("Tooltip cue: full localized label is available on the primary link.")).toBeVisible()
+    await expect(page.getByText("四半期契約レビューの地域別確認資料と承認経路一覧")).toBeVisible()
+    await expect(page.getByText("属性ラベル: 最終確認ステージと担当部門")).toBeVisible()
+    await expect(page.getByText("Final translations, truncation rules, tooltip text, permission copy, and business-specific labels remain outside this mockup.")).toBeVisible()
+
+    await expect(page.locator(".mock-localized-type")).toHaveCount(5)
+    await expect(page.locator(".mock-localized-attribute")).toHaveCount(5)
+    await expect(page.locator(".mock-localized-tooltip-cue")).toHaveCount(2)
+    await expect(page.locator(".tree-row[aria-current='page']")).toHaveCount(2)
+  })
+
+  test("keeps the deliberate copy exception documented in the mockup README", () => {
+    const readme = readFileSync(mockupsReadmePath, "utf8")
+    const mockup = readFileSync(localizedMockupPath, "utf8")
+    const row = deliberateExceptionRowFor(readme, "localized-row-labels.html")
+
+    expect(row).toContain("Long localized-style row labels and metadata")
+    expect(row).toContain("Stress primary label wrapping, badge placement, attribute labels, secondary metadata, and tooltip cues without choosing final translations.")
+    expect(mockup).toContain("Deliberate CJK width stress sample")
+    expect(mockup).toContain("Final translation、permission wording、business action labels remain host-app owned.")
+  })
+})


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1494

## Issue ごとの完了内容

- #1494: `localized-row-labels.html` が単なる行数 smoke だけでなく、長い localized-style label、CJK 幅 stress sample、type badge、attribute label、secondary metadata、tooltip cue、README deliberate exception policy を保っていることを browser smoke で確認できるようにしました。

## 変更内容

- `test/browser/localized_row_labels_mockup_smoke.spec.js` を追加しました。
- mockup page の代表 signal を確認します。
  - English long-label rows
  - Japanese-width sample rows
  - type badge / attribute label / tooltip cue
  - current-row cue
  - host-app-owned final translation boundary
- `docs/mockups/README.md` の deliberate copy/language exception row と mockup 本文の対応も確認します。

## 改善カテゴリ

- test
- docs/mockup smoke
- maintenance

## 既存仕様への影響はないこと

runtime Ruby / JavaScript、public API、CSS、mockup HTML、visual design、translation policy は変更していません。browser smoke の追加のみです。

## 実施した確認内容

- Issue #1494 の eligibility label を個別確認しました。
- 既存 open PR に #1494 対応がないことを確認しました。
- compare: `main...quality/1494-localized-row-labels-smoke`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`test/browser/localized_row_labels_mockup_smoke.spec.js`)
- local `npm run test:browser` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` のため、PR CI を確認します。

## リスク評価

low。既存 mockup の代表 signal を確認するテスト追加のみで、表示や公開挙動は変わりません。

## 補足事項

- visual diff、screenshot baseline、翻訳品質判定、mockup redesign には広げていません。