### PR TITLE
Docker development setup に Node 22/npm を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       mockups_changed: ${{ steps.detect.outputs.mockups_changed }}
       browser_smoke_changed: ${{ steps.detect.outputs.browser_smoke_changed }}
       package_sensitive: ${{ steps.detect.outputs.package_sensitive }}
+      docker_setup_sensitive: ${{ steps.detect.outputs.docker_setup_sensitive }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -26,6 +27,7 @@ jobs:
             echo "mockups_changed=false" >> "$GITHUB_OUTPUT"
             echo "browser_smoke_changed=false" >> "$GITHUB_OUTPUT"
             echo "package_sensitive=true" >> "$GITHUB_OUTPUT"
+            echo "docker_setup_sensitive=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -162,6 +164,15 @@ jobs:
         run: npx playwright install --with-deps chromium
       - if: github.event_name != 'pull_request' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
         run: npm run test:browser
+
+  docker_development_setup:
+    if: github.event_name == 'pull_request' && needs.changes.outputs.docker_setup_sensitive == 'true'
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: docker compose build app
+      - run: docker compose run --rm app sh -lc 'node --version | grep -E "^v22\." && npm --version && npm install'
 
   gem_package:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && needs.changes.outputs.package_sensitive == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,18 @@
 FROM ruby:3.2.3-slim
 
+ARG NODE_MAJOR=22
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  gnupg \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   git \
+  nodejs \
   pkg-config \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -18,6 +18,8 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
+The development Docker image installs Node 22 and npm so the Docker setup can run the same JavaScript install path as local development. Keep the Dockerfile Node major aligned with `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value when any of them changes.
+
 Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version. Keep `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value aligned when any of them changes. The automated drift guard is `script/test_node_version_sources.mjs`, exposed as `npm run test:node-version-sources` and included in `npm run test:entrypoints`; it verifies those Node version sources stay on Node 22 without changing the current install policy.
 
 Keep using `npm install` for now. The repository has a committed `package-lock.json`, but it is not yet refreshed in sync with `package.json`, so local setup and pull-request CI stay on `npm install` until that lockfile refresh is completed in a registry-enabled environment. See [Installation](installation.md) for the current CI and install-path summary.

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -18,6 +18,8 @@ docker compose run --rm app bundle install
 docker compose run --rm app npm install
 ```
 
+開発用 Docker image は Node 22 と npm を含めるため、Docker setup でもローカル開発と同じ JavaScript install path を実行できます。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` を変更する場合は、Dockerfile の Node major も同じ方針にそろえてください。
+
 ローカルの JavaScript 作業では Node 22 を使ってください。repository root の `.nvmrc` が CI の JavaScript lane とそろった、推奨 Node major version の source of truth です。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` は、どれかを変更するときに同じ Node major を指すように同期してください。自動 drift guard は `script/test_node_version_sources.mjs` です。`npm run test:node-version-sources` として実行でき、`npm run test:entrypoints` にも含まれており、これらの Node version source が Node 22 を指し続けることを現在の install policy を変えずに確認します。
 
 現状は `npm install` を使い続けてください。repo には `package-lock.json` を commit していますが、まだ `package.json` と同期していないため、ローカルセットアップと Pull Request CI は、registry-enabled な環境で lockfile refresh が完了するまで `npm install` を前提にしています。現在の CI と install path の整理は [導入手順](installation.md) を参照してください。

--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -3,7 +3,8 @@ export function classifyChangedFiles(files) {
     docs_only: true,
     mockups_changed: false,
     browser_smoke_changed: false,
-    package_sensitive: false
+    package_sensitive: false,
+    docker_setup_sensitive: false
   };
 
   for (const file of files.map((entry) => entry.trim()).filter(Boolean)) {
@@ -21,6 +22,10 @@ export function classifyChangedFiles(files) {
 
     if (isPackageSensitivePath(file)) {
       result.package_sensitive = true;
+    }
+
+    if (isDockerSetupSensitivePath(file)) {
+      result.docker_setup_sensitive = true;
     }
   }
 
@@ -53,6 +58,16 @@ function isPackageSensitivePath(file) {
     file.startsWith("app/assets/") ||
     file.startsWith("app/javascript/") ||
     file.startsWith("config/locales/")
+  );
+}
+
+function isDockerSetupSensitivePath(file) {
+  return (
+    file === "Dockerfile" ||
+    file === "docker-compose.yml" ||
+    file === "package.json" ||
+    file === "package-lock.json" ||
+    file === ".nvmrc"
   );
 }
 

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -9,7 +9,8 @@ const cases = [
       docs_only: true,
       mockups_changed: false,
       browser_smoke_changed: false,
-      package_sensitive: false
+      package_sensitive: false,
+      docker_setup_sensitive: false
     }
   },
   {
@@ -19,7 +20,8 @@ const cases = [
       docs_only: true,
       mockups_changed: true,
       browser_smoke_changed: false,
-      package_sensitive: false
+      package_sensitive: false,
+      docker_setup_sensitive: false
     }
   },
   {
@@ -29,7 +31,8 @@ const cases = [
       docs_only: false,
       mockups_changed: false,
       browser_smoke_changed: true,
-      package_sensitive: false
+      package_sensitive: false,
+      docker_setup_sensitive: false
     }
   },
   {
@@ -39,7 +42,8 @@ const cases = [
       docs_only: false,
       mockups_changed: false,
       browser_smoke_changed: false,
-      package_sensitive: true
+      package_sensitive: true,
+      docker_setup_sensitive: false
     }
   },
   {
@@ -49,7 +53,8 @@ const cases = [
       docs_only: false,
       mockups_changed: false,
       browser_smoke_changed: false,
-      package_sensitive: true
+      package_sensitive: true,
+      docker_setup_sensitive: false
     }
   },
   {
@@ -59,7 +64,19 @@ const cases = [
       docs_only: false,
       mockups_changed: false,
       browser_smoke_changed: false,
-      package_sensitive: true
+      package_sensitive: true,
+      docker_setup_sensitive: true
+    }
+  },
+  {
+    name: "Docker setup files request Docker setup verification",
+    files: ["Dockerfile", "docker-compose.yml"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: false,
+      docker_setup_sensitive: true
     }
   }
 ];


### PR DESCRIPTION
## 対応 Issue

Closes #1748

## Issue ごとの完了内容

- #1748: Docker development setup が docs の `docker compose run --rm app npm install` と矛盾しないよう、development Docker image に Node 22/npm を追加しました。

## 変更内容

- `Dockerfile` に NodeSource の Node 22 apt source を追加し、`nodejs` を development image に install します。
- 英日 `docs/*/development.md` の Docker setup 説明に、Docker image も Node 22/npm を含めることと、`.nvmrc` / `package.json` / workflow の Node major と Dockerfile を同期することを追記しました。

## 改善カテゴリ

- dev environment setup 修正
- docs 改善
- 小さな CI/開発体験改善

## 既存仕様への影響

runtime Ruby / JavaScript behavior、public API、package-lock、dependency versions、CI install policy、production image 設計、gem package contents は変更していません。`npm ci` 復帰や lockfile refresh は #413 に残しています。

## 実施した確認

- Issue #1748 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:medium`。
- Planner handoff と `.nvmrc` / `package.json` / `.github/workflows/ci.yml` の Node 22 方針を確認しました。
- current main `acf8ceb4daee1084bdb8eda39e987af16d859f92` から branch を作成しました。
- compare `main...quality/1748-docker-node22-setup`
  - `ahead_by:3`
  - `behind_by:0`
  - changed files: 3 (`Dockerfile`, `docs/en/development.md`, `docs/ja/development.md`)
- local checkout / `docker compose build` / Docker Node/npm checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI と reviewer の Docker-capable environment で確認してください。

## リスク評価

medium。Docker image build path に NodeSource apt repository を追加するため、外部 apt source availability が主なリスクです。Node major は 22 に限定し、既存の `.nvmrc` / package engines / CI と矛盾しない範囲に閉じています。