### PR TITLE
tree_view_rows helper option contract を manifest に追加する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -74,6 +74,10 @@ helper_methods:
   - tree_view_toolbar_actions
   - tree_view_toolbar_action_metadata
 helper_option_keys:
+  tree_view_rows:
+    - mode
+    - collapsed
+    - window
   tree_view_window:
     - offset
     - limit

--- a/spec/public_api_compatibility_spec.rb
+++ b/spec/public_api_compatibility_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe "Public API compatibility" do
     @javascript_controller_sources[group_name] ||= File.read(JAVASCRIPT_CONTROLLER_PATHS.fetch(group_name))
   end
 
+  def tree_view_rows_helper_keyword_option_keys
+    TreeViewHelper::Rendering.instance_method(:tree_view_rows).parameters.filter_map do |parameter_type, parameter_name|
+      parameter_name.to_s if %i[key keyreq].include?(parameter_type)
+    end
+  end
+
   def breadcrumb_helper_keyword_option_keys
     TreeViewBreadcrumbHelper.instance_method(:tree_view_breadcrumb).parameters.filter_map do |parameter_type, parameter_name|
       parameter_name.to_s if %i[key keyreq].include?(parameter_type)
@@ -252,6 +258,13 @@ RSpec.describe "Public API compatibility" do
     public_api_manifest.fetch("helper_methods").each do |method_name|
       expect(TreeViewHelper.public_instance_methods).to include(method_name.to_sym), "expected TreeViewHelper##{method_name} to remain public"
     end
+  end
+
+  it "keeps tree_view_rows helper option keys aligned with the public helper signature" do
+    manifest_keys = public_helper_option_keys.fetch("tree_view_rows")
+
+    expect(manifest_keys).to eq(tree_view_rows_helper_keyword_option_keys),
+      "expected tree_view_rows option keys to stay aligned with the public keyword signature"
   end
 
   it "keeps breadcrumb helper option keys aligned with the public helper signature" do


### PR DESCRIPTION
tree_view_rows の既存 keyword option surface を manifest-backed contract として固定します。

## 対応 Issue

Closes #1250

## 変更内容

- `config/public_api_manifest.yml` に `helper_option_keys.tree_view_rows` を追加し、既存の `mode` / `collapsed` / `window` keyword option を manifest 対象にしました。
- `spec/public_api_compatibility_spec.rb` に `TreeViewHelper::Rendering#tree_view_rows` の keyword signature と manifest を照合する compatibility spec を追加しました。
- runtime behavior、helper API、`RenderWindow` / window slicing 挙動は変更していません。

## 受け入れ条件との対応

- `tree_view_rows` の option surface を public manifest に含めました。
- 今後 `mode` / `collapsed` / `window` の keyword が意図せず増減した場合に spec で検知できるようにしました。
- docs は既に host app 向けの公開利用として `window:` を中心に記載済みのため、Planner 指示どおり `mode:` / `collapsed:` を新しい workflow として広げる追記は行っていません。

## 変更範囲

- `config/public_api_manifest.yml`
- `spec/public_api_compatibility_spec.rb`

## 実施した確認

- GitHub compare: `main...feature/1250-tree-view-rows-option-manifest-v2` が `ahead_by:2 / behind_by:0` で、変更ファイルが上記2ファイルのみであることを確認しました。
- ローカル checkout / `bundle exec rspec` は GitHub HTTPS が `CONNECT tunnel failed, response 403` で取得不可のため未実行です。PR CI で確認します。

## リスク

- risk: medium。public helper option surface を manifest-backed contract として固定する変更ですが、runtime 挙動や既存 API の追加・削除・rename はありません。

## 未対応・補足

- `tree_view_rows` の `mode:` / `collapsed:` を host-app docs の新しい利用導線として宣伝する変更は intentionally out of scope です。
- PR は作成までで、merge は行いません。