### PR TITLE
EmptyStateHooks の導線を accessibility docs に追加する

### DIFF
--- a/docs/en/accessibility-semantics.md
+++ b/docs/en/accessibility-semantics.md
@@ -39,6 +39,8 @@ If a future browser-level accessibility smoke test treats one of these patterns 
 - Empty rows now wrap the message in `.tree-view-empty-row__content` and `.tree-view-empty-row__message`, with `data-tree-view-empty-state="true"` on the wrapper so host apps can style or target empty states without overriding the partial.
 - Static hidden-count text appends a screen-reader-only suffix from `tree_view.accessibility.hidden_descendants`, which defaults to ` descendants` and can be localized by the host app.
 
+Host apps that target these hooks from JavaScript, tests, or copied CSS can import `TreeViewEmptyStateHooks` from `tree_view/index.js` instead of hand-copying the wrapper attribute or baseline class names. The export covers only `wrapperAttribute`, `contentClass`, and `messageClass`; it does not turn final copy, CTAs, permission messages, or filter-reset behavior into TreeView-owned UI.
+
 For a static comparison of no-root-items and no-results rows, the reusable empty-row wrapper hook, and the host-app-owned copy boundary, see [empty-state.html](../mockups/empty-state.html).
 
 Use that mockup as a visual companion to this policy; it does not redefine ARIA behavior, CTA copy, or filter-reset workflow.

--- a/docs/ja/accessibility-semantics.md
+++ b/docs/ja/accessibility-semantics.md
@@ -39,6 +39,8 @@ TreeView は host app の業務columnsをtable row内に描画するため、現
 - 空状態 row は、message を `.tree-view-empty-row__content` と `.tree-view-empty-row__message` で包み、wrapper に `data-tree-view-empty-state="true"` を付けます。host app は partial override なしで空状態を装飾・target できます。
 - static hidden count の screen reader 向け suffix は `tree_view.accessibility.hidden_descendants` から取得します。default は ` descendants` で、host app 側 locale で差し替えできます。
 
+host app が JavaScript、test、copied CSS からこれらの hook を参照する場合は、wrapper attribute や baseline class name を手で写経せず、`tree_view/index.js` の `TreeViewEmptyStateHooks` を使えます。この export は `wrapperAttribute`、`contentClass`、`messageClass` の3つだけを対象にし、最終copy、CTA、permission message、filter-reset behavior を TreeView-owned UI にするものではありません。
+
 no-root-items と no-results row、再利用可能な empty-row wrapper hook、host-app-owned copy boundary を静的に見比べたい場合は [empty-state.html](../mockups/empty-state.html) を参照してください。
 
 この mockup は、この policy を視覚的に補うためのものです。ARIA behavior、CTA copy、filter-reset workflow を定義し直すものではありません。


### PR DESCRIPTION
## 対応 Issue

Closes #1728

## 判定分類

- `docs-sync`
- `docs-missing`
- docs-only / low risk

## 変更内容

- `docs/en/accessibility-semantics.md` / `docs/ja/accessibility-semantics.md` の empty-state hook guidance に、`TreeViewEmptyStateHooks` を `tree_view/index.js` から参照できることを追記しました。
- host app が wrapper attribute / baseline class name を raw string で写経しなくてよい導線を追加しました。
- export 対象は `wrapperAttribute` / `contentClass` / `messageClass` の 3 hook に閉じ、final empty copy、CTA、permission message、filter-reset behavior は host app responsibility のまま明記しました。

## 変更範囲

- `docs/en/accessibility-semantics.md`
- `docs/ja/accessibility-semantics.md`

runtime Ruby / JavaScript、public API manifest schema、TypeScript declaration、empty-row partial behavior、mockup visual redesign、Public API docs 本文は変更していません。

## 確認内容

- Issue #1728 の labels: `status:ready-for-agent`, `track:docs`, `type:docs`, `risk:low`
- open PR 検索で #1728 / `TreeViewEmptyStateHooks` discoverability を担当する既存 open PR がないことを確認しました。
- current `docs/en/public-api.md` が `TreeViewEmptyStateHooks` と `data-tree-view-empty-state` / `.tree-view-empty-row__content` / `.tree-view-empty-row__message` を説明済みであることを確認しました。
- current `docs/mockups/README.md` / `empty-state.html` の reusable hook guidance と host-app-owned copy boundary を確認しました。
- compare `main...docs/1728-empty-state-hooks-discoverability`: `ahead_by: 2` / `behind_by: 0`
- changed files: 2 docs-only files

## リスク

low。既存 Public API export への discoverability を accessibility docs から補うだけで、公開 surface や empty-state behavior は変更していません。