### PR TITLE
Cookbook に host-app virtual scrolling 境界例を追加する

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -328,6 +328,17 @@ Use windowed rendering when many visible rows remain.
 
 Use lazy loading when children should be loaded only as needed.
 
+When the product needs scroll-position-driven DOM virtualization, keep that controller in the host app and use TreeView only for the HTML row slice it should render. `TreeView::RenderWindow` is useful for outputting a bounded list of already-visible rows, but it does not observe scroll position, reduce host-app queries, fetch pages, or preserve scroll anchoring.
+
+A minimal host-app virtual scrolling shape is:
+
+1. Keep the viewport observer, scroll anchoring, overscan, and analytics in host-app JavaScript.
+2. Let the host app choose the query page, cursor, or offset and authorize the records for that viewport.
+3. Build a `RenderState` from the selected records and render only the visible HTML slice with `TreeView::RenderWindow` or `tree_view_rows(..., window:)`.
+4. Fall back to [Lazy Loading](lazy-loading.md) or [Children Pagination](children-pagination.md) when the problem is child fetching rather than scroll-position-driven DOM work.
+
+Use [Render Scale](render-scale.md) and [Windowed Rendering](windowed-rendering.md) for the TreeView-owned output boundary. Use [Lazy Loading](lazy-loading.md) and [Children Pagination](children-pagination.md) when host-app data loading also needs to shrink. Do not treat this recipe as a built-in virtual scrolling engine or a server-side pagination contract.
+
 ## Combine lazy loading with children pagination
 
 Use this pattern when a branch has many direct children and rendering all of them after the first expand would still be too large. Keep lazy loading responsible for the initial child endpoint and remote-state placeholders, then let the host app return one page of children plus a host-app-owned "Load more" row.

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -328,6 +328,17 @@ render_state = TreeView::RenderState.new(
 
 子nodeを必要な分だけ読み込みたい場合は lazy loading を使います。
 
+product要件として scroll位置に応じたDOM仮想化が必要な場合は、そのcontrollerをhost app側に置き、TreeViewには描画すべきHTML row sliceだけを任せます。`TreeView::RenderWindow` は、すでにvisibleとして計算されたrowを小さく出力するには使えますが、scroll位置の監視、host app queryの削減、page取得、scroll anchoringの維持は行いません。
+
+host-app virtual scrolling の最小構成は次の形です。
+
+1. viewport observer、scroll anchoring、overscan、analytics は host app JavaScript が担当する。
+2. host app が query page、cursor、offset を選び、その viewport で表示してよいrecordをauthorizationする。
+3. 選ばれたrecordから `RenderState` を作り、`TreeView::RenderWindow` または `tree_view_rows(..., window:)` でvisible HTML sliceだけを描画する。
+4. 問題が scroll位置に応じたDOM作業ではなくchild fetching量なら、[Lazy Loading](lazy-loading.md) や [Children Pagination](children-pagination.md) に戻す。
+
+TreeView側の出力境界は [描画スケール](render-scale.md) と [Windowed Rendering](windowed-rendering.md) を参照してください。host appのdata loading量も減らす必要がある場合は [Lazy Loading](lazy-loading.md) と [Children Pagination](children-pagination.md) を使います。このrecipeを組み込みvirtual scrolling engineやserver-side pagination契約として扱わないでください。
+
 ## lazy loading と children pagination を組み合わせる
 
 1つのbranchに大量の直接childrenがあり、最初の展開後も全件描画すると大きすぎる場合に使います。lazy loading は最初のchildren endpointとremote-state placeholderをつなぎ、host app は1page分のchildrenとhost-app-ownedの「もっと見る」行を返します。


### PR DESCRIPTION
## 対応 Issue

Closes #1796

## 変更内容

- `docs/en/cookbook.md` と `docs/ja/cookbook.md` の「大きなtreeの初期HTMLを減らす」節に、host-app-owned virtual scrolling の短い recipe を追加しました。
- `TreeView::RenderWindow` は HTML output control であり、scroll observer / viewport management / query paging / scroll anchoring は host app responsibility であることを明記しました。
- Render Scale / Windowed Rendering / Lazy Loading / Children Pagination への導線を追加し、built-in virtual scrolling engine や server-side pagination contract と誤読されないようにしました。

## 分類

- `docs-sync`
- `docs-missing`

## 変更範囲

- docs only
- runtime Ruby / JavaScript、public API manifest、virtual scroll controller、pagination algorithm は変更していません。

## 確認内容

- current main と Issue #1796、README、Render Scale docs、Product Profile を確認しました。
- compare では `docs/en/cookbook.md` / `docs/ja/cookbook.md` の 2 ファイルのみ、追記だけです。
- local checkout / local docs test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## 補足

PR 作成直前に main が docs smoke script mergeで 1 commit 進んでいましたが、変更ファイルは今回の Cookbook 2ファイルとは非重複です。