### PR TITLE
NodePresenter builder names を current main で再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -36,6 +36,16 @@ public_constants:
   - PersistedState
   - StateStore
   - Diagnostics
+node_presenter_builder_names:
+  - key
+  - label
+  - href
+  - tooltip
+  - row_class
+  - row_data
+  - icon
+  - badge
+  - actions
 path_tree_builder_node_shapes:
   folder_node:
     constant: PathTreeBuilder::FolderNode

--- a/docs/en/node-presenter-row-partials.md
+++ b/docs/en/node-presenter-row-partials.md
@@ -42,6 +42,10 @@ Host apps own product-specific rendering:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` and its builder names are part of the public compatibility contract. The machine-readable builder list lives in `config/public_api_manifest.yml` as `node_presenter_builder_names`, and compatibility specs check it against `TreeView::NodePresenter::BUILDER_NAMES`.
+
+That contract stabilizes the available builder names only. The meaning of returned labels, links, row data, action identifiers, badges, icons, and any authorization or formatting decisions remains host-app owned and is intentionally shown here as cookbook guidance.
+
 ## Example presenter
 
 ```ruby

--- a/docs/ja/node-presenter-row-partials.md
+++ b/docs/ja/node-presenter-row-partials.md
@@ -42,6 +42,10 @@ Host app が担当するもの:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` とその builder 名は public compatibility contract の一部です。machine-readable な builder list は `config/public_api_manifest.yml` の `node_presenter_builder_names` に置き、compatibility spec で `TreeView::NodePresenter::BUILDER_NAMES` と照合します。
+
+この contract が安定させるのは利用可能な builder 名です。返される label、link、row data、action identifier、badge、icon の意味や、authorization / formatting の判断は host app 側の責務であり、この guide では cookbook として例示します。
+
 ## presenter 例
 
 ```ruby

--- a/spec/node_presenter_public_manifest_spec.rb
+++ b/spec/node_presenter_public_manifest_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+NODE_PRESENTER_PUBLIC_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+RSpec.describe "NodePresenter public manifest" do
+  def public_api_manifest
+    @public_api_manifest ||= YAML.safe_load_file(NODE_PRESENTER_PUBLIC_MANIFEST_PATH)
+  end
+
+  it "keeps documented builder names aligned with NodePresenter" do
+    manifest_names = public_api_manifest.fetch("node_presenter_builder_names")
+
+    expect(manifest_names).to eq(TreeView::NodePresenter::BUILDER_NAMES.map(&:to_s)),
+      "expected NodePresenter builder names to stay aligned with the manifest-backed public contract"
+  end
+end

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -10,6 +10,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   module_methods
   configuration_options
   public_constants
+  node_presenter_builder_names
   path_tree_builder_node_shapes
   helper_methods
   helper_option_keys
@@ -85,6 +86,14 @@ RSpec.describe "Public API manifest structure" do
       expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
       expect(keys).to all(be_a(String))
     end
+  end
+
+  it "keeps NodePresenter builder names shaped as a non-empty string list" do
+    builder_names = manifest.fetch("node_presenter_builder_names")
+
+    expect(builder_names).to be_an(Array)
+    expect(builder_names).not_to be_empty
+    expect(builder_names).to all(be_a(String))
   end
 
   it "keeps resource table render state keyword sections shaped as non-empty string lists" do


### PR DESCRIPTION
NodePresenter builder names を current main の manifest-backed public contract として再提案します。

## 対応 Issue / PR

Refs #1032
Superseded by #1556

## 置き換え理由

この PR は作成直後に `main` が 1 commit 進み、`behind_by:1` / `status:diverged` になったため、current main 起点の v2 PR #1556 で置き換えました。