### PR TITLE
CI changed-file policy で package / Node metadata を package-sensitive にする

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -40,6 +40,9 @@ function isDocsOnlyPath(file) {
 function isPackageSensitivePath(file) {
   return (
     file === "tree_view.gemspec" ||
+    file === "package.json" ||
+    file === "package-lock.json" ||
+    file === ".nvmrc" ||
     file === "script/check_gem_package_contents.rb" ||
     file === ".github/workflows/ci.yml" ||
     file === "config/importmap.tree_view.rb" ||

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -51,6 +51,16 @@ const cases = [
       browser_smoke_changed: false,
       package_sensitive: true
     }
+  },
+  {
+    name: "package and Node metadata are package-sensitive full CI changes",
+    files: ["package.json", "package-lock.json", ".nvmrc"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true
+    }
   }
 ];
 


### PR DESCRIPTION
## 対応 Issue

Closes #1658

## Issue ごとの完了内容

- #1658: `package.json` / `package-lock.json` / `.nvmrc` の変更を `package_sensitive: true` として扱うようにし、PR の `gem_package` job 判定から漏れないようにしました。

## 変更内容

- `script/ci_changed_files_policy.mjs`
  - JavaScript package / Node 実行条件 metadata として `package.json`、`package-lock.json`、`.nvmrc` を package-sensitive path に追加しました。
- `script/test_ci_changed_files_policy.mjs`
  - package / Node metadata の代表 case を追加し、docs-only ではなく package-sensitive full CI change と分類されることを確認します。

## 改善カテゴリ

- CI
- test
- devops guard

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、docs-only shortcut、npm install / npm ci policy は変更していません。
- lockfile refresh、dependency update、Node major version change には広げていません。

## 実施した確認

- Issue labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch freshness: current `main` `1c8e9ff647468c24a3ec46dc77b8b77d32245a85` から branch を作成し、compare で `behind_by: 0` を確認しました。
- diff scope: 2 files only (`script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs`)。
- local test は GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク評価

- low
- 変更ファイル分類を明示するだけで、CI workflow 構造や dependency policy は変えていません。

## 補足事項

- `package-lock.json` は lockfile refresh そのものではなく、変更された場合に package-sensitive と判定する対象として追加しています。