### PR TITLE
TreeView.configure value boundary を public API docs で明確にする

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -130,7 +130,7 @@ Documented configuration options include:
 - `initial_state`
 - `render_log_level`
 
-`TreeView.configure`, `TreeView.configuration`, and `TreeView.reset_configuration!` are the stable configuration entry points. Depend on documented option names and behavior rather than the internal shape of the configuration object. See [Render log level](render-log-level.md) for the `render_log_level` values, default, disable path, and host-app logging boundary.
+`TreeView.configure`, `TreeView.configuration`, and `TreeView.reset_configuration!` are the stable configuration entry points. Depend on documented option names and behavior rather than the internal shape of the configuration object. The manifest tracks these option names, not their accepted value sets: `initial_state` accepts `:expanded` and `:collapsed`, while `render_log_level` accepts the documented Ruby logger levels or `nil` to disable TreeView render log silencing. Those accepted values are guarded by compatibility specs and feature docs rather than a separate manifest value schema. See [Render log level](render-log-level.md) for the `render_log_level` values, default, disable path, and host-app logging boundary.
 
 Documented localized display-name helpers include:
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -130,7 +130,7 @@ toolbar helper もこの公開 helper surface に含まれます。
 - `initial_state`
 - `render_log_level`
 
-`TreeView.configure`、`TreeView.configuration`、`TreeView.reset_configuration!` は安定した configuration entry point です。configuration object の内部形状ではなく、documented option name と documented behavior に依存してください。`render_log_level` の値、既定値、無効化方法、host app logging との責務境界は [render log level](render-log-level.md) を参照してください。
+`TreeView.configure`、`TreeView.configuration`、`TreeView.reset_configuration!` は安定した configuration entry point です。configuration object の内部形状ではなく、documented option name と documented behavior に依存してください。manifest が追跡するのはこれらの option 名であり、accepted value set ではありません。`initial_state` は `:expanded` / `:collapsed` を受け取り、`render_log_level` は documented な Ruby logger level または TreeView render log 抑制を無効化する `nil` を受け取ります。これらの accepted value は、manifest に別の value schema を増やすのではなく compatibility spec と feature docs で守ります。`render_log_level` の値、既定値、無効化方法、host app logging との責務境界は [render log level](render-log-level.md) を参照してください。
 
 公開 localized display-name helper には以下を含めます。
 

--- a/spec/configuration_public_value_contract_spec.rb
+++ b/spec/configuration_public_value_contract_spec.rb
@@ -5,7 +5,7 @@ require "yaml"
 
 RSpec.describe "configuration public value contract" do
   let(:manifest) do
-    YAML.safe_load(File.read(File.expand_path("../config/public_api_manifest.yml", __dir__)))
+    YAML.safe_load_file(File.expand_path("../config/public_api_manifest.yml", __dir__))
   end
 
   let(:english_public_api_docs) do

