### PR TITLE
PathTreeBuilder node shape docs signal を smoke で守る

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -33,6 +33,10 @@ const diagnosticsDocs = [
   ["docs/en/tree-diagnostics.md", read("docs/en/tree-diagnostics.md")],
   ["docs/ja/tree-diagnostics.md", read("docs/ja/tree-diagnostics.md")]
 ]
+const pathTreeBuilderDocs = [
+  ["docs/en/path-tree-builder.md", read("docs/en/path-tree-builder.md")],
+  ["docs/ja/path-tree-builder.md", read("docs/ja/path-tree-builder.md")]
+]
 const developmentDocs = [
   ["docs/en/development.md", read("docs/en/development.md")],
   ["docs/ja/development.md", read("docs/ja/development.md")]
@@ -90,6 +94,19 @@ const diagnosticsResultSurfaceSignals = [
   "success?"
 ]
 
+const pathTreeBuilderNodeShapeSignals = [
+  "FolderNode",
+  "RecordNode",
+  "key",
+  "parent_key",
+  "label",
+  "path",
+  "node_type",
+  "record",
+  "folder_node?",
+  "record_node?"
+]
+
 const developmentManifestTrackingSignals = [
   "config/public_api_manifest.yml",
   "RenderState callback builder keys",
@@ -116,7 +133,8 @@ const manifestBackedDocsSignalSurfaces = [
   ["empty-state hooks", "empty_state_hooks:"],
   ["diagnostics accepted checks", "diagnostics:"],
   ["diagnostics accepted checks", "accepted_checks:"],
-  ["diagnostics Result surface", "result_surface:"]
+  ["diagnostics Result surface", "result_surface:"],
+  ["PathTreeBuilder node shapes", "path_tree_builder_node_shapes:"]
 ]
 
 manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
@@ -133,6 +151,10 @@ diagnosticsAcceptedCheckSignals.forEach((signal) => {
 
 diagnosticsResultSurfaceSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest diagnostics Result surface")
+})
+
+pathTreeBuilderNodeShapeSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest PathTreeBuilder node shape surface")
 })
 
 assertIncludes(manifest, "event_names_without_detail", "public API manifest no-detail event surface")
@@ -212,6 +234,24 @@ diagnosticsDocs.forEach(([relativePath, document]) => {
   assert(
     /individual error entry internals|warning detail shape|orphan warning semantics|cycle validation policy|個々の error entry 内部|warning detail shape|orphan warning semantics|cycle validation policy/.test(document),
     `${relativePath}: diagnostics docs no longer keep detailed error and warning shapes outside the manifest schema`
+  )
+})
+
+pathTreeBuilderDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeView::PathTreeBuilder", `${relativePath} PathTreeBuilder docs`)
+
+  pathTreeBuilderNodeShapeSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} PathTreeBuilder node shape docs`)
+  })
+
+  assert(
+    /public API manifest|public API manifest/.test(document),
+    `${relativePath}: PathTreeBuilder docs no longer identify the manifest-backed node shape contract`
+  )
+
+  assert(
+    /folder key generation strategy|sort algorithm|file-manager behavior|row action design|folder key generation strategy|sort algorithm|file-manager behavior|row action design/.test(document),
+    `${relativePath}: PathTreeBuilder docs no longer keep generated-key, sorting, file-manager, and row-action behavior outside the node shape contract`
   )
 })
 


### PR DESCRIPTION
## 対応 Issue

Closes #1760

## Issue ごとの完了内容

- #1760: `PathTreeBuilder` の manifest-backed node shape contract が docs signal smoke で確認されるようにしました。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に `path_tree_builder_node_shapes` の manifest surface 確認を追加しました。
- 英日 `docs/*/path-tree-builder.md` の `FolderNode` / `RecordNode` field・predicate signal を確認する guard を追加しました。
- folder key generation、sort algorithm、file-manager behavior、host-app row action design が contract 外である boundary signal も確認します。

## 改善カテゴリ

- test
- docs signal guard
- public contract docs drift prevention

## 既存仕様への影響

runtime Ruby / JavaScript、PathTreeBuilder behavior、public API manifest schema、docs prose は変更していません。既存 docs / manifest にある signal を軽量 smoke で守るだけです。

## 実施した確認

- Issue #1760 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- review follow-up 対象を確認し、人間判断・実ブラウザ確認・freshness待ちのPRは自動修正対象外としました。
- branch freshness: latest `main` `786eb4aa4a5e2e760461d40c4474224118fdef79` から branch 作成。
- compare `main...quality/1760-path-tree-builder-docs-signal`: `ahead_by:1`, `behind_by:0`, changed files 1件。
- PR metadata: `mergeable: true`。
- GitHub Actions CI #2291: success（`pr_specs`, `lint`, `javascript`, `pr_rails_matrix` など全対象 job green）。
- local checkout / local npm は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク評価

low。既存 manifest/docs signal の smoke 追加のみです。

## 補足事項

#1762 は同じ quality queue ですが browser smoke の大きな既存ファイル編集が必要なため、このPRには混ぜていません。