### PR TITLE
release note candidate helper の CLI validation guard を補強する

### DIFF
--- a/spec/script/release_note_candidates_spec.rb
+++ b/spec/script/release_note_candidates_spec.rb
@@ -5,10 +5,12 @@ require_relative "../../script/release_note_candidates"
 
 def build_fake_release_note_client
   Class.new do
-    attr_reader :queries
+    attr_reader :queries, :compares, :issue_numbers
 
     def initialize
       @queries = []
+      @compares = []
+      @issue_numbers = []
     end
 
     def search(query)
@@ -34,7 +36,8 @@ def build_fake_release_note_client
       end
     end
 
-    def compare(_repo, _base_ref)
+    def compare(repo, base_ref)
+      @compares << [repo, base_ref]
       {
         "commits" => [
           {"commit" => {"message" => "Merge pull request #12 from feature\n\nCloses #34"}},
@@ -43,7 +46,8 @@ def build_fake_release_note_client
       }
     end
 
-    def issue(_repo, number)
+    def issue(repo, number)
+      @issue_numbers << [repo, number]
       case number.to_i
       when 12
         {
@@ -77,7 +81,9 @@ RSpec.describe ReleaseNoteCandidates::Collector do
       "repo:example/repo is:issue is:closed closed:>=2026-06-01"
     ])
     expect(merged_prs.map(&:number)).to eq([12])
+    expect(merged_prs.first.merged_at).to eq("2026-06-01T00:00:00Z")
     expect(closed_issues.map(&:number)).to eq([34])
+    expect(closed_issues.first.closed_at).to eq("2026-06-02T00:00:00Z")
   end
 
   it "collects referenced candidates from commits since a tag" do
@@ -87,6 +93,8 @@ RSpec.describe ReleaseNoteCandidates::Collector do
       since_tag: "v0.1.0"
     )
 
+    expect(client.compares).to eq([["example/repo", "v0.1.0"]])
+    expect(client.issue_numbers).to eq([["example/repo", "12"], ["example/repo", "34"]])
     expect(merged_prs.map(&:number)).to eq([12])
     expect(closed_issues.map(&:number)).to eq([34])
   end
@@ -101,9 +109,47 @@ RSpec.describe ReleaseNoteCandidates::MarkdownFormatter do
       closed_issues: []
     )
 
-    expect(markdown).to include("Release note candidates for example/repo")
+    expect(markdown).to include("# Release note candidates for example/repo")
+    expect(markdown).to include("Source: closed or merged since 2026-06-01")
     expect(markdown).to include("This is a maintainer review aid. It does not rewrite CHANGELOG.md")
+    expect(markdown).to include("## Merged pull requests")
     expect(markdown).to include("#12 Add toolbar helper")
+    expect(markdown).to include("## Closed issues")
     expect(markdown).to include("No candidates found")
+  end
+end
+
+RSpec.describe ReleaseNoteCandidates::CLI do
+  it "parses the date-window source option" do
+    options = described_class.parse_options([
+      "--repo", "example/repo",
+      "--since", "2026-06-01"
+    ])
+
+    expect(options).to eq(repo: "example/repo", since: "2026-06-01")
+  end
+
+  it "parses the since-tag source option" do
+    options = described_class.parse_options([
+      "--repo", "example/repo",
+      "--since-tag", "v0.1.0"
+    ])
+
+    expect(options).to eq(repo: "example/repo", since_tag: "v0.1.0")
+  end
+
+  it "requires the repository option" do
+    expect { described_class.parse_options(["--since", "2026-06-01"]) }.to raise_error(SystemExit)
+  end
+
+  it "requires exactly one source option" do
+    expect { described_class.parse_options(["--repo", "example/repo"]) }.to raise_error(SystemExit)
+    expect do
+      described_class.parse_options([
+        "--repo", "example/repo",
+        "--since", "2026-06-01",
+        "--since-tag", "v0.1.0"
+      ])
+    end.to raise_error(SystemExit)
   end
 end


### PR DESCRIPTION
## 対応 Issue

Closes #1700

## Issue ごとの完了内容

- #1700: `script/release_note_candidates.rb` の lightweight spec を補強し、GitHub API 実通信なしで date window / since-tag collector、Markdown output boundary、CLI option validation を確認できるようにしました。

## 変更内容

- `spec/script/release_note_candidates_spec.rb` を更新しました。
- fake client に compare / issue call tracking を追加し、`--since-tag` flow が commit references から候補 issue / PR を読むことを確認します。
- Markdown output の source / section / maintainer review aid / no `CHANGELOG.md` rewrite signal を明示的に確認します。
- `ReleaseNoteCandidates::CLI.parse_options` の `--repo` 必須、`--since` / `--since-tag` exactly-one validation、正常 parse を確認します。

## 改善カテゴリ

- test
- release helper guard
- maintenance

## 既存仕様への影響

runtime code、release workflow、GitHub API integration、tag / publish / GitHub Release 作成、CHANGELOG 自動編集は変更していません。既存 helper behavior の regression guard 補強だけです。

## 実施した確認内容

- Issue #1700 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch freshness: current `main` `6ad7f1bc77bf737b1db610282ebc39ae80e80e0a` から作成、compare `ahead_by:1` / `behind_by:0`。
- changed files: 1 spec file only。
- local RSpec は未実行です。この環境では GitHub checkout が `CONNECT tunnel failed, response 403` で利用できないため、PR CI で確認します。

## リスク評価

low。spec-only の補強で、実 API 通信や release automation には広げていません。

## 補足事項

#413 も条件を満たしていましたが、`npm view npm version` が今回も `403 Forbidden` だったため、registry-enabled 環境が必要な lockfile refresh は実装していません。