### PR TITLE
docs entrypoint smoke を latest main で再提案する

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -264,6 +264,28 @@ const featureEntrypoints = [
       ["docs/README.md", "ja/selection.md"],
       ["docs/en/README.md", "selection.md"],
       ["docs/ja/README.md", "selection.md"]
+    ],
+    signals: [
+      [
+        "docs/en/public-api.md",
+        /TreeViewSelectionDataHooks[\s\S]*hiddenInputNameValue[\s\S]*maxCountValue[\s\S]*cascadeValue[\s\S]*indeterminateValue[\s\S]*data-tree-view-selection-hidden-input-name-value[\s\S]*data-tree-view-selection-max-count-value[\s\S]*data-tree-view-selection-cascade-value[\s\S]*data-tree-view-selection-indeterminate-value/,
+        "English public API docs no longer expose the TreeViewSelectionDataHooks host-authored value attributes"
+      ],
+      [
+        "docs/ja/public-api.md",
+        /TreeViewSelectionDataHooks[\s\S]*hiddenInputNameValue[\s\S]*maxCountValue[\s\S]*cascadeValue[\s\S]*indeterminateValue[\s\S]*data-tree-view-selection-hidden-input-name-value[\s\S]*data-tree-view-selection-max-count-value[\s\S]*data-tree-view-selection-cascade-value[\s\S]*data-tree-view-selection-indeterminate-value/,
+        "Japanese public API docs no longer expose the TreeViewSelectionDataHooks host-authored value attributes"
+      ],
+      [
+        "docs/en/selection.md",
+        /TreeViewSelectionDataHooks\.hiddenInputNameValue[\s\S]*TreeViewSelectionDataHooks\.maxCountValue[\s\S]*TreeViewSelectionDataHooks\.cascadeValue[\s\S]*TreeViewSelectionDataHooks\.indeterminateValue/,
+        "English selection docs no longer expose the machine-readable selection data hooks"
+      ],
+      [
+        "docs/ja/selection.md",
+        /TreeViewSelectionDataHooks\.hiddenInputNameValue[\s\S]*TreeViewSelectionDataHooks\.maxCountValue[\s\S]*TreeViewSelectionDataHooks\.cascadeValue[\s\S]*TreeViewSelectionDataHooks\.indeterminateValue/,
+        "Japanese selection docs no longer expose the machine-readable selection data hooks"
+      ]
     ]
   },
   {
@@ -308,6 +330,30 @@ const featureEntrypoints = [
       ["docs/README.md", "ja/breadcrumb.md"],
       ["docs/en/README.md", "breadcrumb.md"],
       ["docs/ja/README.md", "breadcrumb.md"]
+    ]
+  },
+  {
+    feature: "Cookbook",
+    rootPattern: /Cookbook/,
+    links: [
+      ["README.md", "docs/en/cookbook.md"],
+      ["README.md", "docs/ja/cookbook.md"],
+      ["docs/README.md", "en/cookbook.md"],
+      ["docs/README.md", "ja/cookbook.md"],
+      ["docs/en/README.md", "cookbook.md"],
+      ["docs/ja/README.md", "cookbook.md"]
+    ],
+    signals: [
+      [
+        "docs/en/cookbook.md",
+        /tree_view_breadcrumb[\s\S]*row_partial[\s\S]*row_actions_partial[\s\S]*data-tree-view-interactive[\s\S]*TreeView::NodePresenter[\s\S]*TreeView\.model_name_for[\s\S]*TreeView\.attribute_name_for[\s\S]*TreeView\.type_name_for/,
+        "English Cookbook no longer exposes the representative host-app pattern signals"
+      ],
+      [
+        "docs/ja/cookbook.md",
+        /tree_view_breadcrumb[\s\S]*row_partial[\s\S]*row_actions_partial[\s\S]*data-tree-view-interactive[\s\S]*TreeView::NodePresenter[\s\S]*TreeView\.model_name_for[\s\S]*TreeView\.attribute_name_for[\s\S]*TreeView\.type_name_for/,
+        "Japanese Cookbook no longer exposes the representative host-app pattern signals"
+      ]
     ]
   },
   {


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1598
Closes #1395
Supersedes #1603

## Issue ごとの完了内容

- #1598: Cookbook の日英 entrypoint link と、代表的な host-app pattern signal（breadcrumb、row partial/action partial、interactive marker、NodePresenter、localized-name helpers）を docs entrypoint smoke で確認します。
- #1395: `TreeViewSelectionDataHooks` の public API docs と selection docs で、host-authored value attributes と machine-readable hook names が残っていることを docs entrypoint smoke で確認します。

## 変更内容

- `script/test_docs_entrypoints.mjs` の `Selection` entry に日英 public API / selection docs の signal check を追加しました。
- 同じ script に `Cookbook` entry を追加し、README / docs index からの導線と、Cookbook 本文の代表コード signal を確認するようにしました。

## 改善カテゴリ

- test
- docs smoke / drift guard
- 小さな CI 補助

## 既存仕様への影響

- runtime、public API、manifest、docs 本文は変更していません。
- docs entrypoint smoke の確認範囲だけを増やす変更のため、既存の UI / API / DB / 認可 / 状態遷移仕様には影響しません。

## 実施した確認

- review follow-up 対象 PR #1603 の最新コメントを確認し、指摘が latest main への載せ直し、1ファイル差分維持、fresh CI であることを確認しました。
- current `main` head `dd6091a66c950a5914f7facb3996a67e5642eb4a` から replacement branch を作成しました。
- GitHub compare: `main...quality/1395-1598-docs-entrypoint-signals-current`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
  - changed file: `script/test_docs_entrypoints.mjs`
- local checkout / local `node script/test_docs_entrypoints.mjs` は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク評価

- risk: low
- docs smoke の確認条件追加のみで、公開挙動を変えません。

## 補足

#1603 は #1602 merge 後に `behind_by:1` / diverged となったため、この PR で current main から同じ1ファイル差分を clean replacement として再提案します。