### PR TITLE
NodePresenter guide と mockup 導線を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Key documents:
 | Turbo Frame option | [Turbo Frame option](docs/en/turbo-frame.md) | [Turbo Frame オプション](docs/ja/turbo-frame.md) |
 | Persisted State | [Persisted State](docs/en/persisted-state.md) | [Persisted State](docs/ja/persisted-state.md) |
 | Localized names | [Localized names](docs/en/localized-names.md) | [ローカライズされた名前](docs/ja/localized-names.md) |
+| NodePresenter row partial patterns | [NodePresenter row partial patterns](docs/en/node-presenter-row-partials.md) | [NodePresenter row partial パターン](docs/ja/node-presenter-row-partials.md) |
 | Decision guide | [Decision guide](docs/en/decision-guide.md) | [API判断ガイド](docs/ja/decision-guide.md) |
 | FAQ | [FAQ](docs/en/faq.md) | [FAQ](docs/ja/faq.md) |
 | Troubleshooting | [Troubleshooting](docs/en/troubleshooting.md) | [Troubleshooting](docs/ja/troubleshooting.md) |

--- a/docs/en/node-presenter-row-partials.md
+++ b/docs/en/node-presenter-row-partials.md
@@ -8,6 +8,7 @@ The goal is to keep shared tree concepts in the gem and leave app-specific table
 
 - Use [Localized names](localized-names.md) when presenter labels, tooltips, badges, or node type names should follow the host app locale.
 - Use [Host app extension points](host-app-extension-points.md#row_partial) to decide whether a concern belongs in `row_partial`, a builder, or host-app UI code.
+- Use [node-presenter-row-partials.html](../mockups/node-presenter-row-partials.html) as the static visual reference when reviewing resolver-provided labels, links, badges, icons, and optional actions beside host-app-owned columns and permissions. The mockup is a review aid, not a Column / Action DSL or final business UI contract.
 
 ## Why not a Column / Action DSL yet?
 

--- a/docs/ja/node-presenter-row-partials.md
+++ b/docs/ja/node-presenter-row-partials.md
@@ -8,6 +8,7 @@
 
 - presenter の label、tooltip、badge、node type 名を host app の locale に合わせたい場合は [Localized names](localized-names.md) を参照してください。
 - その関心ごとを `row_partial`、builder、host app 側 UI code のどこに置くべきか迷う場合は [Host app extension points](host-app-extension-points.md#row_partial) を参照してください。
+- resolver が返す label、link、badge、icon、任意 action を host app 側の column や permission と並べて確認したい場合は、静的な visual reference として [node-presenter-row-partials.html](../mockups/node-presenter-row-partials.html) を使ってください。この mockup は review aid であり、Column / Action DSL や最終的な business UI contract ではありません。
 
 ## なぜ今 Column / Action DSL を入れないのか
 


### PR DESCRIPTION
## 対応 Issue

Closes #1558

## 判定分類

- `docs-sync`
- `docs-missing`
- docs-only / low risk

## 背景

Issue #1558 は、root README から NodePresenter row partial patterns へ辿りにくく、英日 NodePresenter guide から既存 focused mockup へ直接戻れない導線不足を扱います。

current `main` には既に `docs/en|ja/node-presenter-row-partials.md` と `docs/mockups/node-presenter-row-partials.html` があるため、この PR は runtime や manifest を触らず、entrypoint / visual reference cross-reference だけを追加します。

## 変更内容

- `README.md` の Key documents table に NodePresenter row partial patterns を追加しました。
- `docs/en/node-presenter-row-partials.md` に `node-presenter-row-partials.html` への Related guide を追加しました。
- `docs/ja/node-presenter-row-partials.md` に同等の導線を追加しました。
- mockup は resolver-provided values と host-app-owned columns / permissions を並べて見る review aid であり、Column / Action DSL や final business UI contract ではないことを明記しました。

## 変更範囲

- `README.md`
- `docs/en/node-presenter-row-partials.md`
- `docs/ja/node-presenter-row-partials.md`

runtime Ruby / JavaScript、public API manifest、mockup HTML/CSS、Column / Action DSL、NodePresenter runtime behavior は変更していません。

## 確認内容

- GitHub compare: `main...docs/1558-node-presenter-entrypoints`
  - `ahead_by:3`
  - `behind_by:0`
  - changed files: 3 docs-only
  - each file has one additive line
- `docs/mockups/README.md` に `node-presenter-row-partials.html` が focused NodePresenter row partial reference として存在することを確認しました。
- local checkout / local docs link check は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で利用できないため未実行です。PR CI で確認します。

## リスク

low。既存 docs / mockup への discoverability 追加のみで、public manifest contract や runtime behavior には踏み込んでいません。