### PR TITLE
selection checkbox hook names を current main で再提案する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -86,6 +86,11 @@ export declare const TreeViewSelectionDataHooks: Readonly<{
   indeterminateValue: "data-tree-view-selection-indeterminate-value"
 }>
 
+export declare const TreeViewSelectionCheckboxHooks: Readonly<{
+  checkboxClass: "tree-selection-checkbox"
+  disabledReasonAttribute: "data-tree-selection-disabled-reason"
+}>
+
 export declare const TreeViewEmptyStateHooks: Readonly<{
   wrapperAttribute: "data-tree-view-empty-state"
   contentClass: "tree-view-empty-row__content"

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -89,6 +89,11 @@ export const TreeViewSelectionDataHooks = Object.freeze({
   indeterminateValue: "data-tree-view-selection-indeterminate-value"
 })
 
+export const TreeViewSelectionCheckboxHooks = Object.freeze({
+  checkboxClass: "tree-selection-checkbox",
+  disabledReasonAttribute: "data-tree-selection-disabled-reason"
+})
+
 export const TreeViewEmptyStateHooks = Object.freeze({
   wrapperAttribute: "data-tree-view-empty-state",
   contentClass: "tree-view-empty-row__content",

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -201,6 +201,7 @@ javascript_package_root:
     - registerTreeViewControllers
     - TreeViewControllerIdentifiers
     - TreeViewSelectionDataHooks
+    - TreeViewSelectionCheckboxHooks
     - TreeViewEmptyStateHooks
     - TreeViewTransferDropPositions
     - TreeViewRemoteStateValues
@@ -316,6 +317,9 @@ javascript_package_root:
     max_count_value: data-tree-view-selection-max-count-value
     cascade_value: data-tree-view-selection-cascade-value
     indeterminate_value: data-tree-view-selection-indeterminate-value
+  selection_checkbox_hooks:
+    checkbox_class: tree-selection-checkbox
+    disabled_reason_attribute: data-tree-selection-disabled-reason
   empty_state_hooks:
     wrapper_attribute: data-tree-view-empty-state
     content_class: tree-view-empty-row__content

--- a/docs/en/selection-checkbox-hooks.md
+++ b/docs/en/selection-checkbox-hooks.md
@@ -1,0 +1,23 @@
+# Selection checkbox hooks
+
+`TreeViewSelectionCheckboxHooks` exposes the documented selection checkbox DOM hooks from the package root.
+
+Use this export when host-app JavaScript or browser-level tests need to refer to the rendered checkbox class or disabled-reason data attribute without copying raw strings.
+
+```js
+import { TreeViewSelectionCheckboxHooks } from "tree_view"
+
+const checkboxSelector = `.${TreeViewSelectionCheckboxHooks.checkboxClass}`
+const disabledReasonAttribute = TreeViewSelectionCheckboxHooks.disabledReasonAttribute
+```
+
+Documented keys:
+
+- `checkboxClass`: `tree-selection-checkbox`
+- `disabledReasonAttribute`: `data-tree-selection-disabled-reason`
+
+This surface is intentionally limited to the rendered selection checkbox hook. It does not include broader selection markup, generated hidden-input bookkeeping attributes, payload semantics, event payloads, or host-app business actions.
+
+Use `TreeViewSelectionDataHooks` for host-authored `tree-view-selection` controller value attributes such as `data-tree-view-selection-hidden-input-name-value`. Use `TreeViewSelectionCheckboxHooks` only for the checkbox element emitted by TreeView's selection cell partial.
+
+The selection controller still collects only checked and enabled selection checkboxes. Disabled filtering, invalid payload handling, cascade behavior, hidden input sync, and submitted payload parsing are unchanged.

--- a/docs/ja/selection-checkbox-hooks.md
+++ b/docs/ja/selection-checkbox-hooks.md
@@ -1,0 +1,23 @@
+# Selection checkbox hooks
+
+`TreeViewSelectionCheckboxHooks` は、package root から documented selection checkbox DOM hook を参照するための export です。
+
+host app の JavaScript や browser-level test が、描画済み checkbox class や disabled reason data attribute を raw string として写経したくない場合に使います。
+
+```js
+import { TreeViewSelectionCheckboxHooks } from "tree_view"
+
+const checkboxSelector = `.${TreeViewSelectionCheckboxHooks.checkboxClass}`
+const disabledReasonAttribute = TreeViewSelectionCheckboxHooks.disabledReasonAttribute
+```
+
+documented key:
+
+- `checkboxClass`: `tree-selection-checkbox`
+- `disabledReasonAttribute`: `data-tree-selection-disabled-reason`
+
+この surface は、TreeView が描画する selection checkbox hook だけに限定します。selection markup 全体、generated hidden-input bookkeeping attribute、payload semantics、event payload、host app の business action は含めません。
+
+`data-tree-view-selection-hidden-input-name-value` のような host-authored `tree-view-selection` controller value attribute には `TreeViewSelectionDataHooks` を使ってください。`TreeViewSelectionCheckboxHooks` は TreeView の selection cell partial が出力する checkbox element だけを対象にします。
+
+selection controller は引き続き checked かつ enabled な selection checkbox だけを収集します。disabled filtering、不正 payload handling、cascade behavior、hidden input sync、submitted payload parsing は変更していません。

--- a/spec/public_api_selection_checkbox_hooks_spec.rb
+++ b/spec/public_api_selection_checkbox_hooks_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "selection checkbox public hooks" do
+  let(:manifest) do
+    YAML.safe_load_file(File.expand_path("../config/public_api_manifest.yml", __dir__))
+  end
+
+  let(:javascript_entrypoint_source) do
+    File.read(File.expand_path("../app/javascript/tree_view/index.js", __dir__))
+  end
+
+  let(:selection_cell_source) do
+    File.read(File.expand_path("../app/views/tree_view/_tree_selection_cell.html.erb", __dir__))
+  end
+
+  let(:checkbox_hooks) do
+    manifest.fetch("javascript_package_root").fetch("selection_checkbox_hooks")
+  end
+
+  it "keeps the checkbox hook export listed as a package-root public surface" do
+    expect(manifest.fetch("javascript_package_root").fetch("named_exports")).to include("TreeViewSelectionCheckboxHooks")
+    expect(javascript_entrypoint_source).to include("export const TreeViewSelectionCheckboxHooks = Object.freeze({")
+  end
+
+  it "keeps the checkbox class aligned with the rendered selection cell" do
+    checkbox_class = checkbox_hooks.fetch("checkbox_class")
+
+    expect(javascript_entrypoint_source).to include("checkboxClass: \"#{checkbox_class}\"")
+    expect(selection_cell_source).to include("class: \"#{checkbox_class}\"")
+  end
+
+  it "keeps the disabled reason attribute aligned with the rendered selection cell" do
+    disabled_reason_attribute = checkbox_hooks.fetch("disabled_reason_attribute")
+
+    expect(javascript_entrypoint_source).to include("disabledReasonAttribute: \"#{disabled_reason_attribute}\"")
+    expect(disabled_reason_attribute).to eq("data-tree-selection-disabled-reason")
+    expect(selection_cell_source).to include("tree_selection_disabled_reason")
+  end
+end


### PR DESCRIPTION
## 対応 Issue / PR

Closes #641
Supersedes #1565

## 置き換え理由

PR #1565 が current `main` から `behind_by:66` / `status:diverged` / `mergeable:false` になっていました。旧 branch を force update せず、latest `main` `fcbc882de44f025c8b2f1e47dad4b0ada11792f3` から clean replacement branch を作成し、#641 の selection checkbox hook intent だけを再適用しました。

current main 側の `TreeViewEmptyStateHooks`、diagnostics manifest、toolbar metadata などの後続更新は保持しています。

## 変更内容

- package root に `TreeViewSelectionCheckboxHooks` を追加しました。
  - `checkboxClass: "tree-selection-checkbox"`
  - `disabledReasonAttribute: "data-tree-selection-disabled-reason"`
- TypeScript declaration と `config/public_api_manifest.yml` を同期しました。
- selection checkbox hook 専用の focused compatibility spec を追加しました。
- 英日 docs に、`TreeViewSelectionCheckboxHooks` が selection checkbox 専用 surface であり、host-element value attributes 用の `TreeViewSelectionDataHooks` とは別であることを明記しました。

## 変更範囲

- `app/javascript/tree_view/index.js`
- `app/javascript/tree_view/index.d.ts`
- `config/public_api_manifest.yml`
- `spec/public_api_selection_checkbox_hooks_spec.rb`
- `docs/en/selection-checkbox-hooks.md`
- `docs/ja/selection-checkbox-hooks.md`

## 既存仕様への影響

selection cell partial、checked / disabled filtering、payload semantics、selection controller behavior、host app business flow は変更していません。public package-root export / manifest-backed contract の additive expansion に閉じています。

## 確認内容

- GitHub compare: `main...refresh/1565-selection-checkbox-hooks-current-main`
  - `ahead_by: 6`
  - `behind_by: 0`
  - changed files: 6
- local checkout / local RSpec / Node smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR CI で確認します。

## リスク

medium。runtime behavior は変えていませんが、`TreeViewSelectionCheckboxHooks` を public surface として採用するかは #1565 と同じく human review 対象です。