### PR TITLE
CHANGELOG / release checklist signals を軽量 smoke で守る

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const categories = [
+  "Added",
+  "Changed",
+  "Fixed",
+  "Deprecated",
+  "Removed",
+  "Documentation",
+  "Tests"
+]
+
+assertSignals("CHANGELOG.md", "CHANGELOG release category policy", [
+  "## Unreleased",
+  "Release preparation notes:",
+  "public API manifest",
+  "package-root export",
+  "migration note"
+])
+
+categories.forEach((category) => {
+  assertSignals("CHANGELOG.md", "CHANGELOG release category policy", [`${category}`])
+})
+
+const releaseDocs = [
+  [
+    "docs/en/release.md",
+    [
+      "CHANGELOG.md",
+      "config/public_api_manifest.yml",
+      "public API manifest change",
+      "release-facing trail",
+      "breaking changes, removals, or deprecations include migration notes",
+      "Record public API manifest changes by their user-visible effect"
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "CHANGELOG.md",
+      "config/public_api_manifest.yml",
+      "public API manifest",
+      "release-facing",
+      "breaking change、削除、deprecation",
+      "migration note",
+      "user-visible な影響"
+    ]
+  ]
+]
+
+releaseDocs.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Release checklist changelog policy", signals)
+})


### PR DESCRIPTION
## 対応 Issue

Closes #1668

## Issue ごとの完了内容

- #1668: CHANGELOG category / Unreleased release preparation notes と、英日 release checklist の public API manifest / CHANGELOG / migration note guidance を lightweight docs smoke で guard しました。

## 変更内容

- `script/test_release_docs_signals.mjs` を追加しました。
- `CHANGELOG.md` の `Unreleased`、release preparation notes、主要カテゴリ、public API manifest / package-root export / migration note の代表 signal を確認します。
- `docs/en/release.md` / `docs/ja/release.md` の CHANGELOG policy、public API manifest release-facing trail、migration note guidance の代表 signal を確認します。
- `npm run test:docs-entrypoints` に新 smoke を接続しました。

## 改善カテゴリ

- test
- docs smoke

## 既存仕様への影響

- runtime Ruby / JavaScript behavior、release automation、CHANGELOG prose、public API manifest schema は変更していません。
- 既存 docs の代表 signal を lightweight smoke で守るだけです。

## 実施した確認

- Issue labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch freshness: current `main` `cd58513d123dd7681ab025ef59e227ce62f4a626` から branch を作成し、compare で `behind_by: 0` を確認しました。
- diff scope: 2 files only (`package.json`, `script/test_release_docs_signals.mjs`)。
- local `npm run test:docs-entrypoints` は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` のため、PR CI を確認証跡にします。

## リスク評価

low。docs/test-only の代表 signal guard です。