### PR TITLE
Breadcrumb helper の public contract guard を latest main で再提案する

### DIFF
--- a/docs/en/breadcrumb.md
+++ b/docs/en/breadcrumb.md
@@ -99,13 +99,13 @@ For markup changes that need custom wrappers, conditional authorization copy, or
 | `separator:` | Separator between items. |
 | `aria_label:` | Accessible label for the breadcrumb `<nav>` element. |
 
-The option names in this table are also listed in `config/public_api_manifest.yml` under `helper_option_keys.tree_view_breadcrumb`. That manifest-backed list is a compatibility contract for the existing helper option surface; it does not add markup, route, or authorization behavior.
+The option names in this table are also listed in `config/public_api_manifest.yml` under `helper_option_keys.tree_view_breadcrumb`. That manifest-backed list is a compatibility contract for the existing helper option surface; it does not add markup, route, authorization, mode inference, or exact HTML structure behavior. Records-mode lookup, unsupported-mode failure, `aria-current="page"`, and the additive HTML merge hooks are guarded by focused specs and this guide rather than by a broader manifest schema.
 
 ## Supported mode
 
 The breadcrumb helper expects a records-mode tree.
 
-Resolver mode and adapter mode may not have a unique parent path. For unsupported modes, TreeView raises through the tree path helper so the failure is explicit.
+Resolver mode and adapter mode may not have a unique parent path. For unsupported modes, TreeView raises through the tree path helper so the failure is explicit. TreeView does not infer breadcrumb trails for GraphAdapter or resolver-mode data; if the host app owns that path policy, render from its own trail data instead.
 
 ## Visual reference
 

--- a/docs/ja/breadcrumb.md
+++ b/docs/ja/breadcrumb.md
@@ -99,13 +99,13 @@ TreeView は、これらの属性をbuilt-in classやaccessibility属性とmerge
 | `separator:` | item間のseparator。 |
 | `aria_label:` | breadcrumb の `<nav>` 要素に付与するaccessible label。 |
 
-この表の option 名は、`config/public_api_manifest.yml` の `helper_option_keys.tree_view_breadcrumb` にも載っています。この manifest-backed list は既存 helper option surface の互換性 contract であり、markup、route、authorization behavior を追加するものではありません。
+この表の option 名は、`config/public_api_manifest.yml` の `helper_option_keys.tree_view_breadcrumb` にも載っています。この manifest-backed list は既存 helper option surface の互換性 contract であり、markup、route、authorization、mode 推測、exact HTML structure の挙動を追加するものではありません。records mode lookup、unsupported mode failure、`aria-current="page"`、追加HTML属性の merge hook は、より広い manifest schema ではなく focused spec とこのguideでguardします。
 
 ## 対応mode
 
 breadcrumb helper は records mode のtreeを前提にします。
 
-resolver mode や adapter mode では、親方向のpathを一意に辿れない場合があります。そのため、unsupported modeでは `TreeView::Tree` 側のpath helper errorを使って明確に失敗します。
+resolver mode や adapter mode では、親方向のpathを一意に辿れない場合があります。そのため、unsupported modeでは `TreeView::Tree` 側のpath helper errorを使って明確に失敗します。TreeView は GraphAdapter や resolver mode のdataから breadcrumb trail を推測しません。host app がそのpath policyを持つ場合は、host app側のtrail dataから直接renderしてください。
 
 ## Visual reference
 

