### PR TITLE
Add development docs public API signal smoke coverage

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -2,134 +2,92 @@ import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const root = path.resolve(__dirname, "..")
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 
 function read(relativePath) {
-  return readFileSync(path.join(root, relativePath), "utf8")
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
 }
 
 function assert(condition, message) {
-  if (!condition) {
-    throw new Error(message)
-  }
+  if (!condition) throw new Error(message)
 }
 
-function assertIncludes(document, needle, context) {
-  assert(
-    document.includes(needle),
-    `${context} should mention ${JSON.stringify(needle)} so public API docs keep covering manifest-backed surfaces.`
-  )
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
 }
 
 const manifest = read("config/public_api_manifest.yml")
-const publicApiDocs = read("docs/en/public_api.md")
-const lazyLoadingDocs = read("docs/en/lazy_loading.md")
-const selectionDocs = read("docs/en/selection.md")
-const diagnosticsDocs = read("docs/en/diagnostics.md")
+const publicApiDocs = [
+  ["docs/en/public-api.md", read("docs/en/public-api.md")],
+  ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
+]
+const lazyLoadingDocs = [
+  ["docs/en/lazy-loading.md", read("docs/en/lazy-loading.md")],
+  ["docs/ja/lazy-loading.md", read("docs/ja/lazy-loading.md")]
+]
+const selectionDocs = [
+  ["docs/en/selection.md", read("docs/en/selection.md")],
+  ["docs/ja/selection.md", read("docs/ja/selection.md")]
+]
+const diagnosticsDocs = [
+  ["docs/en/tree-diagnostics.md", read("docs/en/tree-diagnostics.md")],
+  ["docs/ja/tree-diagnostics.md", read("docs/ja/tree-diagnostics.md")]
+]
 const developmentDocs = [
   ["docs/en/development.md", read("docs/en/development.md")],
   ["docs/ja/development.md", read("docs/ja/development.md")]
 ]
 
-const manifestBackedDocsSignalSurfaces = [
-  ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
-  ["event names without payload", "event_names_without_detail:"],
-  ["remote state value constants", "remote_state_value_keys:"],
-  ["selection data hook exports", "selection_data_hooks:"],
-  ["empty-state hook exports", "empty_state_hooks:"]
-]
-
-for (const [label, manifestSignal] of manifestBackedDocsSignalSurfaces) {
-  assertIncludes(manifest, manifestSignal, `public API manifest for ${label}`)
-}
-
 const callbackBuilderSignals = [
-  "TreeViewRenderStateCallbackBuilder",
-  "ancestors",
-  "children",
-  "selected",
-  "metadata",
-  "loading",
-  "expanded",
-  "TreeViewRenderState"
+  "render_state_callback_builder_keys",
+  "row_event_payload_builder",
+  "depth_label_builder",
+  "toggle_icon_builder"
 ]
 
 const hostLifecycleSignals = [
-  "TreeViewClickEvent",
-  "TreeViewExpandEvent",
-  "TreeViewCollapseEvent",
-  "TreeViewToggleEvent",
-  "treeView:click",
-  "treeView:expand",
-  "treeView:collapse",
-  "treeView:toggle",
-  "Event detail payloads",
-  "node",
-  "event",
-  "metadata"
+  "TreeViewEventNames.hostLifecycle",
+  "loading",
+  "loaded",
+  "error",
+  "retry",
+  "TreeViewEventNames.remoteState",
+  "TreeViewEventDetailKeys"
 ]
 
 const remoteStateValueSignals = [
-  "remoteStateValue",
-  "setRemoteStateValue",
+  "TreeViewRemoteStateValues",
   "loading",
-  "success",
+  "loaded",
   "error"
 ]
 
 const selectionDataHookSignals = [
   "TreeViewSelectionDataHooks",
-  "selectionDataAction",
-  "selectionDataParam",
-  "selectionDataValuesParam",
-  "selectionDataValue"
+  "TreeViewSelectionDataHooks.hiddenInputNameValue",
+  "data-tree-view-selection-hidden-input-name-value"
 ]
 
 const emptyStateHookSignals = [
   "TreeViewEmptyStateHooks",
-  "emptyStateTitle",
-  "emptyStateDescription"
+  "wrapperAttribute",
+  "contentClass",
+  "messageClass",
+  "data-tree-view-empty-state"
 ]
 
