### PR TITLE
docs entrypoint signal smoke を latest main で再提案する

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const signalGroups = [
+  {
+    feature: "FAQ host responsibility boundary",
+    files: [
+      [
+        "docs/en/faq.md",
+        ["host app", "records, controllers, forms, routes, authorization", "queries"]
+      ],
+      ["docs/ja/faq.md", ["host app", "authorization", "query"]]
+    ]
+  },
+  {
+    feature: "Troubleshooting host responsibility boundary",
+    files: [
+      [
+        "docs/en/troubleshooting.md",
+        ["host app still owns routes", "authorization", "business actions"]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        ["routes、controller action、authorization、query", "business action", "host app の責務"]
+      ]
+    ]
+  },
+  {
+    feature: "Troubleshooting JavaScript event reverse lookup",
+    files: [
+      [
+        "docs/en/troubleshooting.md",
+        [
+          "tree-view-selection:invalid-payload",
+          "tree-view-remote-state:retry",
+          "js-events.md#tree-view-remote-stateretry",
+          "js-events.md#transfer-events"
+        ]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        [
+          "tree-view-selection:invalid-payload",
+          "tree-view-remote-state:retry",
+          "js-events.md#tree-view-remote-stateretry",
+          "js-events.md#transfer-events"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Demo application boundary direct-link policy",
+    files: [
+      [
+        "README.md",
+        ["docs/en/demo-application-boundary.md", "docs/ja/demo-application-boundary.md"]
+      ],
+      [
+        "docs/README.md",
+        ["en/demo-application-boundary.md", "ja/demo-application-boundary.md"]
+      ],
+      [
+        "docs/en/demo-application-boundary.md",
+        [
+          "Do not add a direct demo repository link",
+          "static mockups",
+          "real Rails demo application",
+          "Publication checklist"
+        ]
+      ],
+      [
+        "docs/ja/demo-application-boundary.md",
+        [
+          "demo repository へ直接 link しません",
+          "static mockup",
+          "real Rails demo application",
+          "Publication checklist"
+        ]
+      ]
+    ]
+  }
+]
+
+signalGroups.forEach(({ feature, files }) => {
+  files.forEach(([sourcePath, signals]) => assertSignals(sourcePath, feature, signals))
+})


### PR DESCRIPTION
docs entrypoint signal smoke を current main へ載せ直し、#1611 の freshness blocker に対応します。

## 対応 Issue / PR

Closes #1423
Closes #1426
Closes #1604
Supersedes #1611
Supersedes #1427

## review follow-up

PR #1611 は差分内容としては #1423 / #1426 / #1604 の範囲に合っていましたが、#1614 / #1615 merge 後の current `main` から `behind_by:2` / `status:diverged` になっていました。

既存 branch を force update せず、latest `main` `c4969a879a5526f70640430a0bb90d18966cd64f` から replacement branch を作成し、#1611 と同じ docs entrypoint signal smoke 差分だけを再適用しています。

## Issue ごとの完了内容

- #1423: FAQ / Troubleshooting が host app responsibility boundary の代表 signal を持つことを smoke で確認します。
- #1426: Troubleshooting から selection / remote-state / transfer event の代表 reverse lookup signal が消えないことを smoke で確認します。
- #1604: root README / docs index から demo application boundary docs へ辿れること、英日 boundary docs が direct demo repository link policy と static mockup / real demo app boundary を持つことを smoke で確認します。

## 変更内容

- `script/test_docs_entrypoint_signals.mjs` を追加しました。
- `npm run test:docs-entrypoints` に signal smoke を組み込みました。
- latest main 側の drag/drop guide から drop-position mockup への docs link 追加は保持しています。
- 旧 #1427 に含まれていた `app/javascript/tree_view/index.d.ts` / `spec/public_api_manifest_structure_spec.rb` の古い public surface sync は再適用していません。

## 変更範囲

- `package.json`
- `script/test_docs_entrypoint_signals.mjs`

runtime Ruby / JavaScript、public API manifest、TypeScript declaration、mockup HTML/CSS、CI workflow、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- GitHub compare: `main...quality/1423-1426-1604-doc-signals-current-v2`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2
- connector source review で、差分が #1611 と同じ docs signal smoke に閉じていることを確認しました。
- local full `npm run test:docs-entrypoints` は未実行です。この環境では GitHub checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR CI で確認します。

## リスク評価

- risk: low
- repository-local docs smoke の追加のみで、公開挙動や public API surface は変えません。

## 未対応・補足

- #1611 は stale / diverged な旧提案として、この PR で supersede します。
- PR 作成後に fresh CI / mergeability を確認します。