### PR TITLE
EmptyStateHooks を Public API docs に追加する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -198,6 +198,7 @@ Stable enough for host apps to use:
 - `TreeViewRemoteStateValues`
 - `TreeViewControllerIdentifiers`
 - `TreeViewSelectionDataHooks`
+- `TreeViewEmptyStateHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -215,6 +216,7 @@ Stable enough for host apps to use:
 `TreeViewRemoteStateValues` exposes the documented remote-state value set for lazy-loading rows: `loading`, `loaded`, and `error`. Use it when host-app JavaScript or tests need to compare `data-tree-remote-state` values without hand-copying strings; `TreeViewEventNames.remoteState.*` still names controller-emitted events, and `TreeViewEventDetailKeys.remoteState.*` still lists their `event.detail` keys.
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
 `TreeViewSelectionDataHooks` exposes the documented `tree-view-selection` host-element value attribute names as a machine-readable object. Use it when JavaScript needs to author or query those host-owned attributes without hand-copying strings such as `TreeViewSelectionDataHooks.hiddenInputNameValue`.
+`TreeViewEmptyStateHooks` exposes the documented empty-state wrapper attribute and baseline row classes as a machine-readable object. Use it when host-app JavaScript, tests, or copied styling need to target the shipped empty-state reference pattern without hand-copying `data-tree-view-empty-state`, `.tree-view-empty-row__content`, or `.tree-view-empty-row__message`. The final empty-state copy, CTA, permission message, and filter-reset behavior stay host-app responsibilities.
 
 Within `TreeViewEventNames`, lazy-loading request lifecycle names live under `hostLifecycle`:
 
@@ -246,6 +248,12 @@ Documented keys on `TreeViewSelectionDataHooks`:
 - `cascadeValue`
 - `indeterminateValue`
 
+Documented keys on `TreeViewEmptyStateHooks`:
+
+- `wrapperAttribute`
+- `contentClass`
+- `messageClass`
+
 The `tree-view-selection` controller's documented host-element value attributes are also part of the stable host-app wiring surface:
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -255,7 +263,7 @@ The `tree-view-selection` controller's documented host-element value attributes 
 
 Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
-The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, remote-state values, and selection data hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, remote-state values, selection data hook values, and empty-state hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 
 Internal by default:
 
@@ -277,11 +285,11 @@ Representative documented hooks are tracked where their feature behavior is expl
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | TreeView-owned hooks documented in [Toolbar](toolbar.md). Use helper methods for supported actions and metadata instead of internal constants. |
 | Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Stable host-element controller values documented in [Selection](selection.md) and mirrored by `TreeViewSelectionDataHooks`. Row payloads and disabled decisions stay with `selection:` render-state builders. Generated hidden input marker attributes and source-id attributes are TreeView-managed internals. |
 | Lazy loading | `data-tree-remote-state`, remote placeholder IDs, lazy-loading lifecycle events | Stable placeholder and event hooks documented in [Lazy Loading](lazy-loading.md). Host apps still own request dispatch and response handling. Use `tree_children_container_dom_id`, `tree_remote_state_placeholder_dom_id`, and `tree_remote_state_placeholder_attributes` for placeholder IDs and state attributes rather than internal path or toggle helpers. |
-| Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | Reusable baseline hooks documented in the [mockup inventory](../mockups/README.md). They describe the shipped empty-state reference pattern, not every internal row class. |
+| Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | Reusable baseline hooks documented in the [mockup inventory](../mockups/README.md) and mirrored by `TreeViewEmptyStateHooks`. They describe the shipped empty-state reference pattern, not every internal row class or the host app's final copy / CTA workflow. |
 | Interaction markers | marker row classes and `data-*` hooks shown in focused mockups | Reference hooks documented through [mockups](../mockups/README.md) for review and adoption. Promote any hook to a machine-readable contract in `config/public_api_manifest.yml` only when it needs compatibility checks. |
 | Direction-aware styling | current-row cues, hierarchy connectors, toggle spacing, RTL / vertical writing override references | Responsibility boundary and host-app stylesheet override guidance live in [Direction-aware styling boundary](direction-aware-styling.md). These cues are not machine-readable public styling hooks unless they are explicitly promoted into manifest-backed checks. |
 
-This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, selection data hooks, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
+This inventory is intentionally representative, not exhaustive. `config/public_api_manifest.yml` remains the machine-readable source of truth for helper methods, JavaScript package-root exports, controller identifiers, selection data hooks, empty-state hooks, and RenderState grouped option keys. Docs-only hook inventories should point to feature guides and mockups; they should not turn every emitted class or `data-*` attribute into a compatibility contract.
 
 DOM helper names that are not listed in the manifest remain internal even when the generated DOM IDs or attributes appear in bundled markup. In particular, button, selection-checkbox, toggle-path, and lazy-loading path helper names are not public host-app dependencies unless they are promoted into the manifest and documented here.
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -198,6 +198,7 @@ host app が使ってよい入口:
 - `TreeViewRemoteStateValues`
 - `TreeViewControllerIdentifiers`
 - `TreeViewSelectionDataHooks`
+- `TreeViewEmptyStateHooks`
 - exported controller classes
   - `TreeViewStateController`
   - `TreeViewClientController`
@@ -215,6 +216,7 @@ host app が使ってよい入口:
 `TreeViewRemoteStateValues` は lazy-loading row の documented remote-state value set として、`loading`、`loaded`、`error` を公開します。host app の JavaScript や test が `data-tree-remote-state` の値を string の写経なしに照合したい場合に使えます。controller が emit する remote-state event 名は引き続き `TreeViewEventNames.remoteState.*`、その `event.detail` key は `TreeViewEventDetailKeys.remoteState.*` で扱います。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
 `TreeViewSelectionDataHooks` は、documented された `tree-view-selection` host-element value attribute names を machine-readable object として公開します。JavaScript が host-owned attribute を author / query するとき、`TreeViewSelectionDataHooks.hiddenInputNameValue` のように使うことで string の写経を避けられます。
+`TreeViewEmptyStateHooks` は、documented された empty-state wrapper attribute と baseline row class を machine-readable object として公開します。host app の JavaScript、test、copied styling が shipped empty-state reference pattern を target するとき、`data-tree-view-empty-state`、`.tree-view-empty-row__content`、`.tree-view-empty-row__message` の写経を避けられます。最終的な empty-state copy、CTA、permission message、filter-reset behavior は host app 側の責務です。
 
 `TreeViewEventNames` のうち、lazy-loading の request lifecycle 名は `hostLifecycle` にまとめています。
 
@@ -246,6 +248,12 @@ host app が使ってよい入口:
 - `cascadeValue`
 - `indeterminateValue`
 
+`TreeViewEmptyStateHooks` の documented key:
+
+- `wrapperAttribute`
+- `contentClass`
+- `messageClass`
+
 `tree-view-selection` controller の documented host-element value attribute も、stable な host-app wiring surface の一部です。
 
 - `data-tree-view-selection-hidden-input-name-value`
@@ -255,7 +263,7 @@ host app が使ってよい入口:
 
 これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する内部寄りの属性であり、host app が authoring する public hook ではありません。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
-package-root の JavaScript export、bundled controller identifier、remote-state value、selection data hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+package-root の JavaScript export、bundled controller identifier、remote-state value、selection data hook value、empty-state hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 
 内部扱い:
 
@@ -277,11 +285,11 @@ host app が依存してよい browser-facing surface は、documented された
 | Toolbar | `data-tree-view-toolbar`, `data-tree-view-toolbar-action`, `data-tree-view-toolbar-disabled` | [Toolbar](toolbar.md) で説明している TreeView-owned hook です。supported action や metadata は internal constant ではなく helper method から取得してください。 |
 | Selection | `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | [Selection](selection.md) で説明している stable host-element controller value であり、`TreeViewSelectionDataHooks` からも参照できます。row payload や disabled 判定は `selection:` render-state builder 側に残ります。generated hidden input marker attribute と source-id attribute は TreeView-managed internal です。 |
 | Lazy loading | `data-tree-remote-state`, remote placeholder ID, lazy-loading lifecycle events | [Lazy Loading](lazy-loading.md) で説明している stable placeholder / event hook です。request dispatch と response handling は引き続き host app 側の責務です。placeholder ID と state attribute には `tree_children_container_dom_id`、`tree_remote_state_placeholder_dom_id`、`tree_remote_state_placeholder_attributes` を使い、internal path / toggle helper には依存しないでください。 |
-| Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | [mockup inventory](../mockups/README.md) で説明している reusable baseline hook です。shipped empty-state reference pattern を示すもので、すべての internal row class を公開するものではありません。 |
+| Empty state | `data-tree-view-empty-state`, `.tree-view-empty-row__content`, `.tree-view-empty-row__message` | [mockup inventory](../mockups/README.md) で説明している reusable baseline hook であり、`TreeViewEmptyStateHooks` からも参照できます。shipped empty-state reference pattern を示すもので、すべての internal row class や host app の最終 copy / CTA workflow を公開するものではありません。 |
 | Interaction markers | focused mockup に出てくる marker row classes / `data-*` hooks | review / adoption 用の reference hook として [mockups](../mockups/README.md) で説明します。compatibility check が必要な hook だけを `config/public_api_manifest.yml` の machine-readable contract へ昇格してください。 |
 | Direction-aware styling | current-row cue、hierarchy connector、toggle spacing、RTL / vertical writing override reference | 責務境界と host-app stylesheet override guidance は [Direction-aware styling boundary](direction-aware-styling.md) を参照してください。これらの cue は、明示的に manifest-backed check へ昇格されるまでは machine-readable public styling hook ではありません。 |
 
-この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、selection data hook、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
+この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、selection data hook、empty-state hook、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
 
 manifest に載っていない DOM helper 名は、生成される DOM ID や attribute が bundled markup に現れていても内部扱いです。特に button、selection checkbox、toggle path、lazy-loading path helper 名は、manifest に昇格されこのページで document されるまでは host app の公開依存先ではありません。
 


