### PR TITLE
remote-state value docs smoke guard を最新 main へ載せ直す

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -21,6 +21,10 @@ const publicApiDocs = [
   ["docs/en/public-api.md", read("docs/en/public-api.md")],
   ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
 ]
+const lazyLoadingDocs = [
+  ["docs/en/lazy-loading.md", read("docs/en/lazy-loading.md")],
+  ["docs/ja/lazy-loading.md", read("docs/ja/lazy-loading.md")]
+]
 
 const callbackBuilderSignals = [
   "render_state_callback_builder_keys",
@@ -37,6 +41,13 @@ const hostLifecycleSignals = [
   "retry",
   "TreeViewEventNames.remoteState",
   "TreeViewEventDetailKeys"
+]
+
+const remoteStateValueSignals = [
+  "TreeViewRemoteStateValues",
+  "loading",
+  "loaded",
+  "error"
 ]
 
 callbackBuilderSignals.forEach((signal) => {
@@ -66,5 +77,16 @@ publicApiDocs.forEach(([relativePath, document]) => {
   assert(
     /host app|host-app|host app 側|host-app 側/.test(document),
     `${relativePath}: host lifecycle event docs no longer name the host-app ownership boundary`
+  )
+})
+
+lazyLoadingDocs.forEach(([relativePath, document]) => {
+  remoteStateValueSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} remote-state value docs`)
+  })
+
+  assert(
+    /not event names|event 名ではありません/.test(document),
+    `${relativePath}: remote-state value docs no longer separate state values from event names`
   )
 })


### PR DESCRIPTION
remote-state value docs の smoke guard を latest main から clean refresh します。

Closes #1518
Supersedes #1522

## 変更内容

- `script/test_public_api_docs_signals.mjs` に `docs/en/lazy-loading.md` / `docs/ja/lazy-loading.md` の読み取りを追加
- `TreeViewRemoteStateValues` と `loading` / `loaded` / `error` が lazy-loading docs 上で維持されることを smoke 対象に追加
- remote-state value が event name と別 surface である説明も smoke 対象に追加

## 受け入れ条件との対応

- #1518 の docs drift guard intent を latest main 上へ再適用しました。
- runtime code、public API、UI、DB、認可、外部サービス契約は変更していません。
- docs smoke の対象追加に限定しています。

## 変更範囲

- `script/test_public_api_docs_signals.mjs`

## 実施した確認

- 既存 PR #1522 の Workflow Manager コメントを確認し、latest main refresh / fresh CI が必要な follow-up と分類
- latest `main` commit: `a2ecc868b149254d6e8d73fbd24f957c49fcf0d9`
- 旧 PR branch の対象ファイルと current main の対象ファイルを比較し、意図した 1 ファイル差分だけを再適用
- GitHub compare: `main...quality/1518-remote-state-docs-smoke-refresh`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_public_api_docs_signals.mjs`)
- local `node script/test_public_api_docs_signals.mjs` は GitHub HTTPS checkout 制限により未実行です。PR CI で確認します。

## リスク

low。smoke 対象追加のみで、失敗時も docs drift の検知に限定されます。

## 未対応・補足

- #1522 はこの PR で supersede します。