### PR TITLE
development docs に docs smoke command 導線を追加する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -31,10 +31,11 @@ bundle exec rake build
 npm run test:js
 npm test
 npm run test:entrypoints
+npm run test:docs-entrypoints
 npm run test:browser
 ```
 
-Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use the individual npm commands when you are narrowing a failure.
+Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use the individual npm commands when you are narrowing a failure.
 
 For the Rails version matrix:
 
@@ -84,6 +85,14 @@ npm run test:entrypoints
 ```
 
 That check keeps the documented controller exports and `registerTreeViewControllers` helper aligned with the importmap entrypoint. It uses Ruby to load `config/public_api_manifest.yml` and print the `javascript_package_root` section as JSON before Node assertions run, so run it from the repository root with Ruby available when you are diagnosing manifest loader failures.
+
+Docs-only entrypoint and signal checks can be run separately with:
+
+```bash
+npm run test:docs-entrypoints
+```
+
+That command runs the docs entrypoint smoke, docs entrypoint signal smoke, README Quick Start signal, Public API docs signal, and i18n parity checks without the broader entrypoint and CI policy checks. Use it when a docs-only change fails before moving on to `npm run test:entrypoints` or `npm run test:browser`.
 
 Browser-level smoke tests run through Playwright with:
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -31,10 +31,11 @@ bundle exec rake build
 npm run test:js
 npm test
 npm run test:entrypoints
+npm run test:docs-entrypoints
 npm run test:browser
 ```
 
-CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
+CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。失敗箇所を切り分ける場合は個別の npm command を使ってください。
 
 Rails version matrixを確認する場合:
 
@@ -84,6 +85,14 @@ npm run test:entrypoints
 ```
 
 このcheckで、documented controller exports と `registerTreeViewControllers` helper が importmap entrypoint とずれないようにします。Node 側の assertions を実行する前に Ruby で `config/public_api_manifest.yml` を読み、`javascript_package_root` section を JSON として出力します。manifest loader failure を調べる場合は、repository root から Ruby が使える状態で実行してください。
+
+docs-only の entrypoint / signal checks は次で個別に確認できます。
+
+```bash
+npm run test:docs-entrypoints
+```
+
+この command は、docs entrypoint smoke、docs entrypoint signal smoke、README Quick Start signal、Public API docs signal、i18n parity checks を実行し、より広い entrypoint / CI policy checks は含めません。docs-only change が失敗したときは、`npm run test:entrypoints` や `npm run test:browser` に進む前の切り分けに使ってください。
 
 Browser-level smoke testsはPlaywrightで実行します。
 


### PR DESCRIPTION
## 対応 Issue

Closes #1640

## 判定分類

- `docs-sync`
- `docs-stale`: package scripts には `test:docs-entrypoints` がある一方、英日 development docs の Common commands から直接見つけにくい状態でした。

## 変更内容

- `docs/en/development.md` と `docs/ja/development.md` の Common commands に `npm run test:docs-entrypoints` を追加しました。
- docs-only failure の切り分けで、`test:docs-entrypoints`、`test:entrypoints`、`test:browser` をどう使い分けるかを英日で短く補足しました。
- JavaScript browser smoke tests section に、`test:docs-entrypoints` が docs entrypoint smoke / docs signal / README Quick Start signal / Public API docs signal / i18n parity を束ねることを明記しました。

## 変更範囲

- `docs/en/development.md`
- `docs/ja/development.md`

runtime Ruby / JavaScript、`package.json`、CI workflow、docs smoke scripts、public API manifest、`docs/i18n-audit.md` は変更していません。

## 確認内容

- Issue #1640 本文と Planner handoff を確認しました。
- `package.json` の current script chain を確認しました。
  - `test:docs-entrypoints` は docs entrypoint smoke、docs entrypoint signal、README Quick Start signal、Public API docs signal、i18n parity を実行します。
  - `test:entrypoints` は `test:docs-entrypoints` と `test:ci-policy` も含む broader check です。
  - `test:browser` は Playwright browser smoke です。
- compare: `main...docs/1640-docs-entrypoints-command`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs-only

## リスク

- low
- docs-only の導線追記です。package scripts の挙動や CI policy は変更していません。

## 未対応・補足

- #1637 の i18n checklist smoke や #1510 の public API release trail guard はこの PR に吸収していません。
- connector-only 実行のためローカル `npm run test:docs-entrypoints` は未実行です。PR CI で確認します。