### PR TITLE
mockup copy policy exception を browser smoke で guard する

### DIFF
--- a/test/browser/docs_mockup_copy_policy.spec.js
+++ b/test/browser/docs_mockup_copy_policy.spec.js
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test"
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const mockupsRoot = path.join(repoRoot, "docs/mockups")
+const mockupsReadmePath = path.join(mockupsRoot, "README.md")
+const mockupsSmokePath = path.join(repoRoot, "test/browser/docs_mockups_smoke.spec.js")
+
+function readmeMockupFiles() {
+  const readme = readFileSync(mockupsReadmePath, "utf8")
+  const filesTable = readme.split("## Recommended review flow")[0]
+  const matches = filesTable.matchAll(/\[[^\]]+\.html\]\(([^)]+\.html)\)/g)
+
+  return Array.from(new Set(Array.from(matches, (match) => match[1])))
+}
+
+function mockupCopyExceptionRows() {
+  const readme = readFileSync(mockupsReadmePath, "utf8")
+  const policySection = readme.split("## Copy and language policy")[1]?.split("## Selection form guidance")[0] || ""
+  const rows = policySection
+    .split("\n")
+    .filter((line) => /^\| `[^`]+\.html` \|/.test(line))
+
+  return rows.map((line) => {
+    const [, mockup, exception, reason] = line.split("|").map((part) => part.trim())
+    return {
+      exception,
+      mockup: mockup.replace(/^`|`$/g, ""),
+      reason
+    }
+  })
+}
+
+test.describe("mockup copy and language policy", () => {
+  test("deliberate copy exceptions stay tied to listed browser-smoke mockups", () => {
+    const listedMockups = readmeMockupFiles()
+    const smokeSource = readFileSync(mockupsSmokePath, "utf8")
+    const exceptionRows = mockupCopyExceptionRows()
+
+    expect(exceptionRows.map((row) => row.mockup).sort()).toEqual([
+      "localized-row-labels.html",
+      "toolbar-actions.html"
+    ])
+
+    for (const row of exceptionRows) {
+      expect(row.exception, `${row.mockup} must describe its deliberate copy exception`).not.toEqual("")
+      expect(row.reason, `${row.mockup} must keep a review reason`).not.toEqual("")
+      expect(listedMockups).toContain(row.mockup)
+      expect(existsSync(path.join(mockupsRoot, row.mockup))).toBe(true)
+      expect(smokeSource).toContain(`file: "${row.mockup}"`)
+    }
+  })
+})


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #1531

## Issue ごとの完了内容

- #1531: README の copy / language exception table が、実在する mockup file と browser smoke 対象から drift しないことを lightweight な browser spec で確認できるようにしました。

## 変更内容

- `test/browser/docs_mockup_copy_policy.spec.js` を追加しました。
- `docs/mockups/README.md` の Copy and language policy から deliberate exception table を読み取ります。
- 現在の deliberate exception が `toolbar-actions.html` と `localized-row-labels.html` であることを確認します。
- 各 row について、例外説明と review reason が空でないこと、README Files table に載っていること、実ファイルが存在すること、既存 browser smoke target に含まれることを確認します。

## 改善カテゴリ

- test
- browser smoke
- docs drift guard

## 既存仕様への影響

挙動変更はありません。mockup HTML/CSS、runtime Ruby/JavaScript、public API、DB、認可、外部サービス契約には触れていません。host-app final copy や localization policy も決めていません。

## 実施した確認内容

- Issue #1531 の labels を個別確認しました: `agent:planned`, `status:ready-for-agent`, `track:quality`, `risk:low`。
- PR 作成前、最初の branch 作成後に `main` が進んだため、latest main `688a00ee699d0adc1f6506b14d48be36d497c521` から `quality/1531-mockup-copy-policy-smoke-v2` を作り直しました。
- PR 作成前 compare: `main...quality/1531-mockup-copy-policy-smoke-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- PR metadata: `mergeable:true`
- GitHub Actions CI #1947: success
- local `npm run test:browser` / `node --check` は未実行です。この環境では GitHub HTTPS が `CONNECT tunnel failed, response 403` で checkout できないため、GitHub Actions を確認証跡にしています。

## リスク評価

low。Markdown table parser の brittleness が主なリスクなので、検査は file existence / row completeness / smoke target membership に閉じています。