### PR TITLE
public API docs signal smoke の manifest surface 確認を current main で再提案する

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -60,6 +60,18 @@ const selectionDataHookSignals = [
   "data-tree-view-selection-hidden-input-name-value"
 ]
 
+const manifestBackedDocsSignalSurfaces = [
+  ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
+  ["host lifecycle no-detail events", "event_names_without_detail:"],
+  ["host lifecycle event names", "host_lifecycle:"],
+  ["remote-state values", "remote_state_values:"],
+  ["selection data hooks", "selection_data_hooks:"]
+]
+
+manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
+  assertIncludes(manifest, manifestNeedle, `public API docs signal manifest surface (${label})`)
+})
+
 callbackBuilderSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest callback builder key surface")
 })


### PR DESCRIPTION
public API docs signal smoke の manifest surface 確認を current main から載せ直します。

## 対応 Issue / PR

Closes #1579
Supersedes #1582

## 置き換え理由

PR #1582 は #1579 の docs signal smoke guard として内容は一致していましたが、#1580 merge 後に current `main` から `behind_by:1` / `status:diverged` になり、review comment #4645655545 で latest main 取り込みと fresh CI が求められていました。

この PR は latest `main` `251bdee36225dae317da47466aef09f2e52a0f06` から同じ 1 ファイル差分だけを再適用する replacement です。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に `manifestBackedDocsSignalSurfaces` を追加しました。
- RenderState callback builder keys、host lifecycle events、remote-state values、selection data hooks が manifest 側に存在することを先に確認します。
- 既存の docs 文言確認、manifest の個別 signal 確認、対象 docs は変更していません。

## 変更範囲

- `script/test_public_api_docs_signals.mjs` のみ

runtime Ruby / JavaScript、public API manifest schema、docs 本文、CI workflow、DB、認可、外部サービス契約は変更していません。

## 受け入れ条件との対応

- #1579 の目的どおり、public API docs signal smoke が確認する manifest-backed public surface を明示します。
- package-root / manifest-backed public surface の追加時に docs signal guard の責務を見直しやすくしています。
- #1571 の未マージ前提 PR 依存は本 PR に含めていません。

## 実施した確認

- GitHub compare: `main...quality/1579-docs-signal-manifest-review-current`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_public_api_docs_signals.mjs`)
- local git / local test は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 manifest keys の存在確認を検証 script に追加するだけで、runtime behavior は変更しません。

## 未対応・補足

- #1582 はこの PR で supersede します。
- merge は行いません。