### PR TITLE
docs boundary signal smoke を拡張する

### DIFF
--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -100,6 +100,115 @@ const signalGroups = [
         ]
       ]
     ]
+  },
+  {
+    feature: "Drag/drop visual reference routing",
+    files: [
+      [
+        "docs/en/drag-and-drop.md",
+        [
+          "drag-interactive-controls.html",
+          "interactive-marker-behaviors.html",
+          "drop-positions.html",
+          "before",
+          "inside",
+          "after"
+        ]
+      ],
+      [
+        "docs/ja/drag-and-drop.md",
+        [
+          "drag-interactive-controls.html",
+          "interactive-marker-behaviors.html",
+          "drop-positions.html",
+          "before",
+          "inside",
+          "after"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Design policy responsibility and promotion boundaries",
+    files: [
+      [
+        "docs/en/design-policy.md",
+        [
+          "CRUD",
+          "authorization",
+          "queries, filtering, and pagination",
+          "business behavior remains in the host app",
+          "Prefer adding cookbook guidance before adding new rendering DSLs",
+          "thin resolver, helper, or configuration object",
+          "not coupled to authorization"
+        ]
+      ],
+      [
+        "docs/ja/design-policy.md",
+        [
+          "CRUD",
+          "authorization",
+          "query / filtering / pagination",
+          "業務処理はhost appに残します",
+          "まず cookbook として整理することを優先します",
+          "薄い resolver、helper、configuration object",
+          "authorization、forms、modals、downloads、domain workflows と密結合しない"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Node keys and UI identifiers responsibility boundary",
+    files: [
+      [
+        "docs/en/node-keys.md",
+        [
+          "Tree node key",
+          "UI identifier / DOM ID",
+          "expanded_keys",
+          "collapsed_keys",
+          "persisted state",
+          "diagnostics",
+          "UiConfig"
+        ]
+      ],
+      [
+        "docs/ja/node-keys.md",
+        [
+          "Tree node key",
+          "UI識別子 / DOM ID",
+          "expanded_keys",
+          "collapsed_keys",
+          "persisted state",
+          "diagnostics",
+          "UiConfig"
+        ]
+      ],
+      [
+        "docs/en/api-overview.md",
+        [
+          "Node keys and UI identifiers",
+          "Tree node key",
+          "UI identifier / DOM ID",
+          "expanded_keys",
+          "collapsed_keys",
+          "Changing a UI DOM ID builder",
+          "does not change the keys"
+        ]
+      ],
+      [
+        "docs/ja/api-overview.md",
+        [
+          "node keyとUI識別子",
+          "Tree node key",
+          "UI識別子 / DOM ID",
+          "expanded_keys",
+          "collapsed_keys",
+          "UI側のDOM ID builderを変更しても",
+          "keyは変わりません"
+        ]
+      ]
+    ]
   }
 ]
 


### PR DESCRIPTION
## 対応 Issue

- Closes #1613
- Closes #1616
- Closes #1620

## Issue ごとの完了内容

- #1613: drag/drop guide が `drop-positions.html` / `drag-interactive-controls.html` / `interactive-marker-behaviors.html` と `before` / `inside` / `after` の代表 signal を維持することを smoke で確認します。
- #1616: design policy が gem / host app の責務境界と UI pattern promotion criteria を維持することを smoke で確認します。
- #1620: node key と UI identifier / DOM ID の責務境界が node-keys docs と API overview の両方に残ることを smoke で確認します。

## 変更内容

- 既存の `script/test_docs_entrypoint_signals.mjs` に、上記3系統の docs signal group を追加しました。
- docs 本文、公開 API、UI、runtime 挙動は変更していません。

## 改善カテゴリ

- test
- docs drift guard
- small maintenance

## 既存仕様への影響

- なし。既存 docs の代表文言を軽量に検証するだけです。
- 業務仕様、UI仕様、API契約、DBスキーマ、認可、状態遷移、外部サービス契約には触れていません。

## 実施した確認

- Issue labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch freshness: PR branch は current `main` から作成し、compare で `behind_by: 0` を確認しました。
- diff scope: 変更ファイルは `script/test_docs_entrypoint_signals.mjs` のみです。
- 対象ファイルと参照先 docs の現在内容を connector で確認し、追加した signal が存在することを確認しました。
- GitHub Actions CI run #2055: success。

## リスク評価

- low。docs smoke の検証対象を増やすのみで、runtime code や docs prose は変更しません。

## 補足事項

- 3件はいずれも docs entrypoint / signal smoke で責務境界の drift を防ぐ同系統の quality issue なので、1つの PR にまとめています。