### PR TITLE
docs signal smoke に configure / row status 境界を追加する

### DIFF
--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -209,6 +209,98 @@ const signalGroups = [
         ]
       ]
     ]
+  },
+  {
+    feature: "TreeView.configure option docs boundary",
+    files: [
+      [
+        "config/public_api_manifest.yml",
+        ["configuration_options:", "tree_view_configure:", "initial_state", "render_log_level"]
+      ],
+      [
+        "docs/en/render-log-level.md",
+        [
+          "render_log_level",
+          "config/public_api_manifest.yml",
+          ":debug",
+          ":unknown",
+          "render_log_level = nil",
+          "helper-rendered partials",
+          "It does not change `Rails.logger.level`",
+          "initial_state",
+          ":expanded",
+          ":collapsed",
+          "TreeView::ConfigurationError"
+        ]
+      ],
+      [
+        "docs/ja/render-log-level.md",
+        [
+          "render_log_level",
+          "config/public_api_manifest.yml",
+          ":debug",
+          ":unknown",
+          "render_log_level = nil",
+          "TreeView helper 経由で描画される partial",
+          "host application 全体の `Rails.logger.level` は変更しません",
+          "initial_state",
+          ":expanded",
+          ":collapsed",
+          "TreeView::ConfigurationError"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Row status and depth label docs boundary",
+    files: [
+      [
+        "docs/en/row-status.md",
+        [
+          "row_disabled_builder",
+          "row_readonly_builder",
+          "row_disabled_reason_builder",
+          "data-tree-view-row-disabled",
+          "data-tree-view-row-readonly",
+          "data-tree-view-row-disabled-reason",
+          "selection[:disabled_builder]",
+          "row-status-depth-labels.html",
+          "Business rules, action blocking, authorization, and persistence remain host app responsibilities"
+        ]
+      ],
+      [
+        "docs/ja/row-status.md",
+        [
+          "row_disabled_builder",
+          "row_readonly_builder",
+          "row_disabled_reason_builder",
+          "data-tree-view-row-disabled",
+          "data-tree-view-row-readonly",
+          "data-tree-view-row-disabled-reason",
+          "selection[:disabled_builder]",
+          "row-status-depth-labels.html",
+          "実際の業務ルール、操作制御、認可、保存処理は host app 側で実装します"
+        ]
+      ],
+      [
+        "docs/en/depth-labels.md",
+        [
+          "depth_label_builder",
+          "context.depth",
+          "row-status-depth-labels.html",
+          "The host app decides the label text, business meaning of each depth, and CSS styling"
+        ]
+      ],
+      [
+        "docs/ja/depth-labels.md",
+        [
+          "depth_label_builder",
+          "context.depth",
+          "row-status-depth-labels.html",
+          "どのdepthにどの文言を出すか、業務上の意味付け、CSS表現はhost app側で決めます"
+        ]
+      ]
+    ]
   }
 ]
 


### PR DESCRIPTION
## 対応 Issue

Closes #1647
Closes #1653

## Issue ごとの完了内容

- #1647: `TreeView.configure` option docs の代表 signal を lightweight docs smoke に追加しました。`config/public_api_manifest.yml` の `tree_view_configure` keys、英日 `render-log-level.md` の `render_log_level` accepted values、`nil` boundary、helper-rendered partial log boundary、`initial_state` accepted values / invalid value boundary を確認します。
- #1653: Row status / Depth labels docs の代表 signal を lightweight docs smoke に追加しました。英日 `row-status.md` の row-wide builder/data hooks、selection disabled state との違い、mockup link、host-app responsibility boundary と、英日 `depth-labels.md` の `depth_label_builder` / `context.depth` / mockup link / host-app-owned label boundary を確認します。

## 変更内容

- `script/test_docs_entrypoint_signals.mjs`
  - `TreeView.configure option docs boundary` signal group を追加
  - `Row status and depth label docs boundary` signal group を追加

## 改善カテゴリ

- test
- docs smoke
- documentation drift guard

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、docs 本文、mockup HTML/CSS、CI workflow は変更していません。
- 既存 docs にある representative signal を smoke で守るだけです。

## 実施した確認

- Issue labels を個別確認しました。
  - #1647: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
  - #1653: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
- branch freshness: current `main` `fcbc882de44f025c8b2f1e47dad4b0ada11792f3` から branch を作成し、compare で `behind_by:0` を確認しました。
- diff scope: 1 file only (`script/test_docs_entrypoint_signals.mjs`)。
- local `npm run test:docs-entrypoints` は、repository checkout がない connector-only 実行のため未実行です。PR CI で確認します。

## 今回扱わなかった対象

- #413: `npm view npm version` が `403 Forbidden` で、lockfile refresh に必要な npm registry 到達性がありませんでした。過去コメントと同じ blocker のため、重複コメントは避けています。
- matsuo-haruhito/rails_fields_kit#317: 前提の #313 / PR #1280 がまだ main に入っておらず、helper 名・return shape が未確定のため停止コメントを残し、`status:needs-human` に寄せました。

## リスク評価

low。docs-smoke 追加のみで、公開挙動や public API surface は変更していません。