### PR TITLE
Selection data hook docs signal を current main で再提案する

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -25,6 +25,10 @@ const lazyLoadingDocs = [
   ["docs/en/lazy-loading.md", read("docs/en/lazy-loading.md")],
   ["docs/ja/lazy-loading.md", read("docs/ja/lazy-loading.md")]
 ]
+const selectionDocs = [
+  ["docs/en/selection.md", read("docs/en/selection.md")],
+  ["docs/ja/selection.md", read("docs/ja/selection.md")]
+]
 
 const callbackBuilderSignals = [
   "render_state_callback_builder_keys",
@@ -48,6 +52,12 @@ const remoteStateValueSignals = [
   "loading",
   "loaded",
   "error"
+]
+
+const selectionDataHookSignals = [
+  "TreeViewSelectionDataHooks",
+  "TreeViewSelectionDataHooks.hiddenInputNameValue",
+  "data-tree-view-selection-hidden-input-name-value"
 ]
 
 callbackBuilderSignals.forEach((signal) => {
@@ -78,6 +88,10 @@ publicApiDocs.forEach(([relativePath, document]) => {
     /host app|host-app|host app 側|host-app 側/.test(document),
     `${relativePath}: host lifecycle event docs no longer name the host-app ownership boundary`
   )
+
+  selectionDataHookSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} selection data hook docs`)
+  })
 })
 
 lazyLoadingDocs.forEach(([relativePath, document]) => {
@@ -89,4 +103,10 @@ lazyLoadingDocs.forEach(([relativePath, document]) => {
     /not event names|event 名ではありません/.test(document),
     `${relativePath}: remote-state value docs no longer separate state values from event names`
   )
+})
+
+selectionDocs.forEach(([relativePath, document]) => {
+  selectionDataHookSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} selection data hook docs`)
+  })
 })


### PR DESCRIPTION
## 対応 Issue / PR

Refs #1395
Refs #1397
Refs #1398
Supersedes #1396

## 置き換え理由

PR #1396 は `TreeViewSelectionDataHooks` の docs entrypoint smoke、TypeScript declaration sync、manifest structure spec sync をまとめた quality PR でしたが、current `main` から `behind_by:112` / `status:diverged` / `mergeable:false` になっていました。

current `main` には、#1396 のうち以下が既に入っています。

- `app/javascript/tree_view/index.d.ts` の `TreeViewRemoteStateValues` / `TreeViewSelectionDataHooks` declaration
- `spec/public_api_manifest_structure_spec.rb` の `path_tree_builder_node_shapes` top-level key sync

そのため、この replacement PR では current `main` にまだ残る selection data hook docs signal guard だけを、既存の `script/test_public_api_docs_signals.mjs` へ小さく再適用します。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に selection docs signal checks を追加しました。
- 英日 `public-api.md` と英日 `selection.md` で、以下の代表 signal が落ちないことを確認します。
  - `TreeViewSelectionDataHooks`
  - `TreeViewSelectionDataHooks.hiddenInputNameValue`
  - `data-tree-view-selection-hidden-input-name-value`

## 改善カテゴリ

- test
- docs drift guard
- maintenance

## 既存仕様への影響

既存仕様への影響はありません。runtime Ruby / JavaScript、public export shape、manifest schema、UI、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- GitHub compare: `main...quality/1396-selection-doc-signals-refresh-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local `npm run test:docs-entrypoints` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR CI で確認します。

## リスク評価

low。既存 docs signal smoke への代表 signal 追加のみです。

## 補足

- 旧 #1396 の stale branch に直接追い commit せず、current `main` から replacement branch を作成しました。
- #1397 / #1398 相当の declaration / manifest sync は current `main` で既に満たされているため、このPRの差分には含めていません。