### PR TITLE
documented integration hook names を package root export に追加する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -86,4 +86,17 @@ export declare const TreeViewSelectionDataHooks: Readonly<{
   indeterminateValue: "data-tree-view-selection-indeterminate-value"
 }>
 
+export declare const TreeViewIntegrationHooks: Readonly<{
+  state: Readonly<{
+    viewKeyValue: "data-tree-view-state-view-key-value"
+    nodeKey: "data-tree-view-state-node-key"
+  }>
+  remoteState: Readonly<{
+    childrenUrl: "data-tree-children-url"
+  }>
+  transfer: Readonly<{
+    payload: "data-tree-transfer-payload"
+  }>
+}>
+
 export declare function registerTreeViewControllers(application: Application): void

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -89,6 +89,19 @@ export const TreeViewSelectionDataHooks = Object.freeze({
   indeterminateValue: "data-tree-view-selection-indeterminate-value"
 })
 
+export const TreeViewIntegrationHooks = Object.freeze({
+  state: Object.freeze({
+    viewKeyValue: "data-tree-view-state-view-key-value",
+    nodeKey: "data-tree-view-state-node-key"
+  }),
+  remoteState: Object.freeze({
+    childrenUrl: "data-tree-children-url"
+  }),
+  transfer: Object.freeze({
+    payload: "data-tree-transfer-payload"
+  })
+})
+
 export function registerTreeViewControllers(application) {
   application.register("tree-view-state", TreeViewStateController)
   application.register("tree-view-client", TreeViewClientController)

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -171,6 +171,7 @@ javascript_package_root:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
     - TreeViewSelectionDataHooks
+    - TreeViewIntegrationHooks
     - TreeViewTransferDropPositions
     - TreeViewRemoteStateValues
     - TreeViewStateController
@@ -285,3 +286,11 @@ javascript_package_root:
     max_count_value: data-tree-view-selection-max-count-value
     cascade_value: data-tree-view-selection-cascade-value
     indeterminate_value: data-tree-view-selection-indeterminate-value
+  integration_hooks:
+    state:
+      view_key_value: data-tree-view-state-view-key-value
+      node_key: data-tree-view-state-node-key
+    remote_state:
+      children_url: data-tree-children-url
+    transfer:
+      payload: data-tree-transfer-payload

--- a/docs/en/js-events.md
+++ b/docs/en/js-events.md
@@ -179,13 +179,15 @@ element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStat
 
 `TreeViewEventNames.hostLifecycle.*` is for host apps dispatching lazy-loading request lifecycle events such as `tree-view:loading`; TreeView controller-emitted remote-state events on this page use `TreeViewEventNames.remoteState.*`.
 
+When listener code or browser assertions also need the related documented DOM hook names, import `TreeViewIntegrationHooks` from `tree_view/index.js` instead of hand-copying raw attribute strings. Representative keys are `TreeViewIntegrationHooks.state.viewKeyValue`, `TreeViewIntegrationHooks.state.nodeKey`, `TreeViewIntegrationHooks.remoteState.childrenUrl`, and `TreeViewIntegrationHooks.transfer.payload`.
+
 `tree-view-transfer:invalid-payload` detail contains `value` and `row`.
 
 `tree-view-transfer:invalid-transfer` detail contains `value`.
 
 ## Compatibility policy
 
-The machine-readable public API manifest mirrors the event names and representative required `event.detail` keys documented on this page so compatibility specs can detect drift; this page remains the primary contract. Host app tests may import `TreeViewEventDetailKeys` from the package root when they need a machine-readable list of documented detail key names without changing the event payload shape.
+The machine-readable public API manifest mirrors the event names, representative required `event.detail` keys, and documented integration hook names covered on this page so compatibility specs can detect drift; this page remains the primary contract. Host app tests may import `TreeViewEventDetailKeys` from the package root when they need a machine-readable list of documented detail key names without changing the event payload shape.
 
 Every public event name in the manifest must be classified either under `event_detail_keys` when it has documented detail fields or under `event_names_without_detail` when it intentionally exposes no public detail fields. The entrypoint smoke checks that classification so host lifecycle events do not look like missing `event.detail` coverage.
 

--- a/docs/ja/js-events.md
+++ b/docs/ja/js-events.md
@@ -179,13 +179,15 @@ element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStat
 
 `TreeViewEventNames.hostLifecycle.*` は、`tree-view:loading` など lazy-loading request lifecycle event を host app 側で dispatch するための surface です。このページで説明している TreeView controller 自身が emit する remote-state event は `TreeViewEventNames.remoteState.*` を使います。
 
+listener や browser assertion で関連する documented DOM hook 名も必要な場合は、raw attribute string を写経する代わりに `tree_view/index.js` の `TreeViewIntegrationHooks` を使ってください。代表的な key は `TreeViewIntegrationHooks.state.viewKeyValue`、`TreeViewIntegrationHooks.state.nodeKey`、`TreeViewIntegrationHooks.remoteState.childrenUrl`、`TreeViewIntegrationHooks.transfer.payload` です。
+
 `tree-view-transfer:invalid-payload` の detail は `value` と `row` を含みます。
 
 `tree-view-transfer:invalid-transfer` の detail は `value` を含みます。
 
 ## 互換性方針
 
-machine-readable public API manifest は、このページで文書化している event name と代表的な必須 `event.detail` key を写して drift を検知するための guard です。一次の契約は引き続きこのページです。host app の test が documented detail key 名の machine-readable な一覧を必要とする場合は、event payload shape を変えずに package root の `TreeViewEventDetailKeys` を import できます。
+machine-readable public API manifest は、このページで文書化している event name、代表的な必須 `event.detail` key、documented integration hook 名を写して drift を検知するための guard です。一次の契約は引き続きこのページです。host app の test が documented detail key 名の machine-readable な一覧を必要とする場合は、event payload shape を変えずに package root の `TreeViewEventDetailKeys` を import できます。
 
 manifest 上のすべての public event name は、documented detail field を持つ場合は `event_detail_keys`、意図的に公開 detail field を持たない場合は `event_names_without_detail` のどちらかに分類します。entrypoint smoke はこの分類を確認するため、host lifecycle events が `event.detail` coverage の追加漏れに見えないようになります。
 

--- a/spec/public_api_integration_hooks_spec.rb
+++ b/spec/public_api_integration_hooks_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "Public API integration hooks" do
+  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+  ENTRYPOINT_PATH = File.expand_path("../app/javascript/tree_view/index.js", __dir__)
+
+  def javascript_manifest
+    YAML.safe_load_file(MANIFEST_PATH).fetch("javascript_package_root")
+  end
+
+  def integration_hooks
+    javascript_manifest.fetch("integration_hooks")
+  end
+
+  def entrypoint_source
+    @entrypoint_source ||= File.read(ENTRYPOINT_PATH)
+  end
+
+  def camelize_key(value)
+    value.to_s.gsub(/_([a-z])/) { Regexp.last_match(1).upcase }
+  end
+
+  it "keeps documented integration hooks available through TreeViewIntegrationHooks" do
+    expect(entrypoint_source).to include("export const TreeViewIntegrationHooks = Object.freeze({")
+
+    integration_hooks.each do |group_name, hooks|
+      exported_group_name = camelize_key(group_name)
+
+      expect(entrypoint_source).to include("#{exported_group_name}: Object.freeze({"),
+        "expected TreeViewIntegrationHooks.#{exported_group_name} to remain documented")
+
+      hooks.each do |hook_key, hook_name|
+        exported_hook_key = camelize_key(hook_key)
+
+        expect(entrypoint_source).to include("#{exported_hook_key}: \"#{hook_name}\""),
+          "expected TreeViewIntegrationHooks.#{exported_group_name}.#{exported_hook_key} to remain mapped to #{hook_name}"
+      end
+    end
+  end
+
+  it "does not fold selection host-element value hooks into the general integration hook export" do
+    selection_hooks = javascript_manifest.fetch("selection_data_hooks").values
+    general_hooks = integration_hooks.values.flat_map(&:values)
+
+    expect(general_hooks & selection_hooks).to eq([])
+  end
+end

