### PR TITLE
README Quick Start の代表コード導線を docs smoke で守る

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_readme_quick_start_signal.mjs
+++ b/script/test_readme_quick_start_signal.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const rootReadme = readFileSync(path.join(repoRoot, "README.md"), "utf8")
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+assert(
+  /## Quick Start[\s\S]*Controller:[\s\S]*TreeView::Tree[\s\S]*TreeView::UiConfigBuilder[\s\S]*build_static[\s\S]*TreeView::RenderState[\s\S]*row_partial:\s*"projects\/tree_columns"[\s\S]*View:[\s\S]*tree_view_rows\(@render_state\)[\s\S]*Row partial:[\s\S]*app\/views\/projects\/_tree_columns\.html\.erb/.test(rootReadme),
+  "README.md Quick Start no longer exposes the representative controller/view/row-partial path"
+)


### PR DESCRIPTION
## 対応 Issue

Closes #1584

## Issue ごとの完了内容

- #1584: README Quick Start の代表 controller / view / row partial 導線が維持されることを、docs entrypoints smoke で確認できるようにしました。

## 変更内容

- `script/test_readme_quick_start_signal.mjs` を追加し、README Quick Start が以下の代表要素を含むことを確認します。
  - `TreeView::Tree`
  - `TreeView::UiConfigBuilder#build_static`
  - `TreeView::RenderState`
  - `row_partial: "projects/tree_columns"`
  - `tree_view_rows(@render_state)`
  - `app/views/projects/_tree_columns.html.erb`
- `npm run test:docs-entrypoints` に上記 smoke を組み込みました。

## 改善カテゴリ

- test
- docs smoke
- maintenance

## 既存仕様への影響

なし。README と runtime 実装は変更せず、docs smoke の保護対象を追加しただけです。API、UI、DB、認可、状態遷移、外部サービス契約は変更していません。

## 実施した確認

- Issue #1584 の labels が `status:ready-for-agent`、`track:quality`、`agent:planned`、`risk:low` を満たすことを個別確認しました。
- Planner handoff が README Quick Start の代表シグナルを既存 docs entrypoint smoke に足す範囲であることを確認しました。
- README Quick Start が current `main` に controller / view / row partial の代表コードを含むことを確認しました。
- GitHub compare: `main...quality/1584-readme-quick-start-docs-smoke`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: `package.json`, `script/test_readme_quick_start_signal.mjs`
- Connector-only 作業のため、ローカル `npm run test:docs-entrypoints` は実行していません。

## リスク評価

low。docs smoke の追加のみで、既存挙動への影響はありません。