### PR TITLE
UiConfigBuilder option surface を public manifest contract に追加する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -42,6 +42,27 @@ graph_adapter_initializer:
     - children_resolver
   optional_keywords:
     - node_key_resolver
+ui_config_builder_option_keys:
+  build:
+    - show_descendants_path_builder
+    - hide_descendants_path_builder
+    - toggle_all_path_builder
+    - load_children_path_builder
+    - turbo_frame
+    - indent_unit
+    - scope_format
+  build_turbo:
+    - show_descendants_path_builder
+    - hide_descendants_path_builder
+    - toggle_all_path_builder
+    - load_children_path_builder
+    - turbo_frame
+    - indent_unit
+    - scope_format
+  build_static:
+    - indent_unit
+  build_client_side:
+    - indent_unit
 path_tree_builder_node_shapes:
   folder_node:
     constant: PathTreeBuilder::FolderNode

--- a/docs/en/ui-config-builder-options.md
+++ b/docs/en/ui-config-builder-options.md
@@ -1,0 +1,25 @@
+# UiConfigBuilder option surface
+
+`TreeView::UiConfigBuilder` is a public entry point for building `TreeView::UiConfig` instances in Turbo, static, and client-side rendering modes. Its builder method keyword surface is tracked in `config/public_api_manifest.yml` under `ui_config_builder_option_keys` so maintainers can catch option-name drift during compatibility checks.
+
+This manifest section is a key-surface contract, not a runtime validation schema. Host apps should keep using the documented builder methods directly, and TreeView should not infer new route, Turbo, or lazy-loading behavior from the manifest.
+
+## Manifest-backed keyword groups
+
+| Method | Manifest-backed public keywords | Notes |
+|---|---|---|
+| `build` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder`, `load_children_path_builder`, `turbo_frame`, `indent_unit`, `scope_format` | Convenience entry point that delegates to Turbo mode with the same keyword surface as `build_turbo`. |
+| `build_turbo` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder`, `load_children_path_builder`, `turbo_frame`, `indent_unit`, `scope_format` | Turbo-oriented configuration. Host apps still own route helpers, authorization, Turbo Frame targets, and lazy-loading response behavior. |
+| `build_static` | `indent_unit` | Static rendering keeps only the indentation surface and does not accept Turbo path builders. |
+| `build_client_side` | `indent_unit` | Client-side rendering keeps only the indentation surface and does not accept Turbo path builders. |
+
+## Boundary
+
+The compatibility spec checks the method signatures against the manifest. It intentionally does not add new validation for required versus optional keyword policy, route builder behavior, Turbo response behavior, or lazy-loading strategy.
+
+Use the broader usage and API docs for behavior guidance:
+
+- [Usage](usage.md)
+- [API reference](api.md)
+- [Turbo Frame option](turbo-frame.md)
+- [Lazy Loading](lazy-loading.md)

