### PR TITLE
Diagnostics.run option keys を current main で再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -170,6 +170,9 @@ diagnostics:
     - dom_ids
     - orphans
     - cycles
+  run_options:
+    - checks
+    - raise_errors
   result_surface:
     attributes:
       - checks

--- a/docs/en/tree-diagnostics.md
+++ b/docs/en/tree-diagnostics.md
@@ -74,20 +74,7 @@ end
 
 `Result#success?` only reflects collected errors. Orphan reports are warnings, so review `warnings` when filtered, imported, or permission-scoped data can leave records outside the rendered tree.
 
-The manifest-backed diagnostics contract covers the accepted check names and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
-
-## Pre-render validation review note
-
-Use this focused comparison when reviewing diagnostics without adding a full static mockup page. The goal is to separate the signal TreeView can provide from the correction policy the host app owns.
-
-| Review state | TreeView signal to inspect | Host-app-owned decision |
-|---|---|---|
-| Duplicate node key | `validate_node_keys: true` or `node_keys` diagnostics error before render | Choose a stable key strategy, such as `id_method:` or `node_key_resolver:` |
-| DOM ID collision | `render_state.validate_unique_dom_ids!` or `dom_ids` diagnostics error with the same `UiConfig` used by the page | Fix `node_prefix`, custom DOM ID builders, or node keys that normalize to the same browser-facing ID |
-| Orphaned record | `tree.orphan_items` or `orphans` diagnostics warning after filtering, imports, or permission scoping | Decide whether the subset should raise, render orphans as roots, render only orphans, or document that the filtered subset is intentional |
-| Cycle risk | `TreeView::CycleDiagnostics.new(tree).report` or `cycles` diagnostics error for parent relationships | Correct imported or user-editable parent data before rendering, or repair the resolver logic that creates the cycle |
-
-This note is intentionally a review aid, not a replacement for a production validation UI. Keep remediation copy, dashboards, alerts, data repair workflows, and release gates in the host app or in dedicated quality work.
+The manifest-backed diagnostics contract covers the accepted check names, the `TreeView::Diagnostics.run` option key surface, and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. The run option keys are `checks` and `raise_errors`: `checks:` selects from the accepted check names, while `raise_errors:` selects whether failures are collected into a `Result` or raised immediately. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze accepted value schemas, boolean coercion, individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
 
 ## Node key uniqueness
 

--- a/docs/en/tree-diagnostics.md
+++ b/docs/en/tree-diagnostics.md
@@ -76,6 +76,19 @@ end
 
 The manifest-backed diagnostics contract covers the accepted check names, the `TreeView::Diagnostics.run` option key surface, and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. The run option keys are `checks` and `raise_errors`: `checks:` selects from the accepted check names, while `raise_errors:` selects whether failures are collected into a `Result` or raised immediately. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze accepted value schemas, boolean coercion, individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
 
+## Pre-render validation review note
+
+Use this focused comparison when reviewing diagnostics without adding a full static mockup page. The goal is to separate the signal TreeView can provide from the correction policy the host app owns.
+
+| Review state | TreeView signal to inspect | Host-app-owned decision |
+|---|---|---|
+| Duplicate node key | `validate_node_keys: true` or `node_keys` diagnostics error before render | Choose a stable key strategy, such as `id_method:` or `node_key_resolver:` |
+| DOM ID collision | `render_state.validate_unique_dom_ids!` or `dom_ids` diagnostics error with the same `UiConfig` used by the page | Fix `node_prefix`, custom DOM ID builders, or node keys that normalize to the same browser-facing ID |
+| Orphaned record | `tree.orphan_items` or `orphans` diagnostics warning after filtering, imports, or permission scoping | Decide whether the subset should raise, render orphans as roots, render only orphans, or document that the filtered subset is intentional |
+| Cycle risk | `TreeView::CycleDiagnostics.new(tree).report` or `cycles` diagnostics error for parent relationships | Correct imported or user-editable parent data before rendering, or repair the resolver logic that creates the cycle |
+
+This note is intentionally a review aid, not a replacement for a production validation UI. Keep remediation copy, dashboards, alerts, data repair workflows, and release gates in the host app or in dedicated quality work.
+
 ## Node key uniqueness
 
 Enable validation when building the tree to catch duplicate node keys early.

