### PR TITLE
docs signal smoke に performance / ownership 境界を追加する

### DIFF
--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -352,6 +352,80 @@ const signalGroups = [
         ]
       ]
     ]
+  },
+  {
+    feature: "GraphAdapter ActiveRecord performance guidance",
+    files: [
+      [
+        "docs/en/graph-adapter.md",
+        [
+          "Materialize children before returning them from the resolver",
+          "children_by_project_id",
+          "includes(:latest_version).to_a",
+          "Cookbook: GraphAdapter and ActiveRecord performance"
+        ]
+      ],
+      [
+        "docs/ja/graph-adapter.md",
+        [
+          "resolver から返す children を事前に materialize",
+          "children_by_project_id",
+          "includes(:latest_version).to_a",
+          "Cookbook: GraphAdapter と ActiveRecord の性能"
+        ]
+      ],
+      [
+        "docs/en/cookbook.md",
+        [
+          "GraphAdapter and ActiveRecord performance",
+          "avoid returning lazy relations from `children_resolver`",
+          "Materialize parent records with `to_a`",
+          "Return arrays, not ActiveRecord relations, from `children_resolver`",
+          "Cache child collections by parent id in the host app",
+          "Do not run DB queries or expensive permission/version checks inside row partials"
+        ]
+      ],
+      [
+        "docs/ja/cookbook.md",
+        [
+          "GraphAdapter と ActiveRecord の性能",
+          "`children_resolver` から lazy な relation を返さない",
+          "親recordを `to_a` で確定する",
+          "ActiveRecord relation ではなく配列を返す",
+          "children cache を host app 側で作る",
+          "row partial 内で DB query や高コストな権限・version判定をしない"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Resource table bridge ownership signal",
+    files: [
+      [
+        "docs/en/resource-table-bridge.md",
+        [
+          "ResourceTableRenderState.call",
+          "The required keywords are `records:` and `context:`",
+          "Other keyword options are accepted through `**render_options`",
+          "TreeView owns tree structure and hierarchical row rendering",
+          "Rails Table Preferences owns column inference, labels, saved table state, and preference UI",
+          "The host app can override partials for presentation, queries, authorization, and business behavior",
+          "resource-table-bridge.html"
+        ]
+      ],
+      [
+        "docs/ja/resource-table-bridge.md",
+        [
+          "ResourceTableRenderState.call",
+          "required keyword は `records:` と `context:`",
+          "その他の keyword option は `**render_options` として受け取り",
+          "TreeView: tree構造と階層行の描画",
+          "Rails Table Preferences: カラム推論、ラベル解決、保存済みtable state、preference UI",
+          "host app: 必要に応じたpartial差し替え、query、認可、業務処理",
+          "resource-table-bridge.html"
+        ]
+      ]
+    ]
   }
 ]
 


### PR DESCRIPTION
## 対応 Issue

Closes #1753
Closes #1742

## Issue ごとの完了内容

- #1753
  - GraphAdapter docs と Cookbook の ActiveRecord performance guidance について、materialized children、`children_resolver` の array boundary、host-app-owned cache / query planning / row partial DB query 回避の代表 signal を guard しました。
- #1742
  - Resource table bridge docs について、`ResourceTableRenderState.call`、required / optional keyword boundary、`**render_options` pass-through、TreeView / table layer / host app の ownership split、mockup導線の代表 signal を guard しました。

## 変更内容

- `script/test_docs_entrypoint_signals.mjs` に docs signal group を2つ追加しました。
- 既存 docs の representative signal を確認するだけで、docs prose、runtime Ruby / JavaScript、public API manifest、mockup HTML は変更していません。

## 改善カテゴリ

- test
- docs guard
- drift prevention

## 既存仕様への影響

既存仕様への影響はありません。既に存在する docs signal を軽量 smoke で守るだけです。GraphAdapter traversal semantics、ResourceTableRenderState API、public manifest schema、runtime behavior、DB、認可、外部APIは変更していません。

## 実施した確認

- Issue labels を個別確認しました。
  - #1753: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
  - #1742: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
- branch freshness: latest `main` `16a1ba12df9fd65a96ea0e72d115090490f1a9d5` から作成し、compare で `behind_by:0` を確認しました。
- diff scope: 1 file only (`script/test_docs_entrypoint_signals.mjs`)。
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認します。

## リスク評価

low。既存 docs signal の assertion 追加のみで、失敗時も docs drift を検出する範囲に閉じています。

## 補足事項

2件とも docs/test-only かつ既存 docs の代表境界を守る同系統の quality issue のため、1つの PR にまとめています。