### PR TITLE
Selection docs entrypoint に form sync / max-count 境界を明記する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,8 +31,8 @@
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
 - [English Accessibility Semantics](en/accessibility-semantics.md): table-first ARIA policy, empty-state wrapper hooks, keyboard helper boundary, and intentional automated-check allowances.
 - [日本語Accessibility Semantics](ja/accessibility-semantics.md): table-first ARIA 方針、empty-state wrapper hook、keyboard helper の責務境界、自動 accessibility check の意図的な許容事項。
-- [English Selection](en/selection.md): checkbox selection hooks, disabled state, cascade behavior, and submitted value parsing.
-- [日本語Selection](ja/selection.md): checkbox selection hooks、disabled state、cascade、submitted value parsing の入口。
+- [English Selection](en/selection.md): checkbox selection hooks, hidden input form sync, max-count limits, multi-tree form boundaries, unloaded-descendant boundaries, and submitted value parsing.
+- [日本語Selection](ja/selection.md): checkbox selection hooks、hidden input form sync、最大選択数、複数 tree form の境界、unloaded descendants の境界、submitted value parsing の入口。
 - [English Lazy Loading](en/lazy-loading.md): load children on demand through host-app routes and TreeView remote-state hooks.
 - [日本語Lazy Loading](ja/lazy-loading.md): host app の route と TreeView remote-state hooks で子nodeを必要時に読み込む入口。
 - [English Children Pagination](en/children-pagination.md): combine lazy loading with server-side child paging when a parent has too many direct children to return at once.


### PR DESCRIPTION
## 対応 Issue

Refs #1670

## 判定分類

- `docs-sync`
- `docs-missing`（docs index の Selection entrypoint summary が current Selection docs の hidden input / max-count / multi-tree / unloaded-descendant 境界を十分に示していなかった）

## 変更内容

- `docs/README.md` の English / Japanese Selection entrypoint summary を更新しました。
- hidden input form sync、max-count limits、multi-tree form boundaries、unloaded-descendant boundaries へ気づきやすい説明にしました。

## 変更範囲

- `docs/README.md` のみ

runtime Ruby / JavaScript、selection controller behavior、hidden input generation、max-count API、mockup HTML、AGENTS.md、Product Profile は変更していません。

## 確認内容

- Default PR Check: open docs PR #1630 / #1648 / #1673 / #1674 は current main に対して `behind_by:0`、Actions CI success、追加の明確な修正依頼なしと確認しました。
- README、`docs/README.md`、AGENTS.md、Product Profile を確認し、maintainer entrypoint の大きな欠落は見当たりませんでした。
- compare: `main...docs/selection-entrypoint-sync`
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1 docs-only file
- local checkout / local test は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 Selection docs の実装済み・文書化済み範囲を docs index から見つけやすくするだけです。

## 補足

#1670 の本丸である Troubleshooting 逆引き節の拡充は、長い既存ファイルの安全な全文更新が必要なため、この connector-only run では先に docs index の低リスクな入口同期に閉じています。必要なら後続で `docs/en/troubleshooting.md` / `docs/ja/troubleshooting.md` へ症状別 subsection を追加してください。