### PR TITLE
selection params parser の invalid input 境界を docs/spec で明確化する

### DIFF
--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -59,6 +59,8 @@ selected_nodes = TreeView.parse_selection_params(params[:selected_nodes])
 
 `TreeView.parse_selection_params` accepts arrays of JSON strings and returns parsed hash-like values. Invalid JSON raises a clear error so the host app can handle malformed submissions.
 
+Nil and empty string entries are skipped, which keeps optional checkbox params easy to pass through when nothing was selected. Hash-like entries and JSON objects are accepted as the current server-side parser surface. Malformed JSON and JSON values that are not objects raise `ArgumentError`; host apps own whether to rescue that error, reject the request, show validation copy, or log the malformed submission.
+
 ## Disabled checkboxes
 
 Use `disabled_builder` when some nodes cannot be selected.

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -59,6 +59,8 @@ selected_nodes = TreeView.parse_selection_params(params[:selected_nodes])
 
 `TreeView.parse_selection_params` はJSON文字列配列を受け取り、parse済みのhash-like valuesを返します。不正なJSONは明確なerrorになります。
 
+nil と空文字列の entry は skip されるため、何も選択されていない optional checkbox params もそのまま渡しやすくなっています。Hash-like entry と JSON object は、現在の server-side parser surface として受け付けます。壊れた JSON や object ではない JSON value は `ArgumentError` になります。その error を rescue するか、request を reject するか、validation copy を表示するか、malformed submission を記録するかは host app 側の責務です。
+
 ## disabled checkbox
 
 選択できないnodeがある場合は `disabled_builder` を使います。

--- a/spec/lib/tree_view/selection_params_spec.rb
+++ b/spec/lib/tree_view/selection_params_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe TreeView::SelectionParams do
   describe ".parse" do
     it "returns an empty array for nil and empty input" do
       expect(described_class.parse(nil)).to eq([])
+      expect(described_class.parse("")).to eq([])
       expect(described_class.parse([])).to eq([])
       expect(described_class.parse([nil, ""])).to eq([])
     end


### PR DESCRIPTION
TreeView.parse_selection_params の current behavior を変えず、invalid input の public boundary を英日 selection docs と focused spec で読みやすくします。

## 対応 Issue

Closes #903

## 変更内容

- `docs/en/selection.md` / `docs/ja/selection.md` に server-side parser の nil / empty / Hash-like / JSON object / malformed input 境界を追記しました。
- malformed JSON と non-object JSON は `ArgumentError` になり、その rescue / reject / validation copy / logging 判断は host app 側の責務であることを明記しました。
- 既存 `selection_params_spec` に単体の空文字も skip される代表ケースを追加しました。

## 受け入れ条件との対応

- invalid JSON / non-object JSON: 既存 spec が `ArgumentError` を確認しており、docs に境界を追記しました。
- nil / empty value: 既存 spec の `[nil, ""]` に加えて単体 `""` の代表ケースを追加しました。
- Hash-like / JSON object: 既存 spec が現行成功ケースを固定しています。
- 英日 docs: 両 selection docs に同内容の責務境界を追加しました。
- 戻り値 shape / error class: 実装本体は変更していません。

## 変更範囲

- docs: `docs/en/selection.md`, `docs/ja/selection.md`
- test: `spec/lib/tree_view/selection_params_spec.rb`

## 実施した確認

- Connector 上で `main...feature/903-selection-params-invalid-boundary` の差分を確認しました。
- ローカル checkout は GitHub への直接 network が制限されているため実行できていません。PR CI で対象 spec を確認してください。

## リスク

medium。public helper の境界説明に触れますが、実装挙動・戻り値 shape・error class は変更していません。

## 未対応・補足

- symbolized keys / indifferent access は追加していません。
- selection controller、hidden input sync、cascade、max-count、business action / authorization は変更していません。