### PR TITLE
docs: DOM helper の public boundary を明確にする

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -88,6 +88,8 @@ For host apps that own lazy-loading placeholder regions, these three lazy-loadin
 
 Pass the parent item that owns the lazy-loading placeholder to the lazy-loading helper methods. `tree_node_dom_id(item_or_id, ...)` remains the broader DOM ID helper for item-like or id-like values; the placeholder helpers are documented for item-based lazy-loading regions so they stay aligned with the row and Turbo Stream examples.
 
+DOM and path helpers that are absent from `config/public_api_manifest.yml` remain internal composition helpers, even when bundled partials call them. For example, `tree_button_dom_id`, `tree_show_button_dom_id`, `tree_selection_checkbox_dom_id`, and toggle or lazy-loading path helpers are reserved for TreeView's own partial and helper composition. Host apps should depend on the manifest-backed node, children-container, and remote-state placeholder helpers above rather than those internal helper names.
+
 For app-owned toolbar builders, use `tree_view_toolbar_supported_actions`, `tree_view_toolbar_actions`, and `tree_view_toolbar_action_metadata` rather than internal constants.
 Documented toolbar helpers are part of that public helper surface:
 
@@ -274,12 +276,14 @@ Representative documented hooks are tracked where their feature behavior is expl
 |---|---|---|
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | TreeView-owned hooks documented in [Toolbar](toolbar.md). Use helper methods for supported actions and metadata instead of internal constants. |
 | Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Stable host-element controller values documented in [Selection](selection.md) and mirrored by `TreeViewSelectionDataHooks`. Row payloads and disabled decisions stay with `selection:` render-state builders. Generated hidden input marker attributes and source-id attributes are TreeView-managed internals. |
-| Lazy loading | `data-tree-remote-state`, remote placeholder IDs, lazy-loading lifecycle events | Stable placeholder and event hooks documented in [Lazy Loading](lazy-loading.md). Host apps still own request dispatch and response handling. |
+| Lazy loading | `data-tree-remote-state`, remote placeholder IDs, lazy-loading lifecycle events | Stable placeholder and event hooks documented in [Lazy Loading](lazy-loading.md). Host apps still own request dispatch and response handling. Use `tree_children_container_dom_id`, `tree_remote_state_placeholder_dom_id`, and `tree_remote_state_placeholder_attributes` for placeholder IDs and state attributes rather than internal path or toggle helpers. |
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | Reusable baseline hooks documented in the [mockup inventory](../mockups/README.md). They describe the shipped empty-state reference pattern, not every internal row class. |
 | Interaction markers | marker row classes and `data-*` hooks shown in focused mockups | Reference hooks documented through [mockups](../mockups/README.md) for review and adoption. Promote any hook to a machine-readable contract in `config/public_api_manifest.yml` only when it needs compatibility checks. |
 | Direction-aware styling | current-row cues, hierarchy connectors, toggle spacing, RTL / vertical writing override references | Responsibility boundary and host-app stylesheet override guidance live in [Direction-aware styling boundary](direction-aware-styling.md). These cues are not machine-readable public styling hooks unless they are explicitly promoted into manifest-backed checks. |
 
 This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, selection data hooks, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
+
+DOM helper names that are not listed in the manifest remain internal even when the generated DOM IDs or attributes appear in bundled markup. In particular, button, selection-checkbox, toggle-path, and lazy-loading path helper names are not public host-app dependencies unless they are promoted into the manifest and documented here.
 
 Undocumented CSS helper classes, data attributes, DOM structure details, and gem partial locals are implementation details.
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -88,6 +88,8 @@ lazy-loading の placeholder region を host app 側で持つ場合、上の 3 h
 
 lazy-loading helper には、その placeholder を所有する parent item を渡してください。`tree_node_dom_id(item_or_id, ...)` は item-like / id-like value を扱うより広い DOM ID helper のままです。一方、placeholder helper は row と Turbo Stream の例に合わせて、item-based lazy-loading region 用の公開 surface として document します。
 