--- a/spec/public_api_integration_hooks_spec.rb
+++ b/spec/public_api_integration_hooks_spec.rb
@@ -29,14 +29,12 @@ RSpec.describe "Public API integration hooks" do
     integration_hooks.each do |group_name, hooks|
       exported_group_name = camelize_key(group_name)
 
-      expect(entrypoint_source).to include("#{exported_group_name}: Object.freeze({"),
-        "expected TreeViewIntegrationHooks.#{exported_group_name} to remain documented")
+      expect(entrypoint_source).to include("#{exported_group_name}: Object.freeze({")
 
       hooks.each do |hook_key, hook_name|
         exported_hook_key = camelize_key(hook_key)
 
-        expect(entrypoint_source).to include("#{exported_hook_key}: \"#{hook_name}\""),
-          "expected TreeViewIntegrationHooks.#{exported_group_name}.#{exported_hook_key} to remain mapped to #{hook_name}"
+        expect(entrypoint_source).to include("#{exported_hook_key}: \"#{hook_name}\"")
       end
     end
   end

--- a/spec/public_api_integration_hooks_spec.rb
+++ b/spec/public_api_integration_hooks_spec.rb
@@ -4,11 +4,16 @@ require "spec_helper"
 require "yaml"
 
 RSpec.describe "Public API integration hooks" do
