### PR TITLE
gem package guard に index.d.ts を追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -22,6 +22,7 @@ REQUIRED_PACKAGED_PATHS = %w[
   app/views/tree_view/_tree_row.html.erb
   app/assets/stylesheets/tree_view.scss
   app/javascript/tree_view/index.js
+  app/javascript/tree_view/index.d.ts
   app/javascript/tree_view/client_controller.js
   app/javascript/tree_view/remote_state_controller.js
   app/javascript/tree_view/selection_controller.js


### PR DESCRIPTION
## 対応 Issue

Closes #1689

## Issue ごとの完了内容

- `app/javascript/tree_view/index.d.ts` を gem package contents verification の代表必須ファイルに追加しました。
- Public API docs で TypeScript-aware tooling 用 declaration として案内されている artifact が、package verification でも落ちた時に検出できるようになりました。

## 変更内容

- `script/check_gem_package_contents.rb`
  - `REQUIRED_PACKAGED_PATHS` に `app/javascript/tree_view/index.d.ts` を追加しました。

## 改善カテゴリ

- test / package verification
- devops guard
- release packaging drift guard

## 既存仕様への影響

runtime Ruby / JavaScript behavior、public JavaScript exports、TypeScript declaration 内容、`tree_view.gemspec` の package glob、npm package publish policy は変更していません。既存の gem package verification が確認する代表パスを 1 件増やしただけです。

## 実施した確認

- Issue #1689 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 依存 PR なしで current `main` 上に `app/javascript/tree_view/index.d.ts` が存在することを確認しました。
- `tree_view.gemspec` が `app/javascript/tree_view/**/*` を gem package 対象に含めることを確認しました。
- `docs/en/public-api.md` が `app/javascript/tree_view/index.d.ts` を TypeScript-aware tooling 用 declaration と説明していることを確認しました。
- branch freshness: latest `main` `862a7f6bf6dfe4cf1c54748e236ca9451ca5cdc8` 起点、compare `behind_by: 0`。
- diff scope: 1 file / 1 line (`script/check_gem_package_contents.rb`)。
- local test / gem build は、この環境の GitHub HTTPS access が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク評価

low。既存 package verification の代表ファイル一覧に declaration file を追加するだけで、package policy や runtime behavior は変更しません。

## 補足

- `package.json` `types` field 追加、npm publish policy、`.d.ts` 自動生成、public export の追加・rename は非目標として扱いました。