--- a/spec/breadcrumb_public_contract_spec.rb
+++ b/spec/breadcrumb_public_contract_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_view"
+require "yaml"
+
+BreadcrumbPublicContractNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
+BREADCRUMB_PUBLIC_API_MANIFEST_PATH = File.expand_path("../config/public_api_manifest.yml", __dir__)
+
+RSpec.describe "Breadcrumb public contract" do
+  def manifest
+    @manifest ||= YAML.safe_load_file(BREADCRUMB_PUBLIC_API_MANIFEST_PATH)
+  end
+
+  def helper
+    view = ActionView::Base.empty
+    view.extend(TreeViewBreadcrumbHelper)
+    view
+  end
+
+  def breadcrumb_helper_keyword_option_keys
+    TreeViewBreadcrumbHelper.instance_method(:tree_view_breadcrumb).parameters.filter_map do |parameter_type, parameter_name|
+      parameter_name.to_s if %i[key keyreq].include?(parameter_type)
+    end
+  end
+
+  def records_tree_with_child
+    root = BreadcrumbPublicContractNode.new(id: 1, parent_id: nil, name: "Root")
+    child = BreadcrumbPublicContractNode.new(id: 2, parent_id: 1, name: "Child")
+
+    [TreeView::Tree.new(records: [root, child], parent_id_method: :parent_id), child]
+  end
+
+  it "keeps the manifest-backed breadcrumb option keys aligned with the helper signature" do
+    manifest_keys = manifest.fetch("helper_option_keys").fetch("tree_view_breadcrumb")
+
+    expect(manifest_keys).to eq(breadcrumb_helper_keyword_option_keys)
+  end
+
+  it "keeps current item semantics and HTML merge hooks available" do
+    tree, current_item = records_tree_with_child
+    html = helper.tree_view_breadcrumb(
+      tree,
+      current_item,
+      label_builder: ->(item) { item.name },
+      path_builder: ->(item) { "/nodes/#{item.id}" },
+      html: {data: {controller: "breadcrumb-analytics"}},
+      list_html: {data: {breadcrumb_list: true}},
+      item_html: ->(item) { {data: {breadcrumb_item_id: item.id}} },
+      link_html: ->(item) { {data: {breadcrumb_link_id: item.id}, rel: "up"} },
+      current_html: ->(item) { {data: {breadcrumb_current_id: item.id}} },
+      separator_html: ->(item) { {data: {breadcrumb_separator_for: item.id}} }
+    ).to_s
+
+    expect(html).to include("data-controller=\"breadcrumb-analytics\"")
+    expect(html).to include("data-breadcrumb-list=\"true\"")
+    expect(html).to include("data-breadcrumb-item-id=\"1\"")
+    expect(html).to include("data-breadcrumb-item-id=\"2\"")
+    expect(html).to include("href=\"/nodes/1\"")
+    expect(html).to include("rel=\"up\"")
+    expect(html).to include("data-breadcrumb-link-id=\"1\"")
+    expect(html).to include("aria-current=\"page\"")
+    expect(html).to include("data-breadcrumb-current-id=\"2\"")
+    expect(html).to include("data-breadcrumb-separator-for=\"1\"")
+    expect(html).not_to include("href=\"/nodes/2\"")
+  end
+
+  it "delegates unsupported path handling to the tree path lookup" do
+    tree = instance_double(TreeView::Tree)
+
+    allow(tree).to receive(:path_for).and_raise(TreeView::InvalidTreeError, "breadcrumb path is unsupported")
+
+    expect do
+      helper.tree_view_breadcrumb(tree, :item, label_builder: ->(item) { item.to_s })
+    end.to raise_error(TreeView::InvalidTreeError, "breadcrumb path is unsupported")
+  end
+end


### PR DESCRIPTION
Breadcrumb helper の option surface と records-mode 境界を、latest main 起点の scoped replacement として再提案します。

Closes #1768
Supersedes #1804

## 置き換え理由

PR #1804 は reviewer / conflict sweep で、latest main 進行後に `mergeable:false` となり、#1768 の breadcrumb docs/spec 差分だけを latest main へ semantic reapply する必要があると整理されていました。

この PR は latest `main` `8a96b53919f900f3df11319f236002e67eb153fe` を親にして、#1804 と同じ breadcrumb public contract guard の scoped diff だけを載せ直しています。

## 変更内容

- `spec/breadcrumb_public_contract_spec.rb` を追加し、`helper_option_keys.tree_view_breadcrumb` と helper keyword surface の同期を確認します。
- current item の `aria-current="page"`、link/current/separator/html/list/item の HTML merge hook、current item を link にしない挙動を focused spec で guard します。
- unsupported path handling は helper が `tree.path_for(item)` に委ね、GraphAdapter / resolver mode の breadcrumb trail 推測へ広げないことを spec/docs で明確化しました。
- 英日 `docs/*/breadcrumb.md` に、manifest-backed contract は option key surface に限定され、mode inference / route / authorization / exact HTML structure を広げないことを追記しました。

## 受け入れ条件との対応

- Breadcrumb helper の option key surface は manifest と focused spec で同期しています。
- `label_builder:` required、`path_builder:` optional、current item `aria-current="page"`、HTML merge hook の代表挙動を確認しています。
- records-mode boundary と unsupported mode の明示的 failure は docs/spec-level boundary として扱い、manifest schema に新 section は追加していません。
- `breadcrumb-paths.html`、visual design、route policy、authorization policy、Turbo navigation policy は変更していません。

## 変更範囲

- `spec/breadcrumb_public_contract_spec.rb`
- `docs/en/breadcrumb.md`
- `docs/ja/breadcrumb.md`

Helper implementation、public API manifest schema、runtime route policy、authorization、DB、外部 API は変更していません。

## 実施した確認

- PR #1804 の comments / review context を確認し、latest main refresh が必要な follow-up と判断しました。
- compare `main...refresh/1804-breadcrumb-public-contract-current-main`:
  - `ahead_by:3`
  - `behind_by:0`
  - changed files: 3
- local checkout / local RSpec は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

medium。runtime behavior は変更していませんが、既存 helper option surface を public contract としてより明確に守るため、将来の option rename/removal の互換性コストは上がります。

## 未対応・補足

- GraphAdapter / resolver mode の breadcrumb inference は実装していません。
- route / authorization / layout / visual mockup redesign は対象外です。