### PR TITLE
NodePresenter builder names を current main で再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -36,6 +36,16 @@ public_constants:
   - PersistedState
   - StateStore
   - Diagnostics
+node_presenter_builder_names:
+  - key
+  - label
+  - href
+  - tooltip
+  - row_class
+  - row_data
+  - icon
+  - badge
+  - actions
 path_tree_builder_node_shapes:
   folder_node:
     constant: PathTreeBuilder::FolderNode

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -46,6 +46,12 @@ node_presenter_builder_names:
   - icon
   - badge
   - actions
+graph_adapter_initializer:
+  required_keywords:
+    - roots
+    - children_resolver
+  optional_keywords:
+    - node_key_resolver
 path_tree_builder_node_shapes:
   folder_node:
     constant: PathTreeBuilder::FolderNode
@@ -115,6 +121,17 @@ toolbar_actions:
   expand_all: expanded
   collapse_all: collapsed
   collapse_all_except_current_path: current_path
+toolbar_action_metadata:
+  keys:
+    - action
+    - state
+    - label
+    - path
+    - disabled
+    - data
+  data_keys:
+    - tree_view_toolbar_action
+    - tree_view_toolbar_disabled
 grouped_option_keys:
   initial_expansion:
     - default
@@ -153,6 +170,19 @@ grouped_option_keys:
     - row_disabled_builder
     - row_readonly_builder
     - row_disabled_reason_builder
+diagnostics:
+  accepted_checks:
+    - node_keys
+    - dom_ids
+    - orphans
+    - cycles
+  result_surface:
+    attributes:
+      - checks
+      - errors
+      - warnings
+    methods:
+      - success?
 resource_table_render_state_call:
   required_keywords:
     - records
@@ -181,6 +211,7 @@ javascript_package_root:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
     - TreeViewSelectionDataHooks
+    - TreeViewEmptyStateHooks
     - TreeViewTransferDropPositions
     - TreeViewRemoteStateValues
     - TreeViewStateController
@@ -295,3 +326,7 @@ javascript_package_root:
     max_count_value: data-tree-view-selection-max-count-value
     cascade_value: data-tree-view-selection-cascade-value
     indeterminate_value: data-tree-view-selection-indeterminate-value
+  empty_state_hooks:
+    wrapper_attribute: data-tree-view-empty-state
+    content_class: tree-view-empty-row__content
+    message_class: tree-view-empty-row__message

