### PR TITLE
Installation docs に controller registration 例を追加する

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -89,6 +89,17 @@ Static rendering works without dedicated TreeView JavaScript. Turbo Stream expan
 
 JavaScript controllers are used for browser-side integration hooks such as state tracking, keyboard navigation, selection cascade, transfer events, and remote loading state.
 
+For importmap apps that already boot a Stimulus application, register the bundled controllers from the host app's JavaScript entrypoint:
+
+```js
+import { application } from "controllers/application"
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+Use `registerTreeViewControllers(application)` as the quick-start path for JavaScript-powered TreeView features. Host apps that need selective registration or a custom boot order can use `TreeViewControllerIdentifiers` from the public JavaScript surface; see [Public API](public-api.md#javascript-surface).
+
 ## Packaged files
 
 The gem package should include the files needed by Rails host apps:

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -89,6 +89,17 @@ pin "tree_view", to: "tree_view/index.js"
 
 JavaScript controllers は、state tracking、keyboard navigation、selection cascade、transfer events、remote loading stateなどのbrowser-side integration hookで使います。
 
+Stimulus application をすでに起動している importmap app では、host app の JavaScript entrypoint から bundled controllers を登録します。
+
+```js
+import { application } from "controllers/application"
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+JavaScript-powered な TreeView 機能を使う場合は、quick-start として `registerTreeViewControllers(application)` を使ってください。controller を部分登録したい場合や custom boot order が必要な場合は、public JavaScript surface の `TreeViewControllerIdentifiers` を使えます。詳しくは [Public API](public-api.md#javascript-surface) を参照してください。
+
 ## Packaged files
 
 TreeView gem package には、Rails host app で必要になる以下を含めます。


### PR DESCRIPTION
## 対応 Issue

Closes #1539

## 判定分類

- `docs-missing`
- `docs-sync`
- docs-only / low risk

## 変更内容

- `docs/en/installation.md` の JavaScript / importmap section に、Stimulus application へ `registerTreeViewControllers(application)` を呼ぶ最小例を追加しました。
- `docs/ja/installation.md` に同等の導入例を追加しました。
- quick-start は `registerTreeViewControllers(application)`、selective registration / custom boot order は Public API docs の JavaScript surface へ送る役割分担を明記しました。
- static rendering は専用 JavaScript なしでも使える、という既存の境界は維持しました。

## 変更範囲

- `docs/en/installation.md`
- `docs/ja/installation.md`

runtime JavaScript、controller identifiers、importmap file、public API manifest、TypeScript declaration は変更していません。

## 確認内容

- `app/javascript/tree_view/index.js` で `registerTreeViewControllers(application)` と `TreeViewControllerIdentifiers` が package-root export されていることを確認しました。
- `docs/en|ja/public-api.md` の JavaScript surface と矛盾しない導線にしました。
- GitHub compare: `main...docs/1539-controller-registration-installation`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs-only
- local checkout / local docs link check は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で利用できないため未実行です。
- CI は PR 作成後に確認します。

## リスク

low。既存 export と既存 docs に基づく installation guidance の追加だけで、controller registration behavior は変更していません。
