### PR TITLE
docs smoke: Decision guide と mockup README の代表 signal を守る

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const signalGroups = [
+  {
+    feature: "Decision guide reader journey",
+    files: [
+      [
+        "docs/en/decision-guide.md",
+        [
+          "Render controls",
+          "Data-loading controls",
+          "GraphAdapter",
+          "reverse_tree_for",
+          "Filtered Trees",
+          "Lazy Loading",
+          "Children Pagination",
+          "RenderWindow",
+          "Selection",
+          "Toolbar helper",
+          "Recommended path by project stage",
+          "Common combinations"
+        ]
+      ],
+      [
+        "docs/ja/decision-guide.md",
+        [
+          "描画制御",
+          "データ読み込み制御",
+          "GraphAdapter",
+          "reverse_tree_for",
+          "Filtered Trees",
+          "Lazy Loading",
+          "Children Pagination",
+          "RenderWindow",
+          "Selection",
+          "Toolbar helper",
+          "project stageごとのおすすめ順",
+          "よくある組み合わせ"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Mockup README smoke and review policy",
+    files: [
+      [
+        "docs/mockups/README.md",
+        [
+          "Automated smoke coverage",
+          "npm run test:browser",
+          "review gallery",
+          "local links",
+          "representative sample regions",
+          "without adding screenshot baselines or visual diff review",
+          "Review policy",
+          "static HTML/CSS",
+          "product-neutral",
+          "source HTML/CSS should remain the canonical mockup",
+          "playground app"
+        ]
+      ]
+    ]
+  }
+]
+
+signalGroups.forEach(({ feature, files }) => {
+  files.forEach(([sourcePath, signals]) => assertSignals(sourcePath, feature, signals))
+})


### PR DESCRIPTION
## 対応 Issue

- Closes #1774
- Closes #1797

## Issue ごとの完了内容

- #1774: EN/JA Decision guide の reader journey に必要な主要 signal（描画制御、データ読み込み制御、GraphAdapter、Lazy Loading、Children Pagination、Selection、Toolbar helper など）を docs smoke で確認するようにしました。
- #1797: mockup README の automated smoke coverage と review policy に必要な主要 signal（`npm run test:browser`、review gallery、local links、representative sample regions、visual diff を増やさない境界、static HTML/CSS 方針など）を docs smoke で確認するようにしました。

## 変更内容

- `script/test_docs_reader_journey_signals.mjs` を追加し、Decision guide と mockup README の代表文言を検証します。
- `npm run test:docs-entrypoints` から新しい smoke script を実行するようにしました。

## 改善カテゴリ

- test
- docs guard
- CI smoke coverage

## 既存仕様への影響

- docs / test のみの変更です。
- runtime、public API、UI、DB、認可、外部サービス契約は変更していません。

## 確認内容

- connector 上で main の最新 commit（`7208be4`）から作業ブランチを作成しました。
- 差分対象は `package.json` と新規 smoke script に限定しています。
- CI run #2347 passed。

## リスク評価

- risk: low
- 代表文言の smoke guard 追加のみで、挙動変更はありません。
