### PR TITLE
README の host-app extension summary を同期する

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For the boundary between static mockups and a future real Rails demo app, see [D
 - Flatten currently visible rows with `TreeView::VisibleRows`.
 - Render currently visible rows by offset and limit with `TreeView::RenderWindow` and windowed rendering. This limits HTML output only; it does not reduce host-app queries or fetched records.
 - Customize host-app row content through `row_partial`.
+- Render host-app row action slots through `row_actions_partial` while action availability, routes, authorization, and final copy stay in the host app.
+- Customize transfer payload data through `row_event_payload_builder` while drag/drop business behavior stays in the host app.
 - Control initial expansion with `initial_state`, `expanded_keys`, `collapsed_keys`, and `max_initial_depth`.
 - Limit render scope with `max_render_depth` and `max_leaf_distance`.
 - Limit toggle scope with `max_toggle_depth_from_root` and `max_toggle_leaf_distance`.


### PR DESCRIPTION
## 対応 Issue

Closes #1715

## 判定分類

- `docs-sync`
- `docs-stale`
- docs-only / low risk

## 変更内容

Root `README.md` の Features に、current docs / manifest で整理済みの host-app extension surface を短く同期しました。

- `row_actions_partial` は host app の row action slot として案内
- `row_event_payload_builder` は transfer payload data の builder として案内
- action availability、routes、authorization、final copy、drag/drop business behavior は host app responsibility として残すことを明記

## 変更範囲

- `README.md`

runtime Ruby / JavaScript、public API manifest、row rendering behavior、docs smoke script、英日 detailed docs は変更していません。

## 確認内容

- Issue #1715 の labels: `status:ready-for-agent`, `track:docs`, `type:docs`, `agent:planned`, `risk:low`
- current `docs/en|ja/host-app-extension-points.md` が `row_actions_partial` / `row_event_payload_builder` と host-app responsibility boundary を説明済みであることを確認
- compare `main...docs/1715-readme-host-extension-summary`: `ahead_by: 1` / `behind_by: 0`
- changed files: `README.md` のみ

## 非対象

- README 全体 rewrite
- host-app extension API の追加・rename
- row action menu component の実装
- drag/drop behavior の変更
- public API manifest schema の変更