### PR TITLE
empty-state wrapper hooks の docs entrypoint を補強する

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ If you already know the symptom and want a faster reverse-lookup entry point, se
 
 If you want static visual references for baseline DOM structure and interaction states before wiring a host app, see [TreeView mockups](docs/mockups/README.md). Start with [review-gallery.html](docs/mockups/review-gallery.html) for the fastest first look, open [default-tree.html](docs/mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
 
+For no-root-items or no-results empty-state styling hooks, see [Accessibility Semantics](docs/en/accessibility-semantics.md#empty-state-and-hidden-count-hooks) / [日本語](docs/ja/accessibility-semantics.md) and the focused [empty-state.html](docs/mockups/empty-state.html) mockup. TreeView exposes reusable wrapper hooks for styling; final empty copy, CTAs, and filter-reset behavior stay in the host app.
+
 For the boundary between static mockups and a future real Rails demo app, see [Demo application boundary](docs/en/demo-application-boundary.md) / [日本語](docs/ja/demo-application-boundary.md). The public docs intentionally avoid direct demo repository links until a demo repository is public.
 
 ## Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,8 +29,8 @@
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
-- [English Accessibility Semantics](en/accessibility-semantics.md): table-first ARIA policy, keyboard helper boundary, and intentional automated-check allowances.
-- [日本語Accessibility Semantics](ja/accessibility-semantics.md): table-first ARIA 方針、keyboard helper の責務境界、自動 accessibility check の意図的な許容事項。
+- [English Accessibility Semantics](en/accessibility-semantics.md): table-first ARIA policy, empty-state wrapper hooks, keyboard helper boundary, and intentional automated-check allowances.
+- [日本語Accessibility Semantics](ja/accessibility-semantics.md): table-first ARIA 方針、empty-state wrapper hook、keyboard helper の責務境界、自動 accessibility check の意図的な許容事項。
 - [English Selection](en/selection.md): checkbox selection hooks, disabled state, cascade behavior, and submitted value parsing.
 - [日本語Selection](ja/selection.md): checkbox selection hooks、disabled state、cascade、submitted value parsing の入口。
 - [English Lazy Loading](en/lazy-loading.md): load children on demand through host-app routes and TreeView remote-state hooks.
@@ -45,7 +45,7 @@
 - [日本語Render log level](ja/render-log-level.md): host app 全体の Rails logger level を変えずに、TreeView helper-rendered partial log の出力を調整する入口。
 - [English direction-aware styling boundary](en/direction-aware-styling.md): host-app override guidance for RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing.
 - [日本語Direction-aware styling boundary](ja/direction-aware-styling.md): RTL、writing direction、current-row cue、hierarchy connector、toggle spacing の host-app override guidance。
-- [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure and interaction states. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, then use the mockup index for the focused pages and each page's role.
+- [TreeView mockups](mockups/README.md): static visual reference for baseline DOM structure, interaction states, and focused empty-state rows. Start with [review-gallery.html](mockups/review-gallery.html) for the fastest side-by-side first look, open [default-tree.html](mockups/default-tree.html) when you want the baseline DOM structure and shared CSS reference directly, and use [empty-state.html](mockups/empty-state.html) when checking no-root-items / no-results wrapper hooks and host-app-owned copy boundaries.
 - [English demo application boundary](en/demo-application-boundary.md): decide when to use static mockups versus a real Rails demo app, without adding private or unavailable demo links.
 - [日本語Demo application boundary](ja/demo-application-boundary.md): static mockup と real Rails demo app の役割分担、未公開 demo link を増やさない方針。
 - [English Turbo Frame option](en/turbo-frame.md): target TreeView Turbo toggle links at a host-app Turbo Frame without custom JavaScript.


### PR DESCRIPTION
## 対応 Issue

Closes #1605

## 判定分類

- `docs-sync`
- `docs-missing` / discoverability follow-up

## 変更内容

- root `README.md` の static visual reference 入口に、no-root-items / no-results の empty-state styling hooks と `empty-state.html` への導線を追加しました。
- `docs/README.md` の Accessibility Semantics entry に empty-state wrapper hooks を明記しました。
- `docs/README.md` の mockup entry に `empty-state.html` の役割を追加し、host-app-owned copy boundary を見つけやすくしました。

## 変更範囲

- `README.md`
- `docs/README.md`

runtime Ruby / JavaScript、empty-state partial markup、public API manifest、AGENTS.md、Product Profile は変更していません。

## 確認内容

2026-06-08 JST の Docs Sync follow-up で current `main` (`dd6091a66c950a5914f7facb3996a67e5642eb4a`) へ clean refresh しました。

- head: `cf51e0c1f0ad803f81303d16c7ea3ea6d7bac280`
- compare: `ahead_by:1` / `behind_by:0`
- changed files: 2 docs-only
- PR metadata: `mergeable:true`
- GitHub Actions CI #2034: success
- `docs/en/accessibility-semantics.md` / `docs/ja/accessibility-semantics.md` の既存 empty-state hook 説明を正本として参照し、hook 名の追加・rename・削除はしていません。
- local checkout / local docs link check は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。既存 docs / mockup への導線追加だけで、final empty copy、CTA、filter-reset workflow は host app responsibility のままです。