--- a/docs/ja/ui-config-builder-options.md
+++ b/docs/ja/ui-config-builder-options.md
@@ -1,0 +1,25 @@
+# UiConfigBuilder option surface
+
+`TreeView::UiConfigBuilder` は、Turbo / static / client-side rendering mode 用の `TreeView::UiConfig` を組み立てる公開 entry point です。builder method の keyword surface は、option 名の drift を compatibility check で検出できるように、`config/public_api_manifest.yml` の `ui_config_builder_option_keys` で追跡します。
+
+この manifest section は key surface の contract であり、runtime validation schema ではありません。host app は documented builder method を直接使い、TreeView は manifest から route、Turbo、lazy-loading behavior を新しく推論しません。
+
+## Manifest-backed keyword groups
+
+| Method | manifest-backed public keywords | 補足 |
+|---|---|---|
+| `build` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder`, `load_children_path_builder`, `turbo_frame`, `indent_unit`, `scope_format` | `build_turbo` と同じ keyword surface を持つ Turbo mode への convenience entry point です。 |
+| `build_turbo` | `show_descendants_path_builder`, `hide_descendants_path_builder`, `toggle_all_path_builder`, `load_children_path_builder`, `turbo_frame`, `indent_unit`, `scope_format` | Turbo-oriented configuration です。route helper、authorization、Turbo Frame target、lazy-loading response behavior は引き続き host app が所有します。 |
+| `build_static` | `indent_unit` | static rendering は indentation surface のみに閉じ、Turbo path builder は受け取りません。 |
+| `build_client_side` | `indent_unit` | client-side rendering は indentation surface のみに閉じ、Turbo path builder は受け取りません。 |
+
+## Boundary
+
+compatibility spec は method signature と manifest の一致を確認します。required / optional keyword policy、route builder behavior、Turbo response behavior、lazy-loading strategy の runtime validation を新設するものではありません。
+
+behavior guidance は以下の既存 docs を参照してください。
+
+- [Usage](usage.md)
+- [API reference](api.md)
+- [Turbo Frame option](turbo-frame.md)
+- [Lazy Loading](lazy-loading.md)

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -11,6 +11,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   configuration_options
   public_constants
   graph_adapter_initializer
+  ui_config_builder_option_keys
   path_tree_builder_node_shapes
   helper_methods
   helper_option_keys

--- a/spec/ui_config_builder_public_api_manifest_spec.rb
+++ b/spec/ui_config_builder_public_api_manifest_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "UiConfigBuilder public API manifest" do
+  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+  def manifest_option_keys
+    YAML.safe_load_file(MANIFEST_PATH).fetch("ui_config_builder_option_keys")
+  end
+
+  def keyword_option_keys(method_name)
+    TreeView::UiConfigBuilder.instance_method(method_name).parameters.filter_map do |parameter_type, parameter_name|
+      parameter_name.to_s if %i[key keyreq].include?(parameter_type)
+    end
+  end
+
+  it "keeps build and build_turbo keyword surfaces aligned" do
+    expected_keys = %w[
+      show_descendants_path_builder
+      hide_descendants_path_builder
+      toggle_all_path_builder
+      load_children_path_builder
+      turbo_frame
+      indent_unit
+      scope_format
+    ]
+
+    expect(manifest_option_keys.fetch("build")).to eq(expected_keys)
+    expect(manifest_option_keys.fetch("build_turbo")).to eq(expected_keys)
+    expect(keyword_option_keys(:build)).to eq(expected_keys)
+    expect(keyword_option_keys(:build_turbo)).to eq(expected_keys)
+  end
+
+  it "keeps static and client-side builders on the narrow indent option surface" do
+    expected_keys = %w[indent_unit]
+
+    expect(manifest_option_keys.fetch("build_static")).to eq(expected_keys)
+    expect(manifest_option_keys.fetch("build_client_side")).to eq(expected_keys)
+    expect(keyword_option_keys(:build_static)).to eq(expected_keys)
+    expect(keyword_option_keys(:build_client_side)).to eq(expected_keys)
+  end
+end

--- a/spec/ui_config_builder_public_api_manifest_spec.rb
+++ b/spec/ui_config_builder_public_api_manifest_spec.rb
@@ -3,11 +3,11 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "UiConfigBuilder public API manifest" do
-  MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+UI_CONFIG_BUILDER_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
 
+RSpec.describe "UiConfigBuilder public API manifest" do
   def manifest_option_keys
-    YAML.safe_load_file(MANIFEST_PATH).fetch("ui_config_builder_option_keys")
+    YAML.safe_load_file(UI_CONFIG_BUILDER_MANIFEST_PATH).fetch("ui_config_builder_option_keys")
   end
 
   def keyword_option_keys(method_name)


### PR DESCRIPTION
UiConfigBuilder の builder method keyword surface を manifest-backed contract として固定します。

## 対応 Issue

Closes #1259

## 変更内容

- `config/public_api_manifest.yml` に `ui_config_builder_option_keys` を追加しました。
- `build` / `build_turbo` は同じ Turbo-oriented keyword set として追跡します。
- `build_static` / `build_client_side` は `indent_unit` の narrow surface として追跡します。
- focused compatibility spec を追加し、manifest と `TreeView::UiConfigBuilder` method signature の drift を検出します。
- 英日 docs を追加し、manifest-backed key surface と runtime behavior / validation policy の境界を整理しました。

## 受け入れ条件との対応

- manifest に UiConfigBuilder method ごとの keyword option surface を追加しました。
- spec が `build` / `build_turbo` / `build_static` / `build_client_side` の keyword set drift を確認します。
- `build` と `build_turbo` の alias-like relationship、static / client-side の narrow surface を分けて記述しています。
- route helper、Turbo response、lazy-loading behavior、runtime validation の policy には広げていません。

## 変更範囲

- public API manifest
- focused compatibility spec
- UiConfigBuilder option surface の英日 docs

`UiConfigBuilder` API、`UiConfig` behavior、Turbo route strategy、lazy-loading behavior、public API manifest schema 全体は変更していません。

## 実施した確認

- Issue #1259 の labels を直接確認: `status:ready-for-agent`, `track:feature`, `agent:planned`, `risk:medium`。
- 既存 open PR が #1259 を担当していないことを確認しました。
- compare: `main...feature/1259-ui-config-builder-options-current`
  - base: `fcbc882de44f025c8b2f1e47dad4b0ada11792f3`
  - head: `631e7b3eb1f2f5ef47325795f1d1dd0c5464819a`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 4
- local checkout / local RSpec / StandardRB は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR CI で確認します。

## リスク

medium。public API contract を強めますが、既存 method signature と docs-level boundary を manifest/spec で固定するだけで、runtime behavior は変更していません。

## 未対応・補足

- required / optional keyword runtime validation は追加していません。
- `docs/en|ja/public-api.md` 本体の大きな追記ではなく、focused docs と manifest/spec guard に閉じています。必要なら review follow-up で public API index 側の導線を小さく追加できます。