### PR TITLE
Decision guide に Breadcrumb 導線を追加する

### DIFF
--- a/docs/en/decision-guide.md
+++ b/docs/en/decision-guide.md
@@ -37,6 +37,7 @@ Use Turbo mode for lazy loading or children pagination. Client-side mode can onl
 | Add full virtual scrolling | Host-app JavaScript | Scroll observers, virtualization library, URL/window state | TreeView does not provide built-in DOM virtualization or infinite-scroll control. Combine it with render metadata only when useful. |
 | Show search results with ancestors | `path_tree_for` | `tree.path_tree_for(matches)` | Use when matched records need enough ancestors to preserve context from root to match. |
 | Show child-to-parent paths | `reverse_tree_for` | `tree.reverse_tree_for(items)` | Use when the primary display starts from children and expands toward parents. |
+| Render records-mode breadcrumbs | [Breadcrumb helper](breadcrumb.md) | `tree_view_breadcrumb`, `tree.path_for(item)`, `label_builder`, `path_builder` | Use when a records-mode detail screen needs a root-to-current path. If graph-like data has multiple possible parents, let the host app choose the trail. If path lookup fails, use [Troubleshooting](troubleshooting.md#breadcrumbs-fail-or-cannot-find-a-parent-path). |
 | Render heterogeneous or graph-like nodes | [API overview: adapter mode](api-overview.md#adapter-mode) | `TreeView::GraphAdapter`, `TreeView::Tree.new(adapter:)`, `children_resolver`, `node_key_resolver` | Use when one tree mixes different record classes or derives children from graph-like edges instead of one parent-id column. TreeView traverses roots and children supplied by the host app; data model, authorization, cycle policy, and persistence stay in the host app. |
 | Add checkbox selection | `selection:` options plus host-element `tree-view-selection` wiring | `enabled`, `checkbox_name`, `selected_keys`, `disabled_builder`, `disabled_reason_builder`, `visibility`, `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | Use grouped `selection:` options for row payload generation, disabled reasons, and checkbox visibility. Use the controller value attributes for hidden-input sync, client-side max-count limits, and rendered-row cascade / indeterminate behavior. TreeView renders selection state and values; the host app still owns the submitted business action. |
 | Add editable fields inside rows | [Forms and editing rows](form-editing.md) and [Cookbook](cookbook.md#row-customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Objects | TreeView supports inline-editing layouts. The host app owns edit mode, validation, persistence, authorization, dirty-state handling, and Turbo workflows. |
@@ -105,7 +106,7 @@ flowchart TD
 5. Use [GraphAdapter adapter mode](api-overview.md#adapter-mode) when the tree mixes different record classes or graph-like edges and cannot be represented cleanly by one parent-id column.
 6. Use `build_client_side` when the data is already available, initial HTML volume is acceptable, and Turbo endpoints would be unnecessary overhead.
 7. Add host-app virtual scrolling only when scroll-position-driven DOM virtualization is a product requirement.
-8. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Localized names](localized-names.md), [Toolbar helper](toolbar.md), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
+8. Add [Selection](selection.md), [Forms and editing rows](form-editing.md), [Cookbook row customization](cookbook.md#row-customization-quick-guide), [Localized names](localized-names.md), [Toolbar helper](toolbar.md), [Breadcrumb helper](breadcrumb.md), [Drag and Drop](drag-and-drop.md), or [Persisted State](persisted-state.md) when interaction and row customization requirements are clear.
 9. Use [Tree diagnostics](tree-diagnostics.md) when node keys, DOM IDs, or tree structure need validation.
 
 ## Common combinations
@@ -119,6 +120,7 @@ flowchart TD
 | Large scrolling browser | Host-app virtual scrolling + render/window metadata as needed |
 | Search page | `path_tree_for` + render scope around matches |
 | Breadcrumb-like reverse view | `reverse_tree_for` + custom row partial |
+| Records-mode detail breadcrumbs | Breadcrumb helper + host-app label/path builders |
 | Bulk action page | Static or Turbo rendering + `selection:` + host-app form action |
 | Bulk edit page | Static or Turbo rendering + row partial form controls + host-app Form Object |
 | Per-row inline edit page | Display row partials + `row_actions_partial` + host-app edit action / Turbo response + editing row partial |
@@ -136,6 +138,7 @@ flowchart TD
 - [Cookbook: Row customization quick guide](cookbook.md#row-customization-quick-guide)
 - [Localized names](localized-names.md)
 - [Toolbar helper](toolbar.md)
+- [Breadcrumb helper](breadcrumb.md)
 - [Toolbar actions mockup](../mockups/toolbar-actions.html)
 - [Render Scale](render-scale.md)
 - [Lazy Loading](lazy-loading.md)

--- a/docs/ja/decision-guide.md
+++ b/docs/ja/decision-guide.md
@@ -37,6 +37,7 @@ Lazy LoadingやChildren PaginationにはTurbo modeを使います。Client-side 
 | full virtual scrollingを追加したい | host app JavaScript | scroll observer、virtualization library、URL/window state | TreeViewは組み込みのDOM仮想化やinfinite-scroll制御を提供しません。必要に応じてrender metadataと組み合わせます。 |
 | 検索結果をancestor付きで表示したい | `path_tree_for` | `tree.path_tree_for(matches)` | matchしたrecordをrootからの文脈付きで表示したい場合に使います。 |
 | childからparentへ辿る表示をしたい | `reverse_tree_for` | `tree.reverse_tree_for(items)` | 子側を起点にして親方向へ展開する表示に使います。 |
+| records mode のbreadcrumbを描画したい | [Breadcrumb helper](breadcrumb.md) | `tree_view_breadcrumb`, `tree.path_for(item)`, `label_builder`, `path_builder` | records mode の詳細画面で root から現在nodeまでの path を出したい場合に使います。graph-like data や複数parent候補がある場合、trail の選択は host app 側で行います。path lookup が失敗する場合は [Troubleshooting](troubleshooting.md#breadcrumb-が失敗する--親方向の-path-が見つからない) を参照してください。 |
 | 異種node混在やgraph-like nodeを描画したい | [API概要: adapter mode](api-overview.md#adapter-mode) | `TreeView::GraphAdapter`, `TreeView::Tree.new(adapter:)`, `children_resolver`, `node_key_resolver` | 1つのparent id columnだけでは表しにくい、複数record class混在やgraph-like edge由来のtreeに使います。TreeViewはhost appが渡すrootとchildrenを辿ります。data model、authorization、cycle policy、保存はhost app側の責務です。 |
 | checkbox selectionを追加したい | `selection:` option と host element 上の `tree-view-selection` wiring | `enabled`, `checkbox_name`, `selected_keys`, `disabled_builder`, `disabled_reason_builder`, `visibility`, `data-tree-view-selection-hidden-input-name-value`, `data-tree-view-selection-max-count-value`, `data-tree-view-selection-cascade-value`, `data-tree-view-selection-indeterminate-value` | row payload 生成、disabled reason、checkbox visibility は grouped `selection:` option 側で決めます。hidden input sync、client-side の最大選択数制限、描画済み row の cascade / indeterminate は controller value attribute 側で設定します。TreeViewはselection stateとvalueを描画しますが、送信後の業務 action は引き続き host app が担当します。 |
 | 行内に編集fieldを置きたい | [Form と編集行](form-editing.md) と [Cookbook](cookbook.md#行customization-quick-guide) | `row_partial`, `row_actions_partial`, Rails `form_with`, `fields_for`, host-app Form Object | TreeViewはinline-editing layoutを支援します。edit mode、validation、persistence、authorization、dirty-state handling、Turbo workflowはhost appが担当します。 |
@@ -105,7 +106,7 @@ flowchart TD
 5. 1つのparent id columnだけでは扱いにくい異種recordやgraph-like edgeがある場合は [GraphAdapter adapter mode](api-overview.md#adapter-mode) を使います。
 6. dataは取得済みで、初期HTML量を許容でき、Turbo endpointが過剰な場合は `build_client_side` を使います。
 7. scroll位置に応じたDOM仮想化がproduct要件になった場合だけ、host app側でvirtual scrollingを追加します。
-8. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Localized names](localized-names.md)、[Toolbar helper](toolbar.md)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
+8. interaction要件やrow customization要件が固まったら [Selection](selection.md)、[Form と編集行](form-editing.md)、[Cookbook row customization](cookbook.md#行customization-quick-guide)、[Localized names](localized-names.md)、[Toolbar helper](toolbar.md)、[Breadcrumb helper](breadcrumb.md)、[Drag and Drop](drag-and-drop.md)、[Persisted State](persisted-state.md) を追加します。
 9. node key、DOM ID、tree構造を検証したい場合は [Tree diagnostics](tree-diagnostics.md) を使います。
 
 ## よくある組み合わせ
@@ -119,6 +120,7 @@ flowchart TD
 | 大きなscrolling browser | host app virtual scrolling + 必要に応じてrender/window metadata |
 | 検索ページ | `path_tree_for` + match周辺のrender scope |
 | breadcrumb風のreverse view | `reverse_tree_for` + custom row partial |
+| records mode の詳細画面breadcrumb | Breadcrumb helper + host-app label/path builders |
 | bulk action page | StaticまたはTurbo rendering + `selection:` + host-app form action |
 | bulk edit page | StaticまたはTurbo rendering + row partial form controls + host-app Form Object |
 | per-row inline edit page | 表示用row partial + `row_actions_partial` + host-app edit action / Turbo response + 編集用row partial |
@@ -136,6 +138,7 @@ flowchart TD
 - [Cookbook: 行customization quick guide](cookbook.md#行customization-quick-guide)
 - [Localized names](localized-names.md)
 - [Toolbar helper](toolbar.md)
+- [Breadcrumb helper](breadcrumb.md)
 - [Toolbar actions mockup](../mockups/toolbar-actions.html)
 - [Render Scale](render-scale.md)
 - [Lazy Loading](lazy-loading.md)
@@ -146,3 +149,4 @@ flowchart TD
 - [Drag and Drop](drag-and-drop.md)
 - [Persisted State](persisted-state.md)
 - [Tree diagnostics](tree-diagnostics.md)
+- [Troubleshooting](troubleshooting.md)


### PR DESCRIPTION
## 対応 Issue

Closes #1773

## 判定分類

- `docs-sync`
- `docs-stale`（Breadcrumb / Troubleshooting は整備済みだが、Decision guide からの導線が不足）

## 変更内容

- `docs/en/decision-guide.md` に Breadcrumb helper の use-case 行、推奨順、よくある組み合わせ、関連 docs 導線を追加しました。
- `docs/ja/decision-guide.md` に同等の日本語導線を追加しました。
- Breadcrumb path lookup が records mode 専用であること、graph-like data や複数 parent 候補では host app が trail を選ぶこと、失敗時は Troubleshooting を逆引き入口にすることを Decision guide 側から辿れるようにしました。

## 変更範囲

- docs only
- `docs/en/decision-guide.md`
- `docs/ja/decision-guide.md`

runtime Ruby / JavaScript、Breadcrumb helper API、Troubleshooting 本文、Breadcrumb docs 本文、FAQ 本文は変更していません。

## 確認内容

- latest main: `a7b65e7226cb64836e9df576c42c8b17ef501d6e`
- compare `main...docs/1773-decision-guide-breadcrumb-links`:
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: 2 docs files
- `docs/en|ja/breadcrumb.md` と `docs/en|ja/troubleshooting.md` の既存 records-mode / unsupported-mode boundary を確認しました。
- local checkout / local docs smoke は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 Breadcrumb / Troubleshooting docs への導線を Decision guide に同期するだけで、仕様や実装は変更していません。