### PR TITLE
repository-only maintainer entrypoints を docs smoke で守る

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,8 +67,8 @@ Maintainer entry points には、gem に同梱される `docs/**` と repository
 
 - [English documentation](en/README.md): full English docs map, reading order, and maintainer-facing entry points within the English tree.
 - [日本語ドキュメント](ja/README.md): 日本語 docs tree の full map、reading order、maintainer-facing entry points。
-- Repository-only Product Profile (`Product Profile.md` at the repository root): product positioning, source-of-truth order, host-app responsibility boundary, and non-goals for maintainers and reviewers. This file is not packaged in the gem and is not a host-app API guide; read it from a repository checkout before judging scope or docs sync.
-- Repository-only agent workflow (`AGENTS.md` at the repository root): repository-specific workflow, first-read order, documentation update rules, and CI shortcut policy for maintainers and agents. This file is not packaged in the gem and is not user-facing integration guidance; read it from a repository checkout before changing maintainer workflow or docs policy.
+- [Repository-only Product Profile](../Product%20Profile.md): product positioning, source-of-truth order, host-app responsibility boundary, and non-goals for maintainers and reviewers. This file is not packaged in the gem and is not a host-app API guide; read it from a repository checkout before judging scope or docs sync.
+- [Repository-only agent workflow](../AGENTS.md): repository-specific workflow, first-read order, documentation update rules, and CI shortcut policy for maintainers and agents. This file is not packaged in the gem and is not user-facing integration guidance; read it from a repository checkout before changing maintainer workflow or docs policy.
 - [Documentation maintenance checklist](i18n-audit.md): language-sync rules, technical-asset inventory, and cross-language update coverage.
 - [Public API](en/public-api.md) / [公開 API](ja/public-api.md): compatibility contract and the surfaces host apps may use directly.
 - [Migration guide](en/migration.md) / [移行ガイド](ja/migration.md): upgrade expectations, deprecations, and release-note reading order.

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,8 +67,8 @@ Maintainer entry points には、gem に同梱される `docs/**` と repository
 
 - [English documentation](en/README.md): full English docs map, reading order, and maintainer-facing entry points within the English tree.
 - [日本語ドキュメント](ja/README.md): 日本語 docs tree の full map、reading order、maintainer-facing entry points。
-- [Repository-only Product Profile](../Product%20Profile.md): product positioning, source-of-truth order, host-app responsibility boundary, and non-goals for maintainers and reviewers. This file is not packaged in the gem and is not a host-app API guide; read it from a repository checkout before judging scope or docs sync.
-- [Repository-only agent workflow](../AGENTS.md): repository-specific workflow, first-read order, documentation update rules, and CI shortcut policy for maintainers and agents. This file is not packaged in the gem and is not user-facing integration guidance; read it from a repository checkout before changing maintainer workflow or docs policy.
+- Repository-only Product Profile (`Product Profile.md` at the repository root): product positioning, source-of-truth order, host-app responsibility boundary, and non-goals for maintainers and reviewers. This file is not packaged in the gem and is not a host-app API guide; read it from a repository checkout before judging scope or docs sync.
+- Repository-only agent workflow (`AGENTS.md` at the repository root): repository-specific workflow, first-read order, documentation update rules, and CI shortcut policy for maintainers and agents. This file is not packaged in the gem and is not user-facing integration guidance; read it from a repository checkout before changing maintainer workflow or docs policy.
 - [Documentation maintenance checklist](i18n-audit.md): language-sync rules, technical-asset inventory, and cross-language update coverage.
 - [Public API](en/public-api.md) / [公開 API](ja/public-api.md): compatibility contract and the surfaces host apps may use directly.
 - [Migration guide](en/migration.md) / [移行ガイド](ja/migration.md): upgrade expectations, deprecations, and release-note reading order.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_repository_only_maintainer_entrypoints.mjs
