### PR TITLE
public API docs signal smoke に manifest surface 確認を追加する (#1579)

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -60,6 +60,18 @@ const selectionDataHookSignals = [
   "data-tree-view-selection-hidden-input-name-value"
 ]
 
+const manifestBackedDocsSignalSurfaces = [
+  ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
+  ["host lifecycle no-detail events", "event_names_without_detail:"],
+  ["host lifecycle event names", "host_lifecycle:"],
+  ["remote-state values", "remote_state_values:"],
+  ["selection data hooks", "selection_data_hooks:"]
+]
+
+manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
+  assertIncludes(manifest, manifestNeedle, `public API docs signal manifest surface (${label})`)
+})
+
 callbackBuilderSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest callback builder key surface")
 })


### PR DESCRIPTION
## 対応 Issue

- Closes #1579

## Issue ごとの完了内容

- #1579: `script/test_public_api_docs_signals.mjs` に、この smoke が docs signal として確認する manifest-backed public surface の一覧を追加しました。
- 各 surface が `config/public_api_manifest.yml` に存在することを先に確認するため、package-root / manifest-backed public surface の追加時に docs signal guard の責務を見直しやすくしました。

## 変更内容

- `manifestBackedDocsSignalSurfaces` を追加し、RenderState callback builder keys / host lifecycle events / remote-state values / selection data hooks を manifest 側のキーに紐づけて検証します。
- 既存の docs 文言確認、manifest の個別 signal 確認、対象 docs は変更していません。

## 改善カテゴリ

- test
- docs signal smoke の保守性改善

## 既存仕様への影響

- 実行時コード、公開 API、UI、DB、認可、外部サービス契約は変更していません。
- 変更範囲は Node.js の検証 script 1ファイルのみです。

## 実施した確認内容

- Issue #1579 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:medium`
- PR 作成前に `main...quality/1579-docs-signal-manifest-review` を比較
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_public_api_docs_signals.mjs`)
- CI #2004: success
  - changes
  - lint
  - pr_specs
  - javascript (`npm run test:js:core`)
  - PR Rails matrix representative lanes (7.0 / 7.2 / 8.0)
- local git / local test は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。CI で検証済みです。

## リスク評価

- risk: medium issue ですが、変更は検証 script 内の manifest 存在確認追加に限定しており、挙動変更リスクは低いです。

## 補足事項

- #1571 は planner コメント上、未マージの前提PRに依存するため、このPRには含めていません。