-const diagnosticsReaderSignals = [
-  "TreeViewDiagnostics",
-  "findTreeViewRoot",
-  "getTreeViewDiagnostics",
-  "readTreeViewDatasetDiagnostics"
+const diagnosticsAcceptedCheckSignals = [
+  "node_keys",
+  "dom_ids",
+  "orphans",
+  "cycles"
 ]
 
-const diagnosticsPayloadSignals = [
-  "treeView:diagnostics",
-  "version",
-  "action",
-  "timestamp",
-  "metadata"
-]
-
-const diagnosticsControllerSignals = [
-  "TreeViewDiagnosticsController",
-  "connect",
-  "disconnect",
-  "emit",
-  "emitDiagnostics"
-]
-
-const lazyLoadingRemoteStateSignals = [
-  "remoteStateValue",
-  "setRemoteStateValue",
-  "loading",
-  "success",
-  "error",
-  "remote state"
-]
-
-const selectionDataHookDocsSignals = [
-  "TreeViewSelectionDataHooks",
-  "selectionDataAction",
-  "selectionDataParam",
-  "selectionDataValuesParam",
-  "selectionDataValue"
+const diagnosticsResultSurfaceSignals = [
+  "checks",
+  "errors",
+  "warnings",
+  "success?"
 ]
 
 const developmentManifestTrackingSignals = [
@@ -149,64 +107,120 @@ const developmentEntrypointGuardSignals = [
   "transfer values"
 ]
 
-for (const signal of callbackBuilderSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md RenderState callback builder section")
-}
+const manifestBackedDocsSignalSurfaces = [
+  ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
+  ["host lifecycle no-detail events", "event_names_without_detail:"],
+  ["host lifecycle event names", "host_lifecycle:"],
+  ["remote-state values", "remote_state_values:"],
+  ["selection data hooks", "selection_data_hooks:"],
+  ["empty-state hooks", "empty_state_hooks:"],
+  ["diagnostics accepted checks", "diagnostics:"],
+  ["diagnostics accepted checks", "accepted_checks:"],
+  ["diagnostics Result surface", "result_surface:"]
+]
 
-for (const signal of hostLifecycleSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md host lifecycle event section")
-}
+manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
+  assertIncludes(manifest, manifestNeedle, `public API docs signal manifest surface (${label})`)
+})
 
-for (const signal of remoteStateValueSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md remote state value section")
-}
+callbackBuilderSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest callback builder key surface")
+})
 
-for (const signal of selectionDataHookSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md selection data hooks section")
-}
+diagnosticsAcceptedCheckSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics accepted checks")
+})
 
-for (const signal of emptyStateHookSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md empty-state hooks section")
-}
+diagnosticsResultSurfaceSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics Result surface")
+})
 
-for (const signal of diagnosticsReaderSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md diagnostics readers section")
-}
+assertIncludes(manifest, "event_names_without_detail", "public API manifest no-detail event surface")
+assertIncludes(manifest, "host_lifecycle", "public API manifest no-detail event surface")
+hostLifecycleSignals.slice(1, 5).forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest host lifecycle no-detail event names")
+})
 
-for (const signal of diagnosticsPayloadSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md diagnostics payload section")
-}
+publicApiDocs.forEach(([relativePath, document]) => {
+  callbackBuilderSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} RenderState callback builder docs`)
+  })
 
-for (const signal of diagnosticsControllerSignals) {
-  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md diagnostics controller section")
-}
+  assert(
+    /callback arity|return[- ]value|return value|callback arity|戻り値/.test(document),
+    `${relativePath}: RenderState callback builder docs no longer mention callback arity or return-value boundary`
+  )
 
-for (const signal of lazyLoadingRemoteStateSignals) {
-  assertIncludes(lazyLoadingDocs, signal, "docs/en/lazy_loading.md remote state documentation")
-}
+  hostLifecycleSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} host lifecycle event docs`)
+  })
 
-for (const signal of selectionDataHookDocsSignals) {
-  assertIncludes(selectionDocs, signal, "docs/en/selection.md selection data hook documentation")
-}
+  assert(
+    /host app|host-app|host app 側|host-app 側/.test(document),
+    `${relativePath}: host lifecycle event docs no longer name the host-app ownership boundary`
+  )
 
