### PR TITLE
windowed rendering の first / last boundary mockup を追加する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -35,7 +35,7 @@ When a review starts from the gallery or a focused mockup page, confirm this sta
 | [turbo-frame-target.html](turbo-frame-target.html) | Focused Turbo Frame target boundary showing `data-turbo-frame` on TreeView toggle links beside the host-app-owned frame wrapper. |
 | [drag-interactive-controls.html](drag-interactive-controls.html) | Focused comparison for native interactive controls, `data-tree-view-interactive`, and `data-tree-view-ignore-drag` inside draggable rows. |
 | [interactive-marker-behaviors.html](interactive-marker-behaviors.html) | Focused comparison for `data-tree-view-interactive`, `data-tree-view-ignore-keyboard`, `data-tree-view-ignore-row-click`, and `data-tree-view-ignore-drag`, including the reserved host-app row-click boundary. |
-| [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and previous or next metadata without host-app pagination behavior. |
+| [windowed-rendering.html](windowed-rendering.html) | Focused comparison for `offset` / `limit` slices, current-row anchoring, and first / middle / last window metadata without host-app pagination behavior. |
 | [breadcrumb-paths.html](breadcrumb-paths.html) | Focused comparison for breadcrumb-path context beside the tree's own current-row cue, without modeling host-app routes or Turbo navigation. |
 | [filtered-tree-modes.html](filtered-tree-modes.html) | Focused comparison for `filtered_tree_for` modes, showing matched-only, ancestor-retaining, and descendant-retaining output without host-app search behavior. |
 | [path-tree-builder-rows.html](path-tree-builder-rows.html) | Focused PathTreeBuilder comparison for generated folder rows versus record-backed rows, keeping host-app columns/actions outside the gem contract. |
@@ -73,7 +73,7 @@ When a review starts from the gallery or a focused mockup page, confirm this sta
 20. Use [turbo-frame-target.html](turbo-frame-target.html) when review needs a focused pass on the configured `data-turbo-frame` link attribute and the host-app-owned frame target boundary.
 21. Use [drag-interactive-controls.html](drag-interactive-controls.html) when review needs a focused pass on draggable rows that contain native controls, custom interactive markers, or drag-only ignore markers.
 22. Use [interactive-marker-behaviors.html](interactive-marker-behaviors.html) when review needs to compare the broad interactive marker against the narrower keyboard, row-click, and drag behavior markers.
-23. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing and current-row anchoring without adding host-app paging controls.
+23. Use [windowed-rendering.html](windowed-rendering.html) when review needs to compare visible-row slicing, current-row anchoring, and first / last window boundary metadata without adding host-app paging controls.
 24. Use [breadcrumb-paths.html](breadcrumb-paths.html) when review needs to compare breadcrumb-path context against the tree's own current-row cue without modeling host-app route design.
 25. Use [filtered-tree-modes.html](filtered-tree-modes.html) when review needs to compare matched nodes against ancestor or descendant context without adding host-app search UI.
 26. Use [path-tree-builder-rows.html](path-tree-builder-rows.html) when review needs to compare generated folder rows with record-backed rows without designing a file-manager application.

--- a/docs/mockups/windowed-rendering.html
+++ b/docs/mockups/windowed-rendering.html
@@ -142,6 +142,25 @@
   color: #64748b;
 }
 
