### PR TITLE
release note candidate collector を追加する

### DIFF
--- a/docs/en/release-note-candidates.md
+++ b/docs/en/release-note-candidates.md
@@ -1,0 +1,39 @@
+# Release note candidate collector
+
+`script/release_note_candidates.rb` is a release preparation helper for collecting links that a maintainer may want to review before writing GitHub Release notes.
+
+It is intentionally a candidate collector only:
+
+- It does not edit `CHANGELOG.md`.
+- It does not decide the final release notes.
+- It does not tag, publish, or create a GitHub Release.
+- It does not replace the release preparation PR described in `docs/en/release.md`.
+
+## Date window
+
+Use a date window when you want GitHub Search to return merged pull requests and closed issues directly:
+
+```bash
+ruby script/release_note_candidates.rb --repo matsuo-haruhito/tree_view-rails --since 2026-06-01
+```
+
+This mode queries:
+
+- merged pull requests with `merged:>=YYYY-MM-DD`
+- closed issues with `closed:>=YYYY-MM-DD`
+
+Set `GITHUB_TOKEN` when you need a higher API rate limit or private repository access. Public repositories can usually be checked without a token, subject to GitHub API limits.
+
+## Since tag
+
+Use a tag when you want a local release review based on commit references after the previous release tag:
+
+```bash
+ruby script/release_note_candidates.rb --repo matsuo-haruhito/tree_view-rails --since-tag v0.1.0
+```
+
+This mode compares the tag to `HEAD`, extracts `#123` style references from commit messages, and resolves those numbers as pull requests or issues. It is useful as a fallback when a date window is not obvious, but it only finds references that appear in commit messages.
+
+## Review boundary
+
+Treat the output as a checklist for maintainer review. During the release preparation PR, compare it with `CHANGELOG.md` and the merged PR history, then manually decide which items are notable enough for GitHub Release notes.

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -27,6 +27,8 @@ Release flow:
 7. Create a GitHub Release when appropriate.
 8. Publish the gem when appropriate.
 
+Before writing GitHub Release notes, use the [Release note candidate collector](release-note-candidates.md) to gather merged PR and closed Issue links for maintainer review. The collector is only a checklist aid: it does not rewrite `CHANGELOG.md`, decide the final notes, tag, publish, or create a GitHub Release.
+
 Introduce `release/x.y` branches only when parallel maintenance, long RC verification, or security/compatibility patch lines are needed.
 
 ## Initial release target

--- a/docs/ja/release-note-candidates.md
+++ b/docs/ja/release-note-candidates.md
@@ -1,0 +1,39 @@
+# Release note candidate collector
+
+`script/release_note_candidates.rb` は、GitHub Release notes に載せる候補リンクを release preparation 時に確認するための補助 script です。
+
+この script は candidate collector に限定します。
+
+- `CHANGELOG.md` は編集しません。
+- 最終的な release notes を自動判断しません。
+- tag 作成、gem publish、GitHub Release 作成は行いません。
+- `docs/ja/release.md` に書かれている release preparation PR の代わりにはしません。
+
+## Date window
+
+期間が決まっている場合は、GitHub Search から merged pull request と closed issue を直接集めます。
+
+```bash
+ruby script/release_note_candidates.rb --repo matsuo-haruhito/tree_view-rails --since 2026-06-01
+```
+
+この mode は次を検索します。
+
+- `merged:>=YYYY-MM-DD` の merged pull requests
+- `closed:>=YYYY-MM-DD` の closed issues
+
+API rate limit を上げたい場合や private repository を見る場合は `GITHUB_TOKEN` を設定してください。public repository では token なしでも確認できますが、GitHub API の rate limit に依存します。
+
+## Since tag
+
+前回 release tag 以降の commit reference を起点に確認したい場合は tag を指定します。
+
+```bash
+ruby script/release_note_candidates.rb --repo matsuo-haruhito/tree_view-rails --since-tag v0.1.0
+```
+
+この mode は tag と `HEAD` を compare し、commit message 内の `#123` 形式の参照を pull request / issue として解決します。期間を決めにくいときの fallback として使えますが、commit message に出てこない issue / PR は候補に入りません。
+
+## Review boundary
+
+出力は maintainer review 用 checklist として扱います。release preparation PR では、この候補一覧、`CHANGELOG.md`、merged PR history を見比べ、GitHub Release notes に載せるべき項目を人間が判断してください。

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -27,6 +27,8 @@ releaseの流れ:
 7. 必要に応じてGitHub Releaseを作成する。
 8. 必要に応じてgem publishする。
 
