### PR TITLE
README に Error hierarchy 入口を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Key documents:
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
 | GraphAdapter | [GraphAdapter](docs/en/graph-adapter.md) | [GraphAdapter](docs/ja/graph-adapter.md) |
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |
+| Error hierarchy | [Error hierarchy](docs/en/errors.md) | [エラー階層](docs/ja/errors.md) |
 | PathTreeBuilder | [PathTreeBuilder](docs/en/path-tree-builder.md) | [PathTreeBuilder](docs/ja/path-tree-builder.md) |
 | ReverseTree | [ReverseTree](docs/en/reverse-tree.md) | [ReverseTree](docs/ja/reverse-tree.md) |
 | Filtered Trees | [Filtered Trees](docs/en/filtered-trees.md) | [Filtered Trees](docs/ja/filtered-trees.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #1618

## 判定分類

- `docs-sync`
- `docs-missing`
- low-risk README entrypoint follow-up

## 変更内容

- root `README.md` の Key documents table に Error hierarchy / エラー階層 への日英リンクを追加しました。
- current `main` では API overview / API reference の行は既に存在していたため、残っていた rescue guidance 入口だけを補っています。

## 変更範囲

- `README.md` の1行のみ

Ruby / JavaScript runtime、public API manifest、API docs 本文、error hierarchy 本文、AGENTS.md、Product Profile は変更していません。

## 確認内容

- `docs/en/README.md` / `docs/ja/README.md` に API overview、API reference、Error hierarchy が既にあることを確認しました。
- `docs/en/errors.md` / `docs/ja/errors.md` が TreeView error class と rescue guidance を説明していることを確認しました。
- PR 作成前 compare: `main...docs/1618-readme-error-hierarchy-entry`
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1 docs-only (`README.md`)
  - deletions: 0
- local checkout / local link check は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 docs への README 導線追加のみです。README を full docs index 化せず、Issue #1618 の未充足部分に閉じています。