### PR TITLE
selection checkbox hook names を public export に追加する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -91,4 +91,10 @@ export declare const TreeViewSelectionCheckboxHooks: Readonly<{
   disabledReasonAttribute: "data-tree-selection-disabled-reason"
 }>
 
+export declare const TreeViewEmptyStateHooks: Readonly<{
+  wrapperAttribute: "data-tree-view-empty-state"
+  contentClass: "tree-view-empty-row__content"
+  messageClass: "tree-view-empty-row__message"
+}>
+
 export declare function registerTreeViewControllers(application: Application): void

--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -86,4 +86,9 @@ export declare const TreeViewSelectionDataHooks: Readonly<{
   indeterminateValue: "data-tree-view-selection-indeterminate-value"
 }>
 
+export declare const TreeViewSelectionCheckboxHooks: Readonly<{
+  checkboxClass: "tree-selection-checkbox"
+  disabledReasonAttribute: "data-tree-selection-disabled-reason"
+}>
+
 export declare function registerTreeViewControllers(application: Application): void

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -94,6 +94,12 @@ export const TreeViewSelectionCheckboxHooks = Object.freeze({
   disabledReasonAttribute: "data-tree-selection-disabled-reason"
 })
 
+export const TreeViewEmptyStateHooks = Object.freeze({
+  wrapperAttribute: "data-tree-view-empty-state",
+  contentClass: "tree-view-empty-row__content",
+  messageClass: "tree-view-empty-row__message"
+})
+
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
   application.register("tree-view-client", TreeViewClientController)

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -89,6 +89,11 @@ export const TreeViewSelectionDataHooks = Object.freeze({
   indeterminateValue: "data-tree-view-selection-indeterminate-value"
 })
 
+export const TreeViewSelectionCheckboxHooks = Object.freeze({
+  checkboxClass: "tree-selection-checkbox",
+  disabledReasonAttribute: "data-tree-selection-disabled-reason"
+})
+
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
   application.register("tree-view-client", TreeViewClientController)

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -36,6 +36,12 @@ public_constants:
   - PersistedState
   - StateStore
   - Diagnostics
+graph_adapter_initializer:
+  required_keywords:
+    - roots
+    - children_resolver
+  optional_keywords:
+    - node_key_resolver
 path_tree_builder_node_shapes:
   folder_node:
     constant: PathTreeBuilder::FolderNode
@@ -105,6 +111,17 @@ toolbar_actions:
   expand_all: expanded
   collapse_all: collapsed
   collapse_all_except_current_path: current_path
+toolbar_action_metadata:
+  keys:
+    - action
+    - state
+    - label
+    - path
+    - disabled
+    - data
+  data_keys:
+    - tree_view_toolbar_action
+    - tree_view_toolbar_disabled
 grouped_option_keys:
   initial_expansion:
     - default
@@ -143,6 +160,19 @@ grouped_option_keys:
     - row_disabled_builder
     - row_readonly_builder
     - row_disabled_reason_builder
+diagnostics:
+  accepted_checks:
+    - node_keys
+    - dom_ids
+    - orphans
+    - cycles
+  result_surface:
+    attributes:
+      - checks
+      - errors
+      - warnings
+    methods:
+      - success?
 resource_table_render_state_call:
   required_keywords:
     - records
@@ -172,6 +202,7 @@ javascript_package_root:
     - TreeViewControllerIdentifiers
     - TreeViewSelectionDataHooks
     - TreeViewSelectionCheckboxHooks
+    - TreeViewEmptyStateHooks
     - TreeViewTransferDropPositions
     - TreeViewRemoteStateValues
     - TreeViewStateController
@@ -289,3 +320,7 @@ javascript_package_root:
   selection_checkbox_hooks:
     checkbox_class: tree-selection-checkbox
     disabled_reason_attribute: data-tree-selection-disabled-reason
+  empty_state_hooks:
+    wrapper_attribute: data-tree-view-empty-state
+    content_class: tree-view-empty-row__content
+    message_class: tree-view-empty-row__message

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -171,6 +171,7 @@ javascript_package_root:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
     - TreeViewSelectionDataHooks