+++ b/script/test_repository_only_maintainer_entrypoints.mjs
@@ -14,7 +14,7 @@ function assert(condition, message) {
 
 function assertRelativeLink(sourcePath, href, feature) {
   const source = read(sourcePath)
-  const target = href.split("#", 1)[0]
+  const target = decodeURIComponent(href.split("#", 1)[0])
   const resolvedTarget = path.resolve(path.dirname(path.join(repoRoot, sourcePath)), target)
 
   assert(
@@ -39,8 +39,6 @@ const repositoryOnlyEntrypoints = [
     links: [
       ["docs/README.md", "en/README.md"],
       ["docs/README.md", "ja/README.md"],
-      ["docs/README.md", "../Product%20Profile.md"],
-      ["docs/README.md", "../AGENTS.md"],
       ["docs/README.md", "i18n-audit.md"],
       ["docs/README.md", "../CHANGELOG.md"]
     ],

--- a/script/test_repository_only_maintainer_entrypoints.mjs
+++ b/script/test_repository_only_maintainer_entrypoints.mjs
@@ -1,0 +1,96 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertRelativeLink(sourcePath, href, feature) {
+  const source = read(sourcePath)
+  const target = href.split("#", 1)[0]
+  const resolvedTarget = path.resolve(path.dirname(path.join(repoRoot, sourcePath)), target)
+
+  assert(
+    source.includes(href),
+    `${feature}: ${sourcePath} does not link to ${href}`
+  )
+  assert(
+    resolvedTarget.startsWith(repoRoot) && existsSync(resolvedTarget),
+    `${feature}: ${sourcePath} links to missing local target ${href}`
+  )
+}
+
+function assertDocumentSignal(sourcePath, signalPattern, feature, message) {
+  const source = read(sourcePath)
+
+  assert(signalPattern.test(source), `${feature}: ${message}`)
+}
+
+const repositoryOnlyEntrypoints = [
+  {
+    feature: "Root docs repository-only maintainer entrypoints",
+    links: [
+      ["docs/README.md", "en/README.md"],
+      ["docs/README.md", "ja/README.md"],
+      ["docs/README.md", "../Product%20Profile.md"],
+      ["docs/README.md", "../AGENTS.md"],
+      ["docs/README.md", "i18n-audit.md"],
+      ["docs/README.md", "../CHANGELOG.md"]
+    ],
+    signals: [
+      [
+        "docs/README.md",
+        /Maintainer entry points[\s\S]*gem-packaged docs[\s\S]*repository-only files[\s\S]*Product Profile[\s\S]*AGENTS\.md[\s\S]*Documentation maintenance checklist[\s\S]*CHANGELOG\.md/,
+        "docs/README.md no longer keeps repository-only maintainer files distinct from packaged docs"
+      ]
+    ]
+  },
+  {
+    feature: "English repository-only maintainer entrypoints",
+    links: [
+      ["docs/en/README.md", "../../Product%20Profile.md"],
+      ["docs/en/README.md", "../../AGENTS.md"],
+      ["docs/en/README.md", "../README.md"],
+      ["docs/en/README.md", "../../CHANGELOG.md"],
+      ["docs/en/README.md", "../i18n-audit.md"]
+    ],
+    signals: [
+      [
+        "docs/en/README.md",
+        /For maintainers[\s\S]*Product Profile[\s\S]*AGENTS\.md[\s\S]*Root docs index[\s\S]*CHANGELOG\.md[\s\S]*Documentation i18n audit/,
+        "English docs README no longer exposes the repository-only maintainer table"
+      ]
+    ]
+  },
+  {
+    feature: "Japanese repository-only maintainer entrypoints",
+    links: [
+      ["docs/ja/README.md", "../../Product%20Profile.md"],
+      ["docs/ja/README.md", "../../AGENTS.md"],
+      ["docs/ja/README.md", "../README.md"],
+      ["docs/ja/README.md", "../../CHANGELOG.md"],
+      ["docs/ja/README.md", "../i18n-audit.md"]
+    ],
+    signals: [
+      [
+        "docs/ja/README.md",
+        /保守者向け[\s\S]*Product Profile[\s\S]*AGENTS\.md[\s\S]*root docs index[\s\S]*CHANGELOG\.md[\s\S]*Documentation i18n audit/,
+        "Japanese docs README no longer exposes the repository-only maintainer table"
+      ]
+    ]
+  }
+]
+
+repositoryOnlyEntrypoints.forEach(({ feature, links, signals = [] }) => {
+  links.forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+  signals.forEach(([sourcePath, signalPattern, message]) => {
+    assertDocumentSignal(sourcePath, signalPattern, feature, message)
+  })
+})


### PR DESCRIPTION
## 対応 Issue

Closes #1799

## Issue ごとの完了内容

- #1799: `docs/README.md` / `docs/en/README.md` / `docs/ja/README.md` から repository-only maintainer entrypoints へ辿れる代表導線を lightweight docs smoke で確認するようにしました。
- packaged docs と repository-only files の責務差を示す代表 wording と、`Product Profile.md`、`AGENTS.md`、`docs/i18n-audit.md`、`CHANGELOG.md` への maintainer-facing 導線を守ります。

## 変更内容

- `script/test_repository_only_maintainer_entrypoints.mjs` を追加しました。
  - 既存の docs smoke と同じ軽量な file/link/signal check に閉じています。
  - root `docs/README.md` では repository-only file を packaged docs の実リンクにせず、責務差の signal を確認します。
  - 言語別 `docs/en/README.md` / `docs/ja/README.md` では repository checkout 前提の maintainer-facing link が壊れていないことを確認します。
- `package.json` の `test:docs-entrypoints` に新スクリプトを組み込みました。

## 改善カテゴリ

- test
- docs smoke
- docs maintenance guard

## 既存仕様への影響

- runtime Ruby / JavaScript behavior、public API manifest、mockup HTML、release automation、package contents policy は変更していません。
- docs 本文も最終差分では変更していません。既存 docs の導線を guard するだけです。

## 実施した確認内容

- Issue #1799 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR 前に current `main` を確認しました: `8a96b53919f900f3df11319f236002e67eb153fe`。
- compare `main...quality/1799-maintainer-entrypoints-smoke`: `ahead_by:5`, `behind_by:0`。
- changed files は `package.json` と `script/test_repository_only_maintainer_entrypoints.mjs` の2ファイルのみです。
- GitHub Actions CI #2381: success
  - `javascript`: success (`npm run test:js:core` 経由で docs entrypoint smoke を確認)
  - `gem_package`: success (packaged docs policy と gem contents guard を確認)
  - `pr_specs`, `lint`, representative Rails matrix, `docker_development_setup`: success
- local checkout / local script 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。代替として PR CI の結果を確認しました。

## リスク評価

- risk: low
- 既存 docs の相対 link と代表 wording を確認するだけで、実行時挙動や公開契約は変えません。

## 補足事項

- `Product Profile.md` / `AGENTS.md` 本文の rewrite は行っていません。
- repository-only files を gem-packaged public docs として扱う変更は行っていません。