--- a/docs/ja/tree-diagnostics.md
+++ b/docs/ja/tree-diagnostics.md
@@ -76,6 +76,19 @@ end
 
 manifest-backed な diagnostics contract は、accepted check names、`TreeView::Diagnostics.run` の option key surface、`Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。run option keys は `checks` と `raise_errors` で、`checks:` は accepted check names から実行対象を選び、`raise_errors:` は失敗を `Result` に収集するか即座に例外としてraiseするかを選びます。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、accepted value schema、boolean coercion、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
 
+## 描画前validation review note
+
+full static mockup page を増やさずに diagnostics flow をレビューしたい場合は、この比較表を使ってください。TreeView が出せるsignalと、host appが決めるcorrection policyを分けて見るためのfocused noteです。
+
+| Review state | TreeView側で確認するsignal | Host app側で決めること |
+|---|---|---|
+| duplicate node key | 描画前の `validate_node_keys: true` または `node_keys` diagnostics error | `id_method:` や `node_key_resolver:` など、安定したkey strategyを選ぶ |
+| DOM ID collision | 実画面と同じ `UiConfig` での `render_state.validate_unique_dom_ids!` または `dom_ids` diagnostics error | `node_prefix`、custom DOM ID builder、ブラウザ向けIDへ正規化したときに衝突するnode keyを直す |
+| orphaned record | filter、import、permission scope後の `tree.orphan_items` または `orphans` diagnostics warning | `:raise`、`:as_root`、orphan-only表示、または意図したfiltered subsetとして文書化するかを決める |
+| cycle risk | parent relationship に対する `TreeView::CycleDiagnostics.new(tree).report` または `cycles` diagnostics error | 描画前にimport data / user編集可能な親子data、またはcycleを作るresolver logicを修正する |
+
+このnoteはreview aidであり、production validation UIの代替ではありません。修復文言、dashboard、alert、data repair workflow、release gateはhost app側、または専用quality workで扱ってください。
+
 ## node key uniqueness
 
 node keyの重複を検出したい場合は、tree作成時にvalidationを有効にします。

--- a/docs/ja/tree-diagnostics.md
+++ b/docs/ja/tree-diagnostics.md
@@ -74,20 +74,7 @@ end
 
 `Result#success?` は収集されたerrorsだけを見ます。orphan reportはwarningsとして返るため、filter、import、permission scopeによって描画対象外のrecordsが生じる可能性がある場合は `warnings` も確認してください。
 
-manifest-backed な diagnostics contract は、accepted check names と `Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
-
-## 描画前validation review note
-
-full static mockup page を増やさずに diagnostics flow をレビューしたい場合は、この比較表を使ってください。TreeView が出せるsignalと、host appが決めるcorrection policyを分けて見るためのfocused noteです。
-
-| Review state | TreeView側で確認するsignal | Host app側で決めること |
-|---|---|---|
-| duplicate node key | 描画前の `validate_node_keys: true` または `node_keys` diagnostics error | `id_method:` や `node_key_resolver:` など、安定したkey strategyを選ぶ |
-| DOM ID collision | 実画面と同じ `UiConfig` での `render_state.validate_unique_dom_ids!` または `dom_ids` diagnostics error | `node_prefix`、custom DOM ID builder、ブラウザ向けIDへ正規化したときに衝突するnode keyを直す |
-| orphaned record | filter、import、permission scope後の `tree.orphan_items` または `orphans` diagnostics warning | `:raise`、`:as_root`、orphan-only表示、または意図したfiltered subsetとして文書化するかを決める |
-| cycle risk | parent relationship に対する `TreeView::CycleDiagnostics.new(tree).report` または `cycles` diagnostics error | 描画前にimport data / user編集可能な親子data、またはcycleを作るresolver logicを修正する |
-
-このnoteはreview aidであり、production validation UIの代替ではありません。修復文言、dashboard、alert、data repair workflow、release gateはhost app側、または専用quality workで扱ってください。
+manifest-backed な diagnostics contract は、accepted check names、`TreeView::Diagnostics.run` の option key surface、`Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。run option keys は `checks` と `raise_errors` で、`checks:` は accepted check names から実行対象を選び、`raise_errors:` は失敗を `Result` に収集するか即座に例外としてraiseするかを選びます。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、accepted value schema、boolean coercion、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
 
 ## node key uniqueness
 

--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -83,6 +83,12 @@ const diagnosticsAcceptedCheckSignals = [
   "cycles"
 ]
 
