### PR TITLE
release note candidate collector docs に出力例を追加する

### DIFF
--- a/docs/en/release-note-candidates.md
+++ b/docs/en/release-note-candidates.md
@@ -34,6 +34,30 @@ ruby script/release_note_candidates.rb --repo matsuo-haruhito/tree_view-rails --
 
 This mode compares the tag to `HEAD`, extracts `#123` style references from commit messages, and resolves those numbers as pull requests or issues. It is useful as a fallback when a date window is not obvious, but it only finds references that appear in commit messages.
 
+## Output example
+
+The script prints Markdown that is meant to be copied into release preparation notes, not committed as the final release text:
+
+```markdown
+# Release note candidates for matsuo-haruhito/tree_view-rails
+
+Source: closed or merged since 2026-06-01
+
+This is a maintainer review aid. It does not rewrite CHANGELOG.md and does not decide the final release notes.
+
+## Merged pull requests
+
+- #1691 Persisted State cleanup guide entrypoints (2026-06-09T09:16:47Z)
+  https://github.com/matsuo-haruhito/tree_view-rails/pull/1691
+
+## Closed issues
+
+- #1549 Persisted State cleanup docs entrypoint (2026-06-09T09:16:48Z)
+  https://github.com/matsuo-haruhito/tree_view-rails/issues/1549
+```
+
+During the release preparation PR, paste or link this output as review evidence, then compare it with `CHANGELOG.md`, the merged PR history, and any release-facing compatibility notes. Keep only the human-approved highlights in GitHub Release notes.
+
 ## Review boundary
 
 Treat the output as a checklist for maintainer review. During the release preparation PR, compare it with `CHANGELOG.md` and the merged PR history, then manually decide which items are notable enough for GitHub Release notes.

--- a/docs/ja/release-note-candidates.md
+++ b/docs/ja/release-note-candidates.md
@@ -34,6 +34,30 @@ ruby script/release_note_candidates.rb --repo matsuo-haruhito/tree_view-rails --
 
 この mode は tag と `HEAD` を compare し、commit message 内の `#123` 形式の参照を pull request / issue として解決します。期間を決めにくいときの fallback として使えますが、commit message に出てこない issue / PR は候補に入りません。
 
+## Output example
+
+script は Markdown を出力します。この出力は release preparation の確認メモへ貼るためのもので、最終 release 文として commit する前提ではありません。
+
+```markdown
+# Release note candidates for matsuo-haruhito/tree_view-rails
+
+Source: closed or merged since 2026-06-01
+
+This is a maintainer review aid. It does not rewrite CHANGELOG.md and does not decide the final release notes.
+
+## Merged pull requests
+
+- #1691 Persisted State cleanup guide entrypoints (2026-06-09T09:16:47Z)
+  https://github.com/matsuo-haruhito/tree_view-rails/pull/1691
+
+## Closed issues
+
+- #1549 Persisted State cleanup docs entrypoint (2026-06-09T09:16:48Z)
+  https://github.com/matsuo-haruhito/tree_view-rails/issues/1549
+```
+
+release preparation PR では、この出力を review evidence として貼るか link し、`CHANGELOG.md`、merged PR history、release-facing compatibility note と見比べてください。GitHub Release notes へ残す項目は、人間が確認した highlight に絞ります。
+
 ## Review boundary
 
 出力は maintainer review 用 checklist として扱います。release preparation PR では、この候補一覧、`CHANGELOG.md`、merged PR history を見比べ、GitHub Release notes に載せるべき項目を人間が判断してください。


### PR DESCRIPTION
## 対応 Issue

Closes #1702

## 判定分類

- `docs-missing`
- `docs-sync`

## 変更内容

- 英日 `release-note-candidates.md` に、collector が出力する Markdown の短い例を追加しました。
- 出力は release preparation PR の review evidence であり、`CHANGELOG.md` や GitHub Release notes の正本ではないことを補足しました。
- `--since` / `--since-tag` の既存説明は維持し、script behavior や release automation には広げていません。

## 変更範囲

- `docs/en/release-note-candidates.md`
- `docs/ja/release-note-candidates.md`

`script/release_note_candidates.rb`、release workflow、CHANGELOG policy、GitHub Release 作成、tag / publish automation は変更していません。

## 確認内容

- `script/release_note_candidates.rb` の formatter が `# Release note candidates for <repo>`、`Merged pull requests`、`Closed issues` を出力することを確認しました。
- compare: `main...docs/1702-release-note-candidate-example`
  - base: `6ad7f1bc77bf737b1db610282ebc39ae80e80e0a`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only files
- local checkout / local docs smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 maintainer tooling docs の補足例だけで、collector output format や release判断は変更していません。