### PR TITLE
NodePresenter builder names をcurrent mainで再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -36,6 +36,16 @@ public_constants:
   - PersistedState
   - StateStore
   - Diagnostics
+node_presenter_builder_names:
+  - key
+  - label
+  - href
+  - tooltip
+  - row_class
+  - row_data
+  - icon
+  - badge
+  - actions
 graph_adapter_initializer:
   required_keywords:
     - roots

--- a/docs/en/node-presenter-row-partials.md
+++ b/docs/en/node-presenter-row-partials.md
@@ -43,6 +43,10 @@ Host apps own product-specific rendering:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` and its builder names are part of the public compatibility contract. The machine-readable builder list lives in `config/public_api_manifest.yml` as `node_presenter_builder_names`, and compatibility specs check it against `TreeView::NodePresenter::BUILDER_NAMES`.
+
+That contract stabilizes the available builder names only. The meaning of returned labels, links, row data, action identifiers, badges, icons, and any authorization or formatting decisions remains host-app owned and is intentionally shown here as cookbook guidance.
+
 ## Example presenter
 
 ```ruby

--- a/docs/ja/node-presenter-row-partials.md
+++ b/docs/ja/node-presenter-row-partials.md
@@ -43,6 +43,10 @@ Host app が担当するもの:
 - dialogs and forms
 - domain-specific labels and formatting
 
+`TreeView::NodePresenter` とその builder 名は public compatibility contract の一部です。machine-readable な builder list は `config/public_api_manifest.yml` の `node_presenter_builder_names` に置き、compatibility spec で `TreeView::NodePresenter::BUILDER_NAMES` と照合します。
+
+この contract が安定させるのは利用可能な builder 名です。返される label、link、row data、action identifier、badge、icon の意味や、authorization / formatting の判断は host app 側の責務であり、この guide では cookbook として例示します。
+
 ## presenter 例
 
 ```ruby

--- a/spec/node_presenter_public_manifest_spec.rb
+++ b/spec/node_presenter_public_manifest_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+NODE_PRESENTER_PUBLIC_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+RSpec.describe "NodePresenter public manifest" do
+  def public_api_manifest
+    @public_api_manifest ||= YAML.safe_load_file(NODE_PRESENTER_PUBLIC_MANIFEST_PATH)
+  end
+
+  it "keeps documented builder names aligned with NodePresenter" do
+    manifest_names = public_api_manifest.fetch("node_presenter_builder_names")
+
+    expect(manifest_names).to eq(TreeView::NodePresenter::BUILDER_NAMES.map(&:to_s)),
+      "expected NodePresenter builder names to stay aligned with the manifest-backed public contract"
+  end
+end

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -10,6 +10,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   module_methods
   configuration_options
   public_constants
+  node_presenter_builder_names
   graph_adapter_initializer
   path_tree_builder_node_shapes
   helper_methods
@@ -88,6 +89,14 @@ RSpec.describe "Public API manifest structure" do
       expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
       expect(keys).to all(be_a(String))
     end
+  end
+
+  it "keeps NodePresenter builder names shaped as a non-empty string list" do
+    builder_names = manifest.fetch("node_presenter_builder_names")
+
+    expect(builder_names).to be_an(Array)
+    expect(builder_names).not_to be_empty
+    expect(builder_names).to all(be_a(String))
   end
 
   it "keeps resource table render state keyword sections shaped as non-empty string lists" do


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1032
Supersedes #1556
Supersedes #1553
Supersedes #1299

## 置き換え理由

PR #1556 が current `main` から behind し、public API manifest / docs / spec の後続更新と競合して `mergeable:false` になっていました。

旧ブランチは force 更新せず、current `main` (`7cccde0f0161688df76445052f985968d9fab5f7`) から clean replacement branch を作成し、NodePresenter builder names の manifest-backed contract intent だけを再適用しました。

## 変更内容

- `config/public_api_manifest.yml` に `node_presenter_builder_names` を追加
- `spec/public_api_manifest_structure_spec.rb` に top-level section と non-empty string list guard を追加
- `spec/node_presenter_public_manifest_spec.rb` を追加し、manifest と `TreeView::NodePresenter::BUILDER_NAMES` の同期を確認
- 英日 `docs/*/node-presenter-row-partials.md` に builder 名だけを安定化する責務境界を追記

## current main から保持した内容

- GraphAdapter initializer manifest
- toolbar action metadata
- diagnostics manifest
- EmptyStateHooks / public API docs 更新
- node presenter mockup guide link

## 既存仕様への影響

runtime behavior、builder implementation、row partial locals、Column / Action DSL、authorization / formatting policy は変更していません。

## 確認内容

- branch: `refresh/1556-node-presenter-builder-current-main`
- base: `main` `7cccde0f0161688df76445052f985968d9fab5f7`
- changed files: 5
- local RSpec は未実行（connector-only 実行）。PR CI で確認します。

## リスク

medium。public manifest contract を増やす変更ですが、既存 builder names を machine-readable に固定するだけで runtime behavior は変更していません。