### PR TITLE
Toolbar docs から action_html boundary note へ誘導する

### DIFF
--- a/docs/en/toolbar.md
+++ b/docs/en/toolbar.md
@@ -61,6 +61,8 @@ For a static comparison of expand-all, collapse-all, and current-path-preserving
 
 Use that mockup as a visual companion to this helper boundary: it highlights action affordances and the `:current_path` contract without defining routes, authorization copy, or Turbo response behavior.
 
+When reviewing `html:` or `action_html:` attributes, also read the [Toolbar action HTML boundary note](../toolbar_action_html_boundary.md). The mockup shows visual states, while the boundary note focuses on attribute ownership: TreeView-owned hooks stay present, and analytics, Turbo targets, screen-specific grouping, and final copy remain host-app responsibilities.
+
 ## Label resolution
 
 `tree_view_toolbar`, `tree_view_toolbar_actions`, and `tree_view_toolbar_action_metadata` resolve action labels in this order:

--- a/docs/ja/toolbar.md
+++ b/docs/ja/toolbar.md
@@ -61,6 +61,8 @@ expand-all、collapse-all、current path を残す toolbar state を静的に見
 
 この mockup は、この helper の責務境界を視覚的に補うためのものです。action の見え方と `:current_path` contract を確認できますが、route、authorization copy、Turbo response behavior 自体を定義するものではありません。
 
+`html:` や `action_html:` の attribute をreviewする場合は、あわせて [Toolbar action HTML boundary note](../toolbar_action_html_boundary.md) を読んでください。mockup は visual state を確認するための入口で、boundary note は attribute ownership を確認するための補助資料です。TreeView-owned hook は維持し、analytics、Turbo target、screen-specific grouping、final copy は host app 側の責務として扱います。
+
 ## label resolution
 
 `tree_view_toolbar`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` は、action label を次の順で解決します。


### PR DESCRIPTION
## 対応 Issue

Closes #1626

## 判定分類

- `docs-sync`
- `docs-missing`（merge 済み boundary note への導線不足）

## 変更内容

- `docs/en/toolbar.md` の Visual reference に `docs/toolbar_action_html_boundary.md` への導線を追加しました。
- `docs/ja/toolbar.md` にも同じ導線を追加しました。
- `toolbar-actions.html` は visual state reference、boundary note は `html:` / `action_html:` の attribute ownership review note であることを明記しました。

## 変更範囲

- `docs/en/toolbar.md`
- `docs/ja/toolbar.md`

runtime Ruby / JavaScript、toolbar helper implementation、public API manifest、mockup HTML/CSS は変更していません。

## 確認内容

- 前提 PR #1625 が main に merge 済みで、`docs/toolbar_action_html_boundary.md` が current main に存在することを確認しました。
- compare: `main...docs/1626-toolbar-boundary-note-discovery`
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs-only files
- local checkout / local test は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 docs から merge 済み companion note へリンクするだけで、仕様や実装の変更はありません。