+GitHub Release notes を書く前に、[Release note candidate collector](release-note-candidates.md) で merged PR / closed Issue の候補リンクを集め、maintainer review の checklist として確認します。この collector は `CHANGELOG.md` を書き換えず、最終的な release notes、tag 作成、gem publish、GitHub Release 作成を自動判断しません。
+
 `release/x.y` branch は、複数minor lineの並行保守、長期RC検証、security/compatibility patchなどが必要になった時だけ導入します。
 
 ## 初回リリースの目標

--- a/script/release_note_candidates.rb
+++ b/script/release_note_candidates.rb
@@ -4,7 +4,6 @@
 require "json"
 require "net/http"
 require "optparse"
-require "uri"
 
 module ReleaseNoteCandidates
   Entry = Struct.new(:type, :number, :title, :url, :closed_at, :merged_at, keyword_init: true)

--- a/script/release_note_candidates.rb
+++ b/script/release_note_candidates.rb
@@ -4,8 +4,6 @@
 require "json"
 require "net/http"
 require "optparse"
-require "set"
-require "time"
 require "uri"
 
 module ReleaseNoteCandidates

--- a/script/release_note_candidates.rb
+++ b/script/release_note_candidates.rb
@@ -1,0 +1,175 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "optparse"
+require "set"
+require "time"
+require "uri"
+
+module ReleaseNoteCandidates
+  Entry = Struct.new(:type, :number, :title, :url, :closed_at, :merged_at, keyword_init: true)
+
+  class GitHubClient
+    def initialize(token: ENV["GITHUB_TOKEN"], api_base: "https://api.github.com")
+      @token = token
+      @api_base = api_base
+    end
+
+    def search(query)
+      uri = URI("#{@api_base}/search/issues")
+      uri.query = URI.encode_www_form(q: query, per_page: 100, sort: "updated", order: "desc")
+      get_json(uri).fetch("items", [])
+    end
+
+    def compare(repo, base_ref)
+      owner, name = repo.split("/", 2)
+      encoded_ref = URI.encode_www_form_component(base_ref)
+      get_json(URI("#{@api_base}/repos/#{owner}/#{name}/compare/#{encoded_ref}...HEAD"))
+    end
+
+    def issue(repo, number)
+      owner, name = repo.split("/", 2)
+      get_json(URI("#{@api_base}/repos/#{owner}/#{name}/issues/#{number}"))
+    end
+
+    private
+
+    def get_json(uri)
+      request = Net::HTTP::Get.new(uri)
+      request["Accept"] = "application/vnd.github+json"
+      request["Authorization"] = "Bearer #{@token}" if @token && !@token.empty?
+
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.request(request)
+      end
+
+      unless response.is_a?(Net::HTTPSuccess)
+        abort "GitHub API request failed: #{response.code} #{response.message}\n#{uri}"
+      end
+
+      JSON.parse(response.body)
+    end
+  end
+
+  class Collector
+    MERGE_REF_PATTERN = /#(\d+)/
+
+    def initialize(client: GitHubClient.new)
+      @client = client
+    end
+
+    def by_since_date(repo:, since_date:)
+      merged_prs = @client.search("repo:#{repo} is:pr is:merged merged:>=#{since_date}")
+      closed_issues = @client.search("repo:#{repo} is:issue is:closed closed:>=#{since_date}")
+
+      [entries_from_search(merged_prs, :pull_request), entries_from_search(closed_issues, :issue)]
+    end
+
+    def by_since_tag(repo:, since_tag:)
+      compare = @client.compare(repo, since_tag)
+      numbers = compare.fetch("commits", []).flat_map do |commit|
+        commit.dig("commit", "message").to_s.scan(MERGE_REF_PATTERN).flatten
+      end.uniq
+
+      entries = numbers.map { |number| entry_from_issue(@client.issue(repo, number)) }
+      entries.partition { |entry| entry.type == :pull_request }
+    end
+
+    private
+
+    def entries_from_search(items, type)
+      items.map do |item|
+        Entry.new(
+          type: type,
+          number: item.fetch("number"),
+          title: item.fetch("title"),
+          url: item.fetch("html_url"),
+          closed_at: item["closed_at"],
+          merged_at: item.dig("pull_request", "merged_at")
+        )
+      end
+    end
+
+    def entry_from_issue(item)
+      type = item.key?("pull_request") ? :pull_request : :issue
+      Entry.new(
+        type: type,
+        number: item.fetch("number"),
+        title: item.fetch("title"),
+        url: item.fetch("html_url"),
+        closed_at: item["closed_at"],
+        merged_at: item.dig("pull_request", "merged_at")
+      )
+    end
+  end
+
+  class MarkdownFormatter
+    def call(repo:, source:, merged_prs:, closed_issues:)
+      lines = []
+      lines << "# Release note candidates for #{repo}"
+      lines << ""
+      lines << "Source: #{source}"
+      lines << ""
+      lines << "This is a maintainer review aid. It does not rewrite CHANGELOG.md and does not decide the final release notes."
+      lines << ""
+      append_section(lines, "Merged pull requests", merged_prs)
+      append_section(lines, "Closed issues", closed_issues)
+      lines.join("\n") + "\n"
+    end
+
+    private
+
+    def append_section(lines, title, entries)
+      lines << "## #{title}"
+      lines << ""
+
+      if entries.empty?
+        lines << "- No candidates found."
+      else
+        entries.sort_by(&:number).each do |entry|
+          timestamp = entry.merged_at || entry.closed_at
+          suffix = timestamp ? " (#{timestamp})" : ""
+          lines << "- ##{entry.number} #{entry.title}#{suffix}"
+          lines << "  #{entry.url}"
+        end
+      end
+
+      lines << ""
+    end
+  end
+
+  class CLI
+    def self.run(argv)
+      options = parse_options(argv)
+      collector = Collector.new
+
+      merged_prs, closed_issues = if options[:since]
+        collector.by_since_date(repo: options.fetch(:repo), since_date: options.fetch(:since))
+      else
+        collector.by_since_tag(repo: options.fetch(:repo), since_tag: options.fetch(:since_tag))
+      end
+
+      source = options[:since] ? "closed or merged since #{options[:since]}" : "commit references since tag #{options[:since_tag]}"
+      puts MarkdownFormatter.new.call(repo: options.fetch(:repo), source: source, merged_prs: merged_prs, closed_issues: closed_issues)
+    end
+
+    def self.parse_options(argv)
+      options = {}
+      OptionParser.new do |parser|
+        parser.banner = "Usage: ruby script/release_note_candidates.rb --repo OWNER/REPO (--since YYYY-MM-DD | --since-tag vX.Y.Z)"
+        parser.on("--repo REPO", "GitHub repository, for example matsuo-haruhito/tree_view-rails") { |value| options[:repo] = value }
+        parser.on("--since DATE", "Collect merged PRs and closed issues since YYYY-MM-DD") { |value| options[:since] = value }
+        parser.on("--since-tag TAG", "Collect candidates referenced by commits since TAG") { |value| options[:since_tag] = value }
+      end.parse!(argv)
+
+      abort "--repo is required" unless options[:repo]
+      abort "Use exactly one of --since or --since-tag" unless [options[:since], options[:since_tag]].compact.one?
+
+      options
+    end
+  end
+end
+
+ReleaseNoteCandidates::CLI.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/spec/script/release_note_candidates_spec.rb
+++ b/spec/script/release_note_candidates_spec.rb
@@ -3,68 +3,70 @@
 require "spec_helper"
 require_relative "../../script/release_note_candidates"
 
