### PR TITLE
docs index の Persisted State entrypoint を cleanup 境界に同期する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,8 @@
 - [日本語Toolbar helper](ja/toolbar.md): tree全体のexpand / collapse / current pathへのcollapse actionを描画し、配置と文言はhost appが所有する入口。
 - [English Breadcrumb helper](en/breadcrumb.md): render ancestor path context for a current or target node without taking over host-app routing or navigation policy.
 - [日本語Breadcrumb helper](ja/breadcrumb.md): current nodeや対象nodeのancestor path contextを描画し、routeやnavigation policyはhost app側に残す入口。
-- [English Persisted State](en/persisted-state.md): save and restore TreeView expansion state through host-app-owned storage.
-- [日本語Persisted State](ja/persisted-state.md): TreeView の開閉状態を host app 側の保存先で保存・復元するための入口。
+- [English Persisted State](en/persisted-state.md): save, restore, clear, and prune TreeView expansion state through host-app-owned storage and retention policy boundaries.
+- [日本語Persisted State](ja/persisted-state.md): TreeView の開閉状態を host app 側の保存先で保存・復元・clear・pruneし、retention policy / cleanup schedule の責務境界を確認する入口。
 - [English resource table bridge](en/resource-table-bridge.md): bridge TreeView row rendering with a separate table layer that owns columns and table state.
 - [日本語Resource table bridge](ja/resource-table-bridge.md): 別table layerが列推論やtable stateを持つ場合のTreeView連携。
 


### PR DESCRIPTION
## 対応 Issue

Closes #1693

## 判定分類

- `docs-sync`
- `docs-stale`

## 変更内容

- `docs/README.md` の Persisted State entrypoint を、save / restore だけでなく clear / prune も見つけられる表現に更新しました。
- 英日 entrypoint の両方で、retention policy / cleanup schedule は host app responsibility の境界として読めるようにしました。

## 変更範囲

- `docs/README.md`

runtime Ruby、`TreeView::StateStore` implementation、generator、public API manifest、英日 `persisted-state.md` 本文、docs smoke script は変更していません。

## 確認内容

- PR #1691 が merge 済みで、root `README.md` と英日 `docs/*/README.md` の Persisted State entrypoint が clear / prune / retention boundary を案内していることを確認しました。
- compare: `main...docs/1693-persisted-state-index-boundary`
  - base: `6ad7f1bc77bf737b1db610282ebc39ae80e80e0a`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 docs-only file
- local checkout / local docs smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。root docs index の entrypoint copy のみで、StateStore behavior や cleanup policy は変更していません。