### PR TITLE
docs local link smoke を追加する

### DIFF
--- a/spec/docs_local_links_spec.rb
+++ b/spec/docs_local_links_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "uri"
+
+RSpec.describe "documentation local links" do
+  def repo_path(relative_path = nil)
+    root = File.expand_path("..", __dir__)
+    relative_path ? File.join(root, relative_path) : root
+  end
+
+  def markdown_files
+    ["README.md"] + Dir.glob(repo_path("docs/**/*.md")).map { |path| path.delete_prefix("#{repo_path}/") }.sort
+  end
+
+  def markdown_without_code_blocks(source)
+    source.gsub(/```.*?```/m, "")
+  end
+
+  def link_target(raw_target)
+    target = raw_target.strip
+
+    if target.start_with?("<")
+      target[/\A<([^>]*)>/, 1]
+    else
+      target.split(/\s+/, 2).first
+    end
+  end
+
+  def local_target?(target)
+    return false if target.nil? || target.empty?
+    return false if target.start_with?("#")
+    return false if target.start_with?("//")
+    return false if target.match?(/\A[a-z][a-z0-9+.-]*:/i)
+
+    true
+  end
+
+  def local_links(source)
+    body = markdown_without_code_blocks(source)
+    links = []
+
+    body.scan(/(?<!!)\[[^\]\n]+\]\(([^)]+)\)/) do |match|
+      target = link_target(match.first)
+      links << target if local_target?(target)
+    end
+
+    body.scan(/^\s{0,3}\[[^\]\n]+\]:\s*(\S+)/) do |match|
+      target = link_target(match.first)
+      links << target if local_target?(target)
+    end
+
+    links
+  end
+
+  def target_exists?(source_path, target)
+    path_part = target.split("#", 2).first.split("?", 2).first
+    decoded_path = URI::DEFAULT_PARSER.unescape(path_part)
+    resolved_path = File.expand_path(decoded_path, File.dirname(repo_path(source_path)))
+    root = repo_path
+
+    resolved_path == root || resolved_path.start_with?("#{root}/") && File.exist?(resolved_path)
+  end
+
+  it "keeps README and Markdown docs local relative links pointed at existing repository files" do
+    missing_links = []
+
+    markdown_files.each do |source_path|
+      source = File.read(repo_path(source_path))
+
+      local_links(source).each do |target|
+        next if target_exists?(source_path, target)
+
+        missing_links << "#{source_path} -> #{target}"
+      end
+    end
+
+    expect(missing_links).to be_empty, "Missing local Markdown link targets:\n#{missing_links.join("\n")}"
+  end
+end


### PR DESCRIPTION
## 対応 Issue

Closes #926
Closes #1022

## Issue ごとの完了内容

- #926: `README.md` と `docs/**/*.md` の repository-local relative links を検査する RSpec smoke を追加しました。
- #1022: `render-log-silencing.md` のような存在しない local Markdown target を今後検出できる guard を追加しました。

## 変更内容

- `spec/docs_local_links_spec.rb` を追加
  - `README.md` と `docs/**/*.md` を対象に local relative link target の存在を確認
  - external URL、`mailto:` などの scheme 付き link、fragment-only link、画像 link、fenced code block 内の文字列は対象外
  - fragment / query は path 部分だけ確認し、anchor slug の厳密検証には広げていません
  - missing target があった場合は `source.md -> target` の形で failure message に出します

## 改善カテゴリ

- test
- docs guard
- CI safety net

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、docs 本文、CI workflow は変更していません。
- RSpec に docs guard を追加するだけで、外部リンク監視や full Markdown crawler には広げていません。

## 実施した確認

- Issue #926 / #1022 の labels を個別確認しました。
  - `status:ready-for-agent`
  - `track:quality`
  - `agent:planned`
  - `risk:low`
- #1021 は closed / completed で、current `docs/en/troubleshooting.md` は `render-log-level.md` へリンク済みであることを確認しました。
- compare: `main...quality/926-1022-docs-local-link-smoke`
  - base: `c29ddadaf38c837c8c86b8be014e388d6f42254e`
  - head: `cc2ed5d7ada86e7d0326cb075e8d168109e0ac5c`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- PR metadata: `mergeable:true`
- GitHub Actions CI #2071: success
  - `changes`: success
  - `pr_specs`: success (`bundle exec rspec`)
  - `lint`: success (`bundle exec standardrb`)
  - `javascript`: success (`npm run test:js:core`)
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `gem_package`: skipped（spec-only / package-insensitive diff）
- local `bundle exec rspec spec/docs_local_links_spec.rb` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で失敗するため、PR CI で確認しました。

## リスク評価

low。新規 docs smoke spec のみです。既存 docs に隠れた broken local link が残っている場合は CI で検出されますが、検出対象は repository-local Markdown link の存在確認に限定しています。

## 補足事項

- #926 と #1022 は同じ root cause（Markdown docs の local relative link drift）なので、1本の guard PR にまとめました。
- HTML mockup link smoke、external URL、anchor slug validation、docs generation pipeline は非目標です。