### PR TITLE
Diagnostics.run option keys を latest main で再提案する

### DIFF
--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -170,6 +170,9 @@ diagnostics:
     - dom_ids
     - orphans
     - cycles
+  run_options:
+    - checks
+    - raise_errors
   result_surface:
     attributes:
       - checks

--- a/docs/en/tree-diagnostics.md
+++ b/docs/en/tree-diagnostics.md
@@ -74,7 +74,7 @@ end
 
 `Result#success?` only reflects collected errors. Orphan reports are warnings, so review `warnings` when filtered, imported, or permission-scoped data can leave records outside the rendered tree.
 
-The manifest-backed diagnostics contract covers the accepted check names and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
+The manifest-backed diagnostics contract covers the accepted check names, the `TreeView::Diagnostics.run` option key surface, and the `Result` reader surface. The stable check names are `node_keys`, `dom_ids`, `orphans`, and `cycles`. The run option keys are `checks` and `raise_errors`: `checks:` selects from the accepted check names, while `raise_errors:` selects whether failures are collected into a `Result` or raised immediately. A diagnostics `Result` exposes `checks`, `errors`, `warnings`, and `success?`. The manifest intentionally does not freeze accepted value schemas, boolean coercion, individual error entry internals, warning detail shape, orphan warning semantics, or cycle validation policy; those remain documented behavior and host-app data policy boundaries rather than a broader manifest schema.
 
 ## Pre-render validation review note
 

--- a/docs/ja/tree-diagnostics.md
+++ b/docs/ja/tree-diagnostics.md
@@ -74,7 +74,7 @@ end
 
 `Result#success?` は収集されたerrorsだけを見ます。orphan reportはwarningsとして返るため、filter、import、permission scopeによって描画対象外のrecordsが生じる可能性がある場合は `warnings` も確認してください。
 
-manifest-backed な diagnostics contract は、accepted check names と `Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
+manifest-backed な diagnostics contract は、accepted check names、`TreeView::Diagnostics.run` の option key surface、`Result` の reader surface を対象にします。stable な check names は `node_keys`、`dom_ids`、`orphans`、`cycles` です。run option keys は `checks` と `raise_errors` で、`checks:` は accepted check names から実行対象を選び、`raise_errors:` は失敗を `Result` に収集するか即座に例外としてraiseするかを選びます。diagnostics `Result` は `checks`、`errors`、`warnings`、`success?` を公開します。一方で、accepted value schema、boolean coercion、個々の error entry 内部、warning detail shape、orphan warning semantics、cycle validation policy までは manifest で固定しません。これらは documented behavior と host app data policy の境界として扱い、manifest schema を広げすぎないようにします。
 
 ## 描画前validation review note
 

--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -87,6 +87,12 @@ const diagnosticsAcceptedCheckSignals = [
   "cycles"
 ]
 
+const diagnosticsRunOptionSignals = [
+  "run_options",
+  "checks",
+  "raise_errors"
+]
+
 const diagnosticsResultSurfaceSignals = [
   "checks",
   "errors",
@@ -133,6 +139,7 @@ const manifestBackedDocsSignalSurfaces = [
   ["empty-state hooks", "empty_state_hooks:"],
   ["diagnostics accepted checks", "diagnostics:"],
   ["diagnostics accepted checks", "accepted_checks:"],
+  ["diagnostics run options", "run_options:"],
   ["diagnostics Result surface", "result_surface:"],
   ["PathTreeBuilder node shapes", "path_tree_builder_node_shapes:"]
 ]
@@ -147,6 +154,10 @@ callbackBuilderSignals.forEach((signal) => {
 
 diagnosticsAcceptedCheckSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest diagnostics accepted checks")
+})
+
+diagnosticsRunOptionSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics run options")
 })
 
 diagnosticsResultSurfaceSignals.forEach((signal) => {
@@ -216,10 +227,15 @@ selectionDocs.forEach(([relativePath, document]) => {
 diagnosticsDocs.forEach(([relativePath, document]) => {
   assertIncludes(document, "TreeView::Diagnostics.run", `${relativePath} diagnostics aggregate entrypoint docs`)
   assertIncludes(document, "checks:", `${relativePath} diagnostics accepted checks docs`)
+  assertIncludes(document, "raise_errors:", `${relativePath} diagnostics run option docs`)
   assertIncludes(document, "Result", `${relativePath} diagnostics Result surface docs`)
 
   diagnosticsAcceptedCheckSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} diagnostics accepted check docs`)
