### PR TITLE
README visual asset を package guard に含める

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -39,6 +39,7 @@ REQUIRED_PACKAGED_PATHS = %w[
   docs/mockups/review-gallery.html
   docs/mockups/default-tree.html
   docs/mockups/default-tree.css
+  docs/mockups/assets/readme-default-tree.svg
   docs/en/installation.md
   docs/ja/installation.md
   docs/en/public-api.md


### PR DESCRIPTION
## 対応 Issue

Closes #1692

## Issue ごとの完了内容

- README が参照する `docs/mockups/assets/readme-default-tree.svg` を gem package contents guard の representative required path に追加しました。
- README image path、`tree_view.gemspec` の `docs/**/*` package policy、既存 mockup entrypoint guard が矛盾しないことを確認しました。

## 変更内容

- `script/check_gem_package_contents.rb`
  - `REQUIRED_PACKAGED_PATHS` に `docs/mockups/assets/readme-default-tree.svg` を追加しました。

## 改善カテゴリ

- test
- package verification
- docs asset packaging guard

## 既存仕様への影響

runtime Ruby / JavaScript、README 画像 asset、mockup HTML/CSS、gemspec package glob、CI workflow、public API manifest は変更していません。

## 実施した確認

- Issue #1692 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current main `0bdcc0609a1d2da6ee5d1b97a29ae9d0751ee93a` 起点で branch を作成しました。
- compare `main...quality/1692-readme-asset-package-guard`
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1
- diff scope: `script/check_gem_package_contents.rb` の 1 行追加のみ。
- final newline: updated file content は末尾改行ありとして取得確認しました。
- local gem build / package verification は、この実行が connector-first でローカル checkout なしのため未実行です。PR CI で確認します。

## リスク評価

low。既に gemspec の `docs/**/*` で package 対象に含まれる README 画像 asset を、representative package guard に追加するだけです。

## 補足事項

- README image の見た目、source-of-truth 判断、mockup gallery design、screenshot / visual regression には触れていません。