### PR TITLE
packaged docs の repository-only maintainer link guard を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,8 +63,8 @@
 
 - [English documentation](en/README.md): full English docs map, reading order, and maintainer-facing entry points within the English tree.
 - [日本語ドキュメント](ja/README.md): 日本語 docs tree の full map、reading order、maintainer-facing entry points。
-- [Product Profile](../Product%20Profile.md): repository positioning, source-of-truth order, host app responsibilities, and non-goals.
-- [AGENTS.md](../AGENTS.md): repository-specific maintainer workflow, first-read order, and documentation update rules.
+- Repository-only Product Profile (`Product Profile.md` at the repository root): repository positioning, source-of-truth order, host app responsibilities, and non-goals. This file is not packaged in the gem; read it from a repository checkout.
+- Repository-only maintainer workflow (`AGENTS.md` at the repository root): repository-specific maintainer workflow, first-read order, and documentation update rules. This file is not packaged in the gem; read it from a repository checkout.
 - [Documentation maintenance checklist](i18n-audit.md): language-sync rules, technical-asset inventory, and cross-language update coverage.
 - [Public API](en/public-api.md) / [公開 API](ja/public-api.md): compatibility contract and the surfaces host apps may use directly.
 - [Migration guide](en/migration.md) / [移行ガイド](ja/migration.md): upgrade expectations, deprecations, and release-note reading order.

--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -66,6 +66,13 @@ INSTALLATION_REQUIRED_SIGNALS = [
   "pin \"tree_view\", to: \"tree_view/index.js\""
 ].freeze
 
+PACKAGED_DOCS_FORBIDDEN_RELATIVE_ROOT_LINKS = {
+  "docs/README.md" => [
+    "../Product%20Profile.md",
+    "../AGENTS.md"
+  ]
+}.freeze
+
 root = File.expand_path("..", __dir__)
 gem_path = ARGV.first || Dir[File.join(root, "tree_view-*.gem")].max_by { |path| File.mtime(path) }
 
@@ -77,12 +84,16 @@ missing_installation_signals = INSTALLATION_DOC_PATHS.to_h do |path|
   content = File.read(File.join(root, path))
   [path, INSTALLATION_REQUIRED_SIGNALS.reject { |signal| content.include?(signal) }]
 end.reject { |_path, missing_signals| missing_signals.empty? }
+forbidden_packaged_doc_links = PACKAGED_DOCS_FORBIDDEN_RELATIVE_ROOT_LINKS.to_h do |path, forbidden_links|
+  content = File.read(File.join(root, path))
+  [path, forbidden_links.select { |link| content.include?(link) }]
+end.reject { |_path, links| links.empty? }
 
 importmap_path = File.join(root, "config/importmap.tree_view.rb")
 importmap_content = File.read(importmap_path)
 importmap_pin_missing = !importmap_content.include?("pin \"tree_view\", to: \"tree_view/index.js\"")
 
-if missing.empty? && missing_installation_signals.empty? && !importmap_pin_missing
+if missing.empty? && missing_installation_signals.empty? && forbidden_packaged_doc_links.empty? && !importmap_pin_missing
   puts "Gem package contents verified: #{File.basename(gem_path)}"
 else
   warn "Gem package contents verification failed: #{File.basename(gem_path)}"
@@ -95,6 +106,11 @@ else
   missing_installation_signals.each do |path, signals|
     warn "Missing installation docs signals in #{path}:"
     signals.each { |signal| warn "  - #{signal}" }
+  end
+
+  forbidden_packaged_doc_links.each do |path, links|
+    warn "Forbidden repository-only root doc links in packaged #{path}:"
+    links.each { |link| warn "  - #{link}" }
   end
 
   if importmap_pin_missing


### PR DESCRIPTION
## 対応 Issue

- Closes #1608

## Issue ごとの完了内容

- #1608: `docs/README.md` の maintainer entry points から、gem に同梱されない root maintainer docs への相対リンクを外し、repository checkout で読む repository-only notes として明示しました。
- #1608: package contents check に、packaged docs から `../Product%20Profile.md` / `../AGENTS.md` のような unshipped root docs 相対リンクが再発した場合の代表 guard を追加しました。

## 変更内容

- `docs/README.md` の Product Profile / AGENTS.md entry を、壊れる相対リンクではなく repository-only maintainer notes として説明。
- `script/check_gem_package_contents.rb` に `PACKAGED_DOCS_FORBIDDEN_RELATIVE_ROOT_LINKS` と検出・報告処理を追加。

## 改善カテゴリ

- docs 改善
- package verification / quality guard 追加

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、gemspec の packaged file policy は変更していません。
- root maintainer docs を gem に含めるかどうかの方針判断には踏み込んでいません。

## 実施した確認

- GitHub connector で main 最新 SHA を確認し、branch は main から behind 0 の状態で作成。
- PR 前 compare で変更対象が `docs/README.md` と `script/check_gem_package_contents.rb` の2ファイルだけであることを確認。
- `docs/README.md` から `../Product%20Profile.md` / `../AGENTS.md` の相対リンクが消えたことを確認。

## リスク評価

- risk: low
- docs 表現と package verification の代表 guard に限定しており、公開挙動・API 契約・package file policy は変えていません。

## 補足

- この実行では 3 repository の open PR review follow-up と ready-for-agent quality issue を確認しました。review follow-up は self/status コメントまたは human/visual/public-surface gate が中心で、Quality Fixer として自動対応できる明確な外部指摘はありませんでした。