### PR TITLE
toolbar action_html boundary note を追加する

### DIFF
--- a/docs/toolbar_action_html_boundary.md
+++ b/docs/toolbar_action_html_boundary.md
@@ -1,0 +1,37 @@
+# Toolbar action HTML boundary note
+
+This companion note supports `docs/mockups/toolbar-actions.html` review for #1573 without changing the runtime toolbar helper or the existing mockup page.
+
+## Review question
+
+When a host app passes `html:` or `action_html:` to toolbar helpers, reviewers need to see two ownership lanes at the same time:
+
+- TreeView-owned hooks must remain present: `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, and `data-tree-view-toolbar-disabled`.
+- Host-app attributes may be added for analytics, Turbo targets, screen-specific grouping, or local styling.
+
+The goal is to review ownership, not to define a new public manifest contract. Helper return-shape decisions remain in #1449 / PR #1516.
+
+## Attribute ownership examples
+
+| Scenario | TreeView-owned hook | Host-app-owned attribute | Review cue |
+|---|---|---|---|
+| Enabled expand action | `data-tree-view-toolbar-action="expand_all"` | `data-analytics-action="expand-all"` | Host analytics can attach without replacing the action identity hook. |
+| Disabled collapse action | `data-tree-view-toolbar-disabled="true"` | `data-disabled-reason="all-rows-collapsed"` | The disabled fallback stays machine-readable while the host app owns final reason copy. |
+| Current-path action | `data-tree-view-toolbar-action="collapse_to_current_path"` | `data-turbo-frame="tree_sidebar"` | Turbo targeting is host-owned; TreeView still exposes the toolbar action role. |
+| Toolbar wrapper | `data-tree-view-toolbar="true"` | `data-screen="document-tree"` | Screen grouping can be added without changing the baseline toolbar hook. |
+
+## What to check in `toolbar-actions.html`
+
+Use the current toolbar mockup for visual states, then apply this note while reviewing the markup boundary:
+
+- Enabled, disabled, missing-path, and current-state cues should remain visually distinct.
+- Long or localized labels should wrap without hiding the action role.
+- Host-app attributes should read as additive metadata, not as required TreeView behavior.
+- Authorization, final labels, routes, Turbo responses, analytics policy, and permission copy stay out of the static mockup.
+
+## Non-goals
+
+- No runtime helper implementation change.
+- No public hook export or manifest expansion.
+- No real analytics, Turbo route, or authorization behavior.
+- No redesign of `toolbar-actions.html` or the review gallery.


### PR DESCRIPTION
## 対応Issue

Closes #1573

## 判定分類

- `docs-stale` / review follow-up refresh
- `docs-sync`
- `needs-human` 継続（companion note 方式で #1573 の design review surface として十分か）

## 変更内容

- `docs/toolbar_action_html_boundary.md` を追加し、`action_html:` / `html:` で host app が追加する属性と TreeView-owned hooks の ownership boundary を整理します。
- 既存の長い `docs/mockups/toolbar-actions.html` と `docs/mockups/review-gallery.html` は直接更新せず、visual state reference と companion note の役割を分けます。
- runtime helper、public API manifest、toolbar layout、route / authorization / Turbo behavior には触れていません。

## 変更範囲

- docs-only
- `docs/toolbar_action_html_boundary.md`

## 確認内容

- latest main: `a0a6abf76ec96b0d3c700b6051982908c26a8573`
- head: `46845b9064690f030eb36730f15d656b74f88fcd`
- compare: `main...design/1573-toolbar-action-html-boundary-note`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 docs file
- PR metadata: `mergeable: true`
- CI #2115: success
  - `changes`, `lint`, `pr_specs`: success
  - `javascript`: docs-only non-mockup skip path success
  - representative Rails lanes: docs-only skip path success

## リスク

low。static docs note の追加のみです。実ブラウザ確認が必要な visual artifact ではありませんが、companion note 方式の採用可否は human/design review に残します。

## 補足

- 初回 CI #2058 は `docs/mockups` 配下へ note を置いたことで mockup inventory spec が失敗しました。note を `docs/` 配下へ移し、差分を inventory 対象外の1ファイルに戻しています。
- 2026-06-09 に latest main へ clean refresh し、古い branch blob 全文は戻さず intended docs file だけを再適用しました。