### PR TITLE
release note collector を docs index から辿れるようにする

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@
 - [Development](en/development.md) / [開発・保守方針](ja/development.md): CI, local checks, documentation update workflow, and maintenance habits.
 - [Code quality](en/code-quality.md) / [コード品質](ja/code-quality.md): lint, tests, error message quality, and documentation quality policy.
 - [Release checklist](en/release.md) / [リリースチェックリスト](ja/release.md): release workflow, CI and package verification, and changelog expectations.
+- [Release note candidate collector](en/release-note-candidates.md) / [Release note candidate collector](ja/release-note-candidates.md): maintainer review aid for collecting merged PR and closed Issue candidates without replacing `CHANGELOG.md` or release notes decisions.
 - [CHANGELOG.md](../CHANGELOG.md): release-facing summary of shipped public changes, compatibility notes, and notable documentation additions.
 
 ## Maintenance


### PR DESCRIPTION
## 対応 Issue

Closes #1680

## 判定分類

- `docs-sync`
- `docs-missing`

## 変更内容

- `docs/README.md` の Maintainer entry points に、英日 `release-note-candidates.md` への導線を追加しました。
- collector は merged PR / closed Issue の候補を集める maintainer review aid であり、`CHANGELOG.md` や GitHub Release notes の判断を置き換えないことを短く明記しました。

## 変更範囲

- `docs/README.md`

runtime Ruby library、release script、script spec、英日 release guide、CHANGELOG、tag / publish / GitHub Release automation は変更していません。

## 確認内容

- PR #1676 が merge 済みで、`docs/en/release-note-candidates.md` / `docs/ja/release-note-candidates.md` と英日 release checklist 導線が current main に入っていることを確認しました。
- PR 作成前 compare: `main...docs/1680-release-note-collector-index`
  - base: `0bdcc0609a1d2da6ee5d1b97a29ae9d0751ee93a`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 docs-only file
- local checkout / local docs smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 collector docs への docs index 導線を 1 行追加するだけで、release workflow や collector behavior は変更していません。