### PR TITLE
lazy-loading handoff mockup の helper 境界を明確にする

### DIFF
--- a/docs/mockups/lazy-loading-handoff.html
+++ b/docs/mockups/lazy-loading-handoff.html
@@ -54,6 +54,59 @@
   margin: 0;
 }
 
+.handoff-map {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.handoff-map th,
+.handoff-map td {
+  padding: 0.72rem 0.8rem;
+  border-bottom: 1px solid #e4e7eb;
+  text-align: left;
+  vertical-align: top;
+}
+
+.handoff-map th {
+  background: #f1f5f9;
+  color: #334e68;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.handoff-map code,
+.handoff-flow code {
+  overflow-wrap: anywhere;
+}
+
+.handoff-flow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.handoff-flow__card {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid #d8e0ea;
+  background: #fff;
+}
+
+.handoff-flow__card h3,
+.handoff-flow__card p {
+  margin: 0;
+}
+
+.handoff-flow__label {
+  color: #52606d;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .handoff-boundary-list {
   margin: 0;
   padding-left: 1.2rem;
@@ -94,6 +147,61 @@
         <article class="handoff-note">
           <h3>Out of scope here</h3>
           <p>Requests, authorization, retries, cursor math, and final business copy are intentionally not represented as working behavior.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section" aria-labelledby="helper-map-heading">
+      <h2 id="helper-map-heading">Helper-to-region map</h2>
+      <table class="handoff-map">
+        <thead>
+          <tr>
+            <th scope="col">Guide helper</th>
+            <th scope="col">Rendered region</th>
+            <th scope="col">Host-app ownership</th>
+            <th scope="col">Review cue</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>tree_children_container_dom_id(node)</code></td>
+            <td>Stable children container such as <code>project_alpha_children</code>.</td>
+            <td>Turbo Stream, fetch, or server-rendered replacement decides which child rows appear.</td>
+            <td>The placeholder and final child rows should read as the same branch, not as a second tree.</td>
+          </tr>
+          <tr>
+            <td><code>tree_remote_state_placeholder_dom_id(node)</code></td>
+            <td>Status slot such as <code>project_alpha_remote_state</code>.</td>
+            <td>Loading, empty-after-load, error, retry, and final copy stay with the host app.</td>
+            <td>Remote-state copy should sit near the branch it explains without replacing the tree hierarchy cue.</td>
+          </tr>
+          <tr>
+            <td><code>tree_remote_state_placeholder_attributes(state:)</code></td>
+            <td>Data hook for values such as <code>loading</code>, <code>loaded</code>, or <code>error</code>.</td>
+            <td>The helper provides attributes; it does not validate app-specific states or implement retry policy.</td>
+            <td>The visible label can use host-app words while the data value remains a reviewable state cue.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mock-section" aria-labelledby="replacement-flow-heading">
+      <h2 id="replacement-flow-heading">Replacement flow reference</h2>
+      <div class="handoff-flow">
+        <article class="handoff-flow__card">
+          <p class="handoff-flow__label">Before request</p>
+          <h3>Reserved branch regions</h3>
+          <p>The parent row names both targets with <code>aria-controls</code>; the children container and remote-state slot can be present before data arrives.</p>
+        </article>
+        <article class="handoff-flow__card">
+          <p class="handoff-flow__label">During request</p>
+          <h3>Status changes before rows</h3>
+          <p>The remote-state slot may show loading copy while the children container remains stable for the eventual replacement.</p>
+        </article>
+        <article class="handoff-flow__card">
+          <p class="handoff-flow__label">After response</p>
+          <h3>Rows and status separate cleanly</h3>
+          <p>Loaded child rows replace the children container; error or retry copy stays in the remote-state slot when no rows can be committed.</p>
         </article>
       </div>
     </section>


### PR DESCRIPTION
## 対応Issue

- Closes #1775

## 採用した方針

- 自動実行のため、既存デザインに沿う低リスク案として、既存 `lazy-loading-handoff.html` に helper-to-region mapping と replacement flow reference を追加しました。
- 新規 mockup page や runtime behavior には広げず、Lazy Loading docs の helper examples と既存 mockup の visual reference を対応づけることに閉じています。
- `docs/mockups/README.md` / `review-gallery.html` には既に `lazy-loading-handoff.html` への導線があるため、今回の差分では追加更新していません。

## 比較した案

- 案A: 既存 `lazy-loading-handoff.html` に helper-to-region map と before/during/after flow を追加する
  - 採用。既存ページの文脈で helper 名、DOM region、host-app ownership を横並び確認できます。
- 案B: 新規 before/after comparison page を追加する
  - 不採用。README / review-gallery / smoke inventory の追加同期が必要になり、#1775 の focused lane としては差分が大きくなります。
- 案C: Lazy Loading docs 本体や runtime helper examples を更新する
  - 不採用。今回の目的は static mockup の reviewability 改善であり、Turbo Stream behavior や docs prose の仕様判断には広げません。

## 変更内容

- `docs/mockups/lazy-loading-handoff.html`
  - `Helper-to-region map` section を追加し、`tree_children_container_dom_id`、`tree_remote_state_placeholder_dom_id`、`tree_remote_state_placeholder_attributes` の役割差を整理しました。
  - `Replacement flow reference` section を追加し、before request / during request / after response の見え方を比較できるようにしました。
  - children container replacement と remote-state slot copy を分け、TreeView-owned hooks と host-app-owned copy / retry affordance の境界を明確化しました。

## 変更した画面・コンポーネント

- static mockup: `docs/mockups/lazy-loading-handoff.html`

## 確認内容

- lint / test: GitHub Actions CI #2317 success
- typecheck: runtime Ruby / JavaScript は変更していません。
- UI表示確認: 実ブラウザ未確認です。
- レスポンシブ確認: 実ブラウザ未確認です。追加 section は既存 page と同じ grid / table pattern に閉じています。
- アクセシビリティ確認: static HTML の heading / table 構造に閉じ、runtime ARIA behavior は変更していません。
- 実ブラウザ確認の代替: QA handoff note。desktop / narrow viewport で helper-to-region map、replacement flow cards、既存 loading/loaded/error tables の text overlap がないことを browser-capable review で確認してください。
- local checkout / local browser check: GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。
- compare `main...design/1775-lazy-loading-handoff-boundary`:
  - base: `c04441e08aece9b36d8e90562a814451adfc7928`
  - head: `e068e648f23ad313ed866c8543499b5c0f57018f`
  - `ahead_by:3`
  - `behind_by:0`
  - changed files: 1 (`docs/mockups/lazy-loading-handoff.html`)
- PR metadata: `mergeable:true`

## スクリーンショット

<!-- connector-only 実行のため未添付。desktop / narrow viewport の最終 visual readability は browser-capable review に残します。 -->

## リスク

- low

## 補足

- runtime Ruby / JavaScript、Turbo Stream behavior、public API manifest、authorization、cursor/retry policy、screenshot baseline は変更していません。
- #1248 / #1260 などの large-tree strategy / toggle mode decision mockup は近い design lane ですが、今回は #1775 の Lazy Loading handoff に閉じています。