-for (const signal of diagnosticsReaderSignals) {
-  assertIncludes(diagnosticsDocs, signal, "docs/en/diagnostics.md diagnostics reader documentation")
-}
+  selectionDataHookSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} selection data hook docs`)
+  })
 
-for (const signal of diagnosticsPayloadSignals) {
-  assertIncludes(diagnosticsDocs, signal, "docs/en/diagnostics.md diagnostics event payload documentation")
-}
+  emptyStateHookSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} empty-state hook docs`)
+  })
 
-for (const signal of diagnosticsControllerSignals) {
-  assertIncludes(diagnosticsDocs, signal, "docs/en/diagnostics.md diagnostics controller documentation")
-}
+  assert(
+    /final empty-state copy|permission message|filter-reset behavior|最終的な empty-state copy|permission message/.test(document),
+    `${relativePath}: empty-state hook docs no longer preserve the host-app-owned final-copy boundary`
+  )
+})
 
-for (const [relativePath, document] of developmentDocs) {
-  for (const signal of developmentManifestTrackingSignals) {
+lazyLoadingDocs.forEach(([relativePath, document]) => {
+  remoteStateValueSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} remote-state value docs`)
+  })
+
+  assert(
+    /not event names|event 名ではありません/.test(document),
+    `${relativePath}: remote-state value docs no longer separate state values from event names`
+  )
+})
+
+selectionDocs.forEach(([relativePath, document]) => {
+  selectionDataHookSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} selection data hook docs`)
+  })
+})
+
+diagnosticsDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeView::Diagnostics.run", `${relativePath} diagnostics aggregate entrypoint docs`)
+  assertIncludes(document, "checks:", `${relativePath} diagnostics accepted checks docs`)
+  assertIncludes(document, "Result", `${relativePath} diagnostics Result surface docs`)
+
+  diagnosticsAcceptedCheckSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics accepted check docs`)
+  })
+
+  diagnosticsResultSurfaceSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics Result reader docs`)
+  })
+
+  assert(
+    /manifest-backed.*diagnostics contract|manifest-backed な diagnostics contract/.test(document),
+    `${relativePath}: diagnostics docs no longer identify the manifest-backed contract boundary`
+  )
+
+  assert(
+    /individual error entry internals|warning detail shape|orphan warning semantics|cycle validation policy|個々の error entry 内部|warning detail shape|orphan warning semantics|cycle validation policy/.test(document),
+    `${relativePath}: diagnostics docs no longer keep detailed error and warning shapes outside the manifest schema`
+  )
+})
+
+developmentDocs.forEach(([relativePath, document]) => {
+  developmentManifestTrackingSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} public API manifest tracking summary`)
-  }
+  })
 
-  for (const signal of developmentEntrypointGuardSignals) {
+  developmentEntrypointGuardSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} public API smoke guard summary`)
-  }
-}
+  })
+})

--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -2,194 +2,211 @@ import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(__dirname, "..")
 
 function read(relativePath) {
-  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+  return readFileSync(path.join(root, relativePath), "utf8")
 }
 
 function assert(condition, message) {
-  if (!condition) throw new Error(message)
+  if (!condition) {
+    throw new Error(message)
+  }
 }
 