-class FakeReleaseNoteClient
-  attr_reader :queries
+def build_fake_release_note_client
+  Class.new do
+    attr_reader :queries
 
-  def initialize
-    @queries = []
-  end
+    def initialize
+      @queries = []
+    end
 
-  def search(query)
-    @queries << query
-    if query.include?("is:pr")
-      [
+    def search(query)
+      @queries << query
+      if query.include?("is:pr")
+        [
+          {
+            "number" => 12,
+            "title" => "Add toolbar helper",
+            "html_url" => "https://github.com/example/repo/pull/12",
+            "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
+          }
+        ]
+      else
+        [
+          {
+            "number" => 34,
+            "title" => "Clarify release docs",
+            "html_url" => "https://github.com/example/repo/issues/34",
+            "closed_at" => "2026-06-02T00:00:00Z"
+          }
+        ]
+      end
+    end
+
+    def compare(_repo, _base_ref)
+      {
+        "commits" => [
+          {"commit" => {"message" => "Merge pull request #12 from feature\n\nCloses #34"}},
+          {"commit" => {"message" => "Docs update without issue reference"}}
+        ]
+      }
+    end
+
+    def issue(_repo, number)
+      case number.to_i
+      when 12
         {
           "number" => 12,
           "title" => "Add toolbar helper",
           "html_url" => "https://github.com/example/repo/pull/12",
           "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
         }
-      ]
-    else
-      [
+      when 34
         {
           "number" => 34,
           "title" => "Clarify release docs",
           "html_url" => "https://github.com/example/repo/issues/34",
           "closed_at" => "2026-06-02T00:00:00Z"
         }
-      ]
+      end
     end
