### PR TITLE
Development docs に declaration literal guard の説明を追加する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -37,6 +37,8 @@ npm run test:browser
 
 Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use the individual npm commands when you are narrowing a failure.
 
+Within `npm run test:entrypoints`, `script/test_entrypoints.mjs` checks the runtime package-root exports, controller registration helper, manifest loader, and `.d.ts` export-name inventory. `script/test_declaration_literal_shapes.mjs` then checks the literal shapes in `app/javascript/tree_view/index.d.ts` for the manifest-backed JavaScript constants such as event names, detail keys, remote-state values, transfer values, controller identifiers, selection data hooks, and empty-state hooks. Use the export-name guard when a package-root export is missing or extra; use the literal-shape guard when the export exists but a key, tuple, or representative literal value no longer matches `config/public_api_manifest.yml`. This is a smoke guard, not a TypeScript compiler or declaration generator.
+
 For the Rails version matrix:
 
 ```bash
@@ -85,6 +87,8 @@ npm run test:entrypoints
 ```
 
 That check keeps the documented controller exports and `registerTreeViewControllers` helper aligned with the importmap entrypoint. It uses Ruby to load `config/public_api_manifest.yml` and print the `javascript_package_root` section as JSON before Node assertions run, so run it from the repository root with Ruby available when you are diagnosing manifest loader failures.
+
+The entrypoint command also runs `script/test_declaration_literal_shapes.mjs`. Keep this second guard aligned with `script/test_entrypoints.mjs`: the entrypoint smoke proves runtime exports and `.d.ts` export names exist, while the declaration literal guard proves the exported literal object shapes in `index.d.ts` still mirror `config/public_api_manifest.yml`.
 
 Docs-only entrypoint and signal checks can be run separately with:
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -37,6 +37,8 @@ npm run test:browser
 
 CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。失敗箇所を切り分ける場合は個別の npm command を使ってください。
 
+`npm run test:entrypoints` の中では、`script/test_entrypoints.mjs` が runtime の package-root exports、controller registration helper、manifest loader、`.d.ts` の export-name inventory を確認します。その後 `script/test_declaration_literal_shapes.mjs` が、event names、detail keys、remote-state values、transfer values、controller identifiers、selection data hooks、empty-state hooks などの manifest-backed JavaScript constants について、`app/javascript/tree_view/index.d.ts` の literal shape を確認します。package-root export が足りない、または余分な場合は export-name guard を見ます。export は存在するが key、tuple、代表 literal value が `config/public_api_manifest.yml` とずれた場合は literal-shape guard を見ます。これは smoke guard であり、TypeScript compiler や declaration generator ではありません。
+
 Rails version matrixを確認する場合:
 
 ```bash
@@ -85,6 +87,8 @@ npm run test:entrypoints
 ```
 
 このcheckで、documented controller exports と `registerTreeViewControllers` helper が importmap entrypoint とずれないようにします。Node 側の assertions を実行する前に Ruby で `config/public_api_manifest.yml` を読み、`javascript_package_root` section を JSON として出力します。manifest loader failure を調べる場合は、repository root から Ruby が使える状態で実行してください。
+
+entrypoint command は `script/test_declaration_literal_shapes.mjs` も実行します。この2つ目の guard は `script/test_entrypoints.mjs` と一緒に保守してください。entrypoint smoke は runtime exports と `.d.ts` export names の存在を確認し、declaration literal guard は `index.d.ts` の exported literal object shapes が `config/public_api_manifest.yml` と一致することを確認します。
 
 docs-only の entrypoint / signal checks は次で個別に確認できます。
 


### PR DESCRIPTION
## 対応 Issue

Closes #1687

## 判定分類

- `code-ahead-of-docs`
- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/development.md` / `docs/ja/development.md` に、`npm run test:entrypoints` 内で `script/test_declaration_literal_shapes.mjs` が実行されることを追記しました。
- `script/test_entrypoints.mjs` は runtime export / `.d.ts` export-name inventory を守り、`script/test_declaration_literal_shapes.mjs` は `index.d.ts` の literal object shape と `config/public_api_manifest.yml` の同期を守る、という責務差を整理しました。
- 失敗時に export-name guard と literal-shape guard のどちらを見るべきかを短く説明しました。

## 変更範囲

- `docs/en/development.md`
- `docs/ja/development.md`

runtime JavaScript、TypeScript declaration、public API manifest、test script、package scripts、TypeScript compiler / declaration generator 方針は変更していません。

## 確認内容

- PR #1686 が 2026-06-09 に merge 済みで、current `package.json` の `test:entrypoints` が `script/test_declaration_literal_shapes.mjs` を含むことを確認しました。
- `script/test_entrypoints.mjs` と `script/test_declaration_literal_shapes.mjs` の責務を確認しました。
- compare `main...docs/1687-declaration-literal-guard`: `ahead_by: 2` / `behind_by: 0`
- changed files: 2 docs-only files
- local checkout / local docs smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。merge 済みの docs/test guard を Development docs から見つけやすくするだけで、実装や public surface は変更していません。