### PR TITLE
TreeView controller entries を package-root export に追加する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -79,6 +79,34 @@ export declare const TreeViewControllerIdentifiers: Readonly<{
   remoteState: "tree-view-remote-state"
 }>
 
+export declare const TreeViewControllerEntries: readonly [
+  Readonly<{
+    key: "state"
+    identifier: "tree-view-state"
+    controller: typeof TreeViewStateController
+  }>,
+  Readonly<{
+    key: "client"
+    identifier: "tree-view-client"
+    controller: typeof TreeViewClientController
+  }>,
+  Readonly<{
+    key: "selection"
+    identifier: "tree-view-selection"
+    controller: typeof TreeViewSelectionController
+  }>,
+  Readonly<{
+    key: "transfer"
+    identifier: "tree-view-transfer"
+    controller: typeof TreeViewTransferController
+  }>,
+  Readonly<{
+    key: "remoteState"
+    identifier: "tree-view-remote-state"
+    controller: typeof TreeViewRemoteStateController
+  }>
+]
+
 export declare const TreeViewSelectionDataHooks: Readonly<{
   hiddenInputNameValue: "data-tree-view-selection-hidden-input-name-value"
   maxCountValue: "data-tree-view-selection-max-count-value"

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -82,6 +82,34 @@ export const TreeViewControllerIdentifiers = Object.freeze({
   remoteState: "tree-view-remote-state"
 })
 
+export const TreeViewControllerEntries = Object.freeze([
+  Object.freeze({
+    key: "state",
+    identifier: TreeViewControllerIdentifiers.state,
+    controller: TreeViewStateController
+  }),
+  Object.freeze({
+    key: "client",
+    identifier: TreeViewControllerIdentifiers.client,
+    controller: TreeViewClientController
+  }),
+  Object.freeze({
+    key: "selection",
+    identifier: TreeViewControllerIdentifiers.selection,
+    controller: TreeViewSelectionController
+  }),
+  Object.freeze({
+    key: "transfer",
+    identifier: TreeViewControllerIdentifiers.transfer,
+    controller: TreeViewTransferController
+  }),
+  Object.freeze({
+    key: "remoteState",
+    identifier: TreeViewControllerIdentifiers.remoteState,
+    controller: TreeViewRemoteStateController
+  })
+])
+
 export const TreeViewSelectionDataHooks = Object.freeze({
   hiddenInputNameValue: "data-tree-view-selection-hidden-input-name-value",
   maxCountValue: "data-tree-view-selection-max-count-value",

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -200,6 +200,7 @@ javascript_package_root:
   named_exports:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
+    - TreeViewControllerEntries
     - TreeViewSelectionDataHooks
     - TreeViewEmptyStateHooks
     - TreeViewTransferDropPositions

--- a/docs/en/controller-registration.md
+++ b/docs/en/controller-registration.md
@@ -1,0 +1,31 @@
+# Controller registration
+
+TreeView exports `registerTreeViewControllers(application)` for the default setup and `TreeViewControllerEntries` for host apps that need a custom registration flow.
+
+Use the default helper when the host app wants TreeView to register every bundled controller in the documented order:
+
+```js
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+Use `TreeViewControllerEntries` when the host app needs to register only part of the controller set, merge TreeView registration into an app-owned boot sequence, or inspect the documented identifier/controller pairing without copying TreeView's pairing logic:
+
+```js
+import { TreeViewControllerEntries } from "tree_view"
+
+for (const { identifier, controller } of TreeViewControllerEntries) {
+  application.register(identifier, controller)
+}
+```
+
+Each entry contains:
+
+- `key`: the manifest key for the controller entry
+- `identifier`: the documented Stimulus identifier
+- `controller`: the exported controller class
+
+`TreeViewControllerEntries` follows the same order as `registerTreeViewControllers(application)`: state, client, selection, transfer, then remote state. Custom boot code may filter or reorder entries, but the host app owns the behavior change when it does so.
+
+This export does not rename identifiers, change controller behavior, change event payloads, or add a new registration policy. It is a machine-readable version of the existing documented controller pairing.

--- a/docs/ja/controller-registration.md
+++ b/docs/ja/controller-registration.md
@@ -1,0 +1,31 @@
+# Controller registration
+
+TreeView は、通常の導入向けに `registerTreeViewControllers(application)` を公開し、host app が独自の登録 flow を持つ場合向けに `TreeViewControllerEntries` を公開します。
+
+TreeView bundled controller を documented order のまま全て登録したい場合は、従来どおり default helper を使ってください。
+
+```js
+import { registerTreeViewControllers } from "tree_view"
+
+registerTreeViewControllers(application)
+```
+
+一部 controller だけを登録したい場合、host app 側の boot sequence に TreeView controller 登録を組み込みたい場合、または identifier と controller class の対応を写経せず参照したい場合は、`TreeViewControllerEntries` を使います。
+
+```js
+import { TreeViewControllerEntries } from "tree_view"
+
+for (const { identifier, controller } of TreeViewControllerEntries) {
+  application.register(identifier, controller)
+}
+```
+
+各 entry は以下を持ちます。
+
+- `key`: controller entry の manifest key
+- `identifier`: documented Stimulus identifier
+- `controller`: exported controller class
+
+`TreeViewControllerEntries` の順序は `registerTreeViewControllers(application)` と同じで、state、client、selection、transfer、remote state の順です。host app は entry を filter / reorder できますが、その場合の挙動変更は host app 側の責務です。
+
+この export は identifier の rename、controller behavior、event payload、登録 policy を変更しません。既存の documented controller pairing を machine-readable に参照できるようにする追加 API です。

--- a/spec/public_api_controller_entries_spec.rb
+++ b/spec/public_api_controller_entries_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "TreeView controller entries public export" do
+  let(:manifest) do
+    YAML.safe_load_file(File.expand_path("../config/public_api_manifest.yml", __dir__)).fetch("javascript_package_root")
+  end
+
+  let(:entrypoint_source) do
+    File.read(File.expand_path("../app/javascript/tree_view/index.js", __dir__))
+  end
+
+  it "keeps controller entries aligned with the documented registration order" do
+    expect(manifest.fetch("named_exports")).to include("TreeViewControllerEntries")
+    expect(entrypoint_source).to include("export const TreeViewControllerEntries = Object.freeze([")
+
+    entries_start = entrypoint_source.index("export const TreeViewControllerEntries")
+    register_start = entrypoint_source.index("export function registerTreeViewControllers")
+    entries_source = entrypoint_source[entries_start...register_start]
+
+    previous_index = -1
+
+    manifest.fetch("controller_registrations").each do |registration|
+      key = registration.fetch("key")
+      identifier = registration.fetch("identifier")
+      export_name = registration.fetch("export")
+
+      key_index = entries_source.index("key: \"#{key}\"")
+
+      expect(key_index).not_to be_nil
+      expect(key_index).to be > previous_index
+      expect(entries_source).to include("identifier: TreeViewControllerIdentifiers.#{key}")
+      expect(entries_source).to include("controller: #{export_name}")
+      expect(entrypoint_source).to include("application.register(\"#{identifier}\", #{export_name})")
+
+      previous_index = key_index
+    end
+  end
+end


### PR DESCRIPTION
TreeView の bundled controller と documented identifier の対応を、host app が machine-readable に参照できる package-root export として追加します。

Closes #512

## 変更内容

- `TreeViewControllerEntries` を `tree_view/index.js` から export し、既存の `TreeViewControllerIdentifiers` と controller class を documented order で対応づけました。
- `app/javascript/tree_view/index.d.ts` に `TreeViewControllerEntries` の readonly tuple 型を追加しました。
- `config/public_api_manifest.yml` の package-root export 一覧に `TreeViewControllerEntries` を追加しました。
- manifest の `controller_registrations` と `TreeViewControllerEntries` / `registerTreeViewControllers(application)` の順序・対応を確認する focused spec を追加しました。
- host app 向けに日英の controller registration 参照ページを追加しました。

## 受け入れ条件との対応

- Public な machine-readable surface: `TreeViewControllerEntries` が `{ key, identifier, controller }` の配列として package-root から参照できます。
- Partial registration / custom boot order: host app は entries を filter / reorder し、identifier と controller class の対応を写経せず `application.register` できます。
- 既存 helper の互換性: `registerTreeViewControllers(application)` の実装と登録順は変更していません。
- Docs: `docs/en/controller-registration.md` と `docs/ja/controller-registration.md` に default helper と entries export の使い分け、順序、責務境界を記載しました。

## 変更範囲

JavaScript package-root export、TypeScript declaration、public API manifest、focused spec、日英 docs の追加に限定しています。controller behavior、identifier 名、event payload、Stimulus 登録 policy は変更していません。

## 実施した確認

- GitHub compare で `main` から 6 files / 160 additions の scoped diff であることを確認しました。
- connector-first 作業のため、この環境では repository checkout / test 実行ができませんでした（GitHub への direct clone/fetch が 403 で遮断されました）。PR CI で `spec/public_api_controller_entries_spec.rb` と既存 public API / entrypoint checks の実行を確認してください。

## リスク

- 追加 export のため既存 host app への互換性リスクは低めです。
- Public JavaScript surface の追加なので、export 名・順序・型宣言は今後の互換性対象として扱う必要があります。

## 未対応・補足

- `TreeViewControllerEntries` を使って登録順を変える場合、その挙動変更は host app 側の責務です。
- 既存の `registerTreeViewControllers(application)` を使う host app は変更不要です。
