### PR TITLE
Migration guide の docs smoke signal を追加する

### DIFF
--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -39,7 +39,11 @@ const signalGroups = [
     files: [
       [
         "docs/en/troubleshooting.md",
-        ["host app still owns routes", "authorization", "business actions"]
+        [
+          "host app still owns routes",
+          "authorization",
+          "business actions"
+        ]
       ],
       [
         "docs/ja/troubleshooting.md",
@@ -312,6 +316,39 @@ const signalGroups = [
           "context.depth",
           "row-status-depth-labels.html",
           "どのdepthにどの文言を出すか、業務上の意味付け、CSS表現はhost app側で決めます"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Migration guide compatibility boundary",
+    files: [
+      [
+        "docs/en/migration.md",
+        [
+          "semantic versioning",
+          "documented integration points",
+          "deprecation path",
+          "Renamed APIs and moved entry points",
+          "JavaScript event compatibility",
+          "CSS and data-attribute compatibility",
+          "CHANGELOG.md",
+          "release notes",
+          "migration notes"
+        ]
+      ],
+      [
+        "docs/ja/migration.md",
+        [
+          "semantic versioning",
+          "documented integration point",
+          "deprecation path",
+          "entry point 移動",
+          "JavaScript event の互換性",
+          "CSS / data attribute の互換性",
+          "CHANGELOG.md",
+          "release note",
+          "migration note"
         ]
       ]
     ]


### PR DESCRIPTION
## 対応 Issue

Closes #1743

## Issue ごとの完了内容

- #1743: 英日 `docs/*/migration.md` の compatibility / deprecation / release-note guidance を、既存 docs signal smoke で代表確認できるようにしました。

## 変更内容

- `script/test_docs_entrypoint_signals.mjs` に Migration guide 用の signal group を追加しました。
- 英日 Migration guide の次の代表 signal を確認します。
  - semantic versioning
  - `0.1.x` documented integration points
  - deprecation path
  - renamed / moved entrypoint guidance
  - JavaScript event compatibility
  - CSS / data-attribute compatibility
  - `CHANGELOG.md` / release notes / migration notes

## 改善カテゴリ

- test 追加
- docs smoke 改善

## 既存仕様への影響

runtime Ruby / JavaScript behavior、public API manifest、semantic versioning policy、deprecation policy、release workflow、CHANGELOG 本文は変更していません。既存 docs の代表 signal を守る smoke 追加のみです。

## 実施した確認

- Issue #1743 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff と既存 docs smoke の責務を確認しました。
- current main `acf8ceb4daee1084bdb8eda39e987af16d859f92` から branch を作成しました。
- compare `main...quality/1743-migration-docs-smoke`
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1 (`script/test_docs_entrypoint_signals.mjs`)
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にします。

## リスク評価

low。signal が細かすぎて docs 改善を妨げないよう、既存本文にある代表語の少数 assertion に限定しています。