### PR TITLE
public demo repo link policy guard を current main で再提案する

### DIFF
--- a/spec/docs_demo_repository_link_policy_spec.rb
+++ b/spec/docs_demo_repository_link_policy_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "spec_helper"
+
+module DocsDemoRepositoryLinkPolicySpec
+  ROOT = Pathname.new(File.expand_path("..", __dir__))
+  PUBLIC_ENTRYPOINTS = [
+    "README.md",
+    "docs/README.md",
+    "docs/en/README.md",
+    "docs/ja/README.md"
+  ].freeze
+  BOUNDARY_DOCS = [
+    "docs/en/demo-application-boundary.md",
+    "docs/ja/demo-application-boundary.md"
+  ].freeze
+  MOCKUPS_README = "docs/mockups/README.md"
+  DIRECT_DEMO_REPOSITORY_PATTERN = %r{
+    (?:https?://|git://|git@)github\.com[:/]
+    matsuo-haruhito/tree_view-rails-demo(?:\.git)?(?:[/?#][^\s)\]]*)?
+  }ix
+  MARKDOWN_LINK_HREF_PATTERN = /\[[^\]]+\]\(([^)]+)\)/
+
+  module_function
+
+  def read(relative_path)
+    ROOT.join(relative_path).read
+  end
+
+  def markdown_hrefs(relative_path)
+    read(relative_path).scan(MARKDOWN_LINK_HREF_PATTERN).map do |match|
+      match.first.split(/\s+/, 2).first.delete_prefix("<").delete_suffix(">")
+    end
+  end
+
+  def direct_demo_repository_links(relative_path)
+    content = read(relative_path)
+    markdown_links = markdown_hrefs(relative_path).select do |href|
+      href.match?(DIRECT_DEMO_REPOSITORY_PATTERN)
+    end
+    inline_links = content.scan(DIRECT_DEMO_REPOSITORY_PATTERN)
+
+    (markdown_links + inline_links).uniq
+  end
+end
+
+RSpec.describe "demo repository link policy" do
+  it "keeps public docs free of direct demo repository links until the demo repo is public" do
+    checked_paths = DocsDemoRepositoryLinkPolicySpec::PUBLIC_ENTRYPOINTS +
+      DocsDemoRepositoryLinkPolicySpec::BOUNDARY_DOCS +
+      [DocsDemoRepositoryLinkPolicySpec::MOCKUPS_README]
+
+    direct_links_by_path = checked_paths.to_h do |relative_path|
+      [relative_path, DocsDemoRepositoryLinkPolicySpec.direct_demo_repository_links(relative_path)]
+    end.reject { |_relative_path, links| links.empty? }
+
+    expect(direct_links_by_path).to eq({})
+  end
+
+  it "keeps public entry points routed through the demo application boundary docs" do
+    aggregate_failures do
+      expect(DocsDemoRepositoryLinkPolicySpec.markdown_hrefs("README.md")).to include(
+        "docs/en/demo-application-boundary.md",
+        "docs/ja/demo-application-boundary.md"
+      )
+      expect(DocsDemoRepositoryLinkPolicySpec.markdown_hrefs("docs/README.md")).to include(
+        "en/demo-application-boundary.md",
+        "ja/demo-application-boundary.md"
+      )
+      expect(DocsDemoRepositoryLinkPolicySpec.markdown_hrefs("docs/en/README.md")).to include(
+        "demo-application-boundary.md"
+      )
+      expect(DocsDemoRepositoryLinkPolicySpec.markdown_hrefs("docs/ja/README.md")).to include(
+        "demo-application-boundary.md"
+      )
+    end
+  end
+
+  it "keeps the publication handoff policy explicit in both language boundary docs" do
+    english = DocsDemoRepositoryLinkPolicySpec.read("docs/en/demo-application-boundary.md")
+    japanese = DocsDemoRepositoryLinkPolicySpec.read("docs/ja/demo-application-boundary.md")
+
+    aggregate_failures do
+      expect(english).to include("Do not add a direct demo repository link")
+      expect(english).to include("When a public demo repository is available")
+      expect(english).to include("Before adding links, confirm the repository is public")
+      expect(japanese).to include("直接 link しません")
+      expect(japanese).to include("Public demo repository が利用できる状態")
+      expect(japanese).to include("repository が public")
+    end
+  end
+
+  it "keeps mockups documented as static review assets, not the demo app entry point" do
+    mockups_readme = DocsDemoRepositoryLinkPolicySpec.read(DocsDemoRepositoryLinkPolicySpec::MOCKUPS_README)
+
+    aggregate_failures do
+      expect(mockups_readme).to include("static HTML/CSS mockups")
+      expect(mockups_readme).to include("They are **not** a complete Rails application")
+      expect(mockups_readme).to include("tree_view-rails-demo")
+      expect(mockups_readme).to include("playground app rather than this directory")
+    end
+  end
+end


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1407
Supersedes #1413

## 置き換え理由

PR #1413 は #1407 の spec-only guard として scoped でしたが、current `main` から stale になり `mergeable:false` になっていました。

current `main` には #1396 / #1427 系の public declaration / manifest drift sync が既に入り、#1413 の過去CI blocker は解消済みの前提になっています。この PR は latest `main` から #1407 の新規spec 1ファイルだけを再適用する replacement です。

## Issue ごとの完了内容

- #1407: public demo repository が未公開の間、公開 docs から direct demo repo link が混入しないことを軽量 spec で固定します。

## 変更内容

- `spec/docs_demo_repository_link_policy_spec.rb` を追加しました。
- root README / docs index / 英日 README / 英日 demo boundary docs / mockups README を対象に、direct demo repository URL が入っていないことを確認します。
- public entry point が `demo-application-boundary.md` へ誘導していることを確認します。
- 英日 boundary docs に、demo repository 公開後の更新条件が残っていることを確認します。
- `docs/mockups/README.md` が static review assets として説明され、demo app entry point になっていないことを確認します。

## 改善カテゴリ

- test
- docs drift guard
- maintenance

## 既存仕様への影響

既存仕様への影響はありません。runtime Ruby / JavaScript、public API、CI workflow、DB、認可、外部サービス契約は変更していません。docs 本文も変更せず、既存 policy を guard する spec 追加のみです。

## 実施した確認

- GitHub compare: `main...quality/1413-demo-link-policy-refresh`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local `bundle exec rspec spec/docs_demo_repository_link_policy_spec.rb` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR CI で確認します。

## リスク評価

low。既存 docs policy の代表 signal を固定する spec-only 変更で、demo repository 公開判断や docs link 追加には踏み込んでいません。

## 補足

- 旧 #1413 の stale branch に直接追い commit せず、current `main` から replacement branch を作成しました。