### PR TITLE
drag-and-drop guide から drop-position mockup へリンクする

### DIFF
--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -114,6 +114,8 @@ The transfer controller exposes these reader-facing details:
 
 `position` is a TreeView-owned coarse cue for where the pointer sits inside the target row: the top third is `before`, the middle third is `inside`, and the bottom third is `after`. Treat it as input to host-app business rules, not as final authorization or persistence policy. For example, a host app may ignore `inside` for leaf-only trees, reject drops across projects, or translate `before` / `after` into an ordering update.
 
+For a static comparison of the `before` / `inside` / `after` cues plus disabled and invalid transfer boundary states, see [drop-positions.html](../mockups/drop-positions.html).
+
 Use the package-root `TreeViewTransferDropPositions` export when host-app JavaScript wants to avoid raw drop-position strings. `TreeViewEventNames.transfer.*` names the transfer events, `TreeViewEventDetailKeys.transfer.*` lists the documented detail keys, and `TreeViewTransferDropPositions` carries the coarse `before` / `inside` / `after` position values.
 
 ### Transfer operation and outcome boundary

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -114,6 +114,8 @@ transfer controller が読者向けに公開する主なdetailは次のとおり
 
 `position` は、target row内でpointerがどこにあるかを示すTreeView側の粗いcueです。上 1/3 は `before`、中央 1/3 は `inside`、下 1/3 は `after` になります。これはhost appの業務ルールへの入力として扱い、最終的な許可・保存方針として扱わないでください。たとえば、leaf-only treeでは `inside` を無視したり、projectをまたぐdropを拒否したり、`before` / `after` を並び順更新へ変換したりできます。
 
+`before` / `inside` / `after` のcueと、transfer disabled / invalid transfer 境界状態を静的に見比べたい場合は [drop-positions.html](../mockups/drop-positions.html) を参照してください。
+
 host app の JavaScript で raw な drop-position string を写経したくない場合は、package-root の `TreeViewTransferDropPositions` export を使えます。`TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented detail key、`TreeViewTransferDropPositions` は粗い `before` / `inside` / `after` position value を表します。
 
 ### transfer operation と outcome の境界


### PR DESCRIPTION
## 対応 Issue

Closes #1612

## 判定分類

- `docs-sync`
- `docs-missing`
- low-risk docs-link follow-up

## 変更内容

- `docs/en/drag-and-drop.md` の drop position 説明から `../mockups/drop-positions.html` へ直接リンクしました。
- `docs/ja/drag-and-drop.md` も同じ位置で、`before` / `inside` / `after` cue と transfer disabled / invalid transfer 境界状態を静的に確認できる導線を追加しました。

## 変更範囲

- `docs/en/drag-and-drop.md`
- `docs/ja/drag-and-drop.md`

runtime JavaScript、transfer payload shape、public API manifest、mockup HTML/CSS、review gallery / mockup index は変更していません。

## 確認内容

- GitHub compare: `main...docs/1612-drop-position-visual-link`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs-only
  - deletion: 0
- `docs/mockups/README.md` で `drop-positions.html` が listed / review flow に存在することを確認しました。
- local checkout / local docs link check は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 static mockup へのリンク追加のみで、drop behavior や host-app-owned authorization / persistence boundary は変更していません。