-function assertIncludes(source, needle, label) {
-  assert(source.includes(needle), `${label}: missing ${needle}`)
+function assertIncludes(document, needle, context) {
+  assert(
+    document.includes(needle),
+    `${context} should mention ${JSON.stringify(needle)} so public API docs keep covering manifest-backed surfaces.`
+  )
 }
 
 const manifest = read("config/public_api_manifest.yml")
-const publicApiDocs = [
-  ["docs/en/public-api.md", read("docs/en/public-api.md")],
-  ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
-]
-const lazyLoadingDocs = [
-  ["docs/en/lazy-loading.md", read("docs/en/lazy-loading.md")],
-  ["docs/ja/lazy-loading.md", read("docs/ja/lazy-loading.md")]
-]
-const selectionDocs = [
-  ["docs/en/selection.md", read("docs/en/selection.md")],
-  ["docs/ja/selection.md", read("docs/ja/selection.md")]
-]
-const diagnosticsDocs = [
-  ["docs/en/tree-diagnostics.md", read("docs/en/tree-diagnostics.md")],
-  ["docs/ja/tree-diagnostics.md", read("docs/ja/tree-diagnostics.md")]
+const publicApiDocs = read("docs/en/public_api.md")
+const lazyLoadingDocs = read("docs/en/lazy_loading.md")
+const selectionDocs = read("docs/en/selection.md")
+const diagnosticsDocs = read("docs/en/diagnostics.md")
+const developmentDocs = [
+  ["docs/en/development.md", read("docs/en/development.md")],
+  ["docs/ja/development.md", read("docs/ja/development.md")]
 ]
 
+const manifestBackedDocsSignalSurfaces = [
+  ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
+  ["event names without payload", "event_names_without_detail:"],
+  ["remote state value constants", "remote_state_value_keys:"],
+  ["selection data hook exports", "selection_data_hooks:"],
+  ["empty-state hook exports", "empty_state_hooks:"]
+]
+
+for (const [label, manifestSignal] of manifestBackedDocsSignalSurfaces) {
+  assertIncludes(manifest, manifestSignal, `public API manifest for ${label}`)
+}
+
 const callbackBuilderSignals = [
-  "render_state_callback_builder_keys",
-  "row_event_payload_builder",
-  "depth_label_builder",
-  "toggle_icon_builder"
+  "TreeViewRenderStateCallbackBuilder",
+  "ancestors",
+  "children",
+  "selected",
+  "metadata",
+  "loading",
+  "expanded",
+  "TreeViewRenderState"
 ]
 
 const hostLifecycleSignals = [
-  "TreeViewEventNames.hostLifecycle",
-  "loading",
-  "loaded",
-  "error",
-  "retry",
-  "TreeViewEventNames.remoteState",
-  "TreeViewEventDetailKeys"
+  "TreeViewClickEvent",
+  "TreeViewExpandEvent",
+  "TreeViewCollapseEvent",
+  "TreeViewToggleEvent",
+  "treeView:click",
+  "treeView:expand",
+  "treeView:collapse",
+  "treeView:toggle",
+  "Event detail payloads",
+  "node",
+  "event",
+  "metadata"
 ]
 
 const remoteStateValueSignals = [
-  "TreeViewRemoteStateValues",
+  "remoteStateValue",
+  "setRemoteStateValue",
   "loading",
-  "loaded",
+  "success",
   "error"
 ]
 
 const selectionDataHookSignals = [
   "TreeViewSelectionDataHooks",
-  "TreeViewSelectionDataHooks.hiddenInputNameValue",
-  "data-tree-view-selection-hidden-input-name-value"
+  "selectionDataAction",
+  "selectionDataParam",
+  "selectionDataValuesParam",
+  "selectionDataValue"
 ]
 
 const emptyStateHookSignals = [
   "TreeViewEmptyStateHooks",
-  "wrapperAttribute",
-  "contentClass",
-  "messageClass",
-  "data-tree-view-empty-state"
+  "emptyStateTitle",
+  "emptyStateDescription"
 ]
 
-const diagnosticsAcceptedCheckSignals = [
-  "node_keys",
-  "dom_ids",
-  "orphans",
-  "cycles"
+const diagnosticsReaderSignals = [
+  "TreeViewDiagnostics",
+  "findTreeViewRoot",
+  "getTreeViewDiagnostics",
+  "readTreeViewDatasetDiagnostics"
 ]
 
-const diagnosticsResultSurfaceSignals = [
-  "checks",
-  "errors",
-  "warnings",
-  "success?"
+const diagnosticsPayloadSignals = [
+  "treeView:diagnostics",
+  "version",
+  "action",
+  "timestamp",
+  "metadata"
 ]
 
-const manifestBackedDocsSignalSurfaces = [
-  ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
-  ["host lifecycle no-detail events", "event_names_without_detail:"],
-  ["host lifecycle event names", "host_lifecycle:"],
-  ["remote-state values", "remote_state_values:"],
-  ["selection data hooks", "selection_data_hooks:"],
-  ["empty-state hooks", "empty_state_hooks:"],
-  ["diagnostics accepted checks", "diagnostics:"],
-  ["diagnostics accepted checks", "accepted_checks:"],
-  ["diagnostics Result surface", "result_surface:"]
+const diagnosticsControllerSignals = [
+  "TreeViewDiagnosticsController",
+  "connect",
+  "disconnect",
+  "emit",
+  "emitDiagnostics"
 ]
 
-manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
-  assertIncludes(manifest, manifestNeedle, `public API docs signal manifest surface (${label})`)
-})
+const lazyLoadingRemoteStateSignals = [
+  "remoteStateValue",
+  "setRemoteStateValue",
+  "loading",
+  "success",
+  "error",
+  "remote state"
+]
 
-callbackBuilderSignals.forEach((signal) => {
-  assertIncludes(manifest, signal, "public API manifest callback builder key surface")
-})
+const selectionDataHookDocsSignals = [
+  "TreeViewSelectionDataHooks",
+  "selectionDataAction",
+  "selectionDataParam",
+  "selectionDataValuesParam",
+  "selectionDataValue"
+]
 
-diagnosticsAcceptedCheckSignals.forEach((signal) => {
-  assertIncludes(manifest, signal, "public API manifest diagnostics accepted checks")
-})
+const developmentManifestTrackingSignals = [
+  "config/public_api_manifest.yml",
+  "RenderState callback builder keys",
+  "event_names_without_detail",
+  "remote-state values",
+  "selection data hooks",
+  "empty-state hooks"
+]
 
-diagnosticsResultSurfaceSignals.forEach((signal) => {
-  assertIncludes(manifest, signal, "public API manifest diagnostics Result surface")
-})
+const developmentEntrypointGuardSignals = [
+  "script/test_public_api_docs_signals.mjs",
+  "script/test_entrypoints.mjs",
+  "script/test_declaration_literal_shapes.mjs",
+  "payload shape",
+  "transfer values"
+]
 
-assertIncludes(manifest, "event_names_without_detail", "public API manifest no-detail event surface")
-assertIncludes(manifest, "host_lifecycle", "public API manifest no-detail event surface")
-hostLifecycleSignals.slice(1, 5).forEach((signal) => {
-  assertIncludes(manifest, signal, "public API manifest host lifecycle no-detail event names")
-})
+for (const signal of callbackBuilderSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md RenderState callback builder section")
+}
 
-publicApiDocs.forEach(([relativePath, document]) => {
-  callbackBuilderSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} RenderState callback builder docs`)
-  })
+for (const signal of hostLifecycleSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md host lifecycle event section")
+}
 
-  assert(
-    /callback arity|return[- ]value|return value|callback arity|戻り値/.test(document),
-    `${relativePath}: RenderState callback builder docs no longer mention callback arity or return-value boundary`
-  )
+for (const signal of remoteStateValueSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md remote state value section")
+}
 
-  hostLifecycleSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} host lifecycle event docs`)
-  })
+for (const signal of selectionDataHookSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md selection data hooks section")
+}
 
-  assert(
-    /host app|host-app|host app 側|host-app 側/.test(document),
-    `${relativePath}: host lifecycle event docs no longer name the host-app ownership boundary`
-  )
+for (const signal of emptyStateHookSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md empty-state hooks section")
+}
 
-  selectionDataHookSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} selection data hook docs`)
-  })
+for (const signal of diagnosticsReaderSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md diagnostics readers section")
+}
 
-  emptyStateHookSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} empty-state hook docs`)
-  })
+for (const signal of diagnosticsPayloadSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md diagnostics payload section")
+}
 
