### PR TITLE
transfer DataTransfer MIME type を current main で再提案する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -71,6 +71,11 @@ export declare const TreeViewTransferDropPositions: Readonly<{
   after: "after"
 }>
 
+export declare const TreeViewTransferDataMimeTypes: Readonly<{
+  applicationJson: "application/json"
+  textPlain: "text/plain"
+}>
+
 export declare const TreeViewControllerIdentifiers: Readonly<{
   state: "tree-view-state"
   client: "tree-view-client"

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -74,6 +74,11 @@ export const TreeViewTransferDropPositions = Object.freeze({
   after: "after"
 })
 
+export const TreeViewTransferDataMimeTypes = Object.freeze({
+  applicationJson: "application/json",
+  textPlain: "text/plain"
+})
+
 export const TreeViewControllerIdentifiers = Object.freeze({
   state: "tree-view-state",
   client: "tree-view-client",

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -172,6 +172,7 @@ javascript_package_root:
     - TreeViewControllerIdentifiers
     - TreeViewSelectionDataHooks
     - TreeViewTransferDropPositions
+    - TreeViewTransferDataMimeTypes
     - TreeViewRemoteStateValues
     - TreeViewStateController
     - TreeViewClientController
@@ -184,6 +185,9 @@ javascript_package_root:
     before: before
     inside: inside
     after: after
+  transfer_data_mime_types:
+    application_json: application/json
+    text_plain: text/plain
   remote_state_values:
     loading: loading
     loaded: loaded

--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -93,6 +93,8 @@ function onDrop(event) {
 }
 ```
 
+`application/json` is the primary TreeView transfer MIME type for host apps to read. TreeView also writes the same JSON payload to `text/plain` as a browser compatibility fallback. Host apps that want machine-readable strings can import `TreeViewTransferDataMimeTypes` from the package root and read `TreeViewTransferDataMimeTypes.applicationJson` first, then `TreeViewTransferDataMimeTypes.textPlain` only as fallback.
+
 Host apps can also listen for the public transfer events dispatched by the `tree-view-transfer` controller instead of reading controller internals directly.
 
 ```js

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -93,6 +93,8 @@ function onDrop(event) {
 }
 ```
 
+`application/json` は、host app が通常読む primary な TreeView transfer MIME type です。TreeView は browser compatibility fallback として、同じ JSON payload を `text/plain` にも書き込みます。machine-readable な文字列を使いたい host app は package root から `TreeViewTransferDataMimeTypes` を import し、まず `TreeViewTransferDataMimeTypes.applicationJson` を読み、必要な場合だけ `TreeViewTransferDataMimeTypes.textPlain` を fallback として使ってください。
+
 host appは controller 内部に直接依存せず、`tree-view-transfer` controller がdispatchする公開transfer eventをlistenできます。
 
 ```js

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -341,6 +341,14 @@ assertDeepEqualExport(
 )
 assertFrozenObject(entrypointModule.TreeViewTransferDropPositions, "TreeViewTransferDropPositions")
 
+const expectedTransferDataMimeTypes = deepCamelizeKeys(javascriptPackageManifest.transfer_data_mime_types)
+assertDeepEqualExport(
+  entrypointModule.TreeViewTransferDataMimeTypes,
+  expectedTransferDataMimeTypes,
+  "TreeViewTransferDataMimeTypes"
+)
+assertFrozenObject(entrypointModule.TreeViewTransferDataMimeTypes, "TreeViewTransferDataMimeTypes")
+
 const expectedRemoteStateValues = javascriptPackageManifest.remote_state_values
 assert(
   JSON.stringify(entrypointModule.TreeViewRemoteStateValues) === JSON.stringify(expectedRemoteStateValues),


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1177
Supersedes #1302
Supersedes #1181

## 置き換え理由

PR #1302 は #1177 の意図には合っていましたが、current `main` から `base_sha:77cb354e...` のまま古くなり、`mergeable:false` になっていました。旧 branch の blob を戻すと、current main の selection / remote-state export、manifest、docs smoke、NodePresenter manifest 周辺の後続変更を巻き戻すリスクがあるため、current `main` (`ec65dc4a67e7565d9f508341c35fa8da07a2c3a4`) から clean replacement として同じ MIME type contract だけを再適用しました。

## 変更内容

- package root export に `TreeViewTransferDataMimeTypes` を追加しました。
  - `applicationJson: "application/json"`
  - `textPlain: "text/plain"`
- TypeScript declaration に同じ export を追加し、current main の entrypoint smoke と整合させました。
- `config/public_api_manifest.yml` に named export と `transfer_data_mime_types` key set を追加しました。
- `script/test_entrypoints.mjs` で manifest / runtime export / declaration の同期を確認します。
- 英日 drag-and-drop docs に、host app が通常読む primary key は `application/json`、`text/plain` は browser compatibility fallback であることを追記しました。

## current main から保持した内容

current `main` の `TreeViewSelectionDataHooks` / `TreeViewRemoteStateValues` declarations、event detail manifest、docs entrypoint smoke、NodePresenter builder names manifest PR 由来の main 差分などは保持しています。旧 #1302 branch の古いファイル全文は戻していません。

## 既存仕様への影響

transfer payload shape、event names、event detail keys、drop positions、runtime drag/drop behavior、認可、DB、外部 API、host-app authorization / business operation policy は変更していません。既存実装済みの MIME key set を machine-readable な public package-root export / manifest contract として固定する additive quality 変更です。

## 確認内容

- GitHub compare: `main...feature/1177-transfer-mime-types-current-v2`
  - `ahead_by: 6`
  - `behind_by: 0`
  - changed files: 6
    - `app/javascript/tree_view/index.js`
    - `app/javascript/tree_view/index.d.ts`
    - `config/public_api_manifest.yml`
    - `script/test_entrypoints.mjs`
    - `docs/en/drag-and-drop.md`
    - `docs/ja/drag-and-drop.md`
- local checkout / local test は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR CI で確認します。

## リスク

medium。public package-root export と manifest contract の追加ですが、runtime behavior は変更せず、既存 controller が利用している MIME type 値を公開定数として固定する範囲に閉じています。

## 補足

#1302 は、この PR の作成後に superseded としてコメント / close します。