### PR DESCRIPTION
## 対応 Issue

Closes #1642

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

`TreeViewEmptyStateHooks` は current main の `tree_view/index.js` と `config/public_api_manifest.yml` で package-root export / manifest-backed hook として存在していますが、英日 Public API docs の JavaScript surface から見つけにくい状態でした。

## 変更内容

- `docs/en/public-api.md` と `docs/ja/public-api.md` の JavaScript surface list に `TreeViewEmptyStateHooks` を追加しました。
- `wrapperAttribute` / `contentClass` / `messageClass` の documented keys を英日で追加しました。
- empty-state hooks は shipped empty-state reference pattern を target するための machine-readable surface であり、final copy / CTA / permission message / filter-reset behavior は host app responsibility のままであることを明記しました。
- CSS / DOM surface table と manifest source-of-truth 文を、`TreeViewEmptyStateHooks` と矛盾しないように同期しました。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`

runtime JavaScript、TypeScript declaration、public API manifest、empty-state mockup、accessibility docs、README、AGENTS.md、Product Profile は変更していません。

## 確認内容

- Issue #1642 本文と labels を確認しました。
- current main の `app/javascript/tree_view/index.js` に `TreeViewEmptyStateHooks` export があることを確認しました。
- current main の `config/public_api_manifest.yml` に `TreeViewEmptyStateHooks` と `empty_state_hooks` があることを確認しました。
- current main の `docs/en|ja/accessibility-semantics.md` の empty-state hook説明と矛盾しないことを確認しました。
- compare: `main...docs/1642-empty-state-hooks-public-api`
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 2 docs-only

## リスク

- low
- docs-only の追従修正です。hook export、manifest schema、empty-state rendering behavior は変更していません。

## 未対応・補足

- connector-only 実行のためローカル docs smoke は未実行です。PR CI で確認します。