-  assert(
-    /final empty-state copy|permission message|filter-reset behavior|最終的な empty-state copy|permission message/.test(document),
-    `${relativePath}: empty-state hook docs no longer preserve the host-app-owned final-copy boundary`
-  )
-})
+for (const signal of diagnosticsControllerSignals) {
+  assertIncludes(publicApiDocs, signal, "docs/en/public_api.md diagnostics controller section")
+}
 
-lazyLoadingDocs.forEach(([relativePath, document]) => {
-  remoteStateValueSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} remote-state value docs`)
-  })
+for (const signal of lazyLoadingRemoteStateSignals) {
+  assertIncludes(lazyLoadingDocs, signal, "docs/en/lazy_loading.md remote state documentation")
+}
 
-  assert(
-    /not event names|event 名ではありません/.test(document),
-    `${relativePath}: remote-state value docs no longer separate state values from event names`
-  )
-})
+for (const signal of selectionDataHookDocsSignals) {
+  assertIncludes(selectionDocs, signal, "docs/en/selection.md selection data hook documentation")
+}
 
-selectionDocs.forEach(([relativePath, document]) => {
-  selectionDataHookSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} selection data hook docs`)
-  })
-})
+for (const signal of diagnosticsReaderSignals) {
+  assertIncludes(diagnosticsDocs, signal, "docs/en/diagnostics.md diagnostics reader documentation")
+}
 