+  })
+
+  diagnosticsRunOptionSignals.slice(1).forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics run option docs`)
   })
 
   diagnosticsResultSurfaceSignals.forEach((signal) => {
@@ -229,6 +245,11 @@ diagnosticsDocs.forEach(([relativePath, document]) => {
   assert(
     /manifest-backed.*diagnostics contract|manifest-backed な diagnostics contract/.test(document),
     `${relativePath}: diagnostics docs no longer identify the manifest-backed contract boundary`
+  )
+
+  assert(
+    /run option key surface|option key surface/.test(document),
+    `${relativePath}: diagnostics docs no longer identify the run option key surface boundary`
   )
 
   assert(

--- a/spec/public_api_manifest_structure_spec.rb
+++ b/spec/public_api_manifest_structure_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "psych"
+require "tree_view/diagnostics"
 require "tree_view/resource_table_render_state"
 require "yaml"
 
@@ -88,6 +89,28 @@ RSpec.describe "Public API manifest structure" do
       expect(keys).not_to be_empty, "expected grouped_option_keys.#{group_name} to list public keys"
       expect(keys).to all(be_a(String))
     end
+  end
+
+  it "keeps diagnostics sections shaped as explicit public contract lists" do
+    diagnostics = manifest.fetch("diagnostics")
+
+    expect(diagnostics.fetch("accepted_checks")).to all(be_a(String))
+    expect(diagnostics.fetch("accepted_checks")).not_to be_empty
+    expect(diagnostics.fetch("run_options")).to all(be_a(String))
+    expect(diagnostics.fetch("run_options")).not_to be_empty
+    expect(diagnostics.fetch("result_surface").fetch("attributes")).to all(be_a(String))
+    expect(diagnostics.fetch("result_surface").fetch("methods")).to all(be_a(String))
+  end
+
+  it "keeps diagnostics run option keys synchronized with the public runtime entrypoint" do
+    diagnostics = manifest.fetch("diagnostics")
+    parameters = TreeView::Diagnostics.method(:run).parameters
+    parameters_by_kind = parameters.group_by(&:first)
+    keyword_names = parameters_by_kind.fetch(:key, []).map(&:last).map(&:to_s)
+
+    expect(keyword_names).to include("tree", "render_state")
+    expect(diagnostics.fetch("run_options")).to eq(%w[checks raise_errors])
+    expect(keyword_names & diagnostics.fetch("run_options")).to eq(diagnostics.fetch("run_options"))
   end
 
   it "keeps resource table render state keyword sections shaped as non-empty string lists" do


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1722
Supersedes #1755
Supersedes #1745

## 置き換え理由

PR #1755 は current `main` 進行後に `mergeable:false` のまま残っていました。競合原因は `script/test_public_api_docs_signals.mjs` に current main 側の PathTreeBuilder docs signal guard が追加された一方、#1755 側でも diagnostics run option signal guard を追加していたことです。

旧 branch へ diagnostics guard と current-main guard を合成する follow-up commit を追加しましたが、GitHub の mergeability は回復しなかったため、force update せず current `main` 起点の clean replacement branch として再提案します。

## 変更内容

- `config/public_api_manifest.yml` の `diagnostics` section に `run_options` を追加し、`checks` / `raise_errors` を記録しました。
- `spec/public_api_manifest_structure_spec.rb` に diagnostics section shape と `TreeView::Diagnostics.run` runtime keyword surface の同期確認を追加しました。
- 英日 `docs/*/tree-diagnostics.md` で、manifest-backed diagnostics contract が accepted check names / run option keys / Result reader surface までであることを明記しました。
- `script/test_public_api_docs_signals.mjs` に `run_options` と `raise_errors:` の docs signal を追加しました。
- current main の PathTreeBuilder docs signal guard は保持しています。

## 受け入れ条件との対応

- manifest から `diagnostics.run_options` として `checks` / `raise_errors` が読めます。
- `TreeView::Diagnostics.run` の public keyword surface と manifest の `run_options` が focused spec で確認されます。
- docs で `checks:` / `raise_errors:`、accepted check names、Result reader surface の責務差が読めます。
- error entry internals、warning detail shape、orphan warning semantics、cycle validation policy は manifest に含めない境界を維持しています。

## 変更範囲

- `config/public_api_manifest.yml`
- `docs/en/tree-diagnostics.md`
- `docs/ja/tree-diagnostics.md`
- `script/test_public_api_docs_signals.mjs`
- `spec/public_api_manifest_structure_spec.rb`

Diagnostics runtime behavior、accepted value schema、boolean coercion、error / warning payload shape、cycle validation policy、public API manifest schema 全体は変更していません。

## 確認内容

- 対象4リポジトリの open PR を古い順に確認し、現在の conflict 対象は tree_view-rails #1755 のみでした。
- #1755 の変更ファイルと current main 側の更新を確認し、重複更新は `script/test_public_api_docs_signals.mjs` の docs signal guard であることを確認しました。
- compare `main...refresh/1755-diagnostics-run-options-current-main-v2` は changed files 5件に閉じています。
- local checkout / local RSpec / npm scripts は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認します。

## リスク

medium。manifest-backed public contract を少し広げますが、option key surface だけに限定し、runtime behavior や detail schema は固定していません。

## 未対応・補足

- `raise_errors:` の value schema や例外 policy の変更は行っていません。
- diagnostics dashboard、production workflow、manifest schema redesign には広げていません。
- `raise_errors:` を manifest-backed run option surface として固定する採用判断は human review に残します。