+.mock-windowed-boundary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.mock-windowed-boundary {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.mock-windowed-boundary__title {
+  margin: 0;
+  color: #102a43;
+  font-size: 0.98rem;
+  font-weight: 700;
+}
+
 .mock-windowed-table {
   width: 100%;
   border-collapse: collapse;
@@ -176,6 +195,12 @@
   background: #fffbeb;
   color: #92400e;
   font-style: italic;
+}
+
+@media (max-width: 760px) {
+  .mock-windowed-boundary-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>
 </head>
@@ -525,6 +550,103 @@
                 <tr>
                   <td>Current-row anchoring is possible because TreeView exposes the visible-row list</td>
                   <td>What counts as the current row and where it should sit inside the window</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-windowed-state">
+        <div class="mock-windowed-state__header">
+          <p class="mock-windowed-eyebrow">Mode D</p>
+          <h2>Boundary windows</h2>
+          <p class="mock-windowed-note">
+            Use this state when the review goal is to compare first-window and last-window metadata without designing host-app paging controls.
+          </p>
+        </div>
+
+        <div class="mock-windowed-frame">
+          <div class="mock-windowed-toolbar">
+            <div class="mock-windowed-toolbar__copy">
+              <p class="mock-windowed-toolbar__title">Unavailable directions stay metadata-only</p>
+            </div>
+            <div class="mock-windowed-toolbar__meta" aria-label="Representative first and last boundary metadata">
+              <span class="mock-windowed-chip">limit: 5</span>
+              <span class="mock-windowed-chip mock-windowed-chip--secondary">total_count: 143</span>
+            </div>
+          </div>
+          <div class="mock-windowed-body">
+            <p class="mock-windowed-callout">
+              First and last windows show when one direction is unavailable. TreeView exposes boundary metadata; the host app decides whether that becomes disabled copy, hidden controls, or another paging pattern.
+            </p>
+            <div class="mock-windowed-boundary-grid">
+              <div class="mock-windowed-boundary">
+                <h3 class="mock-windowed-boundary__title">First window</h3>
+                <div class="mock-windowed-pagination" aria-label="First window boundary availability">
+                  <span class="is-muted">has_previous?: false</span>
+                  <span class="is-muted">previous_offset: nil</span>
+                  <span>rows: 1-5</span>
+                  <span class="is-available">next_offset: 5</span>
+                </div>
+                <table class="mock-windowed-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Boundary cue</th>
+                      <th scope="col">Review meaning</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Previous unavailable</td>
+                      <td>The window starts at offset <code>0</code>, so TreeView has no earlier visible rows to expose.</td>
+                    </tr>
+                    <tr>
+                      <td>Next available</td>
+                      <td>The host app can decide whether <code>next_offset: 5</code> becomes a button, link, or observer.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="mock-windowed-boundary">
+                <h3 class="mock-windowed-boundary__title">Last window</h3>
+                <div class="mock-windowed-pagination" aria-label="Last window boundary availability">
+                  <span class="is-available">previous_offset: 138</span>
+                  <span>rows: 139-143</span>
+                  <span class="is-muted">has_next?: false</span>
+                  <span class="is-muted">next_offset: nil</span>
+                </div>
+                <table class="mock-windowed-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Boundary cue</th>
+                      <th scope="col">Review meaning</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Previous available</td>
+                      <td>The host app may offer a way back to an earlier window without changing TreeView's row slice.</td>
+                    </tr>
+                    <tr>
+                      <td>Next unavailable</td>
+                      <td>The rendered slice reaches the end of the visible-row list, so no next offset is exposed.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <table class="mock-windowed-table">
+              <thead>
+                <tr>
+                  <th scope="col">Kept inside this mock</th>
+                  <th scope="col">Kept in the host app</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Availability flags, nil offsets, and visible-row range copy that explains the boundary.</td>
+                  <td>Disabled button styling, numbered page labels, route params, cursor persistence, and infinite-scroll behavior.</td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## 対応Issue

- Closes #1054

## 採用した方針

- 自動実行のため、Planner handoff に沿って既存 `windowed-rendering.html` へ `Mode D / Boundary windows` を追加する案を採用しました。
- 新規 mockup page は増やさず、既存 browser smoke target と review flow をそのまま使います。
- runtime Ruby / JavaScript、`RenderWindow` API、pagination behavior、host-app paging component、query state、infinite scroll には触れていません。

## 比較した案

- 案A: 既存 `windowed-rendering.html` に first / last boundary section を追加する
  - 採用。既存の visible-row slice / current-row anchoring / metadata-only cue と同じ文脈で確認できます。
- 案B: dedicated focused page を新規追加する
  - 不採用。README / gallery / browser smoke inventory の同期範囲が広がり、#1054 の low-risk first slice にはやや重いです。
- 案C: docs prose だけで first / last boundary を説明する
  - 不採用。#1054 は static mockup 上で boundary state を比較できることが主目的です。

## 変更内容

- `docs/mockups/windowed-rendering.html`
  - `Mode D / Boundary windows` を追加
  - first window で `has_previous?: false` / `previous_offset: nil` / `next_offset: 5` を表示
  - last window で `previous_offset: 138` / `has_next?: false` / `next_offset: nil` を表示
  - TreeView-owned metadata と host-app-owned paging controls の境界を表で補足
  - 狭幅では first / last comparison が1カラムに落ちるように調整
- `docs/mockups/README.md`
  - Files table と review flow の `windowed-rendering.html` 説明を boundary metadata まで含む文言に更新

## 変更した画面・コンポーネント

- static mockup: `docs/mockups/windowed-rendering.html`
- mockup index: `docs/mockups/README.md`

## 確認内容

- lint: GitHub Actions CI #2068 success
- typecheck: 該当なし。runtime Ruby / JavaScript は変更していません。
- UI表示確認: GitHub Actions CI #2068 の browser smoke を含む CI success で代替。connector-only 実行のため screenshot は未取得です。
- レスポンシブ確認: source 上で `760px` 以下の first / last boundary 1-column fallback を追加。実ブラウザ確認は browser-capable review に残します。
- アクセシビリティ確認: static HTML の heading / table / aria-label pattern を既存 Mode A-C と揃えています。
- 実ブラウザ確認の代替: PR CI browser smoke + QA handoff note。
- current compare: `main...design/1054-window-boundary-mockup`
  - base: `278832af838e323458bf8cfd8f60dc72e6b23e4c`
  - head: `acaf475365c83bf99827d21959ae20c07e02b016`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2
  - PR metadata: `mergeable: true`
- GitHub Actions CI #2068: success

## スクリーンショット

<!-- connector-only 実行のため未添付。必要なら browser-capable review で desktop / narrow viewport を確認してください。 -->

## リスク

- low
- static mockup と README wording のみです。runtime behavior、public API manifest、pagination feature、host-app route / query / infinite-scroll policy には触れていません。

## 補足

- #1599 / PR #1630 は同じ filtered tree mockup area ですが、Planner が #1054 を単独 lane として扱うよう明記しているため、この PR には束ねていません。