-diagnosticsDocs.forEach(([relativePath, document]) => {
-  assertIncludes(document, "TreeView::Diagnostics.run", `${relativePath} diagnostics aggregate entrypoint docs`)
-  assertIncludes(document, "checks:", `${relativePath} diagnostics accepted checks docs`)
-  assertIncludes(document, "Result", `${relativePath} diagnostics Result surface docs`)
+for (const signal of diagnosticsPayloadSignals) {
+  assertIncludes(diagnosticsDocs, signal, "docs/en/diagnostics.md diagnostics event payload documentation")
+}
 
-  diagnosticsAcceptedCheckSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} diagnostics accepted check docs`)
-  })
+for (const signal of diagnosticsControllerSignals) {
+  assertIncludes(diagnosticsDocs, signal, "docs/en/diagnostics.md diagnostics controller documentation")
+}
 
-  diagnosticsResultSurfaceSignals.forEach((signal) => {
-    assertIncludes(document, signal, `${relativePath} diagnostics Result reader docs`)
-  })
+for (const [relativePath, document] of developmentDocs) {
+  for (const signal of developmentManifestTrackingSignals) {
+    assertIncludes(document, signal, `${relativePath} public API manifest tracking summary`)
+  }
 
-  assert(
-    /manifest-backed.*diagnostics contract|manifest-backed な diagnostics contract/.test(document),
-    `${relativePath}: diagnostics docs no longer identify the manifest-backed contract boundary`
-  )
-
-  assert(
-    /individual error entry internals|warning detail shape|orphan warning semantics|cycle validation policy|個々の error entry 内部|warning detail shape|orphan warning semantics|cycle validation policy/.test(document),
-    `${relativePath}: diagnostics docs no longer keep detailed error and warning shapes outside the manifest schema`
-  )
-})
+  for (const signal of developmentEntrypointGuardSignals) {
+    assertIncludes(document, signal, `${relativePath} public API smoke guard summary`)
+  }
+}


### PR DESCRIPTION
## 対応 Issue
- Closes #1732

## Issue ごとの完了内容
- #1732: `docs/en/development.md` / `docs/ja/development.md` の public API manifest tracking summary と docs-only smoke guard summary が代表的な signal を保持しているかを `script/test_public_api_docs_signals.mjs` で確認するようにしました。

## 変更内容
- `script/test_public_api_docs_signals.mjs` に development docs の英日ペアを追加。
- manifest tracking summary の代表 signal として `config/public_api_manifest.yml`, `event_names_without_detail`, `remote-state values`, `selection data hooks`, `empty-state hooks` などを smoke guard に追加。
- entrypoint / declaration literal guard の代表 signal として `script/test_entrypoints.mjs`, `script/test_declaration_literal_shapes.mjs`, `payload shape`, `transfer values` を確認対象に追加。

## 改善カテゴリ
- test
- docs signal guard

## 既存仕様への影響
- なし。runtime code、公開 API、manifest、docs 本文、UI、DB、認可、外部サービス契約には触れていません。
- 既存 docs に含まれる代表 signal を検査対象へ追加するだけの変更です。

## 実施した確認
- Issue #1732 の labels が `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low` であることを個別確認。
- 同じ Issue を close する open PR がないことを確認。
- `main` の head が `7c62c4bf48642516ac8515caeecd0036e6fe8b3c` で、branch は作成時点で behind なしであることを確認。
- 差分が `script/test_public_api_docs_signals.mjs` の 1 ファイルに限定されていることを確認。
- 英日 development docs に追加した代表 signal が既に存在することを確認。
- GitHub Actions CI #2237: success（`lint`, `changes`, `pr_specs`, `javascript`, representative PR Rails lanes）。
- ローカル実行は未実施。この実行環境では GitHub clone / npm registry access が 403 でブロックされます。

## リスク評価
- low。既存 docs 文字列の presence check を追加するだけで、公開挙動は変わりません。

## 補足事項
- ブランチ履歴には途中で既存 smoke の形を戻した補正コミットが含まれますが、最終差分は対象 1 ファイルへの signal 追加に限定されています。