### PR TITLE
docs同梱ファイル変更時に gem package guard を走らせる

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -44,6 +44,9 @@ function isDocsOnlyPath(file) {
 
 function isPackageSensitivePath(file) {
   return (
+    file === "README.md" ||
+    file === "CHANGELOG.md" ||
+    file.startsWith("docs/") ||
     file === "tree_view.gemspec" ||
     file === "package.json" ||
     file === "package-lock.json" ||

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -3,8 +3,19 @@ import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
 
 const cases = [
   {
-    name: "root and language docs stay docs-only",
-    files: ["README.md", "docs/en/development.md", "docs/ja/development.md", "Product Profile.md", "CHANGELOG.md", "AGENTS.md"],
+    name: "gem-packaged docs stay docs-only and request package guard",
+    files: ["README.md", "docs/en/development.md", "docs/ja/development.md", "CHANGELOG.md"],
+    expected: {
+      docs_only: true,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false
+    }
+  },
+  {
+    name: "repository-only docs stay docs-only without package guard",
+    files: ["Product Profile.md", "AGENTS.md"],
     expected: {
       docs_only: true,
       mockups_changed: false,
@@ -14,13 +25,13 @@ const cases = [
     }
   },
   {
-    name: "mockup docs remain docs-only but request browser smoke",
+    name: "mockup docs remain docs-only but request browser smoke and package guard",
     files: ["docs/mockups/default-tree.html"],
     expected: {
       docs_only: true,
       mockups_changed: true,
       browser_smoke_changed: false,
-      package_sensitive: false,
+      package_sensitive: true,
       docker_setup_sensitive: false
     }
   },


### PR DESCRIPTION
## 対応 Issue

Closes #1757

## Issue ごとの完了内容

- #1757: gem に同梱される docs 変更時だけ `package_sensitive: true` になるようにし、既存 `gem_package` job が docs-only PR でも package contents guard / forbidden packaged-doc link guard を実行できるようにしました。

## 変更内容

- `script/ci_changed_files_policy.mjs`
  - `README.md`、`CHANGELOG.md`、`docs/**` を package-sensitive path に追加しました。
  - `Product Profile.md` と `AGENTS.md` は repository-only docs として package-sensitive にはしていません。
- `script/test_ci_changed_files_policy.mjs`
  - gem-packaged docs と repository-only docs の期待値を分けました。
  - mockup docs が `docs_only: true` / `mockups_changed: true` / `package_sensitive: true` を両立することを固定しました。

## 改善カテゴリ

- CI
- test
- package guard
- docs packaging safety

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、gemspec file list、package contents checker本体は変更していません。
- `docs_only: true` は維持しているため、docs-only PR の Rails matrix skip 方針は変えていません。
- 既存の `gem_package` job 条件をそのまま利用し、新しい job は追加していません。

## 実施した確認

- Issue labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch freshness: latest `main` `e1466c3aa1e6243259898df5d60ea3d1940bee0d` 起点で作成し、compare `behind_by:0` を確認しました。
- diff scope: 2 files only (`script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs`)。
- local equivalent check: `node --input-type=module` で 8 CI changed-file policy cases を確認しました。
- repository checkout はこの環境の GitHub HTTPS 制限のため未実行です。PR CI を確認します。

## リスク評価

low。docs-only skip 方針を保ったまま、gem に同梱される docs 変更時の package guard 実行対象だけを広げる変更です。

## 補足事項

- `tree_view.gemspec` の package file list redesign、full-site link checker、release automation、RubyGems publish flow、package-root JavaScript artifact guardには広げていません。