### PR TITLE
remote-state value docs の smoke guard を追加する

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -21,6 +21,10 @@ const publicApiDocs = [
   ["docs/en/public-api.md", read("docs/en/public-api.md")],
   ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
 ]
+const lazyLoadingDocs = [
+  ["docs/en/lazy-loading.md", read("docs/en/lazy-loading.md")],
+  ["docs/ja/lazy-loading.md", read("docs/ja/lazy-loading.md")]
+]
 
 const callbackBuilderSignals = [
   "render_state_callback_builder_keys",
@@ -37,6 +41,13 @@ const hostLifecycleSignals = [
   "retry",
   "TreeViewEventNames.remoteState",
   "TreeViewEventDetailKeys"
+]
+
+const remoteStateValueSignals = [
+  "TreeViewRemoteStateValues",
+  "loading",
+  "loaded",
+  "error"
 ]
 
 callbackBuilderSignals.forEach((signal) => {
@@ -66,5 +77,16 @@ publicApiDocs.forEach(([relativePath, document]) => {
   assert(
     /host app|host-app|host app 側|host-app 側/.test(document),
     `${relativePath}: host lifecycle event docs no longer name the host-app ownership boundary`
+  )
+})
+
+lazyLoadingDocs.forEach(([relativePath, document]) => {
+  remoteStateValueSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} remote-state value docs`)
+  })
+
+  assert(
+    /not event names|event 名ではありません/.test(document),
+    `${relativePath}: remote-state value docs no longer separate state values from event names`
   )
 })


### PR DESCRIPTION
## 対応 Issue

- Closes #1518

## Issue ごとの完了内容

- #1518: `TreeViewRemoteStateValues` と `loading` / `loaded` / `error` が lazy-loading docs 上で維持されるよう、既存の public API docs smoke に focused guard を追加しました。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に `docs/en/lazy-loading.md` / `docs/ja/lazy-loading.md` の読み取りを追加
- remote-state value が event name と別 surface である説明も smoke 対象に追加

## 改善カテゴリ

- docs drift guard
- test / smoke check 改善

## 既存仕様への影響

- runtime code、public API、UI、DB、認可、外部サービス契約は変更していません。
- docs smoke の対象を追加するだけで、既存挙動は変わりません。

## 実施した確認

- Issue #1518 の eligibility label を個別確認済み: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`
- PR 前に `main` との差分確認済み: 1 commit ahead / 0 behind、変更ファイルは `script/test_public_api_docs_signals.mjs` のみ
- 対象 docs の現行本文に `TreeViewRemoteStateValues`, `loading`, `loaded`, `error`, event-name との境界説明があることを確認済み
- この実行環境では GitHub への直接 clone が `CONNECT tunnel failed, response 403` でブロックされたため、ローカルでの `node script/test_public_api_docs_signals.mjs` 実行は未実施です。GitHub Actions での確認をお願いします。

## リスク評価

- risk: low
- smoke 対象追加のみで、失敗時も docs drift の検知に限定されます。

## 補足事項

- 既存 open PR #1516 は `review:needs-human` コメントがあるため、この実行では自動修正・merge せず停止扱いにしました。