### PR TITLE
diagnostics pre-render validation note を追加する

### DIFF
--- a/docs/en/tree-diagnostics.md
+++ b/docs/en/tree-diagnostics.md
@@ -76,6 +76,19 @@ end
 
 The manifest-backed diagnostics contract covers the accepted check names and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
 
+## Pre-render validation review note
+
+Use this focused comparison when reviewing diagnostics without adding a full static mockup page. The goal is to separate the signal TreeView can provide from the correction policy the host app owns.
+
+| Review state | TreeView signal to inspect | Host-app-owned decision |
+|---|---|---|
+| Duplicate node key | `validate_node_keys: true` or `node_keys` diagnostics error before render | Choose a stable key strategy, such as `id_method:` or `node_key_resolver:` |
+| DOM ID collision | `render_state.validate_unique_dom_ids!` or `dom_ids` diagnostics error with the same `UiConfig` used by the page | Fix `node_prefix`, custom DOM ID builders, or node keys that normalize to the same browser-facing ID |
+| Orphaned record | `tree.orphan_items` or `orphans` diagnostics warning after filtering, imports, or permission scoping | Decide whether the subset should raise, render orphans as roots, render only orphans, or document that the filtered subset is intentional |
+| Cycle risk | `TreeView::CycleDiagnostics.new(tree).report` or `cycles` diagnostics error for parent relationships | Correct imported or user-editable parent data before rendering, or repair the resolver logic that creates the cycle |
+
+This note is intentionally a review aid, not a replacement for a production validation UI. Keep remediation copy, dashboards, alerts, data repair workflows, and release gates in the host app or in dedicated quality work.
+
 ## Node key uniqueness
 
 Enable validation when building the tree to catch duplicate node keys early.

--- a/docs/ja/tree-diagnostics.md
+++ b/docs/ja/tree-diagnostics.md
@@ -76,6 +76,19 @@ end
 
 manifest-backed な diagnostics contract は、accepted check names と `Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
 
+## 描画前validation review note
+
+full static mockup page を増やさずに diagnostics flow をレビューしたい場合は、この比較表を使ってください。TreeView が出せるsignalと、host appが決めるcorrection policyを分けて見るためのfocused noteです。
+
+| Review state | TreeView側で確認するsignal | Host app側で決めること |
+|---|---|---|
+| duplicate node key | 描画前の `validate_node_keys: true` または `node_keys` diagnostics error | `id_method:` や `node_key_resolver:` など、安定したkey strategyを選ぶ |
+| DOM ID collision | 実画面と同じ `UiConfig` での `render_state.validate_unique_dom_ids!` または `dom_ids` diagnostics error | `node_prefix`、custom DOM ID builder、ブラウザ向けIDへ正規化したときに衝突するnode keyを直す |
+| orphaned record | filter、import、permission scope後の `tree.orphan_items` または `orphans` diagnostics warning | `:raise`、`:as_root`、orphan-only表示、または意図したfiltered subsetとして文書化するかを決める |
+| cycle risk | parent relationship に対する `TreeView::CycleDiagnostics.new(tree).report` または `cycles` diagnostics error | 描画前にimport data / user編集可能な親子data、またはcycleを作るresolver logicを修正する |
+
+このnoteはreview aidであり、production validation UIの代替ではありません。修復文言、dashboard、alert、data repair workflow、release gateはhost app側、または専用quality workで扱ってください。
+
 ## node key uniqueness
 
 node keyの重複を検出したい場合は、tree作成時にvalidationを有効にします。


### PR DESCRIPTION
## 対応Issue

- Closes #1714

## 採用した方針

- 自動実行のため、最も低リスクで既存 docs に沿う案を採用しました。
- 新規 `docs/mockups/*.html` を増やすのではなく、Issue 本文が許容している existing diagnostics-related visual note として `docs/en|ja/tree-diagnostics.md` に focused comparison table を追加しました。
- TreeView が出せる diagnostics signal と、host app が所有する data correction / remediation policy を分けて読めるようにしました。

## 比較した案

- 案A: 新規 `docs/mockups/tree-diagnostics-*.html` を追加する
  - diagnostics flow を視覚的に見せやすい一方、mockup README / review gallery / browser smoke inventory の同期が必要で、今回の low-risk docs lane としては差分が大きくなります。
- 案B: 既存 `tree-diagnostics.md` に focused comparison note を追加する
  - 採用。既存 diagnostics docs の文脈で、node key / DOM ID / orphan / cycle の代表状態と責務境界を小さく比較できます。
- 案C: runtime diagnostics / public manifest / validation behavior を変更する
  - 不採用。Issue は review aid が目的であり、runtime behavior や public contract 変更は非目標です。

## 変更内容

- `docs/en/tree-diagnostics.md`
  - `Pre-render validation review note` を追加
  - duplicate node key / DOM ID collision / orphaned record / cycle risk の review state を比較表に整理
- `docs/ja/tree-diagnostics.md`
  - 同内容の日本語 note を追加
  - TreeView signal と host app decision の責務境界を同期

## 変更した画面・コンポーネント

- English docs: `docs/en/tree-diagnostics.md`
- Japanese docs: `docs/ja/tree-diagnostics.md`

## 確認内容

- lint: GitHub Actions CI #2249 success (`lint` job success)
- typecheck: runtime Ruby / JavaScript は変更していません。
- RSpec / docs checks: GitHub Actions CI #2249 success (`pr_specs` job success)
- UI表示確認: 実ブラウザ確認は未実施です。Markdown docs の比較表追加であり、static HTML mockup は変更していません。
- レスポンシブ確認: 実ブラウザ確認は未実施です。docs Markdown の table 表示は host docs renderer に委ねます。
- アクセシビリティ確認: Markdown heading と table のみ追加しました。runtime ARIA / DOM は変更していません。
- 実ブラウザ確認の代替: QA handoff note。docs renderer で table wrapping が気になる場合は browser-capable review で確認してください。
- JavaScript / browser smoke: docs-only PR without mockup or browser-smoke changes として GitHub Actions CI #2249 の `javascript` job は skip-path success
- Rails compatibility: docs-only skip path success (7.0 / 7.2 / 8.0)
- final compare: `main...design/1714-diagnostics-validation-note`
  - `ahead_by: 2`
  - `behind_by: 0`
  - changed files: 2 docs-only files
- PR metadata: `mergeable:true`

## スクリーンショット

<!-- docs-only Markdown change のため未添付。 -->

## リスク

- low
- runtime Ruby / JavaScript、Diagnostics behavior、public API manifest、docs/mockups inventory、browser smoke target、host-app validation UI は変更していません。

## 補足

- Rails Table Preferences には #306 / #447 などの対象 design Issue もありましたが、どちらも長大 controller / interaction behavior に触れるため、今回の scheduled run ではより低リスクな docs-only #1714 を優先しました。
- Rails Fields Kit には今回の label-qualified search で対象 design Issue は見つかりませんでした。