-  end
-
-  def compare(_repo, _base_ref)
-    {
-      "commits" => [
-        {"commit" => {"message" => "Merge pull request #12 from feature\n\nCloses #34"}},
-        {"commit" => {"message" => "Docs update without issue reference"}}
-      ]
-    }
-  end
-
-  def issue(_repo, number)
-    case number.to_i
-    when 12
-      {
-        "number" => 12,
-        "title" => "Add toolbar helper",
-        "html_url" => "https://github.com/example/repo/pull/12",
-        "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
-      }
-    when 34
-      {
-        "number" => 34,
-        "title" => "Clarify release docs",
-        "html_url" => "https://github.com/example/repo/issues/34",
-        "closed_at" => "2026-06-02T00:00:00Z"
-      }
-    end
-  end
+  end.new
 end
 
 RSpec.describe ReleaseNoteCandidates::Collector do
   it "collects merged pull requests and closed issues for a date window" do
-    client = FakeReleaseNoteClient.new
+    client = build_fake_release_note_client
     merged_prs, closed_issues = described_class.new(client: client).by_since_date(
       repo: "example/repo",
       since_date: "2026-06-01"
@@ -79,7 +81,7 @@ RSpec.describe ReleaseNoteCandidates::Collector do
   end
 
   it "collects referenced candidates from commits since a tag" do
-    client = FakeReleaseNoteClient.new
+    client = build_fake_release_note_client
     merged_prs, closed_issues = described_class.new(client: client).by_since_tag(
       repo: "example/repo",
       since_tag: "v0.1.0"

--- a/spec/script/release_note_candidates_spec.rb
+++ b/spec/script/release_note_candidates_spec.rb
@@ -3,66 +3,66 @@
 require "spec_helper"
 require_relative "../../script/release_note_candidates"
 
-RSpec.describe ReleaseNoteCandidates::Collector do
-  class FakeReleaseNoteClient
-    attr_reader :queries
+class FakeReleaseNoteClient
+  attr_reader :queries
 
-    def initialize
-      @queries = []
-    end
+  def initialize
+    @queries = []
+  end
 
-    def search(query)
-      @queries << query
-      if query.include?("is:pr")
-        [
-          {
-            "number" => 12,
-            "title" => "Add toolbar helper",
-            "html_url" => "https://github.com/example/repo/pull/12",
-            "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
-          }
-        ]
-      else
-        [
-          {
-            "number" => 34,
-            "title" => "Clarify release docs",
-            "html_url" => "https://github.com/example/repo/issues/34",
-            "closed_at" => "2026-06-02T00:00:00Z"
-          }
-        ]
-      end
-    end
-
-    def compare(_repo, _base_ref)
-      {
-        "commits" => [
-          {"commit" => {"message" => "Merge pull request #12 from feature\n\nCloses #34"}},
-          {"commit" => {"message" => "Docs update without issue reference"}}
-        ]
-      }
-    end
-
-    def issue(_repo, number)
-      case number.to_i
-      when 12
+  def search(query)
+    @queries << query
+    if query.include?("is:pr")
+      [
         {
           "number" => 12,
           "title" => "Add toolbar helper",
           "html_url" => "https://github.com/example/repo/pull/12",
           "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
         }
-      when 34
+      ]
+    else
+      [
         {
           "number" => 34,
           "title" => "Clarify release docs",
           "html_url" => "https://github.com/example/repo/issues/34",
           "closed_at" => "2026-06-02T00:00:00Z"
         }
-      end
+      ]
     end
   end
 
+  def compare(_repo, _base_ref)
+    {
+      "commits" => [
+        {"commit" => {"message" => "Merge pull request #12 from feature\n\nCloses #34"}},
+        {"commit" => {"message" => "Docs update without issue reference"}}
+      ]
+    }
+  end
+
+  def issue(_repo, number)
+    case number.to_i
+    when 12
+      {
+        "number" => 12,
+        "title" => "Add toolbar helper",
+        "html_url" => "https://github.com/example/repo/pull/12",
+        "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
+      }
+    when 34
+      {
+        "number" => 34,
+        "title" => "Clarify release docs",
+        "html_url" => "https://github.com/example/repo/issues/34",
+        "closed_at" => "2026-06-02T00:00:00Z"
+      }
+    end
+  end
+end
+
+RSpec.describe ReleaseNoteCandidates::Collector do
   it "collects merged pull requests and closed issues for a date window" do
     client = FakeReleaseNoteClient.new
     merged_prs, closed_issues = described_class.new(client: client).by_since_date(

--- a/spec/script/release_note_candidates_spec.rb
+++ b/spec/script/release_note_candidates_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../script/release_note_candidates"
+
+RSpec.describe ReleaseNoteCandidates::Collector do
+  class FakeReleaseNoteClient
+    attr_reader :queries
+
+    def initialize
+      @queries = []
+    end
+
+    def search(query)
+      @queries << query
+      if query.include?("is:pr")
+        [
+          {
+            "number" => 12,
+            "title" => "Add toolbar helper",
+            "html_url" => "https://github.com/example/repo/pull/12",
+            "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
+          }
+        ]
+      else
+        [
+          {
+            "number" => 34,
+            "title" => "Clarify release docs",
+            "html_url" => "https://github.com/example/repo/issues/34",
+            "closed_at" => "2026-06-02T00:00:00Z"
+          }
+        ]
+      end
+    end
+
+    def compare(_repo, _base_ref)
+      {
+        "commits" => [
+          {"commit" => {"message" => "Merge pull request #12 from feature\n\nCloses #34"}},
+          {"commit" => {"message" => "Docs update without issue reference"}}
+        ]
+      }
+    end
+
+    def issue(_repo, number)
+      case number.to_i
+      when 12
+        {
+          "number" => 12,
+          "title" => "Add toolbar helper",
+          "html_url" => "https://github.com/example/repo/pull/12",
+          "pull_request" => {"merged_at" => "2026-06-01T00:00:00Z"}
+        }
+      when 34
+        {
+          "number" => 34,
+          "title" => "Clarify release docs",
+          "html_url" => "https://github.com/example/repo/issues/34",
+          "closed_at" => "2026-06-02T00:00:00Z"
+        }
+      end
+    end
+  end
+
+  it "collects merged pull requests and closed issues for a date window" do
+    client = FakeReleaseNoteClient.new
+    merged_prs, closed_issues = described_class.new(client: client).by_since_date(
+      repo: "example/repo",
+      since_date: "2026-06-01"
+    )
+
+    expect(client.queries).to eq([
+      "repo:example/repo is:pr is:merged merged:>=2026-06-01",
+      "repo:example/repo is:issue is:closed closed:>=2026-06-01"
+    ])
+    expect(merged_prs.map(&:number)).to eq([12])
+    expect(closed_issues.map(&:number)).to eq([34])
+  end
+
+  it "collects referenced candidates from commits since a tag" do
+    client = FakeReleaseNoteClient.new
+    merged_prs, closed_issues = described_class.new(client: client).by_since_tag(
+      repo: "example/repo",
+      since_tag: "v0.1.0"
+    )
+
+    expect(merged_prs.map(&:number)).to eq([12])
+    expect(closed_issues.map(&:number)).to eq([34])
+  end
+end
+
+RSpec.describe ReleaseNoteCandidates::MarkdownFormatter do
+  it "formats candidates without implying changelog automation" do
+    markdown = described_class.new.call(
+      repo: "example/repo",
+      source: "closed or merged since 2026-06-01",
+      merged_prs: [ReleaseNoteCandidates::Entry.new(type: :pull_request, number: 12, title: "Add toolbar helper", url: "https://github.com/example/repo/pull/12", merged_at: "2026-06-01T00:00:00Z")],
+      closed_issues: []
+    )
+
+    expect(markdown).to include("Release note candidates for example/repo")
+    expect(markdown).to include("This is a maintainer review aid. It does not rewrite CHANGELOG.md")
+    expect(markdown).to include("#12 Add toolbar helper")
+    expect(markdown).to include("No candidates found")
+  end
+end


### PR DESCRIPTION
release preparation 時に merged PR / closed Issue の候補リンクを確認できる補助 script を追加します。

## 対応 Issue

Closes #1669

## 変更内容

- `script/release_note_candidates.rb` を追加しました。
  - `--since YYYY-MM-DD` で GitHub Search から merged PR / closed Issue の候補を集めます。
  - `--since-tag vX.Y.Z` で tag 以降の commit message に含まれる `#123` 参照を候補化します。
  - 出力は Markdown の review checklist に限定し、`CHANGELOG.md` は自動編集しません。
- `spec/script/release_note_candidates_spec.rb` を追加し、date window / since-tag / Markdown 出力の代表挙動を fake client で確認します。
- `docs/en/release-note-candidates.md` と `docs/ja/release-note-candidates.md` を追加し、使いどころ、GitHub token 境界、CHANGELOG 非自動編集の責務境界を説明しました。
- review follow-up として `docs/en/release.md` / `docs/ja/release.md` から collector docs へ辿れる短い導線を追加しました。

## 受け入れ条件との対応

- release note candidate collector を追加する方針にしました。
- 期間指定では merged PR / closed Issue の候補リンクを取得できます。
- tag 指定では compare commit から参照番号を候補化する fallback を用意しました。
- `CHANGELOG.md` を自動 rewrite せず、maintainer review 用 output に閉じています。
- release docs と dedicated docs の英日両方で、script の使いどころ、限界、release preparation PR を置き換えないことを明記しました。
- gem publish、tag 作成、GitHub Release 作成の自動化には広げていません。

## 変更範囲

- maintainer script
- script spec
- release preparation helper docs
- release checklist から collector docs への英日導線

runtime Ruby library、Rails helper、JavaScript、public API manifest、gem publish flow、tag / release 作成処理は変更していません。

## 実施した確認

- Issue #1669 の labels を直接確認しました。
- follow-up 前の review comment で、release docs から collector docs への導線不足を `review:changes-requested` として確認しました。
- review follow-up 後の head: `f8a6026e48b9b346f134eec84bbcbfb4c21cf9ce`
- 最終確認時点の compare: `main...feature/1669-release-note-candidates-v2`
  - base: `0686085b7cbf89e5a22f50285126b89e4d25a3d5`
  - `ahead_by: 10`
  - `behind_by: 3`
  - changed files: 6
- PR metadata: `mergeable: true`
- GitHub Actions CI #2144: success
  - `changes`, `lint`, `pr_specs`: success
  - `javascript`: docs-only/core path success
  - representative Rails lanes: docs-only skip path success
  - `gem_package`: skipped
- local checkout / local RSpec は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。release preparation 用の補助 script と docs / spec、release guide 導線の追加に限定し、CHANGELOG や release automation 本体は変更していません。

## 未対応・補足

- GitHub API の rate limit が必要な場合は `GITHUB_TOKEN` を使う前提です。
- `--since-tag` mode は commit message に現れる issue / PR references だけを候補化する fallback であり、最終 release notes は maintainer review で判断します。
- main が作業中にも進んでいるため behind 数は変動します。最終確認時点では `behind_by: 3` ですが、PR metadata は `mergeable: true` で、main 側の後続変更は toolbar docs など別 docs のため、この PR の release note candidate collector 差分とは重複していません。