### PR TITLE
FilteredTree modes manifest を current main で再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -36,6 +36,11 @@ public_constants:
   - PersistedState
   - StateStore
   - Diagnostics
+filtered_tree_modes:
+  - matched_only
+  - with_ancestors
+  - with_descendants
+  - with_ancestors_and_descendants
 graph_adapter_initializer:
   required_keywords:
     - roots

--- a/docs/en/filtered-trees.md
+++ b/docs/en/filtered-trees.md
@@ -31,6 +31,8 @@ render_state = TreeView::RenderState.new(
 
 ## Modes
 
+The mode set below is a manifest-backed public contract tracked in `config/public_api_manifest.yml` and guarded against `TreeView::FilteredTree::VALID_MODES`.
+
 | mode | meaning |
 |---|---|
 | `:matched_only` | Include only matched nodes. |

--- a/docs/ja/filtered-trees.md
+++ b/docs/ja/filtered-trees.md
@@ -31,6 +31,8 @@ render_state = TreeView::RenderState.new(
 
 ## mode
 
+下の mode set は `config/public_api_manifest.yml` に記録され、`TreeView::FilteredTree::VALID_MODES` と照合される manifest-backed public contract です。
+
 | mode | 意味 |
 |---|---|
 | `:matched_only` | matchしたnodeだけを含めます。 |

--- a/spec/public_api_filtered_tree_modes_spec.rb
+++ b/spec/public_api_filtered_tree_modes_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "yaml"
+
+PUBLIC_API_FILTERED_TREE_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+PUBLIC_API_FILTERED_TREE_DOC_PATHS = [
+  File.expand_path("../docs/en/filtered-trees.md", __dir__),
+  File.expand_path("../docs/ja/filtered-trees.md", __dir__)
+].freeze
+
+RSpec.describe "FilteredTree public mode contract" do
+  def manifest_modes
+    YAML.safe_load_file(PUBLIC_API_FILTERED_TREE_MANIFEST_PATH).fetch("filtered_tree_modes")
+  end
+
+  def runtime_modes
+    TreeView::FilteredTree::VALID_MODES.map(&:to_s)
+  end
+
+  it "keeps manifest modes aligned with TreeView::FilteredTree::VALID_MODES" do
+    expect(manifest_modes).to eq(%w[
+      matched_only
+      with_ancestors
+      with_descendants
+      with_ancestors_and_descendants
+    ])
+    expect(manifest_modes).to eq(runtime_modes)
+  end
+
+  it "keeps filtered-tree docs aligned with the manifest-backed mode set" do
+    PUBLIC_API_FILTERED_TREE_DOC_PATHS.each do |doc_path|
+      source = File.read(doc_path)
+
+      expect(source).to include("manifest-backed")
+
+      manifest_modes.each do |mode|
+        expect(source).to include("| `:#{mode}` |"),
+          "expected #{doc_path} to document the FilteredTree mode #{mode.inspect}"
+      end
+    end
+  end
+end

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -10,6 +10,7 @@ PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w[
   module_methods
   configuration_options
   public_constants
+  filtered_tree_modes
   graph_adapter_initializer
   path_tree_builder_node_shapes
   helper_methods
@@ -79,6 +80,14 @@ RSpec.describe "Public API manifest structure" do
     YAML
 
     expect(duplicate_mapping_keys(yaml)).to eq(["javascript_package_root.event_names.state"])
+  end
+
+  it "keeps filtered tree modes shaped as a non-empty string list" do
+    modes = manifest.fetch("filtered_tree_modes")
+
+    expect(modes).to be_an(Array)
+    expect(modes).not_to be_empty
+    expect(modes).to all(be_a(String))
   end
 
   it "keeps grouped option key sections shaped as non-empty string lists" do


### PR DESCRIPTION
FilteredTree mode set を latest main から scoped diff として再提案します。

Closes #1600
Supersedes #1622

## 対応内容

- `config/public_api_manifest.yml` に `filtered_tree_modes` section を追加しました。
- `TreeView::FilteredTree::VALID_MODES` と manifest の mode set が一致する focused spec を追加しました。
- 英日 `docs/*/filtered-trees.md` の mode table が manifest-backed contract であることを明記しました。
- manifest top-level structure spec を新 section に同期しました。

## 受け入れ条件との対応

- FilteredTree mode set を manifest-backed contract として含める方針にしています。
- manifest / compatibility spec / filtered-tree docs が同じ4 modeを確認します。
- `TreeView::Tree#filtered_tree_for(items, mode:)` の利用導線は維持しています。
- search query、ranking、authorization、text highlighting、PathTree / ReverseTree との使い分けには広げていません。
- runtime filtered tree behavior は変更していません。

## 変更範囲

- public API manifest
- focused compatibility spec
- manifest structure spec
- 英日 filtered-tree docs

## #1622 からの修正点

- latest `main` 起点の replacement branch に載せ直しました。
- review 指摘に従い、Issue 範囲外だった `docs/ja/lazy-loading.md` の差分を除外しました。
- compare は `main...refresh/1622-filtered-tree-modes-current` で `ahead_by:5` / `behind_by:0`、変更ファイルは #1600 関連の5件のみです。

## 実施した確認

- Issue #1600 と PR #1622 の review:changes-requested コメントを確認しました。
- GitHub compare で scope drift がないことを確認しました。
- local checkout / local RSpec / npm docs smoke は、この環境の GitHub HTTPS checkout が制限されるため未実行です。PR CI を確認対象にします。

## リスク

medium。runtime は変更していませんが、FilteredTree mode set を public manifest contract として固定するため、採用判断は maintainer / human review に残ります。

## 未対応・補足

- FilteredTree algorithm、search UI、ranking、text highlighting、PathTree / ReverseTree behavior は扱っていません。
- #1622 はこの PR で supersede します。