### PR TITLE
README から render log level docs へ導線を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Row partial:
 
 You can also render the `tree_view/tree_row` partial directly when needed.
 
-TreeView silences its own helper-rendered partial logs at `:warn` by default to avoid noisy `Rendered tree_view/...` entries in the host app log. Change or disable this with `TreeView.configure { |config| config.render_log_level = :info }` or `nil`.
+TreeView silences its own helper-rendered partial logs at `:warn` by default to avoid noisy `Rendered tree_view/...` entries in the host app log. Change or disable this with `TreeView.configure { |config| config.render_log_level = :info }` or `nil`. See [Render log level](docs/en/render-log-level.md) / [日本語](docs/ja/render-log-level.md) for accepted values and the boundary with the host app's global Rails logger level.
 
 See [Usage](docs/en/usage.md) for details.
 


### PR DESCRIPTION
## 対応 Issue

Closes #1646

## 判定分類

- `docs-sync`
- `docs-stale`

`render_log_level` の詳細 docs は `docs/en|ja/render-log-level.md` と `docs/README.md` から辿れる状態でしたが、root README の Quick Start 直後の説明から直接辿る導線が薄い状態でした。

## 変更内容

- `README.md` の `render_log_level` 説明に、英日 Render log level docs へのリンクを追加しました。
- TreeView helper-rendered partial logs だけを抑制する設定であり、host app の global Rails logger level とは別であることを README 入口から確認できるようにしました。

## 変更範囲

- `README.md`

runtime Ruby、public API manifest、logger implementation、`docs/README.md`、英日 render-log-level docs は変更していません。`docs/README.md` は current main ですでに Render log level entry を持つため、今回は重複追記していません。

## 確認内容

- Issue #1646 本文を確認しました。
- current main の `docs/README.md` に Render log level entry があることを確認しました。
- compare: `main...docs/1646-render-log-entrypoint`
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1 docs-only (`README.md`)

## リスク

low。README の導線追加のみです。logger behavior、accepted values、CI setup、package-lock 方針には触れていません。

## 未対応・補足

- connector-only 実行のためローカル docs smoke は未実行です。PR CI で確認します。