### PR TITLE
selection の unloaded descendants 境界を英日 docs に補足する

### DIFF
--- a/docs/en/children-pagination.md
+++ b/docs/en/children-pagination.md
@@ -174,6 +174,8 @@ Pagination means some descendants are not present in the DOM yet. Define product
 | Bulk actions | Use query-backed actions when the action should affect unloaded children. Use DOM-submitted checkbox values only for loaded-row actions. |
 | Retry/error UI | Keep retry controls scoped to the parent/page that failed so another page can remain loaded. |
 
+The [Selection](selection.md#linked-checkbox-behavior) guide is the contract for loaded-row checkbox payloads, hidden input sync, and rendered-only cascade / indeterminate behavior. The [children-pagination-selection-boundary.html](../mockups/children-pagination-selection-boundary.html) mockup is a visual review aid for this boundary; it does not add a TreeView API for unloaded descendants.
+
 ## Notes
 
 - Always use stable ordering, for example `order(:name, :id)`.

--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -199,6 +199,10 @@ Use `TreeViewSelectionDataHooks.cascadeValue` and `TreeViewSelectionDataHooks.in
 
 This behavior is DOM-based. It affects rendered rows only and skips disabled checkboxes.
 
+The controller reads checkbox elements that are currently present in the page. It does not create selection semantics for descendants that lazy loading or children pagination has not rendered yet. When a bulk action should include unloaded descendants, submit a host-app-owned server-side intent or query filter in addition to the loaded-row checkbox payloads.
+
+See [Children Pagination](children-pagination.md#selection-and-dragdrop-interactions) for the pagination-specific boundary and [children-pagination-selection-boundary.html](../mockups/children-pagination-selection-boundary.html) for a static visual reference.
+
 ## Responsibility boundary
 
 | Area | TreeView | Host app |

--- a/docs/ja/children-pagination.md
+++ b/docs/ja/children-pagination.md
@@ -174,6 +174,8 @@ pagination中は、まだDOM上に存在しないdescendantsがあります。pr
 | Bulk actions | unloaded childrenにも作用するactionはquery-backed actionにする。DOMから送られるcheckbox値はloaded-row actionsに限定する。 |
 | Retry/error UI | 失敗したparent/pageにretry controlをscopeし、他のpageがloadedのまま残れるようにする。 |
 
+loaded-row checkbox payload、hidden input sync、rendered-only cascade / indeterminate behavior の contract は [Selection](selection.md#連動checkbox挙動) が正本です。[children-pagination-selection-boundary.html](../mockups/children-pagination-selection-boundary.html) はこの境界を確認するための visual review aid であり、unloaded descendants 向けの TreeView API を追加するものではありません。
+
 ## 注意点
 
 - 並び順は必ず安定させてください。例: `order(:name, :id)`

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -199,6 +199,10 @@ JavaScript が host-authored cascade / indeterminate wiring の documented attri
 
 この挙動はDOMベースです。影響するのは描画済み行だけで、disabled checkboxはskipします。
 
+controller は、現在のpageに存在するcheckbox elementだけを読み取ります。lazy loading や children pagination でまだ描画されていない descendants について、TreeView は選択 semantics を作りません。unloaded descendants も含む bulk action が必要な場合は、loaded-row checkbox payload に加えて、host app 側の server-side intent や query filter を送ってください。
+
+pagination 固有の境界は [Children Pagination](children-pagination.md#selection--drag-drop-との相互作用) を参照してください。静的な確認用 visual reference は [children-pagination-selection-boundary.html](../mockups/children-pagination-selection-boundary.html) です。
+
 ## 責務範囲
 
 | Area | TreeView | Host app |


### PR DESCRIPTION
## 対応 Issue

Closes #1479

## 判定分類

- `docs-sync`
- docs-only clarification

## 変更内容

- `docs/en/selection.md` / `docs/ja/selection.md`
  - cascade / indeterminate は現在 DOM に存在する checkbox だけを読むことを補足しました。
  - lazy loading / children pagination で未描画の descendants を含む bulk action は、host app 側の server-side intent / query filter として表現する境界を明記しました。
  - children pagination guide と static mockup への導線を追加しました。
- `docs/en/children-pagination.md` / `docs/ja/children-pagination.md`
  - loaded-row checkbox payload / hidden input sync / rendered-only cascade の正本が Selection guide であることを補足しました。
  - `children-pagination-selection-boundary.html` は visual review aid であり、unloaded descendants 向け TreeView API を追加するものではないことを明記しました。

## 変更範囲

- docs-only 4 files
- runtime Ruby / JavaScript、selection controller、hidden input sync、DataTransfer payload、public API manifest、mockup HTML/CSS は変更していません。

## 確認内容

- GitHub compare: `main...docs/1479-selection-unloaded-boundary`
  - `ahead_by:4`
  - `behind_by:0`
  - changed files: 4 docs-only
  - additions only
- 英日 selection / children pagination の対応箇所を connector で確認しました。
- local docs smoke は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` になるため、PR 作成後に GitHub Actions を確認します。

## リスク

low。既存の rendered-only selection contract と host-app-owned pagination / bulk action 境界を説明するだけで、実装や public surface は変更していません。