### PR TITLE
Tree diagnostics docs signal を smoke で守る

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -29,6 +29,10 @@ const selectionDocs = [
   ["docs/en/selection.md", read("docs/en/selection.md")],
   ["docs/ja/selection.md", read("docs/ja/selection.md")]
 ]
+const diagnosticsDocs = [
+  ["docs/en/tree-diagnostics.md", read("docs/en/tree-diagnostics.md")],
+  ["docs/ja/tree-diagnostics.md", read("docs/ja/tree-diagnostics.md")]
+]
 
 const callbackBuilderSignals = [
   "render_state_callback_builder_keys",
@@ -68,13 +72,30 @@ const emptyStateHookSignals = [
   "data-tree-view-empty-state"
 ]
 
+const diagnosticsAcceptedCheckSignals = [
+  "node_keys",
+  "dom_ids",
+  "orphans",
+  "cycles"
+]
+
+const diagnosticsResultSurfaceSignals = [
+  "checks",
+  "errors",
+  "warnings",
+  "success?"
+]
+
 const manifestBackedDocsSignalSurfaces = [
   ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
   ["host lifecycle no-detail events", "event_names_without_detail:"],
   ["host lifecycle event names", "host_lifecycle:"],
   ["remote-state values", "remote_state_values:"],
   ["selection data hooks", "selection_data_hooks:"],
-  ["empty-state hooks", "empty_state_hooks:"]
+  ["empty-state hooks", "empty_state_hooks:"],
+  ["diagnostics accepted checks", "diagnostics:"],
+  ["diagnostics accepted checks", "accepted_checks:"],
+  ["diagnostics Result surface", "result_surface:"]
 ]
 
 manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
@@ -83,6 +104,14 @@ manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
 
 callbackBuilderSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest callback builder key surface")
+})
+
+diagnosticsAcceptedCheckSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics accepted checks")
+})
+
+diagnosticsResultSurfaceSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics Result surface")
 })
 
 assertIncludes(manifest, "event_names_without_detail", "public API manifest no-detail event surface")
@@ -139,4 +168,28 @@ selectionDocs.forEach(([relativePath, document]) => {
   selectionDataHookSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} selection data hook docs`)
   })
+})
+
+diagnosticsDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeView::Diagnostics.run", `${relativePath} diagnostics aggregate entrypoint docs`)
+  assertIncludes(document, "checks:", `${relativePath} diagnostics accepted checks docs`)
+  assertIncludes(document, "Result", `${relativePath} diagnostics Result surface docs`)
+
+  diagnosticsAcceptedCheckSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics accepted check docs`)
+  })
+
+  diagnosticsResultSurfaceSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics Result reader docs`)
+  })
+
+  assert(
+    /manifest-backed.*diagnostics contract|manifest-backed な diagnostics contract/.test(document),
+    `${relativePath}: diagnostics docs no longer identify the manifest-backed contract boundary`
+  )
+
+  assert(
+    /individual error entry internals|warning detail shape|orphan warning semantics|cycle validation policy|個々の error entry 内部|warning detail shape|orphan warning semantics|cycle validation policy/.test(document),
+    `${relativePath}: diagnostics docs no longer keep detailed error and warning shapes outside the manifest schema`
+  )
 })


### PR DESCRIPTION
## 対応 Issue

Closes #1713

## Issue ごとの完了内容

- #1713
  - Tree diagnostics docs が `TreeView::Diagnostics.run`、accepted checks、Result reader surface を保持していることを public API docs signal smoke で確認できるようにしました。
  - manifest の `diagnostics` / `accepted_checks` / `result_surface` と docs 側の代表 signal を同じ script で確認します。
  - error entry internals / warning detail shape / orphan warning semantics / cycle validation policy までは manifest schema として固定しない境界も guard します。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に diagnostics docs signal group を追加しました。
- runtime Ruby / JavaScript、manifest schema、public API surface、docs prose は変更していません。

## 改善カテゴリ

- test
- docs smoke
- public contract drift guard

## 既存仕様への影響

既存挙動への影響はありません。current docs と manifest に既にある diagnostics contract signal を lightweight smoke で守るだけです。

## 確認内容

- Issue #1713 の実ラベル確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- 既存 open PR が #1713 を担当していないことを確認しました。
- compare `main...quality/1713-diagnostics-docs-smoke`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1
- local checkout / local `npm run test:docs-entrypoints` は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にします。

## リスク評価

low。テスト script の representative signal 追加のみで、runtime behavior や public manifest schema は変更していません。