### PR TITLE
Children Pagination guide から focused mockup へ導線を追加する

### DIFF
--- a/docs/en/children-pagination.md
+++ b/docs/en/children-pagination.md
@@ -155,6 +155,8 @@ Render the initial next-page placeholder where the host app wants it to appear:
 </tr>
 ```
 
+Use [children-pagination.html](../mockups/children-pagination.html) when you want a static visual reference for next-page placeholder placement and branch-scoped load-more affordances. The mockup is a review aid only; cursor encoding, Turbo Stream responses, final button copy, and retry behavior remain host-app responsibilities.
+
 ## Relationship to lazy loading
 
 Children pagination is built by the host app on top of lazy loading.

--- a/docs/ja/children-pagination.md
+++ b/docs/ja/children-pagination.md
@@ -155,6 +155,8 @@ host app側で、children rowsと「もっと見る」UIを返します。
 </tr>
 ```
 
+次page placeholder の配置や branch-scoped load-more affordance を静的に確認したい場合は、[children-pagination.html](../mockups/children-pagination.html) を使ってください。この mockup は review aid であり、cursor encoding、Turbo Stream response、最終 button copy、retry behavior は host app 側の責務です。
+
 ## lazy loadingとの関係
 
 children pagination は lazy loading の上にhost app側で作る仕組みです。


### PR DESCRIPTION
## 対応 Issue

Closes #651

## 判定分類

- `docs-sync`
- `docs-stale`
- docs-only / low risk

## 背景

Issue #651 は、Selection / Children Pagination guide から focused mockup への導線を補う docs follow-up です。過去 run では参照先 mockup が `main` に無く `docs-ahead-of-code` として停止していましたが、current `main` では `docs/mockups/children-pagination.html` と `docs/mockups/children-pagination-selection-boundary.html` が存在します。

Selection guide 側は既に `selection-multi-tree-form.html` と `children-pagination-selection-boundary.html` への導線を持っているため、この PR では Children Pagination guide の次ページ placeholder / load-more placement への導線だけを補います。

## 変更内容

- `docs/en/children-pagination.md` に `children-pagination.html` への short cross-reference を追加しました。
- `docs/ja/children-pagination.md` に同等の導線を追加しました。
- mockup は review aid であり、cursor encoding、Turbo Stream response、final button copy、retry behavior は host app responsibility のままと明記しました。

## 変更範囲

- `docs/en/children-pagination.md`
- `docs/ja/children-pagination.md`

runtime Ruby / JavaScript、mockup HTML/CSS、docs index、README、AGENTS.md、Product Profile は変更していません。

## 確認内容

- current main: `ec65dc4a67e7565d9f508341c35fa8da07a2c3a4`
- compare: `main...docs/651-children-pagination-mockup-links-v2`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs-only
- `docs/mockups/README.md` に `children-pagination.html` と `children-pagination-selection-boundary.html` が存在することを確認しました。
- local checkout / local docs link check は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で利用できないため未実行です。
- CI は PR 作成後に確認します。

## リスク

low。既存 mockup への cross-reference 追加だけで、pagination behavior や mockup surface は変更していません。