### PR TITLE
Breadcrumb docs / visual reference entrypoint を smoke で守る

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_breadcrumb_docs_signals.mjs
+++ b/script/test_breadcrumb_docs_signals.mjs
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertRelativeLink(sourcePath, href, feature) {
+  const source = read(sourcePath)
+  const target = href.split("#", 1)[0]
+  const resolvedTarget = path.resolve(path.dirname(path.join(repoRoot, sourcePath)), target)
+
+  assert(source.includes(href), `${feature}: ${sourcePath} does not link to ${href}`)
+  assert(
+    resolvedTarget.startsWith(repoRoot) && existsSync(resolvedTarget),
+    `${feature}: ${sourcePath} links to missing local target ${href}`
+  )
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const feature = "Breadcrumb docs and visual reference"
+
+;[
+  ["README.md", "docs/en/breadcrumb.md"],
+  ["README.md", "docs/ja/breadcrumb.md"],
+  ["docs/README.md", "en/breadcrumb.md"],
+  ["docs/README.md", "ja/breadcrumb.md"],
+  ["docs/en/README.md", "breadcrumb.md"],
+  ["docs/ja/README.md", "breadcrumb.md"],
+  ["docs/en/breadcrumb.md", "../mockups/breadcrumb-paths.html"],
+  ["docs/ja/breadcrumb.md", "../mockups/breadcrumb-paths.html"],
+  ["docs/mockups/README.md", "breadcrumb-paths.html"]
+].forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+
+assertSignals("docs/en/breadcrumb.md", feature, [
+  "tree_view_breadcrumb(tree, item, ...)",
+  "label_builder:",
+  "path_builder:",
+  "records-mode",
+  "helper_option_keys.tree_view_breadcrumb",
+  "host app remains responsible for routes, authorization",
+  "layout placement",
+  "breadcrumb-paths.html"
+])
+
+assertSignals("docs/ja/breadcrumb.md", feature, [
+  "tree_view_breadcrumb(tree, item, ...)",
+  "label_builder:",
+  "path_builder:",
+  "records mode",
+  "helper_option_keys.tree_view_breadcrumb",
+  "route、認可、現在nodeの決定",
+  "layout",
+  "breadcrumb-paths.html"
+])
+
+assertSignals("docs/mockups/README.md", feature, [
+  "breadcrumb-paths.html",
+  "breadcrumb-path context",
+  "current-row cue",
+  "without modeling host-app routes or Turbo navigation"
+])


### PR DESCRIPTION
## 対応 Issue
- Closes #1791

## Issue ごとの完了内容
- #1791: README、英日ドキュメント、visual mockups README の breadcrumb / records-mode / visual reference の導線が落ちないよう、docs entrypoint smoke に専用チェックを追加しました。
- #1791: 既存 `test:docs-entrypoints` に組み込み、通常の docs smoke 実行で確認される状態にしました。

## 変更内容
- `script/test_breadcrumb_docs_signals.mjs` を追加しました。
- `package.json` の `test:docs-entrypoints` に上記 smoke を接続しました。

## 改善カテゴリ
- test 追加
- docs smoke 改善
- 回帰防止

## 既存仕様への影響
- なし。ドキュメント導線の存在確認だけで、公開 API、UI、DB、認可、外部サービス契約は変更していません。

## 実施した確認
- connector compare で `main` から `behind_by: 0` を確認しました。
- 差分が `package.json` と `script/test_breadcrumb_docs_signals.mjs` に限定されていることを確認しました。
- ローカル環境から GitHub への通常 network fetch は 403 のため、CI 実行は PR 作成後の GitHub Actions に委ねます。

## リスク評価
- low。docs smoke の追加と npm script 接続のみで、runtime への影響はありません。

## 補足
- 既存の docs entrypoint smoke 群と同じ粒度で、breadcrumb 関連の public documentation signals を固定しています。