### PR TITLE
docs entrypoint smoke で cookbook と children pagination の導線を守る

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@
 - [日本語Lazy Loading](ja/lazy-loading.md): host app の route と TreeView remote-state hooks で子nodeを必要時に読み込む入口。
 - [English Children Pagination](en/children-pagination.md): combine lazy loading with server-side child paging when a parent has too many direct children to return at once.
 - [日本語Children Pagination](ja/children-pagination.md): direct children が多すぎる親nodeで、lazy loading と server-side child paging を組み合わせる入口。
+- [English Cookbook](en/cookbook.md): common host-app patterns that combine existing TreeView APIs while keeping CRUD, authorization, routes, and final copy in the host app.
+- [日本語Cookbook](ja/cookbook.md): 既存TreeView APIを組み合わせるhost app向けpattern集。CRUD、authorization、route、最終copyはhost app側に残します。
 - [English Windowed Rendering](en/windowed-rendering.md): render visible rows by offset and limit while host apps keep query and paging ownership.
 - [日本語Windowed Rendering](ja/windowed-rendering.md): offset / limit で visible rows を描画し、query や paging は host app が所有する前提の入口。
 - [English Render log level](en/render-log-level.md): configure TreeView helper-rendered partial log verbosity without changing the host app's global Rails logger level.

--- a/spec/docs_entrypoint_smoke_spec.rb
+++ b/spec/docs_entrypoint_smoke_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "documentation entrypoint smoke" do
+  def repo_path(relative_path)
+    File.expand_path("../#{relative_path}", __dir__)
+  end
+
+  def read(relative_path)
+    File.read(repo_path(relative_path))
+  end
+
+  def expect_relative_link(source_path, href)
+    source = read(source_path)
+    target = href.split("#", 2).first
+    resolved_target = File.expand_path(target, File.dirname(repo_path(source_path)))
+
+    expect(source).to include(href)
+    expect(File.file?(resolved_target)).to be(true)
+  end
+
+  def expect_ordered_signals(source_path, *signals)
+    pattern = signals.map { |signal| Regexp.escape(signal) }.join("[\\s\\S]*")
+
+    expect(read(source_path)).to match(Regexp.new(pattern))
+  end
+
+  it "keeps cookbook common pattern entrypoints and boundary signals visible" do
+    [
+      ["README.md", "docs/en/cookbook.md"],
+      ["README.md", "docs/ja/cookbook.md"],
+      ["docs/README.md", "en/cookbook.md"],
+      ["docs/README.md", "ja/cookbook.md"],
+      ["docs/en/README.md", "cookbook.md"],
+      ["docs/ja/README.md", "cookbook.md"]
+    ].each do |source_path, href|
+      expect_relative_link(source_path, href)
+    end
+
+    expect_ordered_signals(
+      "docs/en/cookbook.md",
+      "Row customization quick guide",
+      "`row_partial`",
+      "`row_actions_partial`",
+      "Routes, controller actions, authorization, confirmation text",
+      "final copy"
+    )
+    expect_ordered_signals(
+      "docs/ja/cookbook.md",
+      "行customization quick guide",
+      "`row_partial`",
+      "`row_actions_partial`",
+      "route、controller action、authorization、confirm文言",
+      "最終copy"
+    )
+  end
+
+  it "keeps children pagination visual review and host-app boundary signals visible" do
+    [
+      ["docs/en/children-pagination.md", "../mockups/children-pagination.html"],
+      ["docs/en/children-pagination.md", "../mockups/children-pagination-selection-boundary.html"],
+      ["docs/ja/children-pagination.md", "../mockups/children-pagination.html"],
+      ["docs/ja/children-pagination.md", "../mockups/children-pagination-selection-boundary.html"]
+    ].each do |source_path, href|
+      expect_relative_link(source_path, href)
+    end
+
+    expect_ordered_signals(
+      "docs/en/children-pagination.md",
+      "cursor encoding",
+      "Turbo Stream responses",
+      "retry behavior",
+      "unloaded descendants"
+    )
+    expect_ordered_signals(
+      "docs/ja/children-pagination.md",
+      "cursor encoding",
+      "Turbo Stream response",
+      "retry behavior",
+      "unloaded descendants"
+    )
+  end
+end


### PR DESCRIPTION
## 対応 Issue

- Closes #1562
- Closes #1563

## Issue ごとの完了内容

- #1562: root README、docs index、EN/JA README から Cookbook への入口と、Cookbook 内の row customization / host-app boundary signals を RSpec の docs smoke で確認するようにしました。docs index には EN/JA Cookbook への直接導線も追加しました。
- #1563: EN/JA Children Pagination から関連 mockup への導線と、cursor encoding / Turbo Stream response / retry behavior / unloaded descendants の host-app boundary signals を RSpec の docs smoke で確認するようにしました。

## 変更内容

- `docs/README.md` に EN/JA Cookbook の recommended entry point を追加しました。
- `spec/docs_entrypoint_smoke_spec.rb` を追加し、docs の相対リンク存在確認と代表的な boundary 文言の順序確認を行います。
- 公開 API、UI、runtime 実装は変更していません。

## 改善カテゴリ

- test
- docs drift guard
- docs entrypoint maintenance

## 既存仕様への影響

- 既存仕様への影響はありません。docs 導線とテスト追加のみです。

## 実施した確認

- GitHub connector で対象 Issue の label eligibility を個別確認しました。
- branch freshness: `main` と比較し、ブランチは `behind_by: 0` です。
- 差分対象: `docs/README.md` と `spec/docs_entrypoint_smoke_spec.rb` のみです。
- GitHub Actions CI run 1987: green
  - lint
  - pr_specs
  - pr_rails_matrix Rails 7.0 / 7.2 / 8.0
  - javascript

## リスク評価

- risk: low
- docs smoke と docs index 導線の追加のみで、runtime/API/UI への影響はありません。

## 補足事項

- 既存 `script/test_docs_entrypoints.mjs` に近い目的ですが、CI が拾う RSpec の等価 guard として追加しています。