### PR TITLE
Guard installation docs setup signals

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -67,6 +67,16 @@ const foundationalEntrypoints = [
     ],
     signals: [
       [
+        "docs/en/installation.md",
+        /@import "tree_view";[\s\S]*pin "tree_view", to: "tree_view\/index\.js"[\s\S]*app\/assets\/stylesheets\/tree_view\.scss[\s\S]*app\/javascript\/tree_view\/\*\*\/\*[\s\S]*config\/importmap\.tree_view\.rb[\s\S]*config\/public_api_manifest\.yml[\s\S]*Propshaft[\s\S]*explicitly import CSS and add the importmap pin[\s\S]*Sprockets[\s\S]*explicit CSS\/importmap setup/,
+        "English installation docs no longer expose the CSS/importmap, packaged files, and explicit Propshaft/Sprockets setup signals"
+      ],
+      [
+        "docs/ja/installation.md",
+        /@import "tree_view";[\s\S]*pin "tree_view", to: "tree_view\/index\.js"[\s\S]*app\/assets\/stylesheets\/tree_view\.scss[\s\S]*app\/javascript\/tree_view\/\*\*\/\*[\s\S]*config\/importmap\.tree_view\.rb[\s\S]*config\/public_api_manifest\.yml[\s\S]*Propshaft[\s\S]*CSS \/ importmap を明示的に読み込む構成[\s\S]*Sprockets[\s\S]*CSS \/ importmapを明示的に読み込む運用/,
+        "Japanese installation docs no longer expose the CSS/importmap, packaged files, and explicit Propshaft/Sprockets setup signals"
+      ],
+      [
         "docs/en/minimal-usage.md",
         /TreeView::Tree[\s\S]*TreeView::UiConfigBuilder[\s\S]*build_static[\s\S]*TreeView::RenderState[\s\S]*tree_view_rows\(@render_state\)[\s\S]*row_partial[\s\S]*minimal-usage-first-render\.html/,
         "English minimal-usage docs no longer expose the minimal controller/view/row-partial path and first-render mockup link"


### PR DESCRIPTION
## 対応 Issue

- Closes #1513

## Issue ごとの完了内容

- #1513: `docs/en/installation.md` / `docs/ja/installation.md` が、リンク先として存在するだけでなく、host app setup に必要な代表 signal を保っていることを `script/test_docs_entrypoints.mjs` で確認するようにしました。

## 変更内容

- `script/test_docs_entrypoints.mjs` の `First-time setup docs` signals に、英日 Installation docs 用の lightweight signal guard を追加しました。
- 追加した signal は次に閉じています。
  - `@import "tree_view";`
  - `pin "tree_view", to: "tree_view/index.js"`
  - representative packaged paths: `app/assets/stylesheets/tree_view.scss`, `app/javascript/tree_view/**/*`, `config/importmap.tree_view.rb`, `config/public_api_manifest.yml`
  - Propshaft / Sprockets で CSS/importmap setup を明示する guidance

## 改善カテゴリ

- test
- docs drift guard

## 既存仕様への影響

- Runtime Ruby / JavaScript behavior は変更していません。
- docs prose の全文 snapshot や translation quality 判定には広げていません。
- #413 の lockfile / `npm ci` 復帰や #1506 の troubleshooting docs には触れていません。

## 実施した確認

- Branch freshness: `main` と比較し、branch は 1 commit ahead / 0 behind であることを確認しました。
- 差分範囲: `script/test_docs_entrypoints.mjs` のみであることを確認しました。
- Local smoke: 追加した英日 regex が代表文字列に一致することを Node で確認しました。

完全な `node script/test_docs_entrypoints.mjs` は、この実行環境では repository checkout / raw fetch が 403 で使えないため実行できていません。PR CI で full docs smoke を確認してください。

## リスク評価

- risk: low
- 既存 docs smoke に representative signal を足すだけのため影響範囲は小さいです。
- 正規表現は少数の stable setup signal に限定し、本文全体の brittle snapshot にはしていません。

## 補足事項

- 今回の3リポジトリ確認では、review follow-up は人間判断や既存環境制約が必要なものが中心で、この PR では新規 ready-for-agent quality issue #1513 を処理しました。