### PR TITLE
table-caption mockup の責務境界 signal を browser smoke で守る

### DIFF
--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -208,6 +208,20 @@ test.describe("docs mockup browser smoke", () => {
     })
   }
 
+  test("table-caption-context.html preserves host and TreeView responsibility boundary signals", async ({ page }) => {
+    await openMockup(page, "table-caption-context.html")
+
+    await expect(page.getByRole("heading", { name: "Workspace hierarchy" })).toBeVisible()
+    await expect(page.locator("[aria-label='Host app actions']")).toBeVisible()
+    await expect(page.locator(".tree-view-table caption")).toContainText("Host-owned table caption")
+    await expect(page.getByRole("heading", { name: "Responsibility boundary" })).toBeVisible()
+    await expect(page.getByText("Host app owns page heading", { exact: false })).toBeVisible()
+    await expect(page.getByText("TreeView owns row hierarchy cues", { exact: false })).toBeVisible()
+    expect(await page.locator(".tree-toggle__branches").count()).toBeGreaterThanOrEqual(4)
+    expect(await page.locator(".tree-depth-label").count()).toBeGreaterThanOrEqual(4)
+    expect(await page.locator("[data-tree-selection-payload]").count()).toBeGreaterThanOrEqual(4)
+  })
+
   test("direction-aware-cues/index.html preserves LTR, RTL, and vertical representative regions", async ({ page }) => {
     await openMockup(page, "direction-aware-cues/index.html")
 


### PR DESCRIPTION
## 対応 Issue

- Closes #1631

## Issue ごとの完了内容

- #1631: `docs/mockups/table-caption-context.html` の docs mockup smoke test に、host app と TreeView の責務境界を示す代表 signal を追加しました。

## 変更内容

- `test/browser/docs_mockups_smoke.spec.js` に `table-caption-context.html` 専用の smoke assertion を追加
- 既存の mockup HTML、runtime、public API、UI 仕様は変更なし
- heading、host action 領域、table caption、責務境界テキスト、tree hierarchy/selection payload の代表要素を確認

## 改善カテゴリ

- test
- docs mockup smoke coverage

## 既存仕様への影響

- なし。ブラウザ smoke test の検証観点追加のみで、実装・ドキュメント mockup・公開 API・DB・認可・状態遷移には触れていません。

## 実施した確認

- Issue #1631 の eligibility labels を個別確認済み: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`
- 既存 PR に #1631 対応の open PR がないことを確認
- `main...quality/1631-table-caption-smoke-signals` の compare で `ahead_by: 1`, `behind_by: 0` を確認
- 変更ファイルが `test/browser/docs_mockups_smoke.spec.js` のみであることを確認
- ローカル checkout はネットワーク制約により不可だったため、ローカル test は未実行。PR CI で browser smoke を確認します。

## リスク評価

- risk: low
- test-only の追加であり、runtime behavior への影響はありません。

## 補足

- 今回は #1631 の docs mockup smoke coverage に限定しました。別 repo / 別 Issue の品質改善は共通変更としてまとめず、対象範囲外にしています。