### PR TITLE
localized labels mockup に node key と DOM ID 境界を追加する

### DIFF
--- a/docs/mockups/localized-row-labels.html
+++ b/docs/mockups/localized-row-labels.html
@@ -82,10 +82,32 @@
       </table>
     </section>
 
+    <section class="mock-section mock-localized-frame" aria-labelledby="localized-identity-heading">
+      <h2 id="localized-identity-heading">Node key and DOM ID boundary note</h2>
+      <p class="mock-localized-note">Localized labels and type badges are presentation cues. Tree-side node keys remain the stable identity for selection, expansion, persisted state, and diagnostics; browser DOM IDs remain rendered targets that can be scoped by the tree instance.</p>
+      <table class="tree-view-table mock-localized-table">
+        <thead><tr><th scope="col">rendered tree</th><th scope="col">same node key</th><th scope="col">browser DOM ID</th><th scope="col">review boundary</th></tr></thead>
+        <tbody>
+          <tr class="tree-row" data-tree-node-key="localized-cjk:invoice" data-tree-depth="1" aria-level="2">
+            <td>Workspace navigation</td>
+            <td><code>localized-cjk:invoice</code></td>
+            <td><code>workspace_tree_localized_cjk_invoice</code></td>
+            <td>Use the node key for data identity; use the DOM ID only for this rendered browser target.</td>
+          </tr>
+          <tr class="tree-row" data-tree-node-key="localized-cjk:invoice" data-tree-depth="1" aria-level="2">
+            <td>Picker dialog</td>
+            <td><code>localized-cjk:invoice</code></td>
+            <td><code>picker_tree_localized_cjk_invoice</code></td>
+            <td>The same data node can render in another tree instance without reusing the same DOM ID.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
     <section class="mock-section mock-localized-cards" aria-labelledby="localized-boundary-heading">
       <div class="mock-localized-card"><h2 id="localized-boundary-heading">TreeView-owned cues</h2><p>Hierarchy controls, current or selected state, depth labels, and toggle affordances must stay visible when labels wrap.</p></div>
       <div class="mock-localized-card"><h3>Host-app-owned copy</h3><p>Final translations, truncation rules, tooltip text, permission copy, and business-specific labels remain outside this mockup.</p></div>
-      <div class="mock-localized-card"><h3>Review focus</h3><p>Inspect primary label wrapping, type badge placement, attribute label length, secondary metadata, and tooltip cue proximity.</p></div>
+      <div class="mock-localized-card"><h3>Review focus</h3><p>Inspect primary label wrapping, type badge placement, attribute label length, secondary metadata, tooltip cue proximity, and node key versus DOM ID boundaries.</p></div>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## 対応Issue

Closes #1619
Refs #813

## 判定分類

- `docs-stale` / review follow-up refresh
- `docs-sync`
- `needs-human` 継続（desktop / narrow viewport の最終 visual check）

## 変更内容

- `docs/mockups/localized-row-labels.html` に `Node key and DOM ID boundary note` section を追加します。
- same node key が workspace navigation / picker dialog で別 DOM ID になる例を追加します。
- node key は selection / expansion / persisted state / diagnostics の stable identity、DOM ID は rendered browser target であることを明記します。
- runtime Ruby / JavaScript、public API manifest、key generation、GraphAdapter traversal、NodePresenter behavior、host-app route / authorization / final copy には触れていません。

## 変更範囲

- docs/static mockup only
- `docs/mockups/localized-row-labels.html`

## 確認内容

- latest main: `a0a6abf76ec96b0d3c700b6051982908c26a8573`
- head: `8b1a58b9158a4f099ce304c5901ee92e1ec435d8`
- compare: `main...design/1619-node-key-dom-id-boundary-v2`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 docs/static mockup file
- PR metadata: `mergeable: true`
- CI #2117: success
  - `changes`, `lint`, `pr_specs`: success
  - `javascript`: `npm run test:browser` success
  - representative Rails lanes: docs-only skip path success

## リスク

low。static docs/design artifact の既存 mockup 追記のみです。runtime behavior、public API、key generation、GraphAdapter traversal、selection / persisted-state behavior は変更していません。

## スクリーンショット

<!-- connector-only 実行のため未添付。desktop / narrow viewport の最終 visual check は browser-capable review に残します。 -->

## 補足

- #813 は heterogeneous / localized node 表示の一部を補助的に満たしますが、README / gallery 導線まで含む完了条件には未対応のため `Refs` に留めています。
- 2026-06-09 に latest main へ clean refresh し、current main の docs 更新を保持したまま intended mockup blob だけを再適用しました。