### PR TITLE
remote-state / toolbar data hook exports を latest main で再提案する

### DIFF
--- a/app/javascript/tree_view/index.d.ts
+++ b/app/javascript/tree_view/index.d.ts
@@ -65,6 +65,19 @@ export declare const TreeViewRemoteStateValues: Readonly<{
   error: "error"
 }>
 
+export declare const TreeViewRemoteStateDataHooks: Readonly<{
+  lazyAttribute: "data-tree-lazy"
+  childrenUrlAttribute: "data-tree-children-url"
+  loadedAttribute: "data-tree-loaded"
+  remoteStateAttribute: "data-tree-remote-state"
+}>
+
+export declare const TreeViewToolbarDataHooks: Readonly<{
+  toolbarAttribute: "data-tree-view-toolbar"
+  actionAttribute: "data-tree-view-toolbar-action"
+  disabledAttribute: "data-tree-view-toolbar-disabled"
+}>
+
 export declare const TreeViewTransferDropPositions: Readonly<{
   before: "before"
   inside: "inside"

--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -68,6 +68,19 @@ export const TreeViewRemoteStateValues = Object.freeze({
   error: "error"
 })
 
+export const TreeViewRemoteStateDataHooks = Object.freeze({
+  lazyAttribute: "data-tree-lazy",
+  childrenUrlAttribute: "data-tree-children-url",
+  loadedAttribute: "data-tree-loaded",
+  remoteStateAttribute: "data-tree-remote-state"
+})
+
+export const TreeViewToolbarDataHooks = Object.freeze({
+  toolbarAttribute: "data-tree-view-toolbar",
+  actionAttribute: "data-tree-view-toolbar-action",
+  disabledAttribute: "data-tree-view-toolbar-disabled"
+})
+
 export const TreeViewTransferDropPositions = Object.freeze({
   before: "before",
   inside: "inside",

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -206,6 +206,8 @@ javascript_package_root:
     - TreeViewControllerIdentifiers
     - TreeViewSelectionDataHooks
     - TreeViewEmptyStateHooks
+    - TreeViewRemoteStateDataHooks
+    - TreeViewToolbarDataHooks
     - TreeViewTransferDropPositions
     - TreeViewTransferDataMimeTypes
     - TreeViewRemoteStateValues
@@ -227,6 +229,15 @@ javascript_package_root:
     loading: loading
     loaded: loaded
     error: error
+  remote_state_data_hooks:
+    lazy_attribute: data-tree-lazy
+    children_url_attribute: data-tree-children-url
+    loaded_attribute: data-tree-loaded
+    remote_state_attribute: data-tree-remote-state
+  toolbar_data_hooks:
+    toolbar_attribute: data-tree-view-toolbar
+    action_attribute: data-tree-view-toolbar-action
+    disabled_attribute: data-tree-view-toolbar-disabled
   controller_registrations:
     - key: state
       identifier: tree-view-state

--- a/docs/en/data-hook-exports.md
+++ b/docs/en/data-hook-exports.md
@@ -1,0 +1,47 @@
+# Data hook exports
+
+TreeView exposes selected, host-authored data hooks from the JavaScript package root so host apps can build custom lazy-loading and toolbar integrations without hand-copying string literals.
+
+These exports mirror the documented hooks already rendered by TreeView helpers. They do not change controller behavior, helper options, event payloads, or the responsibility boundary between TreeView and the host app.
+
+## Remote state hooks
+
+Import `TreeViewRemoteStateDataHooks` when shared JavaScript or tests need the lazy-loading row and placeholder attributes.
+
+```js
+import { TreeViewRemoteStateDataHooks } from "tree_view"
+
+row.matches(`[${TreeViewRemoteStateDataHooks.childrenUrlAttribute}]`)
+placeholder.dataset.treeRemoteState = "loaded"
+```
+
+Documented keys:
+
+| Key | Value | Use |
+|---|---|---|
+| `lazyAttribute` | `data-tree-lazy` | Marks rows rendered for lazy loading. |
+| `childrenUrlAttribute` | `data-tree-children-url` | Carries the host-app children endpoint URL. |
+| `loadedAttribute` | `data-tree-loaded` | Carries whether the row's children have already been loaded. |
+| `remoteStateAttribute` | `data-tree-remote-state` | Carries the placeholder state for loading, loaded, and error UI. |
+
+Use the Ruby helpers `tree_children_container_dom_id`, `tree_remote_state_placeholder_dom_id`, and `tree_remote_state_placeholder_attributes` when rendering placeholder IDs and state attributes in Rails views. This JavaScript export is for host-app JavaScript and tests that need the same attribute names.
+
+## Toolbar hooks
+
+Import `TreeViewToolbarDataHooks` when custom toolbar markup, tests, or analytics setup need the TreeView-owned toolbar attributes.
+
+```js
+import { TreeViewToolbarDataHooks } from "tree_view"
+
+const action = toolbar.querySelector(`[${TreeViewToolbarDataHooks.actionAttribute}="expand_all"]`)
+```
+
+Documented keys:
+
+| Key | Value | Use |
+|---|---|---|
+| `toolbarAttribute` | `data-tree-view-toolbar` | Marks the toolbar container rendered or owned by TreeView integration code. |
+| `actionAttribute` | `data-tree-view-toolbar-action` | Identifies a supported toolbar action. |
+| `disabledAttribute` | `data-tree-view-toolbar-disabled` | Marks disabled fallback controls when no toolbar path is available. |
+
+For action metadata, continue to use `tree_view_toolbar_supported_actions`, `tree_view_toolbar_actions`, or `tree_view_toolbar_action_metadata`. The JavaScript export only publishes stable attribute names; it does not replace the Ruby helper contract or define routes, authorization, copy, or Turbo response behavior.

--- a/docs/ja/data-hook-exports.md
+++ b/docs/ja/data-hook-exports.md
@@ -1,0 +1,47 @@
+# Data hook exports
+
+TreeView は、host app が author する一部の data hook を JavaScript package root から公開します。これにより、host app 側の custom lazy-loading / toolbar integration で string literal を手で写さずに済みます。
+
+これらの export は、既存の TreeView helper が描画している documented hook を mirror するだけです。controller behavior、helper option、event payload、TreeView と host app の責務境界は変更しません。
+
+## Remote state hooks
+
+共有 JavaScript や test で lazy-loading row / placeholder attribute 名が必要な場合は `TreeViewRemoteStateDataHooks` を import します。
+
+```js
+import { TreeViewRemoteStateDataHooks } from "tree_view"
+
+row.matches(`[${TreeViewRemoteStateDataHooks.childrenUrlAttribute}]`)
+placeholder.dataset.treeRemoteState = "loaded"
+```
+
+Documented key:
+
+| Key | Value | 用途 |
+|---|---|---|
+| `lazyAttribute` | `data-tree-lazy` | lazy loading 用に描画された row を示します。 |
+| `childrenUrlAttribute` | `data-tree-children-url` | host app の children endpoint URL を保持します。 |
+| `loadedAttribute` | `data-tree-loaded` | その row の children が読み込み済みかを保持します。 |
+| `remoteStateAttribute` | `data-tree-remote-state` | loading / loaded / error UI 用の placeholder state を保持します。 |
+
+Rails view で placeholder ID や state attribute を描画する場合は、引き続き `tree_children_container_dom_id`、`tree_remote_state_placeholder_dom_id`、`tree_remote_state_placeholder_attributes` を使ってください。この JavaScript export は、同じ attribute 名を host app の JavaScript や test で参照するためのものです。
+
+## Toolbar hooks
+
+custom toolbar markup、test、analytics setup で TreeView-owned toolbar attribute 名が必要な場合は `TreeViewToolbarDataHooks` を import します。
+
+```js
+import { TreeViewToolbarDataHooks } from "tree_view"
+
+const action = toolbar.querySelector(`[${TreeViewToolbarDataHooks.actionAttribute}="expand_all"]`)
+```
+
+Documented key:
+
+| Key | Value | 用途 |
+|---|---|---|
+| `toolbarAttribute` | `data-tree-view-toolbar` | TreeView integration code が描画または所有する toolbar container を示します。 |
+| `actionAttribute` | `data-tree-view-toolbar-action` | supported toolbar action を識別します。 |
+| `disabledAttribute` | `data-tree-view-toolbar-disabled` | toolbar path がない場合の disabled fallback control を示します。 |
+
+action metadata には、引き続き `tree_view_toolbar_supported_actions`、`tree_view_toolbar_actions`、`tree_view_toolbar_action_metadata` を使ってください。この JavaScript export は安定した attribute 名だけを公開し、Ruby helper contract の置き換えや route、authorization、copy、Turbo response behavior の定義は行いません。

--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -302,6 +302,22 @@ assert(
 )
 assertFrozenObject(entrypointModule.TreeViewEmptyStateHooks, "TreeViewEmptyStateHooks")
 
+const expectedRemoteStateDataHooks = deepCamelizeKeys(javascriptPackageManifest.remote_state_data_hooks)
+assertDeepEqualExport(
+  entrypointModule.TreeViewRemoteStateDataHooks,
+  expectedRemoteStateDataHooks,
+  "TreeViewRemoteStateDataHooks"
+)
+assertFrozenObject(entrypointModule.TreeViewRemoteStateDataHooks, "TreeViewRemoteStateDataHooks")
+
+const expectedToolbarDataHooks = deepCamelizeKeys(javascriptPackageManifest.toolbar_data_hooks)
+assertDeepEqualExport(
+  entrypointModule.TreeViewToolbarDataHooks,
+  expectedToolbarDataHooks,
+  "TreeViewToolbarDataHooks"
+)
+assertFrozenObject(entrypointModule.TreeViewToolbarDataHooks, "TreeViewToolbarDataHooks")
+
 const expectedRegistrations = javascriptPackageManifest.controller_registrations.map(({ identifier, export: exportName }) => {
   assert(exportName in entrypointModule, `${exportName} export is missing`)
   return [identifier, entrypointModule[exportName]]


### PR DESCRIPTION
remote-state / toolbar の host-app 向け data hook 名を latest main 起点で再提案します。

Closes #1134
Supersedes #1772

## 置き換え理由

PR #1772 は head `7ff6c3a144222ef9852e6de44e8eeb0642f20559` の CI は success でしたが、#1777 / #1779 merge 後に `main...feature/1134-remote-toolbar-data-hooks` が `ahead_by:1` / `behind_by:4` / `status:diverged` になりました。

この PR は latest `main` `c04441e08aece9b36d8e90562a814451adfc7928` を親にして、#1134 / #1772 の scoped diff だけを再適用しています。

## 変更内容

- `TreeViewRemoteStateDataHooks` を package root export に追加しました。
  - `data-tree-lazy`
  - `data-tree-children-url`
  - `data-tree-loaded`
  - `data-tree-remote-state`
- `TreeViewToolbarDataHooks` を package root export に追加しました。
  - `data-tree-view-toolbar`
  - `data-tree-view-toolbar-action`
  - `data-tree-view-toolbar-disabled`
- TypeScript declaration と `config/public_api_manifest.yml` を同じ public surface に同期しました。
- `script/test_entrypoints.mjs` に manifest と runtime export の同期確認を追加しました。
- 英日 docs に、追加した data hook export の用途と責務境界を追加しました。

## 受け入れ条件との対応

- remote-state の host-app 向け data hook 名を public export として参照可能にしました。
- toolbar の TreeView-owned data hook 名を public export として参照可能にしました。
- manifest / declaration / entrypoint smoke を更新し、公開契約の drift を検出できるようにしました。
- 既存の remote retry / loading behavior、toolbar helper API、event payload、manifest schema には変更を入れていません。

## 変更範囲

- JavaScript package root export
- TypeScript declaration
- public API manifest
- entrypoint smoke check
- data hook export docs

## 実施した確認

- PR #1772 の review follow-up コメントを確認し、latest main refresh / fresh CI が必要な follow-up と判断しました。
- compare `main...refresh/1772-remote-toolbar-data-hooks-current-main`:
  - `ahead_by:6`
  - `behind_by:0`
  - changed files: 6
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認します。

## リスク

medium。runtime behavior は変更しませんが、data hook 名を public package-root export / manifest-backed contract として扱うため、採用判断は human review に残します。

## 未対応・補足

- #890 / #908 の selection lane は対象外です。
- remote-state controller の retry/loading 挙動や toolbar helper の振る舞いは変更していません。