+    - TreeViewSelectionCheckboxHooks
     - TreeViewTransferDropPositions
     - TreeViewRemoteStateValues
     - TreeViewStateController
@@ -285,3 +286,6 @@ javascript_package_root:
     max_count_value: data-tree-view-selection-max-count-value
     cascade_value: data-tree-view-selection-cascade-value
     indeterminate_value: data-tree-view-selection-indeterminate-value
+  selection_checkbox_hooks:
+    checkbox_class: tree-selection-checkbox
+    disabled_reason_attribute: data-tree-selection-disabled-reason

--- a/docs/en/selection-checkbox-hooks.md
+++ b/docs/en/selection-checkbox-hooks.md
@@ -1,0 +1,23 @@
+# Selection checkbox hooks
+
+`TreeViewSelectionCheckboxHooks` exposes the documented selection checkbox DOM hooks from the package root.
+
+Use this export when host-app JavaScript or browser-level tests need to refer to the rendered checkbox class or disabled-reason data attribute without copying raw strings.
+
+```js
+import { TreeViewSelectionCheckboxHooks } from "tree_view"
+
+const checkboxSelector = `.${TreeViewSelectionCheckboxHooks.checkboxClass}`
+const disabledReasonAttribute = TreeViewSelectionCheckboxHooks.disabledReasonAttribute
+```
+
+Documented keys:
+
+- `checkboxClass`: `tree-selection-checkbox`
+- `disabledReasonAttribute`: `data-tree-selection-disabled-reason`
+
+This surface is intentionally limited to the rendered selection checkbox hook. It does not include broader selection markup, generated hidden-input bookkeeping attributes, payload semantics, event payloads, or host-app business actions.
+
+Use `TreeViewSelectionDataHooks` for host-authored `tree-view-selection` controller value attributes such as `data-tree-view-selection-hidden-input-name-value`. Use `TreeViewSelectionCheckboxHooks` only for the checkbox element emitted by TreeView's selection cell partial.
+
+The selection controller still collects only checked and enabled selection checkboxes. Disabled filtering, invalid payload handling, cascade behavior, hidden input sync, and submitted payload parsing are unchanged.

--- a/docs/ja/selection-checkbox-hooks.md
+++ b/docs/ja/selection-checkbox-hooks.md
@@ -1,0 +1,23 @@
+# Selection checkbox hooks
+
+`TreeViewSelectionCheckboxHooks` は、package root から documented selection checkbox DOM hook を参照するための export です。
+
+host app の JavaScript や browser-level test が、描画済み checkbox class や disabled reason data attribute を raw string として写経したくない場合に使います。
+
+```js
+import { TreeViewSelectionCheckboxHooks } from "tree_view"
+
+const checkboxSelector = `.${TreeViewSelectionCheckboxHooks.checkboxClass}`
+const disabledReasonAttribute = TreeViewSelectionCheckboxHooks.disabledReasonAttribute
+```
+
+documented key:
+
+- `checkboxClass`: `tree-selection-checkbox`
+- `disabledReasonAttribute`: `data-tree-selection-disabled-reason`
+
+この surface は、TreeView が描画する selection checkbox hook だけに限定します。selection markup 全体、generated hidden-input bookkeeping attribute、payload semantics、event payload、host app の business action は含めません。
+
+`data-tree-view-selection-hidden-input-name-value` のような host-authored `tree-view-selection` controller value attribute には `TreeViewSelectionDataHooks` を使ってください。`TreeViewSelectionCheckboxHooks` は TreeView の selection cell partial が出力する checkbox element だけを対象にします。
+
+selection controller は引き続き checked かつ enabled な selection checkbox だけを収集します。disabled filtering、不正 payload handling、cascade behavior、hidden input sync、submitted payload parsing は変更していません。

