### PR TITLE
test: Node version source drift guard を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "test": "vitest run",
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
+    "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
     "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
-    "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy",
+    "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"
   },

--- a/script/test_node_version_sources.mjs
+++ b/script/test_node_version_sources.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+const nvmrc = readFileSync(join(repoRoot, ".nvmrc"), "utf8").trim();
+const workflow = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+
+const workflowNodeVersions = Array.from(workflow.matchAll(/node-version:\s*["']?(\d+)["']?/g), (match) => match[1]);
+
+assert.equal(nvmrc, "22", ".nvmrc must keep Node 22 as the local source of truth");
+assert.equal(packageJson.engines.node, "22.x", "package.json engines.node must stay aligned with .nvmrc");
+assert.deepEqual(workflowNodeVersions, ["22"], "CI workflow node-version values must stay aligned with .nvmrc");
+
+console.log("Node version sources stay aligned with Node 22.");


### PR DESCRIPTION
## 対応 Issue

Closes #1659

## Issue ごとの完了内容

- #1659: `.nvmrc`、`package.json` `engines.node`、CI workflow の `node-version` が Node 22 にそろっていることを確認する repository-local guard を追加しました。

## 変更内容

- `script/test_node_version_sources.mjs` を追加し、Node version source の代表3箇所を検査します。
- `package.json` に `test:node-version-sources` を追加しました。
- `npm run test:entrypoints` から新しい guard を実行するようにしました。

## 改善カテゴリ

- test
- CI / devops guard
- 小さな maintenance check

## 既存仕様への影響

- runtime code、public API、UI、DB、認可、install policy は変更していません。
- `npm install` policy と lockfile refresh issue (#413) には触れていません。

## 確認内容

- Issue #1659 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
- branch freshness: latest `main` `357524e098df75b52a5eb6004ffd08de45ff80a5` から作成
- compare: `main...quality/1659-node-version-sources`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: `package.json`, `script/test_node_version_sources.mjs`
- local checkout / npm 実行は、この環境の GitHub HTTPS / npm registry が 403 になるため未実行です。PR CI で確認します。

## リスク評価

low。既存挙動は変えず、repository-local の drift guard を追加するだけです。

## 補足事項

#413 の lockfile refresh は registry-enabled environment が必要なため、この PR では扱っていません。