### PR TITLE
FAQ に Breadcrumb helper の records-mode 境界を追加する

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -73,6 +73,18 @@ See also:
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Host App Extension Points](host-app-extension-points.md)
 
+## Does TreeView infer breadcrumbs for resolver or adapter mode?
+
+No. The bundled breadcrumb helper uses a records-mode tree and `tree.path_for(item)` to walk from the current record back to a root. Resolver mode, adapter mode, and graph-like data may have more than one possible parent path, so TreeView does not guess which breadcrumb trail is correct.
+
+When the data comes from `GraphAdapter` or another graph-like source, let the host app choose the breadcrumb trail and render its own links or labels. Routes, authorization, layout placement, and analytics behavior stay in the host app.
+
+See also:
+
+- [Breadcrumb: Supported mode](breadcrumb.md#supported-mode)
+- [Troubleshooting: Breadcrumbs fail or cannot find a parent path](troubleshooting.md#breadcrumbs-fail-or-cannot-find-a-parent-path)
+- [GraphAdapter](graph-adapter.md)
+
 ## Why do rows look duplicated, disappear, or fail before rendering?
 
 Start with tree diagnostics before changing the row partial or JavaScript wiring. Duplicate node keys can make expansion and persisted state look unstable, orphan records can appear when filtering or permission scopes hide parents, DOM ID collisions can break browser-facing targets, and cycles can make parent-path traversal invalid.

--- a/docs/ja/faq.md
+++ b/docs/ja/faq.md
@@ -73,6 +73,18 @@ TreeView は host app の path builder を呼んだり、host app の row partia
 - [Rendering Boundaries](rendering-boundaries.md)
 - [Host App Extension Points](host-app-extension-points.md)
 
+## resolver mode や adapter mode でも TreeView が breadcrumb を推測しますか？
+
+いいえ。bundled breadcrumb helper は records mode の tree と `tree.path_for(item)` を使い、現在 record から root までの path を辿ります。resolver mode、adapter mode、graph-like data では親方向の候補が複数あり得るため、TreeView はどの breadcrumb trail が正しいかを推測しません。
+
+`GraphAdapter` や graph-like source の data では、host app 側で breadcrumb trail を選び、独自の link または label を描画してください。route、authorization、layout placement、analytics behavior も host app 側の責務です。
+
+関連:
+
+- [Breadcrumb: 対応mode](breadcrumb.md#対応mode)
+- [Troubleshooting: breadcrumb が失敗する / 親方向の path が見つからない](troubleshooting.md#breadcrumb-が失敗する--親方向の-path-が見つからない)
+- [GraphAdapter](graph-adapter.md)
+
 ## row が重複する / 消える / 描画前に失敗する場合はどこを見ますか？
 
 row partial や JavaScript wiring を変える前に tree diagnostics から確認してください。node key の重複は展開状態や persisted state を不安定に見せることがあり、filter や permission scope で親が隠れると orphan が出ます。DOM ID collision は browser 向け target を壊し、cycle は parent path traversal を不正にします。


### PR DESCRIPTION
## 対応 Issue

Closes #1769

## 判定分類

- `docs-sync`
- `docs-missing`（FAQ から Breadcrumb helper の records-mode boundary へ辿る短い Q&A が不足）

## 変更内容

- `docs/en/faq.md` に、resolver mode / adapter mode / graph-like data では TreeView が breadcrumb trail を推測しないことを説明する Q&A を追加しました。
- `docs/ja/faq.md` に同じ責務境界の日本語 Q&A を追加しました。
- Breadcrumb docs、Troubleshooting、GraphAdapter への導線を追加しました。

## 変更範囲

- docs only
- `docs/en/faq.md`
- `docs/ja/faq.md`

runtime Ruby / JavaScript、Breadcrumb helper API、public API manifest、mockup HTML、Troubleshooting 本文、Breadcrumb docs 本文は変更していません。

## 確認内容

- Issue #1769 と関連 docs / helper 実装を確認しました。
- `tree_view_breadcrumb` が `tree.path_for(item)` を使う records-mode path lookup であることを確認しました。
- `docs/en|ja/breadcrumb.md` と `docs/en|ja/troubleshooting.md` が supported mode / unsupported mode boundary を既に説明していることを確認しました。
- compare `main...docs/1769-breadcrumb-faq-boundary-v3`:
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs files
- local checkout / local docs smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 Breadcrumb helper behavior と既存 docs の境界を FAQ へ短く同期するだけで、仕様や実装は変更していません。