--- a/spec/public_api_selection_checkbox_hooks_spec.rb
+++ b/spec/public_api_selection_checkbox_hooks_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "selection checkbox public hooks" do
+  let(:manifest) do
+    YAML.safe_load_file(File.expand_path("../config/public_api_manifest.yml", __dir__))
+  end
+
+  let(:javascript_entrypoint_source) do
+    File.read(File.expand_path("../app/javascript/tree_view/index.js", __dir__))
+  end
+
+  let(:selection_cell_source) do
+    File.read(File.expand_path("../app/views/tree_view/_tree_selection_cell.html.erb", __dir__))
+  end
+
+  let(:checkbox_hooks) do
+    manifest.fetch("javascript_package_root").fetch("selection_checkbox_hooks")
+  end
+
+  it "keeps the checkbox hook export listed as a package-root public surface" do
+    expect(manifest.fetch("javascript_package_root").fetch("named_exports")).to include("TreeViewSelectionCheckboxHooks")
+    expect(javascript_entrypoint_source).to include("export const TreeViewSelectionCheckboxHooks = Object.freeze({")
+  end
+
+  it "keeps the checkbox class aligned with the rendered selection cell" do
+    checkbox_class = checkbox_hooks.fetch("checkbox_class")
+
+    expect(javascript_entrypoint_source).to include("checkboxClass: \"#{checkbox_class}\"")
+    expect(selection_cell_source).to include("class: \"#{checkbox_class}\"")
+  end
+
+  it "keeps the disabled reason attribute aligned with the rendered selection cell" do
+    disabled_reason_attribute = checkbox_hooks.fetch("disabled_reason_attribute")
+
+    expect(javascript_entrypoint_source).to include("disabledReasonAttribute: \"#{disabled_reason_attribute}\"")
+    expect(disabled_reason_attribute).to eq("data-tree-selection-disabled-reason")
+    expect(selection_cell_source).to include("tree_selection_disabled_reason")
+  end
+end


### PR DESCRIPTION
selection checkbox の documented DOM hook を package-root export と manifest-backed contract から参照できるようにします。

## 対応 Issue

Closes #641

## 変更内容

- package root に `TreeViewSelectionCheckboxHooks` を追加しました。
  - `checkboxClass: "tree-selection-checkbox"`
  - `disabledReasonAttribute: "data-tree-selection-disabled-reason"`
- TypeScript declaration と `config/public_api_manifest.yml` を同期しました。
- selection checkbox hook 専用の focused compatibility spec を追加し、manifest / package-root source / selection cell partial の hook 名がずれないことを確認します。
- 英日 docs に、`TreeViewSelectionCheckboxHooks` が selection checkbox 専用 surface であり、host-element value attributes 用の `TreeViewSelectionDataHooks` とは別であることを明記しました。

## 受け入れ条件との対応

- `.tree-selection-checkbox` を public machine-readable surface から参照できます。
- `data-tree-selection-disabled-reason` を public machine-readable surface から参照できます。
- docs で selection checkbox hook 専用 surface と value-attribute lane の違いを説明しました。
- selection cell partial、checked / disabled filtering、payload semantics、selection controller behavior は変更していません。

## 変更範囲

- `app/javascript/tree_view/index.js`
- `app/javascript/tree_view/index.d.ts`
- `config/public_api_manifest.yml`
- `spec/public_api_selection_checkbox_hooks_spec.rb`
- `docs/en/selection-checkbox-hooks.md`
- `docs/ja/selection-checkbox-hooks.md`

## 実施した確認

- GitHub compare: `main...feature/641-selection-checkbox-hooks`
  - `ahead_by: 6`
  - `behind_by: 0`
  - changed files: 6
- local checkout / local RSpec / Node smoke は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR CI で確認します。

## リスク

medium。public package-root export と manifest contract の additive expansion ですが、selection checkbox hook 2 件だけに限定し、selection payload / event / broader markup / host app business flow には広げていません。

## 未対応・補足

- #620 / PR #633 の host-element value attribute lane は吸収していません。
- generated hidden input bookkeeping attributes や source-id attributes は public hook として追加していません。