### PR TITLE
event value exports の使い分けを js-events docs に同期する

### DIFF
--- a/docs/en/js-events.md
+++ b/docs/en/js-events.md
@@ -183,6 +183,28 @@ element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStat
 
 `tree-view-transfer:invalid-transfer` detail contains `value`.
 
+## Using documented event values in host-app code
+
+Some `event.detail` fields intentionally expose a small documented value set. Host apps can import the package-root value exports when listener branches or tests need those values without hand-copying strings:
+
+```js
+import {
+  TreeViewEventNames,
+  TreeViewRemoteStateValues,
+  TreeViewTransferDropPositions
+} from "tree_view/index.js"
+
+element.addEventListener(TreeViewEventNames.remoteState.change, (event) => {
+  if (event.detail.state === TreeViewRemoteStateValues.error) showRetryNotice(event.detail.row)
+})
+
+element.addEventListener(TreeViewEventNames.transfer.drop, (event) => {
+  if (event.detail.position === TreeViewTransferDropPositions.inside) attachAsChild(event.detail)
+})
+```
+
+`TreeViewEventNames` names events, `TreeViewEventDetailKeys` lists documented payload field names, and these value exports carry documented enum-like values for those fields. `TreeViewRemoteStateValues` is limited to remote-state row values (`loading`, `loaded`, `error`), and `TreeViewTransferDropPositions` is limited to transfer drop positions (`before`, `inside`, `after`). They do not add listener helpers or change controller dispatch behavior.
+
 ## Compatibility policy
 
 The machine-readable public API manifest mirrors the event names and representative required `event.detail` keys documented on this page so compatibility specs can detect drift; this page remains the primary contract. Host app tests may import `TreeViewEventDetailKeys` from the package root when they need a machine-readable list of documented detail key names without changing the event payload shape.

--- a/docs/ja/js-events.md
+++ b/docs/ja/js-events.md
@@ -183,6 +183,28 @@ element.addEventListener(TreeViewEventNames.remoteState.change, handleRemoteStat
 
 `tree-view-transfer:invalid-transfer` の detail は `value` を含みます。
 
+## host app code で documented event values を使う
+
+一部の `event.detail` field は、小さな documented value set を公開します。listener の分岐や test でそれらの値が必要な場合、host app は package-root の value export を import し、string を写経せずに参照できます。
+
+```js
+import {
+  TreeViewEventNames,
+  TreeViewRemoteStateValues,
+  TreeViewTransferDropPositions
+} from "tree_view/index.js"
+
+element.addEventListener(TreeViewEventNames.remoteState.change, (event) => {
+  if (event.detail.state === TreeViewRemoteStateValues.error) showRetryNotice(event.detail.row)
+})
+
+element.addEventListener(TreeViewEventNames.transfer.drop, (event) => {
+  if (event.detail.position === TreeViewTransferDropPositions.inside) attachAsChild(event.detail)
+})
+```
+
+`TreeViewEventNames` は event 名、`TreeViewEventDetailKeys` は documented payload field 名、これらの value export は field に入る documented enum-like value を表します。`TreeViewRemoteStateValues` は remote-state row value (`loading`, `loaded`, `error`) に限定し、`TreeViewTransferDropPositions` は transfer drop position (`before`, `inside`, `after`) に限定します。listener helper を追加したり、controller dispatch behavior を変更したりするものではありません。
+
 ## 互換性方針
 
 machine-readable public API manifest は、このページで文書化している event name と代表的な必須 `event.detail` key を写して drift を検知するための guard です。一次の契約は引き続きこのページです。host app の test が documented detail key 名の machine-readable な一覧を必要とする場合は、event payload shape を変えずに package root の `TreeViewEventDetailKeys` を import できます。


### PR DESCRIPTION
current main に存在する event value exports の使い分けを、#563 の受け入れ条件に合わせて英日 js-events docs に同期します。

Closes #563

## 対応 Issue

- #563

## 変更内容

- `docs/en/js-events.md` に `TreeViewRemoteStateValues` と `TreeViewTransferDropPositions` の利用例を追加しました。
- `docs/ja/js-events.md` に同じ内容を同期しました。
- `TreeViewEventNames` は event 名、`TreeViewEventDetailKeys` は payload field 名、value exports は `state` / `position` に入る documented enum-like value を表す、という使い分けを明記しました。

## 受け入れ条件との対応

- remote-state `state` values は current main の `TreeViewRemoteStateValues` から参照できます。
- transfer `position` values は current main の `TreeViewTransferDropPositions` から参照できます。
- `docs/en|ja/js-events.md` に、event names / detail keys / enum-like values の役割差が分かる最小追記を入れました。
- controller dispatch behavior、event names、payload key 名は変更していません。

## 変更範囲

- docs only
- runtime JavaScript、manifest、TypeScript declaration、controller、event payload shape は変更していません。

## 実施した確認

- Issue #563 の labels を直接確認: `status:ready-for-agent`, `track:feature`, `agent:planned`, `risk:medium`。
- 既存 open PR が #563 を担当していないことを確認しました。過去の stacked PR #568 は closed / unmerged で、current main には別 export 名で必要 surface が入っているため、この PR は docs sync に閉じています。
- compare `main...feature/563-event-values-docs-current`:
  - `ahead_by:2`
  - `behind_by:0`
  - changed files: 2 docs files
- local checkout / local test は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR CI を確認します。

## リスク

low to medium。docs-only ですが、public JavaScript surface の使い分け説明に関わるため、current main の export 名と責務境界に合わせて最小追記にしています。

## 未対応・補足

- 旧 #568 の `TreeViewEventDetailValues` という bundled export 案は復活させていません。
- listener helper 追加、event payload redesign、undocumented internal value の公開は扱っていません。