### PR TITLE
Node version guard の未実装状態を development docs に反映する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -18,7 +18,7 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
-Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version. The Node version source drift spec keeps `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value aligned without changing the current install policy.
+Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version. Keep `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value aligned when any of them changes. A dedicated automated Node version drift guard is not present on current `main`; #1659 tracks whether to add a lightweight guard without changing the current install policy.
 
 Keep using `npm install` for now. The repository has a committed `package-lock.json`, but it is not yet refreshed in sync with `package.json`, so local setup and pull-request CI stay on `npm install` until that lockfile refresh is completed in a registry-enabled environment. See [Installation](installation.md) for the current CI and install-path summary.
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -18,7 +18,7 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
-ローカルの JavaScript 作業では Node 22 を使ってください。repository root の `.nvmrc` が CI の JavaScript lane とそろった、推奨 Node major version の source of truth です。Node version source drift spec は `.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` を同期確認し、現在の install policy は変更しません。
+ローカルの JavaScript 作業では Node 22 を使ってください。repository root の `.nvmrc` が CI の JavaScript lane とそろった、推奨 Node major version の source of truth です。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` は、どれかを変更するときに同じ Node major を指すように同期してください。current `main` には専用の自動 Node version drift guard はまだありません。現在の install policy を変えずに lightweight guard を追加するかどうかは #1659 で追跡しています。
 
 現状は `npm install` を使い続けてください。repo には `package-lock.json` を commit していますが、まだ `package.json` と同期していないため、ローカルセットアップと Pull Request CI は、registry-enabled な環境で lockfile refresh が完了するまで `npm install` を前提にしています。現在の CI と install path の整理は [導入手順](installation.md) を参照してください。
 


### PR DESCRIPTION
## 対応 Issue

Refs #1659

## 判定分類

- `docs-stale`
- `docs-ahead-of-code` の明確化

## 変更内容

- 英日 `docs/*/development.md` の Node 22 / `.nvmrc` 説明を更新しました。
- current `main` に専用の Node version drift guard がまだ存在しないことを明記しました。
- `.nvmrc`、`package.json` `engines.node`、workflow `node-version` は変更時に同じ Node major へ同期する、という手動方針は残しました。
- lightweight guard の追加判断は #1659 の残タスクとして明示しました。

## 範囲

- docs-only
- `docs/en/development.md`
- `docs/ja/development.md`

## 確認内容

- repository search で `test_node_version_sources` / Node version drift guard 相当の dedicated script は見つかりませんでした。
- `package.json` は `engines.node: "22.x"` を持つことを確認しました。
- compare: `main...docs/1659-node-version-guard-docs`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only

## 残る作業

#1659 の受け入れ条件にある lightweight test / guard 追加は `area:test` / `track:quality` の範囲であり、この PR では実装していません。そのため `Closes` ではなく `Refs` にしています。

## リスク

low。実装、CI workflow、Node version、install policy、lockfile には触れていません。