+const diagnosticsRunOptionSignals = [
+  "run_options",
+  "checks",
+  "raise_errors"
+]
+
 const diagnosticsResultSurfaceSignals = [
   "checks",
   "errors",
@@ -116,6 +122,7 @@ const manifestBackedDocsSignalSurfaces = [
   ["empty-state hooks", "empty_state_hooks:"],
   ["diagnostics accepted checks", "diagnostics:"],
   ["diagnostics accepted checks", "accepted_checks:"],
+  ["diagnostics run options", "run_options:"],
   ["diagnostics Result surface", "result_surface:"]
 ]
 
@@ -129,6 +136,10 @@ callbackBuilderSignals.forEach((signal) => {
 
 diagnosticsAcceptedCheckSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest diagnostics accepted checks")
+})
+
+diagnosticsRunOptionSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics run options")
 })
 
 diagnosticsResultSurfaceSignals.forEach((signal) => {
@@ -194,10 +205,15 @@ selectionDocs.forEach(([relativePath, document]) => {
 diagnosticsDocs.forEach(([relativePath, document]) => {
   assertIncludes(document, "TreeView::Diagnostics.run", `${relativePath} diagnostics aggregate entrypoint docs`)
   assertIncludes(document, "checks:", `${relativePath} diagnostics accepted checks docs`)
+  assertIncludes(document, "raise_errors:", `${relativePath} diagnostics run option docs`)
   assertIncludes(document, "Result", `${relativePath} diagnostics Result surface docs`)
 
   diagnosticsAcceptedCheckSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} diagnostics accepted check docs`)
+  })
+
+  diagnosticsRunOptionSignals.slice(1).forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics run option docs`)
   })
 
   diagnosticsResultSurfaceSignals.forEach((signal) => {
@@ -207,6 +223,11 @@ diagnosticsDocs.forEach(([relativePath, document]) => {
   assert(
     /manifest-backed.*diagnostics contract|manifest-backed な diagnostics contract/.test(document),
     `${relativePath}: diagnostics docs no longer identify the manifest-backed contract boundary`
+  )
+
+  assert(
+    /run option key surface|option key surface/.test(document),
+    `${relativePath}: diagnostics docs no longer identify the run option key surface boundary`
   )
 
   assert(

--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -33,6 +33,10 @@ const diagnosticsDocs = [
   ["docs/en/tree-diagnostics.md", read("docs/en/tree-diagnostics.md")],
   ["docs/ja/tree-diagnostics.md", read("docs/ja/tree-diagnostics.md")]
 ]
+const pathTreeBuilderDocs = [
+  ["docs/en/path-tree-builder.md", read("docs/en/path-tree-builder.md")],
+  ["docs/ja/path-tree-builder.md", read("docs/ja/path-tree-builder.md")]
+]
 const developmentDocs = [
   ["docs/en/development.md", read("docs/en/development.md")],
   ["docs/ja/development.md", read("docs/ja/development.md")]
@@ -96,6 +100,19 @@ const diagnosticsResultSurfaceSignals = [
   "success?"
 ]
 
+const pathTreeBuilderNodeShapeSignals = [
+  "FolderNode",
+  "RecordNode",
+  "key",
+  "parent_key",
+  "label",
+  "path",
+  "node_type",
+  "record",
+  "folder_node?",
+  "record_node?"
+]
+
 const developmentManifestTrackingSignals = [
   "config/public_api_manifest.yml",
   "RenderState callback builder keys",
@@ -123,7 +140,8 @@ const manifestBackedDocsSignalSurfaces = [
   ["diagnostics accepted checks", "diagnostics:"],
   ["diagnostics accepted checks", "accepted_checks:"],
   ["diagnostics run options", "run_options:"],
-  ["diagnostics Result surface", "result_surface:"]
+  ["diagnostics Result surface", "result_surface:"],
+  ["PathTreeBuilder node shapes", "path_tree_builder_node_shapes:"]
 ]
 
 manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
@@ -144,6 +162,10 @@ diagnosticsRunOptionSignals.forEach((signal) => {
 
 diagnosticsResultSurfaceSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest diagnostics Result surface")
+})
+
+pathTreeBuilderNodeShapeSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest PathTreeBuilder node shape surface")
 })
 
 assertIncludes(manifest, "event_names_without_detail", "public API manifest no-detail event surface")
@@ -233,6 +255,24 @@ diagnosticsDocs.forEach(([relativePath, document]) => {
   assert(
     /individual error entry internals|warning detail shape|orphan warning semantics|cycle validation policy|個々の error entry 内部|warning detail shape|orphan warning semantics|cycle validation policy/.test(document),
     `${relativePath}: diagnostics docs no longer keep detailed error and warning shapes outside the manifest schema`
+  )
+})
+
+pathTreeBuilderDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeView::PathTreeBuilder", `${relativePath} PathTreeBuilder docs`)
+
+  pathTreeBuilderNodeShapeSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} PathTreeBuilder node shape docs`)
+  })
+
+  assert(
+    /public API manifest|public API manifest/.test(document),
+    `${relativePath}: PathTreeBuilder docs no longer identify the manifest-backed node shape contract`
+  )
+
+  assert(
+    /folder key generation strategy|sort algorithm|file-manager behavior|row action design|folder key generation strategy|sort algorithm|file-manager behavior|row action design/.test(document),
+    `${relativePath}: PathTreeBuilder docs no longer keep generated-key, sorting, file-manager, and row-action behavior outside the node shape contract`
   )
 })
 

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "psych"
+require "tree_view/diagnostics"
 require "tree_view/resource_table_render_state"
 require "yaml"
 
@@ -88,6 +89,28 @@ RSpec.describe "Public API manifest structure" do
       expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
       expect(keys).to all(be_a(String))
     end
+  end
+
+  it "keeps diagnostics sections shaped as explicit public contract lists" do
+    diagnostics = manifest.fetch("diagnostics")
+
+    expect(diagnostics.fetch("accepted_checks")).to all(be_a(String))
+    expect(diagnostics.fetch("accepted_checks")).not_to be_empty
+    expect(diagnostics.fetch("run_options")).to all(be_a(String))
+    expect(diagnostics.fetch("run_options")).not_to be_empty
+    expect(diagnostics.fetch("result_surface").fetch("attributes")).to all(be_a(String))
+    expect(diagnostics.fetch("result_surface").fetch("methods")).to all(be_a(String))
+  end
+
+  it "keeps diagnostics run option keys synchronized with the public runtime entrypoint" do
+    diagnostics = manifest.fetch("diagnostics")
+    parameters = TreeView::Diagnostics.method(:run).parameters
+    parameters_by_kind = parameters.group_by(&:first)
+    keyword_names = parameters_by_kind.fetch(:key, []).map(&:last).map(&:to_s)
+
+    expect(keyword_names).to include("tree", "render_state")
+    expect(diagnostics.fetch("run_options")).to eq(%w[checks raise_errors])
+    expect(keyword_names & diagnostics.fetch("run_options")).to eq(diagnostics.fetch("run_options"))
   end
 
   it "keeps resource table render state keyword sections shaped as non-empty string lists" do


### PR DESCRIPTION
Diagnostics.run の公開 option key surface を latest main 起点で再提案します。

Closes #1722
Supersedes #1745

## 置き換え理由

PR #1745 は current `main` から `behind_by:3` / `status:diverged` になっていました。既存 branch を force update せず、latest `main` `4b859c83c5276eafea464a354eba3dd3550f061e` を親にした replacement branch で #1722 の scoped diff だけを再適用しています。

## 変更内容

- `config/public_api_manifest.yml` の `diagnostics` section に `run_options` を追加し、`checks` / `raise_errors` を記録しました。
- `spec/public_api_manifest_structure_spec.rb` に diagnostics section shape と `TreeView::Diagnostics.run` runtime keyword surface の同期確認を追加しました。
- 英日 `docs/*/tree-diagnostics.md` で、manifest-backed diagnostics contract が accepted check names / run option keys / Result reader surface までであることを明記しました。
- `script/test_public_api_docs_signals.mjs` に `run_options` と `raise_errors:` の docs signal を追加しました。

## 受け入れ条件との対応

- manifest から `diagnostics.run_options` として `checks` / `raise_errors` が読めます。
- `TreeView::Diagnostics.run` の public keyword surface と manifest の `run_options` が focused spec で確認されます。
- docs で `checks:` / `raise_errors:`、accepted check names、Result reader surface の責務差が読めます。
- error entry internals、warning detail shape、orphan warning semantics、cycle validation policy は manifest に含めない境界を維持しています。

## 変更範囲

- `config/public_api_manifest.yml`
- `docs/en/tree-diagnostics.md`
- `docs/ja/tree-diagnostics.md`
- `script/test_public_api_docs_signals.mjs`
- `spec/public_api_manifest_structure_spec.rb`

Diagnostics runtime behavior、accepted value schema、boolean coercion、error / warning payload shape、cycle validation policy、public API manifest schema 全体は変更していません。

## 実施した確認

- PR #1745 の review follow-up コメントと current compare を確認しました。
- compare `main...feature/1722-diagnostics-run-options` が changed files 5件に閉じていることを確認しました。
- replacement commit は latest `main` `4b859c83c5276eafea464a354eba3dd3550f061e` を親にしています。
- local checkout / local RSpec / npm scripts は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認します。

## リスク

medium。manifest-backed public contract を少し広げますが、option key surface だけに限定し、runtime behavior や detail schema は固定していません。

## 未対応・補足

- `raise_errors:` の value schema や例外 policy の変更は行っていません。
- diagnostics dashboard、production workflow、manifest schema redesign には広げていません。
- `raise_errors:` を manifest-backed run option surface として固定する採用判断は human review に残します。