### PR TITLE
docs entrypoint signal smoke を current main で再提案する

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const signalGroups = [
+  {
+    feature: "FAQ host responsibility boundary",
+    files: [
+      [
+        "docs/en/faq.md",
+        ["host app", "records, controllers, forms, routes, authorization", "queries"]
+      ],
+      ["docs/ja/faq.md", ["host app", "authorization", "query"]]
+    ]
+  },
+  {
+    feature: "Troubleshooting host responsibility boundary",
+    files: [
+      [
+        "docs/en/troubleshooting.md",
+        ["host app still owns routes", "authorization", "business actions"]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        ["routes、controller action、authorization、query", "business action", "host app の責務"]
+      ]
+    ]
+  },
+  {
+    feature: "Troubleshooting JavaScript event reverse lookup",
+    files: [
+      [
+        "docs/en/troubleshooting.md",
+        [
+          "tree-view-selection:invalid-payload",
+          "tree-view-remote-state:retry",
+          "js-events.md#tree-view-remote-stateretry",
+          "js-events.md#transfer-events"
+        ]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        [
+          "tree-view-selection:invalid-payload",
+          "tree-view-remote-state:retry",
+          "js-events.md#tree-view-remote-stateretry",
+          "js-events.md#transfer-events"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Demo application boundary direct-link policy",
+    files: [
+      [
+        "README.md",
+        ["docs/en/demo-application-boundary.md", "docs/ja/demo-application-boundary.md"]
+      ],
+      [
+        "docs/README.md",
+        ["en/demo-application-boundary.md", "ja/demo-application-boundary.md"]
+      ],
+      [
+        "docs/en/demo-application-boundary.md",
+        [
+          "Do not add a direct demo repository link",
+          "static mockups",
+          "real Rails demo application",
+          "Publication checklist"
+        ]
+      ],
+      [
+        "docs/ja/demo-application-boundary.md",
+        [
+          "demo repository へ直接 link しません",
+          "static mockup",
+          "real Rails demo application",
+          "Publication checklist"
+        ]
+      ]
+    ]
+  }
+]
+
+signalGroups.forEach(({ feature, files }) => {
+  files.forEach(([sourcePath, signals]) => assertSignals(sourcePath, feature, signals))
+})


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1423
Closes #1426
Closes #1604
Supersedes #1427

## review follow-up

PR #1427 は #1423 / #1426 の intent に合っていましたが、current `main` から大きく diverged し、PR metadata も `mergeable:false` でした。旧 branch には当時の CI-discovered TypeScript declaration / public API manifest structure sync も含まれており、current main へそのまま戻すと後続の public API / docs smoke 更新を巻き戻すリスクがありました。

この PR は current `main` `65382e0a79f762f61a530e81fbd0de487f8405d3` から clean replacement branch を作成し、docs entrypoint signal smoke だけを再適用します。あわせて同じ docs signal guard 系の #1604 を同じ script に小さく追加しています。

## Issue ごとの完了内容

- #1423: FAQ / Troubleshooting が host app responsibility boundary の代表 signal を持つことを smoke で確認します。
- #1426: Troubleshooting から selection / remote-state / transfer event の代表 reverse lookup signal が消えないことを smoke で確認します。
- #1604: root README / docs index から demo application boundary docs へ辿れること、英日 boundary docs が direct demo repository link policy と static mockup / real demo app boundary を持つことを smoke で確認します。

## 変更内容

- `script/test_docs_entrypoint_signals.mjs` を追加しました。
- `npm run test:docs-entrypoints` に signal smoke を組み込みました。
- 旧 #1427 に含まれていた `app/javascript/tree_view/index.d.ts` / `spec/public_api_manifest_structure_spec.rb` の古い public surface sync は current main では再適用していません。

## 改善カテゴリ

- test
- docs smoke
- regression guard

## 既存仕様への影響

- docs smoke と package script のみです。
- runtime Ruby / JavaScript、public API manifest、TypeScript declaration、mockup HTML/CSS、CI workflow、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- GitHub compare: `main...quality/1423-1426-1604-doc-signals-current`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2
    - `package.json`
    - `script/test_docs_entrypoint_signals.mjs`
- local syntax check: Node ESM syntax check for the script shape succeeded using a temporary `.mjs` file.
- local full `npm run test:docs-entrypoints` は未実行です。この環境では GitHub checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR CI で確認します。

## リスク評価

- risk: low
- repository-local docs smoke の追加のみで、公開挙動や public API surface は変えません。

## 補足

- #413 は eligibility を確認しましたが、lockfile refresh は registry-enabled environment が前提です。今回の coherent bundle は docs entrypoint signal smoke に閉じています。