### PR TITLE
Selection troubleshooting から関連 mockup へ戻れるようにする

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -313,10 +313,14 @@ Check these points.
 - When one form contains multiple trees, use separate hidden input names when the server should receive separate params. Reuse a name only when the host app intentionally accepts one combined array; TreeView uses source ids only to keep each controller from removing another controller's generated inputs.
 - If you expect client-side max-count limits or linked checkbox behavior, configure `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, and `data-tree-view-selection-indeterminate-value` on the same host element.
 - Cascade and indeterminate behavior only affects rendered rows in the current DOM.
+- If max-count, multi-tree, or unloaded-descendant behavior still does not match the product action, keep final params grouping, bulk-action semantics, server-side validation, and user-facing business copy in the host app.
 
 Read next:
 
 - [Selection](selection.md)
+- [selection max-count mockup](../mockups/selection-max-count.html)
+- [selection multi-tree form mockup](../mockups/selection-multi-tree-form.html)
+- [children-pagination-selection-boundary mockup](../mockups/children-pagination-selection-boundary.html)
 - [Host App Extension Points](host-app-extension-points.md)
 - [Public API](public-api.md)
 - [JavaScript event contract](js-events.md)

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -313,10 +313,14 @@ selection checkbox の送信値は plain ID ではなく JSON string です。
 - 1つの form に複数 tree がある場合、server 側で別々の params として受け取りたいなら hidden input name を分ける。同じ name を使うのは、host app が1つの配列としてまとめて受け取る設計のときだけです。TreeView の source id は、各 controller が他 controller の generated input を消さないために使われます
 - client-side の最大選択数制限や連動 checkbox 挙動を使う場合は、同じ host element に `data-tree-view-selection-max-count-value`、`data-tree-view-selection-cascade-value`、`data-tree-view-selection-indeterminate-value` を設定する
 - cascade と indeterminate は、現在 DOM に描画されている row にだけ効く
+- max-count、multi-tree、unloaded descendant の挙動が product action の期待とまだ合わない場合、最終的な params grouping、bulk action semantics、server-side validation、ユーザー向け business copy は host app 側に置く
 
 次に読む文書:
 
 - [Selection](selection.md)
+- [selection max-count mockup](../mockups/selection-max-count.html)
+- [selection multi-tree form mockup](../mockups/selection-multi-tree-form.html)
+- [children-pagination-selection-boundary mockup](../mockups/children-pagination-selection-boundary.html)
 - [Host App 拡張ポイント](host-app-extension-points.md)
 - [公開 API](public-api.md)
 - [JavaScript event contract](js-events.md)


### PR DESCRIPTION
## 対応 Issue

Closes #1670

## 判定分類

- `docs-sync`
- `docs-missing`

## 変更内容

- 英日 `troubleshooting.md` の selection payload 節に、max-count / multi-tree / unloaded descendants が product action と合わない場合の host-app-owned 境界を追加しました。
- `selection-max-count.html`、`selection-multi-tree-form.html`、`children-pagination-selection-boundary.html` への Read next 導線を追加しました。

## 変更範囲

- `docs/en/troubleshooting.md`
- `docs/ja/troubleshooting.md`

runtime Ruby / JavaScript、selection controller behavior、hidden input generation、max-count API、cascade behavior、mockup HTML は変更していません。

## 確認内容

- Issue #1670 と Planner handoff を確認しました。
- current main の既存 selection payload 節を正本にし、本文 rewrite ではなく不足していた導線だけを追記しました。
- compare `main...docs/1670-selection-troubleshooting-entrypoint`
  - base: `f1b464a8a20bc26f42b7ce99eb96d4c88532d449`
  - head: `1ab7ac579acc2059766552dbac863f35fbfefcac`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 2 docs-only files
- local checkout / `npm run test:docs-entrypoints` は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 Troubleshooting の selection payload 節に、関連 mockup 導線と host-app-owned 境界を最小追記するだけです。