--- a/spec/configuration_public_value_contract_spec.rb
+++ b/spec/configuration_public_value_contract_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "configuration public value contract" do
+  let(:manifest) do
+    YAML.safe_load(File.read(File.expand_path("../config/public_api_manifest.yml", __dir__)))
+  end
+
+  let(:english_public_api_docs) do
+    File.read(File.expand_path("../docs/en/public-api.md", __dir__))
+  end
+
+  let(:japanese_public_api_docs) do
+    File.read(File.expand_path("../docs/ja/public-api.md", __dir__))
+  end
+
+  let(:english_render_log_docs) do
+    File.read(File.expand_path("../docs/en/render-log-level.md", __dir__))
+  end
+
+  let(:japanese_render_log_docs) do
+    File.read(File.expand_path("../docs/ja/render-log-level.md", __dir__))
+  end
+
+  it "keeps configuration option keys manifest-backed without adding a value schema section" do
+    expect(manifest.fetch("configuration_options").fetch("tree_view_configure")).to eq(%w[initial_state render_log_level])
+    expect(manifest).not_to have_key("configuration_option_values")
+    expect(manifest.fetch("configuration_options").fetch("tree_view_configure")).to all(be_a(String))
+  end
+
+  it "keeps initial_state accepted values guarded by runtime constants and compatibility behavior" do
+    expect(TreeView::Configuration::VALID_INITIAL_STATES).to eq(%i[expanded collapsed])
+
+    config = TreeView::Configuration.new(initial_state: "collapsed")
+    expect(config.initial_state).to eq(:collapsed)
+
+    expect { TreeView::Configuration.new(initial_state: :invalid) }
+      .to raise_error(TreeView::ConfigurationError, /initial_state/)
+  end
+
+  it "keeps render_log_level accepted values and nil disable path guarded by runtime constants" do
+    expect(TreeView::Configuration::VALID_RENDER_LOG_LEVELS.keys).to eq(%i[debug info warn error fatal unknown])
+
+    config = TreeView::Configuration.new(render_log_level: Logger::ERROR)
+    expect(config.render_log_level).to eq(:error)
+
+    config.render_log_level = nil
+    expect(config.render_log_level).to be_nil
+
+    expect { TreeView::Configuration.new(render_log_level: :verbose) }
+      .to raise_error(TreeView::ConfigurationError, /render_log_level/)
+  end
+
+  it "keeps public API docs aligned with the docs/spec value-boundary policy" do
+    [english_public_api_docs, japanese_public_api_docs].each do |document|
+      expect(document).to include("initial_state")
+      expect(document).to include("render_log_level")
+      expect(document).to include("config/public_api_manifest.yml")
+    end
+
+    expect(english_public_api_docs).to include("The manifest tracks these option names, not their accepted value sets")
+    expect(japanese_public_api_docs).to include("manifest が追跡するのはこれらの option 名であり、accepted value set ではありません")
+  end
+
+  it "keeps render log docs explicit about accepted values staying in docs and specs" do
+    [english_render_log_docs, japanese_render_log_docs].each do |document|
+      expect(document).to include("initial_state")
+      expect(document).to include("render_log_level")
+      expect(document).to include("manifest")
+    end
+
+    expect(english_render_log_docs).to include("compatibility specs and docs rather than a separate manifest value schema")
+    expect(japanese_render_log_docs).to include("manifest に value schema を増やすのではなく compatibility spec と docs で守ります")
+  end
+end


### PR DESCRIPTION
TreeView.configure の option key contract と accepted value contract の境界を Public API docs と focused spec で固定します。

Closes #1701
Supersedes #1710

## 対応内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の Public option surface に、`TreeView.configure` の manifest-backed contract は `initial_state` / `render_log_level` の option 名であり、accepted value set は docs / compatibility spec で守る方針であることを追記しました。
- `spec/configuration_public_value_contract_spec.rb` を追加し、次を確認します。
  - `config/public_api_manifest.yml` は configuration option key のみを持ち、accepted value schema section を追加していないこと
  - `initial_state` は `:expanded` / `:collapsed` を accepted public values とし、文字列を symbol に正規化し、無効値を拒否すること
  - `render_log_level` は Ruby logger levels と `nil` disable path を受け、無効値を拒否すること
  - Public API docs と render-log-level docs が value-boundary 方針を説明していること

## 受け入れ条件との対応

- configuration option accepted value schema を manifest に含めない現行方針を Public API docs から読めるようにしました。
- `initial_state` / `render_log_level` の accepted values は runtime constants、compatibility behavior、docs signal で guard します。
- `config/public_api_manifest.yml` の schema には accepted value set 用 section を追加していません。
- configuration runtime behavior、Logger policy、新しい option、`initial_state` value の追加・rename は行っていません。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`
- `spec/configuration_public_value_contract_spec.rb`

## 実施した確認

- Issue #1701 の実ラベル確認: `status:ready-for-agent`, `track:feature`, `agent:planned`, `risk:medium`。
- #1701 を担当する既存 open PR がないことを確認しました。
- replacement branch は latest `main` `da218f115eaf4b526f3f0757ca5d839d722e8ab2` 起点で、compare は `ahead_by:1` / `behind_by:0` / changed files 3件です。
- local checkout / local RSpec は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR CI で確認します。

## リスク

medium。public contract boundary の docs/spec clarification ですが、manifest schema や runtime behavior には触れていません。

## 未対応・補足

- value schema を manifest-backed contract に昇格する変更は行っていません。