### PR TITLE
docs smoke: FAQ/Troubleshooting の入口シグナルを固定する

### DIFF
--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -135,7 +135,7 @@ const foundationalEntrypoints = [
       ],
       [
         "docs/en/troubleshooting.md",
-        /localized label[\s\S]*toggle link[\s\S]*toolbar action[\s\S]*breadcrumb[\s\S]*row partial[\s\S]*empty[\s\S]*ActiveRecord time[\s\S]*virtual scroll[\s\S]*children pagination[\s\S]*GraphAdapter[\s\S]*CSS or JavaScript integration[\s\S]*lazy loading[\s\S]*persisted state/,
+        /Localized labels[\s\S]*Toggle links[\s\S]*Toolbar actions[\s\S]*Breadcrumbs[\s\S]*Row partial[\s\S]*Empty or no-results[\s\S]*ActiveRecord time[\s\S]*virtual scrolling[\s\S]*Children pagination[\s\S]*GraphAdapter[\s\S]*CSS or JavaScript integration[\s\S]*Lazy loading[\s\S]*persisted state/i,
         "English troubleshooting docs no longer expose the representative symptom-driven entrypoints"
       ],
       [

--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -125,7 +125,7 @@ const foundationalEntrypoints = [
     signals: [
       [
         "docs/en/faq.md",
-        /DB queries[\s\S]*RenderWindow[\s\S]*virtual scroll[\s\S]*keyboard navigation[\s\S]*CRUD[\s\S]*authorization[\s\S]*TreeView::Diagnostics\.run[\s\S]*persisted state[\s\S]*children pagination/,
+        /database queries[\s\S]*TreeView::RenderWindow[\s\S]*virtual scrolling[\s\S]*keyboard navigation[\s\S]*CRUD[\s\S]*authorization[\s\S]*TreeView::Diagnostics\.run[\s\S]*persisted state[\s\S]*children pagination/i,
         "English FAQ no longer covers the main host-app responsibility boundary questions"
       ],
       [

--- a/script/test_docs_entrypoints.mjs
+++ b/script/test_docs_entrypoints.mjs
@@ -121,6 +121,28 @@ const foundationalEntrypoints = [
       ["docs/en/README.md", "troubleshooting.md"],
       ["docs/ja/README.md", "faq.md"],
       ["docs/ja/README.md", "troubleshooting.md"]
+    ],
+    signals: [
+      [
+        "docs/en/faq.md",
+        /DB queries[\s\S]*RenderWindow[\s\S]*virtual scroll[\s\S]*keyboard navigation[\s\S]*CRUD[\s\S]*authorization[\s\S]*TreeView::Diagnostics\.run[\s\S]*persisted state[\s\S]*children pagination/,
+        "English FAQ no longer covers the main host-app responsibility boundary questions"
+      ],
+      [
+        "docs/ja/faq.md",
+        /DB query[\s\S]*TreeView::RenderWindow[\s\S]*virtual scroll[\s\S]*keyboard navigation[\s\S]*CRUD[\s\S]*authorization[\s\S]*TreeView::Diagnostics\.run[\s\S]*persisted state[\s\S]*children pagination/,
+        "Japanese FAQ no longer covers the main host-app responsibility boundary questions"
+      ],
+      [
+        "docs/en/troubleshooting.md",
+        /localized label[\s\S]*toggle link[\s\S]*toolbar action[\s\S]*breadcrumb[\s\S]*row partial[\s\S]*empty[\s\S]*ActiveRecord time[\s\S]*virtual scroll[\s\S]*children pagination[\s\S]*GraphAdapter[\s\S]*CSS or JavaScript integration[\s\S]*lazy loading[\s\S]*persisted state/,
+        "English troubleshooting docs no longer expose the representative symptom-driven entrypoints"
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        /localized label[\s\S]*toggle link[\s\S]*toolbar action[\s\S]*breadcrumb[\s\S]*row partial[\s\S]*empty[\s\S]*ActiveRecord time[\s\S]*virtual scroll[\s\S]*children pagination[\s\S]*GraphAdapter[\s\S]*CSS や JavaScript の統合[\s\S]*lazy loading[\s\S]*persisted state/,
+        "Japanese troubleshooting docs no longer expose the representative symptom-driven entrypoints"
+      ]
     ]
   }
 ]


### PR DESCRIPTION
## 対応 Issue

- Closes #1767

## Issue ごとの完了内容

- #1767: FAQ / Troubleshooting の入口リンクだけでなく、英日それぞれの代表的な責務境界・症状別導線が残っていることを docs smoke で検知するようにしました。

## 変更内容

- `script/test_docs_entrypoints.mjs` の `FAQ and troubleshooting docs` entry に signals を追加しました。
- docs 本文、公開API、UI、実行時挙動は変更していません。

## 改善カテゴリ

- test
- docs smoke / regression guard

## 既存仕様への影響

- なし。既存ドキュメント本文にある語句を検査対象へ追加しただけです。

## 実施した確認

- Issue ラベルを個別確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- PR 前に `main` との差分を確認し、変更対象が `script/test_docs_entrypoints.mjs` のみであることを確認しました。
- connector-only 作業のためローカル test は未実行です。PR CI で `script/test_docs_entrypoints.mjs` の実行結果を確認してください。

## リスク評価

- Low。docs smoke の検知追加のみで、runtime behavior には触れていません。

## 補足事項

- final newline は保持しています。