### PR TITLE
GraphAdapter heterogeneous node mockup を current main で再提案する

### DIFF
--- a/docs/mockups/graph-adapter-heterogeneous-nodes/index.html
+++ b/docs/mockups/graph-adapter-heterogeneous-nodes/index.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GraphAdapter heterogeneous nodes mock</title>
+<link rel="stylesheet" href="../default-tree.css">
+<style>
+.graph-adapter-page { max-width: 1180px; }
+.graph-adapter-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.85fr); gap: 18px; align-items: start; }
+.graph-adapter-note { margin: 0 0 1rem; color: #52606d; }
+.graph-adapter-type { display: inline-flex; align-items: center; justify-content: center; min-width: 5.5rem; padding: 0.12rem 0.55rem; border-radius: 999px; background: #edf2f7; color: #334e68; font-size: 0.78rem; font-weight: 800; }
+.graph-adapter-type--project { background: #e0f2fe; color: #075985; }
+.graph-adapter-type--folder { background: #fef3c7; color: #92400e; }
+.graph-adapter-type--document { background: #ecfdf5; color: #047857; }
+.graph-adapter-type--external { background: #ede9fe; color: #5b21b6; }
+.graph-adapter-icon { display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; inline-size: 1.8rem; block-size: 1.8rem; border-radius: 8px; background: #e2e8f0; color: #334155; font-weight: 800; }
+.graph-adapter-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.graph-adapter-actions button { border: 1px solid #cbd5e1; border-radius: 8px; background: #fff; padding: 0.35rem 0.6rem; }
+.graph-adapter-actions button[aria-disabled="true"] { color: #9aa5b1; background: #f1f5f9; }
+.graph-adapter-card { display: grid; gap: 0.6rem; padding: 1rem; border: 1px solid #dde4ec; border-radius: 10px; background: #f8fafc; }
+.graph-adapter-card h3, .graph-adapter-card p { margin: 0; }
+.graph-adapter-card p { color: #52606d; }
+.graph-adapter-table-wrap { overflow-x: auto; }
+.graph-adapter-boundary { width: 100%; border-collapse: collapse; }
+.graph-adapter-boundary th, .graph-adapter-boundary td { border-bottom: 1px solid #e4e7eb; padding: 0.7rem 0.75rem; text-align: left; vertical-align: top; }
+.graph-adapter-boundary th { background: #f1f5f9; color: #334e68; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; }
+@media (max-width: 860px) { .graph-adapter-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+  <main class="mock-page graph-adapter-page">
+    <header class="mock-header">
+      <p class="mock-kicker">tree_view-rails</p>
+      <h1>GraphAdapter heterogeneous nodes mock</h1>
+      <p>
+        Focused static reference for reviewing a mixed tree of projects, folders, documents, and external references.
+        GraphAdapter can supply graph-like parent/child relationships; this page keeps traversal, authorization, routes,
+        and final business copy outside the mockup.
+      </p>
+    </header>
+
+    <nav class="mock-return-nav" aria-label="Mockup return links">
+      <a class="mock-return-nav__link" href="../review-gallery.html">Back to review gallery</a>
+      <a class="mock-return-nav__link mock-return-nav__link--secondary" href="../README.md">Open mockup index</a>
+    </nav>
+
+    <section class="mock-section" aria-labelledby="graph-adapter-summary-heading">
+      <h2 id="graph-adapter-summary-heading">Responsibility boundary</h2>
+      <div class="mock-boundary-grid">
+        <article class="graph-adapter-card">
+          <h3>TreeView-owned cues</h3>
+          <p>Hierarchy depth, expanded or collapsed state, current-row cue, and generated branch lines stay reusable across node types.</p>
+        </article>
+        <article class="graph-adapter-card">
+          <h3>Host-owned labels</h3>
+          <p>Node type names, icons, status labels, row actions, and policy wording belong to the host app.</p>
+        </article>
+        <article class="graph-adapter-card">
+          <h3>GraphAdapter scope</h3>
+          <p>The adapter can connect heterogeneous records, but this mockup does not define graph traversal or data model behavior.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="mock-section graph-adapter-grid" aria-labelledby="heterogeneous-tree-heading">
+      <div>
+        <h2 id="heterogeneous-tree-heading">Mixed node types in one tree</h2>
+        <p class="graph-adapter-note">The first table column keeps the TreeView hierarchy cue stable while the host app varies badge, icon, status, and action content by node type.</p>
+        <div class="graph-adapter-table-wrap">
+          <table class="tree-view-table" data-controller="tree-view-state" data-tree-view-state-keyboard-value="true">
+            <thead>
+              <tr>
+                <th scope="col">type</th>
+                <th scope="col">tree</th>
+                <th scope="col">host metadata</th>
+                <th scope="col">host status</th>
+                <th scope="col">host action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr id="graph_node_project" class="tree-row is-expanded" data-tree-node-key="project:atlas" data-tree-parent-key="" data-tree-depth="0" data-tree-expanded="true" aria-level="1" aria-expanded="true">
+                <td><span class="graph-adapter-type graph-adapter-type--project">project</span></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Atlas project expanded"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a><span class="tree-toggle__level">root</span></span></span>
+                  <span class="mock-node-stack"><span class="mock-node-primary"><span class="graph-adapter-icon" aria-hidden="true">P</span><span class="mock-node-title">Atlas workspace</span><span class="tree-node-badge tree-node-badge--info">Graph root</span></span><span class="mock-node-secondary">A project record can be the graph root while TreeView keeps the same depth and expansion cues.</span></span>
+                </td>
+                <td>Host column: 12 linked items</td>
+                <td><span class="mock-status mock-status--active">active</span></td>
+                <td class="tree-row-actions"><span class="graph-adapter-actions"><button type="button">Open</button><button type="button">Share</button></span></td>
+              </tr>
+              <tr id="graph_node_folder" class="tree-row is-expanded" data-tree-node-key="folder:research" data-tree-parent-key="project:atlas" data-tree-depth="1" data-tree-expanded="true" aria-level="2" aria-expanded="true">
+                <td><span class="graph-adapter-type graph-adapter-type--folder">folder</span></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Research folder expanded"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">hide</a><span class="tree-toggle__level">child</span></span></span>
+                  <span class="mock-node-stack"><span class="mock-node-primary"><span class="graph-adapter-icon" aria-hidden="true">F</span><span class="mock-node-title">Research folder</span><span class="tree-node-badge tree-node-badge--warning">mixed children</span></span><span class="mock-node-secondary">Folder-like grouping is a host concept; TreeView only renders the hierarchy row.</span></span>
+                </td>
+                <td>Host column: owner Team A</td>
+                <td><span class="mock-status mock-status--pending">draft</span></td>
+                <td class="tree-row-actions"><span class="graph-adapter-actions"><button type="button">Rename</button></span></td>
+              </tr>
+              <tr id="graph_node_document" class="tree-row is-selected" data-tree-node-key="document:brief" data-tree-parent-key="folder:research" data-tree-depth="2" data-tree-expanded="false" aria-level="3" aria-current="page">
+                <td><span class="graph-adapter-type graph-adapter-type--document">document</span></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="Current document"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span><span class="tree-toggle__control"><span class="tree-toggle__level">leaf</span></span></span>
+                  <span class="mock-node-stack"><span class="mock-node-primary"><span class="graph-adapter-icon" aria-hidden="true">D</span><span class="mock-node-title">Launch brief</span><span class="tree-node-badge tree-node-badge--info">current</span></span><span class="mock-node-secondary">Current-row styling stays TreeView-owned even when the node type changes.</span></span>
+                </td>
+                <td>Host column: edited today</td>
+                <td><span class="mock-status mock-status--active">ready</span></td>
+                <td class="tree-row-actions"><span class="graph-adapter-actions"><button type="button">Open</button><button type="button" aria-disabled="true">Archive</button></span></td>
+              </tr>
+              <tr id="graph_node_external" class="tree-row is-collapsed" data-tree-node-key="external:roadmap" data-tree-parent-key="folder:research" data-tree-depth="2" data-tree-expanded="false" aria-level="3" aria-expanded="false">
+                <td><span class="graph-adapter-type graph-adapter-type--external">external</span></td>
+                <td class="btn-cell tree-toggle-cell">
+                  <span class="tree-toggle" aria-label="External reference collapsed"><span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span><span class="tree-toggle__control"><a class="tree-toggle__action" href="#" data-turbo-stream="true">show</a><span class="tree-toggle__level">leaf</span><span class="tree-toggle__hidden-count" title="Linked children">2</span></span></span>
+                  <span class="mock-node-stack"><span class="mock-node-primary"><span class="graph-adapter-icon" aria-hidden="true">X</span><span class="mock-node-title">External roadmap</span><span class="tree-node-badge">linked</span></span><span class="mock-node-secondary">External reference copy, link policy, and permission messaging remain host-app owned.</span></span>
+                </td>
+                <td>Host column: vendor source</td>
+                <td><span class="mock-status mock-status--archived">read-only</span></td>
+                <td class="tree-row-actions"><span class="graph-adapter-actions"><button type="button">Preview</button></span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <aside class="graph-adapter-card" aria-labelledby="adapter-shape-heading">
+        <h3 id="adapter-shape-heading">Review cue</h3>
+        <p>Use this page when the question is whether mixed node types stay readable in one tree. Use API docs for adapter construction, graph traversal, or data normalization details.</p>
+      </aside>
+    </section>
+
+    <section class="mock-section" aria-labelledby="comparison-heading">
+      <h2 id="comparison-heading">What to review</h2>
+      <table class="graph-adapter-boundary"><thead><tr><th scope="col">Question</th><th scope="col">Expected boundary</th></tr></thead><tbody>
+        <tr><td>Can project, folder, document, and external nodes share the same hierarchy cue?</td><td>Yes. Depth, branch lines, current row, and expansion state should remain consistent across types.</td></tr>
+        <tr><td>Who owns node type badge, icon, status, and actions?</td><td>The host app. This page uses neutral placeholders to compare layout impact only.</td></tr>
+        <tr><td>Does the mock define GraphAdapter traversal or graph data modeling?</td><td>No. Runtime adapter behavior, authorization, persistence, and routes stay outside this static reference.</td></tr>
+      </tbody></table>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## 対応 Issue / PR

Refs #813
Supersedes #1785

## 置き換え理由

PR #1785 は GraphAdapter heterogeneous node mockup の first slice でしたが、current `main` から `behind_by:2` / `status:diverged` になっていました。latest main `7b5b9096834fd3eabe1849af88660c7c4eb5b951` を親にして、同じ static mockup 差分だけを再提案します。

## 変更内容

- `docs/mockups/graph-adapter-heterogeneous-nodes/index.html` を追加
- project / folder / document / external reference を同じ tree 内で比較
- TreeView-owned hierarchy cues と host-app-owned badge / icon / status / action の境界を整理

## 変更範囲

- docs/static mockup only
- GraphAdapter runtime、adapter traversal、docs/API、authorization、route policy、final business copy は変更していません。

## 確認内容

- compare `main...design/813-graph-adapter-heterogeneous-mockup-current-v2`: `ahead_by:2` / `behind_by:0`
- changed files: `docs/mockups/graph-adapter-heterogeneous-nodes/index.html` のみ
- local checkout / local browser check は GitHub HTTPS 制限のため未実行です。PR CI と browser-capable review で確認してください。

## リスク / 残確認

- low。static mockup の first slice です。
- desktop / narrow viewport の visual readability は browser-capable human review に残します。
- #813 を完全に close するには README / review-gallery 導線同期が別途必要です。