### PR TITLE
Cookbook から PathTree / ReverseTree の使い分けを辿れるようにする

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -48,6 +48,21 @@ When the host app needs custom wrappers, conditional copy, per-level authorizati
 
 TreeView owns path lookup in records mode and the bundled helper option surface. The host app owns routes, authorization, where the breadcrumb appears, and any Turbo or analytics behavior attached to custom attributes.
 
+## Choose a path-shaped tree view
+
+Use the path-shaped APIs when a screen is about context, not about showing every record in one hierarchy.
+
+| Use case | Start with | Host app owns |
+|---|---|---|
+| Search results need enough ancestors to show where each match lives | `tree.path_tree_for(matches)` | Search query, result authorization, and which matched records are included |
+| Generated folders or virtual grouping rows should sit beside record-backed rows | [PathTreeBuilder](path-tree-builder.md) | Folder labels, grouping rules, generated row keys, and final business copy |
+| A child-first screen should expand back toward parents | [ReverseTree](reverse-tree.md) / `tree.reverse_tree_for(items)` | Which child records seed the view and how parent context is presented |
+| A detail page needs one compact root-to-current trail | [Breadcrumb helper](breadcrumb.md) / `tree_view_breadcrumb` | Route helpers, labels, authorization copy, and placement |
+
+`path_tree_for` and the breadcrumb helper require records-mode path lookup. `PathTreeBuilder` is the better fit when the host app creates generated grouping rows that are not backed by the same records. `reverse_tree_for` is for child-to-parent presentation; it is not GraphAdapter resolver support and should not be used to imply support for graph-like reverse traversal.
+
+For a broader comparison, start with [API decision guide](decision-guide.md#start-from-the-use-case), then read [PathTreeBuilder](path-tree-builder.md), [ReverseTree](reverse-tree.md), and [Breadcrumb](breadcrumb.md) for the full constraints and examples.
+
 ## Row customization quick guide
 
 Use the smallest TreeView extension point that matches the UI you are adding.

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -48,6 +48,21 @@ records mode のtreeと現在itemがあり、rootからそのitemまでの短い
 
 TreeView は records mode のpath lookupとbundled helper option surfaceを担当します。route、authorization、breadcrumbを置く場所、追加属性に紐づくTurbo / analytics behaviorはhost app側の責務です。
 
+## path-shaped tree view を選ぶ
+
+画面の主目的が全recordの階層表示ではなく、contextを短く見せることなら path-shaped API を使います。
+
+| やりたいこと | まず使うAPI | host appの責務 |
+|---|---|---|
+| 検索結果に、matchがどこにあるか分かるだけのancestorを付けたい | `tree.path_tree_for(matches)` | 検索query、結果のauthorization、どのmatched recordを含めるか |
+| record-backed row と並ぶ generated folder / virtual grouping row を作りたい | [PathTreeBuilder](path-tree-builder.md) | folder label、grouping rule、generated row key、最終的な業務copy |
+| child起点の画面でparent方向へ展開したい | [ReverseTree](reverse-tree.md) / `tree.reverse_tree_for(items)` | viewの起点になるchild recordと、parent contextの見せ方 |
+| 詳細画面にrootから現在nodeまでの短いtrailが必要 | [Breadcrumb helper](breadcrumb.md) / `tree_view_breadcrumb` | route helper、label、authorization copy、配置 |
+
+`path_tree_for` と breadcrumb helper は records mode の path lookup を前提にします。host app が同じrecordではない generated grouping row を作る場合は `PathTreeBuilder` が向いています。`reverse_tree_for` は child-to-parent 表示用であり、GraphAdapter の resolver support を意味するものではありません。
+
+より広い比較は [API判断ガイド](decision-guide.md#やりたいことから選ぶ) から始め、制約と例は [PathTreeBuilder](path-tree-builder.md)、[ReverseTree](reverse-tree.md)、[Breadcrumb](breadcrumb.md) を参照してください。
+
 ## 行customization quick guide
 
 追加したいUIに合わせて、最小のTreeView extension pointを使います。


### PR DESCRIPTION
## 対応 Issue

Closes #1801

## 変更内容

- `docs/en/cookbook.md` と `docs/ja/cookbook.md` に path-shaped tree view の短い使い分け entrypoint を追加しました。
- `path_tree_for(matches)`、`PathTreeBuilder`、`reverse_tree_for(items)`、`tree_view_breadcrumb` を use case ごとに整理しました。
- `decision-guide.md`、`path-tree-builder.md`、`reverse-tree.md`、`breadcrumb.md` への導線を追加しました。

## 分類

- `docs-sync`
- `docs-missing`

## 変更範囲

- docs only
- runtime Ruby / JavaScript、public API manifest、ReverseTree resolver / GraphAdapter support、static mockup は変更していません。

## 確認内容

- Issue #1801、current main の Cookbook / API decision guide を確認しました。
- compare は `behind_by:0`、変更ファイルは `docs/en/cookbook.md` / `docs/ja/cookbook.md` の 2 件のみ、追記だけです。
- local checkout / local docs test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。