### PR TITLE
remote-state value docs signal を日本語 Lazy Loading docs に同期する

### DIFF
--- a/docs/ja/lazy-loading.md
+++ b/docs/ja/lazy-loading.md
@@ -215,7 +215,7 @@ host app側は、fetchやTurbo requestの状態に応じてこれらのeventをd
 
 これらの lifecycle event 名は package root から `TreeViewEventNames.hostLifecycle.loading` / `.loaded` / `.error` / `.retry` として参照できます。この group は host app 側の request-state dispatch 専用です。`TreeViewEventNames.remoteState.*` は引き続き TreeView controller が emit する event 用の別 surface として扱います。
 
-`TreeViewRemoteStateValues.loading` / `.loaded` / `.error` は、よく使う documented state value 用の別 package-root export であり、event 名でも `tree_remote_state_placeholder_attributes` の validation list でもありません。共有 JavaScript でそれらの代表 remote-state value を比較または受け渡すときに使えます。host app 固有の placeholder state が必要な場合は、helper に string value を渡し、その state を host app 側で document してください。`retry` は action / event であって row state value ではないため、この value set には含めません。
+`TreeViewRemoteStateValues.loading` / `.loaded` / `.error` は、よく使う documented state value 用の別 package-root export であり、event 名ではありません。また、`tree_remote_state_placeholder_attributes` の validation list でもありません。共有 JavaScript でそれらの代表 remote-state value を比較または受け渡すときに使えます。host app 固有の placeholder state が必要な場合は、helper に string value を渡し、その state を host app 側で document してください。`retry` は action / event であって row state value ではないため、この value set には含めません。
 
 ## children pagination
 


### PR DESCRIPTION
## 対応 Issue

Closes #1667

## CI Fix Summary

### Failed check
- PR #1672 / CI #2122 / `javascript`
- `npm run test:js:core`
- `script/test_public_api_docs_signals.mjs`

### Classification
- `baseline_drift`

### Cause
- PR #1665 merge 後の `docs/ja/lazy-loading.md` は remote-state values と event names の境界を説明していましたが、docs smoke が代表 signal として確認する `event 名ではありません` の日本語表現と一致していませんでした。
- #1672 の変更ファイル外で落ちており、#1672 固有の keyboard navigation failure ではありません。

### Fix
- `docs/ja/lazy-loading.md` の remote-state value 説明を、英語版と同じく「event 名ではない」ことと `tree_remote_state_placeholder_attributes` の validation list ではないことが分かる文に分けました。
- runtime、helper、JavaScript export、manifest、test の検証強度は変更していません。

### Verification
- [x] current head_sha の workflow / check を確認
- [ ] local test
- [x] lint
- [ ] typecheck
- [x] CI rerun checked

### Risk
- low

### Notes
- local checkout / local `npm run test:docs-entrypoints` は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。
- CI #2124 は success: `changes`, `lint`, `pr_specs`, `javascript`, representative `pr_rails_matrix` が success。docs-only skip path により browser/core JS 実行は skip されています。
- 各 open PR へ同じ docs fix を混ぜず、baseline drift を専用 PR に切り出しています。