### PR TITLE
AGENTS.md の Public API docs 入口を現行構成に同期する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ Use these files as the durable documentation source:
 - `docs/en/design-policy.md` / `docs/ja/design-policy.md` — design intent, responsibility boundaries, include/exclude policy
 - `docs/en/installation.md` / `docs/ja/installation.md` — installation and asset/importmap setup
 - `docs/en/usage.md` / `docs/ja/usage.md` — usage examples
-- `docs/en/api.md` / `docs/ja/api.md` — public API reference
+- `docs/en/api.md` / `docs/ja/api.md` — practical API reference, options, behavior, and constraints
+- `docs/en/public-api.md` / `docs/ja/public-api.md` — public compatibility contract and machine-readable manifest surface
 - `docs/en/development.md` / `docs/ja/development.md` — development, CI, and documentation update rules
 - `docs/en/release.md` / `docs/ja/release.md` — release checklist, changelog expectations, and compatibility-note policy
 - `CHANGELOG.md` — release-facing summary of public changes, compatibility notes, and notable documentation additions
@@ -97,7 +98,8 @@ When behavior, public API, setup steps, or design intent changes, update the rel
 - Design decisions: `docs/en/design-policy.md` and `docs/ja/design-policy.md`
 - Installation changes: `docs/en/installation.md` and `docs/ja/installation.md`
 - Usage changes: `docs/en/usage.md` and `docs/ja/usage.md`
-- API changes: `docs/en/api.md` and `docs/ja/api.md`
+- API reference changes: `docs/en/api.md` and `docs/ja/api.md`
+- Public API contract or manifest-backed surface changes: `docs/en/public-api.md` and `docs/ja/public-api.md`
 - Development and CI changes: `docs/en/development.md` and `docs/ja/development.md`
 - Cross-language maintenance rules: `docs/i18n-audit.md`
 - When `config/public_api_manifest.yml` changes, also review `docs/en/public-api.md`, `docs/ja/public-api.md`, the affected usage or feature docs, `CHANGELOG.md`, and `docs/en/release.md` / `docs/ja/release.md` when release notes or migration expectations need to change


### PR DESCRIPTION
## 判定分類

- `docs-stale`
- docs-only / low risk

## 背景

現行 docs では、実用的な API reference は `docs/en|ja/api.md`、互換性契約と machine-readable manifest surface は `docs/en|ja/public-api.md` に分かれています。

一方で `AGENTS.md` の durable documentation source と docs update rules は `api.md` だけを public API reference として挙げており、`public-api.md` の役割が同じ一覧に出ていませんでした。

## 変更内容

- `docs/en/api.md` / `docs/ja/api.md` を practical API reference として説明し直しました。
- `docs/en/public-api.md` / `docs/ja/public-api.md` を public compatibility contract / machine-readable manifest surface として durable docs list に追加しました。
- Documentation Rules でも API reference changes と Public API contract / manifest-backed surface changes を分けました。

## 変更範囲

- `AGENTS.md`

README、docs本文、Product Profile、CHANGELOG、runtime code、spec、CI workflow、public API manifest は変更していません。

## 確認内容

- current main: `ea5fbcf346d9bc1e9260507a3a9bfe3a79ef913b`
- compare: `main...docs/agents-public-api-source-v2`
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1 docs-only (`AGENTS.md`)
- local checkout / local docs link check は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で利用できないため未実行です。
- CI は PR 作成後に確認します。

## リスク

low。現行 docs 構造への AGENTS.md の追従だけで、仕様・公開 API・実装・manifest contract は変更していません。