### PR TITLE
docs smoke の lifecycle / direction-aware signal を強化する

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -59,6 +59,16 @@ const hostLifecycleSignals = [
   "TreeViewEventDetailKeys"
 ]
 
+const lazyLoadingHostLifecycleSignals = [
+  "TreeViewEventNames.hostLifecycle",
+  "tree-view:loading",
+  "tree-view:loaded",
+  "tree-view:error",
+  "tree-view:retry",
+  "TreeViewEventNames.remoteState",
+  "TreeViewRemoteStateValues"
+]
+
 const remoteStateValueSignals = [
   "TreeViewRemoteStateValues",
   "loading",
@@ -204,6 +214,20 @@ lazyLoadingDocs.forEach(([relativePath, document]) => {
   assert(
     /not event names|event 名ではありません/.test(document),
     `${relativePath}: remote-state value docs no longer separate state values from event names`
+  )
+
+  lazyLoadingHostLifecycleSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} host lifecycle event reader-journey docs`)
+  })
+
+  assert(
+    /The host app can dispatch these events|host app側は、fetchやTurbo requestの状態に応じてこれらのeventをdispatchできます/.test(document),
+    `${relativePath}: Lazy Loading docs no longer say host apps dispatch the lifecycle events`
+  )
+
+  assert(
+    /separate surface|別 surface/.test(document),
+    `${relativePath}: Lazy Loading docs no longer separate host lifecycle events from remote-state controller events`
   )
 })
 

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -208,6 +208,18 @@ test.describe("docs mockup browser smoke", () => {
     })
   }
 
+  test("direction-aware-cues/index.html preserves LTR, RTL, and vertical representative regions", async ({ page }) => {
+    await openMockup(page, "direction-aware-cues/index.html")
+
+    await expect(page.getByRole("heading", { name: "LTR baseline" })).toBeVisible()
+    await expect(page.locator("[aria-label='LTR baseline tree sample'] .tree-row.is-selected")).toBeVisible()
+    await expect(page.getByRole("heading", { name: "RTL host-app override" })).toBeVisible()
+    await expect(page.locator("[aria-label='RTL override tree sample'][dir='rtl'] .tree-row.is-selected")).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Vertical writing stress case" })).toBeVisible()
+    await expect(page.locator("[aria-label='Vertical writing tree sample'].direction-frame--vertical .tree-row.is-selected")).toBeVisible()
+    await expect(page.locator("[aria-label='Vertical writing tree sample'].direction-frame--vertical")).toHaveCSS("writing-mode", "vertical-rl")
+  })
+
   test("toolbar-actions.html preserves action and responsibility boundary signals", async ({ page }) => {
     await openMockup(page, "toolbar-actions.html")
 


### PR DESCRIPTION
## 対応 Issue

Closes #1455
Closes #1776

## Issue ごとの完了内容

- #1455: direction-aware mockup について、既存の row count smoke に加えて LTR / RTL / vertical writing の代表領域を明示的に確認する browser smoke を追加しました。
- #1776: Lazy Loading guide 側の host lifecycle event surface を、Public API docs signal とは別の reader journey signal として軽量 smoke で確認するようにしました。

## 変更内容

- `test/browser/docs_mockups_smoke.spec.js`
  - `direction-aware-cues/index.html` の LTR / RTL / vertical representative regions を dedicated test で確認します。
  - `dir="rtl"` frame と `writing-mode: vertical-rl` stress sample が消えた場合に検出できるようにしています。
- `script/test_public_api_docs_signals.mjs`
  - 英日 Lazy Loading docs の `TreeViewEventNames.hostLifecycle`、`tree-view:loading` / `loaded` / `error` / `retry`、host app dispatch boundary、`TreeViewEventNames.remoteState.*` との分離、`TreeViewRemoteStateValues` への導線を確認します。

## 改善カテゴリ

- test
- docs smoke
- browser smoke

## 既存仕様への影響

- runtime Ruby / JavaScript behavior は変更していません。
- public API manifest、package-root export、TypeScript declaration、event name、event detail payload、remote-state controller behavior は変更していません。
- mockup HTML / CSS / visual design は変更していません。

## 実施した確認

- Issue #1455 / #1776 の labels を個別確認しました。
  - `status:ready-for-agent`
  - `agent:planned`
  - `track:quality`
  - `risk:low`
- branch freshness: current `main` `a7b65e7226cb64836e9df576c42c8b17ef501d6e` から branch を作成し、compare で `behind_by: 0` を確認しました。
- diff scope: 2 files only。
  - `script/test_public_api_docs_signals.mjs`
  - `test/browser/docs_mockups_smoke.spec.js`
- local checkout / local npm test は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク評価

low。既存 docs / mockup の代表 signal を追加で守る test-only 変更です。文言変更や runtime 変更には広げていません。

## 補足事項

- #1776 は Lazy Loading guide の reader journey signal に閉じ、#1774 の Decision guide smoke とは混ぜていません。
- #1455 は direction-aware page 固有の構造 signal に閉じ、complete RTL support や visual regression baseline には広げていません。