### PR TITLE
docs entrypoint smoke を current main で再提案する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@
 - [日本語Lazy Loading](ja/lazy-loading.md): host app の route と TreeView remote-state hooks で子nodeを必要時に読み込む入口。
 - [English Children Pagination](en/children-pagination.md): combine lazy loading with server-side child paging when a parent has too many direct children to return at once.
 - [日本語Children Pagination](ja/children-pagination.md): direct children が多すぎる親nodeで、lazy loading と server-side child paging を組み合わせる入口。
+- [English Cookbook](en/cookbook.md): common host-app patterns that combine existing TreeView APIs while keeping CRUD, authorization, routes, and final copy in the host app.
+- [日本語Cookbook](ja/cookbook.md): 既存TreeView APIを組み合わせるhost app向けpattern集。CRUD、authorization、route、最終copyはhost app側に残します。
 - [English Windowed Rendering](en/windowed-rendering.md): render visible rows by offset and limit while host apps keep query and paging ownership.
 - [日本語Windowed Rendering](ja/windowed-rendering.md): offset / limit で visible rows を描画し、query や paging は host app が所有する前提の入口。
 - [English Render log level](en/render-log-level.md): configure TreeView helper-rendered partial log verbosity without changing the host app's global Rails logger level.

--- a/spec/docs_entrypoint_smoke_spec.rb
+++ b/spec/docs_entrypoint_smoke_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "documentation entrypoint smoke" do
+  def repo_path(relative_path)
+    File.expand_path("../#{relative_path}", __dir__)
+  end
+
+  def read(relative_path)
+    File.read(repo_path(relative_path))
+  end
+
+  def expect_relative_link(source_path, href)
+    source = read(source_path)
+    target = href.split("#", 2).first
+    resolved_target = File.expand_path(target, File.dirname(repo_path(source_path)))
+
+    expect(source).to include(href)
+    expect(File.file?(resolved_target)).to be(true)
+  end
+
+  def expect_ordered_signals(source_path, *signals)
+    pattern = signals.map { |signal| Regexp.escape(signal) }.join("[\\s\\S]*")
+
+    expect(read(source_path)).to match(Regexp.new(pattern))
+  end
+
+  it "keeps cookbook common pattern entrypoints and boundary signals visible" do
+    [
+      ["README.md", "docs/en/cookbook.md"],
+      ["README.md", "docs/ja/cookbook.md"],
+      ["docs/README.md", "en/cookbook.md"],
+      ["docs/README.md", "ja/cookbook.md"],
+      ["docs/en/README.md", "cookbook.md"],
+      ["docs/ja/README.md", "cookbook.md"]
+    ].each do |source_path, href|
+      expect_relative_link(source_path, href)
+    end
+
+    expect_ordered_signals(
+      "docs/en/cookbook.md",
+      "Row customization quick guide",
+      "`row_partial`",
+      "`row_actions_partial`",
+      "Routes, controller actions, authorization, confirmation text",
+      "final copy"
+    )
+    expect_ordered_signals(
+      "docs/ja/cookbook.md",
+      "行customization quick guide",
+      "`row_partial`",
+      "`row_actions_partial`",
+      "route、controller action、authorization、confirm文言",
+      "最終copy"
+    )
+  end
+
+  it "keeps children pagination visual review and host-app boundary signals visible" do
+    [
+      ["docs/en/children-pagination.md", "../mockups/children-pagination.html"],
+      ["docs/en/children-pagination.md", "../mockups/children-pagination-selection-boundary.html"],
+      ["docs/ja/children-pagination.md", "../mockups/children-pagination.html"],
+      ["docs/ja/children-pagination.md", "../mockups/children-pagination-selection-boundary.html"]
+    ].each do |source_path, href|
+      expect_relative_link(source_path, href)
+    end
+
+    expect_ordered_signals(
+      "docs/en/children-pagination.md",
+      "cursor encoding",
+      "Turbo Stream responses",
+      "retry behavior",
+      "unloaded descendants"
+    )
+    expect_ordered_signals(
+      "docs/ja/children-pagination.md",
+      "cursor encoding",
+      "Turbo Stream response",
+      "retry behavior",
+      "unloaded descendants"
+    )
+  end
+end


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1562
Closes #1563
Supersedes #1567

## 置き換え理由

PR #1567 は #1562 / #1563 の intent には合っていましたが、#1564 merge と dev dependency patch update 後の current `main` から `behind_by:1` / `status:diverged` / `mergeable:false` になりました。

この PR は latest `main` `cab7e7f1518ade105ab1384e1ef5990e52b7f24c` から同じ docs entrypoint smoke 差分だけを再適用し、review follow-up の freshness 指摘に対応します。

## Issue ごとの完了内容

- #1562: root README、docs index、EN/JA README から Cookbook への入口と、Cookbook 内の row customization / host-app boundary signals を RSpec docs smoke で確認します。
- #1563: EN/JA Children Pagination から関連 mockup への導線と、cursor encoding / Turbo Stream response / retry behavior / unloaded descendants の host-app boundary signals を RSpec docs smoke で確認します。

## 変更内容

- `docs/README.md` に EN/JA Cookbook の recommended entry point を追加しました。
- `spec/docs_entrypoint_smoke_spec.rb` を追加し、docs の相対リンク存在確認と代表的な boundary 文言の順序確認を行います。

## 改善カテゴリ

- test
- docs drift guard
- docs entrypoint maintenance

## 既存仕様への影響

既存仕様への影響はありません。docs 導線とテスト追加のみで、runtime Ruby / JavaScript、UI、public API、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- branch freshness: `main...quality/1562-1563-doc-entrypoint-smoke-refresh`
  - `ahead_by: 2`
  - `behind_by: 0`
- changed files:
  - `docs/README.md`
  - `spec/docs_entrypoint_smoke_spec.rb`
- local checkout / local RSpec は、この環境の GitHub HTTPS 制限により未実行です。PR CI で fresh head を確認します。

## リスク評価

low。docs index と docs smoke spec のみの変更です。