-  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
-  ENTRYPOINT_PATH = File.expand_path("../app/javascript/tree_view/index.js", __dir__)
+  def manifest_path
+    File.expand_path("../config/public_api_manifest.yml", __dir__)
+  end
+
+  def entrypoint_path
+    File.expand_path("../app/javascript/tree_view/index.js", __dir__)
+  end
 
   def javascript_manifest
-    YAML.safe_load_file(MANIFEST_PATH).fetch("javascript_package_root")
+    YAML.safe_load_file(manifest_path).fetch("javascript_package_root")
   end
 
   def integration_hooks
@@ -16,7 +21,7 @@ RSpec.describe "Public API integration hooks" do
   end
 
   def entrypoint_source
-    @entrypoint_source ||= File.read(ENTRYPOINT_PATH)
+    @entrypoint_source ||= File.read(entrypoint_path)
   end
 
   def camelize_key(value)


### PR DESCRIPTION
documented な data-tree-view / data-tree hook 名を、host app が package root から参照できるようにします。

## 対応 Issue

Closes #583

## 変更内容

- `tree_view/index.js` に `TreeViewIntegrationHooks` を追加しました。
  - `state.viewKeyValue`: `data-tree-view-state-view-key-value`
  - `state.nodeKey`: `data-tree-view-state-node-key`
  - `remoteState.childrenUrl`: `data-tree-children-url`
  - `transfer.payload`: `data-tree-transfer-payload`
- TypeScript declaration と `config/public_api_manifest.yml` に同じ surface を同期しました。
- focused spec を追加し、manifest と package-root export の hook 名がずれないことを確認します。
- `docs/en|ja/js-events.md` に、event name / detail key と DOM hook 名の使い分けを短く追記しました。

## 受け入れ条件との対応

- documented integration hook 名を package-root export から参照できます。
- manifest と focused compatibility guard で hook 名の drift を検出します。
- event 名は `TreeViewEventNames`、event detail key は `TreeViewEventDetailKeys`、DOM hook 名は `TreeViewIntegrationHooks` という役割分担を docs に追記しました。
- controller behavior、DOM emission、event payload shape、helper API は変更していません。

## 変更範囲

- `app/javascript/tree_view/index.js`
- `app/javascript/tree_view/index.d.ts`
- `config/public_api_manifest.yml`
- `spec/public_api_integration_hooks_spec.rb`
- `docs/en/js-events.md`
- `docs/ja/js-events.md`

## 実施した確認

- Issue #583 の labels を直接確認: `agent:planned`, `status:ready-for-agent`, `track:feature`, `risk:medium`。
- 既存 open PR が #583 を担当していないことを確認しました。
- GitHub compare: `main...feature/583-integration-hooks-export`
  - `ahead_by: 3`
  - `behind_by: 0`
  - changed files: 6
- PR metadata: `mergeable:true`
- GitHub Actions CI #1994: green
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success
  - `gem_package`: success
  - `pr_rails_matrix` 7.0 / 7.2 / 8.0: success
- local checkout / local RSpec / Node smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

medium。package-root public JavaScript surface の additive expansion です。公開対象は current docs / event contract で既に documented な hook 名に閉じ、selection host-element value hooks は既存 `TreeViewSelectionDataHooks` のまま分離しています。

## 未対応・補足

- selection checkbox hooks、transfer disabled hook、remote-state / toolbar hook の broader public export は吸収していません。
- controller file layout、DOM structure、event payload shape、host app query/helper は変更していません。