### PR TITLE
TypeScript declaration literal shape guard を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
     "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
-    "test:entrypoints": "node script/test_entrypoints.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
+    "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"
   },

--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+
+function loadJavascriptPackageManifest() {
+  const manifestJson = execFileSync(
+    "ruby",
+    [
+      "-e",
+      [
+        'require "json"',
+        'require "yaml"',
+        'data = YAML.load_file("config/public_api_manifest.yml")',
+        'print JSON.generate(data.fetch("javascript_package_root"))'
+      ].join("; ")
+    ],
+    { encoding: "utf8" }
+  )
+
+  return JSON.parse(manifestJson)
+}
+
+function camelizeKey(value) {
+  return value.replace(/_([a-z])/g, (_match, character) => character.toUpperCase())
+}
+
+function deepCamelizeKeys(value) {
+  if (Array.isArray(value)) return value.map((item) => deepCamelizeKeys(item))
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [camelizeKey(key), deepCamelizeKeys(item)])
+    )
+  }
+
+  return value
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function declarationBlock(declarationSource, exportName) {
+  const marker = `export declare const ${exportName}:`
+  const start = declarationSource.indexOf(marker)
+  assert(start !== -1, `${exportName} declaration is missing`)
+
+  const nextExport = declarationSource.indexOf("\n\nexport declare", start + marker.length)
+  return nextExport === -1 ? declarationSource.slice(start) : declarationSource.slice(start, nextExport)
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function assertBlockContains(block, pattern, message) {
+  assert(pattern.test(block), message)
+}
+
+function assertDeclarationShape(block, expectedValue, path = []) {
+  Object.entries(expectedValue).forEach(([key, value]) => {
+    const currentPath = [...path, key]
+    const keyPattern = escapeRegExp(key)
+
+    if (Array.isArray(value)) {
+      const tupleBody = value.map((item) => `"${escapeRegExp(item)}"`).join(", ")
+      assertBlockContains(
+        block,
+        new RegExp(`${keyPattern}:\\s+readonly \\[${tupleBody}\\]`),
+        `${currentPath.join(".")} tuple declaration is out of sync`
+      )
+      return
+    }
+
+    if (value && typeof value === "object") {
+      assertBlockContains(
+        block,
+        new RegExp(`${keyPattern}:\\s+Readonly<\\{`),
+        `${currentPath.join(".")} object declaration is missing`
+      )
+      assertDeclarationShape(block, value, currentPath)
+      return
+    }
+
+    assertBlockContains(
+      block,
+      new RegExp(`${keyPattern}:\\s+"${escapeRegExp(value)}"`),
+      `${currentPath.join(".")} literal declaration is out of sync`
+    )
+  })
+}
+
+const manifest = loadJavascriptPackageManifest()
+const declarationSource = readFileSync("app/javascript/tree_view/index.d.ts", "utf8")
+const literalExports = {
+  TreeViewEventNames: deepCamelizeKeys(manifest.event_names),
+  TreeViewEventDetailKeys: deepCamelizeKeys(manifest.event_detail_keys),
+  TreeViewRemoteStateValues: manifest.remote_state_values,
+  TreeViewTransferDropPositions: manifest.transfer_drop_positions,
+  TreeViewTransferDataMimeTypes: deepCamelizeKeys(manifest.transfer_data_mime_types),
+  TreeViewControllerIdentifiers: Object.fromEntries(
+    manifest.controller_registrations.map(({ key, identifier }) => [key, identifier])
+  ),
+  TreeViewSelectionDataHooks: deepCamelizeKeys(manifest.selection_data_hooks),
+  TreeViewEmptyStateHooks: deepCamelizeKeys(manifest.empty_state_hooks)
+}
+
+Object.entries(literalExports).forEach(([exportName, expectedShape]) => {
+  assertDeclarationShape(declarationBlock(declarationSource, exportName), expectedShape, [exportName])
+})
+
+console.log("TypeScript declaration literal shape smoke passed")

--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -48,7 +48,7 @@ function declarationBlock(declarationSource, exportName) {
 }
 
 function escapeRegExp(value) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return String(value).replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
 }
 
 function assertBlockContains(block, pattern, message) {


### PR DESCRIPTION
## 対応 Issue

Closes #1684

## Issue ごとの完了内容

- `index.d.ts` が export 名だけでなく、public JavaScript literal surface の key set / representative literal values / tuple key list でも manifest と同期していることを軽量 smoke で確認できるようにしました。
- TypeScript compiler や declaration generator は導入せず、既存 entrypoint smoke family に追加しています。

## 変更内容

- `script/test_declaration_literal_shapes.mjs` を追加しました。
  - `config/public_api_manifest.yml` の `javascript_package_root` を読みます。
  - `TreeViewEventNames`, `TreeViewEventDetailKeys`, `TreeViewRemoteStateValues`, `TreeViewTransferDropPositions`, `TreeViewTransferDataMimeTypes`, `TreeViewControllerIdentifiers`, `TreeViewSelectionDataHooks`, `TreeViewEmptyStateHooks` の `.d.ts` literal shape を確認します。
- `package.json` の `test:entrypoints` に新 smoke を追加しました。

## 改善カテゴリ

- test
- devops / entrypoint smoke
- TypeScript declaration drift guard

## 既存仕様への影響

runtime JavaScript、public API manifest、TypeScript declaration 内容、controller identifiers、event payload shape は変更していません。

## 実施した確認

- Issue #1684 の labels を直接確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch freshness: latest `main` `0a12cb8c4d6895838eef0481c5a70c022bd44733` 起点、compare `behind_by: 0`。
- diff scope: 2 files (`script/test_declaration_literal_shapes.mjs`, `package.json`)。
- local full `npm run test:entrypoints` は、この環境の GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` のため未実行です。正規表現 escaping の Node 構文断片のみローカル確認し、PR CI で全体確認します。

## リスク評価

low。test runner 追加のみで、公開 surface や実行時挙動は変えません。失敗時は stale declaration surface が分かるよう export/path 名をエラーに含めています。