--- a/docs/en/node-presenter-row-partials.md
+++ b/docs/en/node-presenter-row-partials.md
@@ -8,6 +8,7 @@ The goal is to keep shared tree concepts in the gem and leave app-specific table
 
 - Use [Localized names](localized-names.md) when presenter labels, tooltips, badges, or node type names should follow the host app locale.
 - Use [Host app extension points](host-app-extension-points.md#row_partial) to decide whether a concern belongs in `row_partial`, a builder, or host-app UI code.
+- Use [node-presenter-row-partials.html](../mockups/node-presenter-row-partials.html) as the static visual reference when reviewing resolver-provided labels, links, badges, icons, and optional actions beside host-app-owned columns and permissions. The mockup is a review aid, not a Column / Action DSL or final business UI contract.
 
 ## Why not a Column / Action DSL yet?
 

--- a/docs/en/node-presenter-row-partials.md
+++ b/docs/en/node-presenter-row-partials.md
@@ -42,6 +42,10 @@ Host apps own product-specific rendering:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` and its builder names are part of the public compatibility contract. The machine-readable builder list lives in `config/public_api_manifest.yml` as `node_presenter_builder_names`, and compatibility specs check it against `TreeView::NodePresenter::BUILDER_NAMES`.
+
+That contract stabilizes the available builder names only. The meaning of returned labels, links, row data, action identifiers, badges, icons, and any authorization or formatting decisions remains host-app owned and is intentionally shown here as cookbook guidance.
+
 ## Example presenter
 
 ```ruby

--- a/docs/ja/node-presenter-row-partials.md
+++ b/docs/ja/node-presenter-row-partials.md
@@ -8,6 +8,7 @@
 
 - presenter の label、tooltip、badge、node type 名を host app の locale に合わせたい場合は [Localized names](localized-names.md) を参照してください。
 - その関心ごとを `row_partial`、builder、host app 側 UI code のどこに置くべきか迷う場合は [Host app extension points](host-app-extension-points.md#row_partial) を参照してください。
+- resolver が返す label、link、badge、icon、任意 action を host app 側の column や permission と並べて確認したい場合は、静的な visual reference として [node-presenter-row-partials.html](../mockups/node-presenter-row-partials.html) を使ってください。この mockup は review aid であり、Column / Action DSL や最終的な business UI contract ではありません。
 
 ## なぜ今 Column / Action DSL を入れないのか
 

--- a/docs/ja/node-presenter-row-partials.md
+++ b/docs/ja/node-presenter-row-partials.md
@@ -42,6 +42,10 @@ Host app が担当するもの:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` とその builder 名は public compatibility contract の一部です。machine-readable な builder list は `config/public_api_manifest.yml` の `node_presenter_builder_names` に置き、compatibility spec で `TreeView::NodePresenter::BUILDER_NAMES` と照合します。
+
+この contract が安定させるのは利用可能な builder 名です。返される label、link、row data、action identifier、badge、icon の意味や、authorization / formatting の判断は host app 側の責務であり、この guide では cookbook として例示します。
+
 ## presenter 例
 
 ```ruby

--- a/spec/node_presenter_public_manifest_spec.rb
+++ b/spec/node_presenter_public_manifest_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+NODE_PRESENTER_PUBLIC_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+RSpec.describe "NodePresenter public manifest" do
+  def public_api_manifest
+    @public_api_manifest ||= YAML.safe_load_file(NODE_PRESENTER_PUBLIC_MANIFEST_PATH)
+  end
+
+  it "keeps documented builder names aligned with NodePresenter" do
+    manifest_names = public_api_manifest.fetch("node_presenter_builder_names")
+
+    expect(manifest_names).to eq(TreeView::NodePresenter::BUILDER_NAMES.map(&:to_s)),
+      "expected NodePresenter builder names to stay aligned with the manifest-backed public contract"
+  end
+end

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -10,6 +10,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   module_methods
   configuration_options
   public_constants
+  node_presenter_builder_names
   path_tree_builder_node_shapes
   helper_methods
   helper_option_keys
@@ -85,6 +86,14 @@ RSpec.describe "Public API manifest structure" do
       expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
       expect(keys).to all(be_a(String))
     end
+  end
+
+  it "keeps NodePresenter builder names shaped as a non-empty string list" do
+    builder_names = manifest.fetch("node_presenter_builder_names")
+
+    expect(builder_names).to be_an(Array)
+    expect(builder_names).not_to be_empty
+    expect(builder_names).to all(be_a(String))
   end
 
   it "keeps resource table render state keyword sections shaped as non-empty string lists" do

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -11,11 +11,14 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   configuration_options
   public_constants
   node_presenter_builder_names
+  graph_adapter_initializer
   path_tree_builder_node_shapes
   helper_methods
   helper_option_keys
   toolbar_actions
+  toolbar_action_metadata
   grouped_option_keys
+  diagnostics
   resource_table_render_state_call
   render_state_callback_builder_keys
   javascript_package_root


### PR DESCRIPTION
NodePresenter builder names を current main の manifest-backed public contract として再提案します。

## 対応 Issue / PR

Closes #1032
Supersedes #1299
Supersedes #1553

## 置き換え理由

PR #1299 は #1032 の意図には合っていましたが、current `main` から大きく diverged し、PR diff が public API manifest / docs / mockup / JS entrypoint 周辺まで 26 files に広がっていました。旧 branch の blob を戻すと current main の public API / docs 更新を巻き戻すリスクがあるため、current `main` (`ec65dc4a67e7565d9f508341c35fa8da07a2c3a4`) から clean replacement branch を作成し、NodePresenter builder names の最小差分だけを再適用しました。

#1553 は直前 main から作成後に `main` が 1 commit 進み、`behind_by:1` / `status:diverged` になったため、この v2 PR で置き換えます。

## 変更内容

- `config/public_api_manifest.yml` に `node_presenter_builder_names` を追加しました。
- manifest structure spec に新 top-level section を追加し、builder list が非空の string list であることを確認します。
- focused spec を追加し、manifest の builder names が `TreeView::NodePresenter::BUILDER_NAMES` と一致することを確認します。
- 英日 `docs/*/node-presenter-row-partials.md` に、安定化するのは builder 名であり、返り値の意味・markup・authorization・formatting は host app responsibility のままであることを追記しました。

## 受け入れ条件との対応

- NodePresenter builder names を manifest-backed public contract に含めました。
- manifest と spec が builder list drift を検出します。
- NodePresenter docs は public contract と cookbook-level rendering examples を混同しない説明にしています。
- Column / Action DSL、NodePresenter runtime behavior、builder 名、return value、row partial locals は変更していません。

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_api_manifest_structure_spec.rb`
- `spec/node_presenter_public_manifest_spec.rb`
- `docs/en/node-presenter-row-partials.md`
- `docs/ja/node-presenter-row-partials.md`

## 確認内容

- GitHub compare: `main...feature/1032-node-presenter-builder-manifest-current-v2`
  - `ahead_by: 5`
  - `behind_by: 0`
  - changed files: 5
- local checkout / local RSpec は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR CI で確認します。

## リスク

medium。public manifest contract を増やす変更ですが、既存 documented / tested builder names を固定するだけで runtime behavior は変更していません。

## 未対応・補足

- #1299 と #1553 はこの PR で supersede します。
- public manifest contract として採用する最終判断は human review に残します。