### PR TITLE
README host extension summary を docs smoke で guard する

### DIFF
--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -102,6 +102,20 @@ const signalGroups = [
     ]
   },
   {
+    feature: "README host extension summary boundary",
+    files: [
+      [
+        "README.md",
+        [
+          "row_actions_partial",
+          "action availability, routes, authorization, and final copy stay in the host app",
+          "row_event_payload_builder",
+          "drag/drop business behavior stays in the host app"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Drag/drop visual reference routing",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue

Closes #1718

## Issue ごとの完了内容

- #1718: root `README.md` の Features にある `row_actions_partial` / `row_event_payload_builder` と、host app 側が action availability / routes / authorization / final copy / drag/drop business behavior を所有する境界を lightweight docs smoke で guard しました。

## 変更内容

- `script/test_docs_entrypoint_signals.mjs` に `README host extension summary boundary` signal group を追加しました。
- 既存 README 本文が持つ短い entrypoint signal だけを確認し、英日 detailed docs や host-app-extension docs の全文 coverage には広げていません。

## 改善カテゴリ

- test
- docs smoke
- docs drift guard

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、row rendering behavior、README prose は変更していません。
- docs smoke の代表 signal 追加のみです。

## 実施した確認

- Issue #1718 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 open PR 検索で #1718 を close するPRがないことを確認しました。
- branch base: latest `main` `26c2d81f07facad93b0eb7ae4aa7bcb9aa9abaa8`。
- compare `main...quality/1718-readme-host-extension-smoke`:
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 1 (`script/test_docs_entrypoint_signals.mjs`)
- local checkout / `npm run test:docs-entrypoints` は、この環境の GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` になるため未実行です。PR CI を確認します。

## リスク評価

low。既存 README の representative signal を docs smoke に追加するだけで、公開APIや runtime behavior は変更していません。

## 補足

- #1732 は #1731 / PR #1733 の development docs 本文同期が前提のため、このPRには含めていません。#1731 が main に入った後、または #1733 へ stack する形で扱うのが安全です。