+`config/public_api_manifest.yml` に存在しない DOM / path helper は、bundled partial から呼ばれていても内部 composition helper のままです。たとえば `tree_button_dom_id`、`tree_show_button_dom_id`、`tree_selection_checkbox_dom_id`、toggle / lazy-loading path helper 群は TreeView 自身の partial / helper composition 用に予約されています。host app はそれらの内部 helper 名ではなく、上記の manifest-backed な node、children container、remote-state placeholder helper に依存してください。
+
 app-owned toolbar builder では、internal constant を直接参照せず、`tree_view_toolbar_supported_actions`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` を使ってください。
 toolbar helper もこの公開 helper surface に含まれます。
 
@@ -274,12 +276,14 @@ host app が依存してよい browser-facing surface は、documented された
 |---|---|---|
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | [Toolbar](toolbar.md) で説明している TreeView-owned hook です。supported action や metadata は internal constant ではなく helper method から取得してください。 |
 | Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | [Selection](selection.md) で説明している stable host-element controller value であり、`TreeViewSelectionDataHooks` からも参照できます。row payload や disabled 判定は `selection:` render-state builder 側に残ります。generated hidden input marker attribute と source-id attribute は TreeView-managed internal です。 |
-| Lazy loading | `data-tree-remote-state`, remote placeholder ID, lazy-loading lifecycle events | [Lazy Loading](lazy-loading.md) で説明している stable placeholder / event hook です。request dispatch と response handling は引き続き host app 側の責務です。 |
+| Lazy loading | `data-tree-remote-state`, remote placeholder ID, lazy-loading lifecycle events | [Lazy Loading](lazy-loading.md) で説明している stable placeholder / event hook です。request dispatch と response handling は引き続き host app 側の責務です。placeholder ID と state attribute には `tree_children_container_dom_id`、`tree_remote_state_placeholder_dom_id`、`tree_remote_state_placeholder_attributes` を使い、internal path / toggle helper には依存しないでください。 |
 | Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | [mockup inventory](../mockups/README.md) で説明している reusable baseline hook です。shipped empty-state reference pattern を示すもので、すべての internal row class を公開するものではありません。 |
 | Interaction markers | focused mockup に出てくる marker row classes / `data-*` hooks | review / adoption 用の reference hook として [mockups](../mockups/README.md) で説明します。compatibility check が必要な hook だけを `config/public_api_manifest.yml` の machine-readable contract へ昇格してください。 |
 | Direction-aware styling | current-row cue、hierarchy connector、toggle spacing、RTL / vertical writing override reference | 責務境界と host-app stylesheet override guidance は [Direction-aware styling boundary](direction-aware-styling.md) を参照してください。これらの cue は、明示的に manifest-backed check へ昇格されるまでは machine-readable public styling hook ではありません。 |
 
 この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、selection data hook、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
+
+manifest に載っていない DOM helper 名は、生成される DOM ID や attribute が bundled markup に現れていても内部扱いです。特に button、selection checkbox、toggle path、lazy-loading path helper 名は、manifest に昇格されこのページで document されるまでは host app の公開依存先ではありません。
 
 undocumented な CSS helper class、data attribute、DOM 構造詳細、gem partial 内部 locals は内部実装です。
 


### PR DESCRIPTION
DOM / path helper 群の public / internal 境界を、manifest-backed helper surface に合わせて英日 public API docs へ明記します。

## 対応 Issue

Closes #1380

## 変更内容

- `docs/en/public-api.md` に、`config/public_api_manifest.yml` に載っていない DOM / path helper は internal composition helper であることを追記しました。
- `docs/ja/public-api.md` に同等の説明を追加しました。
- `tree_button_dom_id` / `tree_show_button_dom_id` / `tree_selection_checkbox_dom_id` / toggle・lazy-loading path helper 群は public contract へ昇格しない、と具体例で明示しました。
- host app が依存してよい DOM helper は、現行 manifest-backed な node / children container / remote-state placeholder helper に寄せる説明にしました。

## 受け入れ条件との対応

- public に昇格しない判断が docs から読めるようになりました。
- 英日 public API docs で manifest 掲載 helperと bundled partial 内部 helper の境界を揃えました。
- 既存 public helper contract は変更していません。
- `config/public_api_manifest.yml` と `spec/public_api_compatibility_spec.rb` は、Planner handoff に従い変更していません。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`

runtime Ruby / JavaScript、DOM id generation、UiConfig builder behavior、selection checkbox markup、Turbo route policy、public API manifest schema は変更していません。

## 実施した確認

- Issue #1380 の label と Planner handoff を確認しました。
- 対応する既存 open PR がないことを確認しました。
- GitHub compare: `main...docs/1380-dom-helper-boundary-current`
  - changed files: 2 docs-only
  - `docs/en/public-api.md`
  - `docs/ja/public-api.md`
- 作業中に main が 1 commit 進みましたが、latest main の対象2ファイル SHA は作業前と同じで、対象ファイルに重なりがないことを確認しました。
- local checkout / docs smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR 作成後に GitHub Actions を確認します。

## リスク

medium。public / internal boundary の docs 明確化のみですが、host app が依存してよい helper 範囲の読み方に関わるため、manifest-backed helper を増やさない既存方針として表現しています。

## 未対応・補足

- 新しい helper の public manifest 追加はしていません。
- 既存の古い空 branch `docs/1380-dom-helper-boundary` は変更していません。