### PR TITLE
Development docs に repository-only maintainer entrypoint smoke を追記する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -38,7 +38,7 @@ npm run test:node-version-sources
 npm run test:browser
 ```
 
-Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use `npm run test:node-version-sources` when you only need to confirm that `.nvmrc`, `package.json` `engines.node`, and CI workflow `node-version` still agree on Node 22. Use the individual npm commands when you are narrowing a failure.
+Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, repository-only maintainer entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use `npm run test:node-version-sources` when you only need to confirm that `.nvmrc`, `package.json` `engines.node`, and CI workflow `node-version` still agree on Node 22. Use the individual npm commands when you are narrowing a failure.
 
 Within `npm run test:entrypoints`, `script/test_entrypoints.mjs` checks the runtime package-root exports, controller registration helper, manifest loader, and `.d.ts` export-name inventory. `script/test_declaration_literal_shapes.mjs` then checks the literal shapes in `app/javascript/tree_view/index.d.ts` for the manifest-backed JavaScript constants such as event names, detail keys, remote-state values, transfer values, controller identifiers, selection data hooks, and empty-state hooks. Use the export-name guard when a package-root export is missing or extra; use the literal-shape guard when the export exists but a key, tuple, or representative literal value no longer matches `config/public_api_manifest.yml`. This is a smoke guard, not a TypeScript compiler or declaration generator.
 
@@ -59,7 +59,7 @@ BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake
 
 Public API compatibility specs protect documented Ruby entry points, helper methods, helper option keys, grouped options, and JavaScript package-root exports from accidental removals or renames. The JavaScript entrypoint smoke also checks manifest-backed controller registrations, public event names, and documented `event.detail` key groups. Keep these specs focused on API existence and representative behavior rather than full implementation details.
 
-Docs entrypoint smoke and public API docs signal smoke have separate responsibilities within `npm run test:docs-entrypoints`: `script/test_docs_entrypoints.mjs` protects broad documentation entry points, links, and feature-guide signals, while `script/test_public_api_docs_signals.mjs` protects representative Public API and feature-doc signals. When a public API manifest entry, package-root export, public helper surface, or docs signal is added or renamed, review and update the public API docs signal smoke alongside the affected English and Japanese docs.
+Docs entrypoint smoke and public API docs signal smoke have separate responsibilities within `npm run test:docs-entrypoints`: `script/test_docs_entrypoints.mjs` protects broad documentation entry points, links, and feature-guide signals, while `script/test_repository_only_maintainer_entrypoints.mjs` protects repository-only maintainer entry points such as `Product Profile.md`, `AGENTS.md`, `CHANGELOG.md`, and `docs/i18n-audit.md` from disappearing out of the root docs map or language README files. `script/test_public_api_docs_signals.mjs` protects representative Public API and feature-doc signals. When a public API manifest entry, package-root export, public helper surface, or docs signal is added or renamed, review and update the public API docs signal smoke alongside the affected English and Japanese docs.
 
 When an intentional breaking change is accepted, update the public API docs and the compatibility specs together so the documented contract and test coverage stay aligned.
 
@@ -101,7 +101,7 @@ Docs-only entrypoint and signal checks can be run separately with:
 npm run test:docs-entrypoints
 ```
 
-That command runs the docs entrypoint smoke, docs entrypoint signal smoke, README Quick Start signal, Public API docs signal, and i18n parity checks without the broader entrypoint and CI policy checks. Use it when a docs-only change fails before moving on to `npm run test:entrypoints` or `npm run test:browser`.
+That command runs the docs entrypoint smoke, repository-only maintainer entrypoint smoke, docs entrypoint signal smoke, README Quick Start signal, Public API docs signal, and i18n parity checks without the broader entrypoint and CI policy checks. The repository-only maintainer entrypoint smoke keeps checkout-only files such as `Product Profile.md`, `AGENTS.md`, `CHANGELOG.md`, and `docs/i18n-audit.md` discoverable from `docs/README.md` and the language README files without treating them as gem-packaged host-app API guides. Use it when a docs-only change fails before moving on to `npm run test:entrypoints` or `npm run test:browser`.
 
 Browser-level smoke tests run through Playwright with:
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -38,7 +38,7 @@ npm run test:node-version-sources
 npm run test:browser
 ```
 
-CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。`.nvmrc`、`package.json` の `engines.node`、CI workflow の `node-version` が Node 22 でそろっていることだけを確認したい場合は `npm run test:node-version-sources` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
+CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、repository-only maintainer entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。`.nvmrc`、`package.json` の `engines.node`、CI workflow の `node-version` が Node 22 でそろっていることだけを確認したい場合は `npm run test:node-version-sources` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
 
 `npm run test:entrypoints` の中では、`script/test_entrypoints.mjs` が runtime の package-root exports、controller registration helper、manifest loader、`.d.ts` の export-name inventory を確認します。その後 `script/test_declaration_literal_shapes.mjs` が、event names、detail keys、remote-state values、transfer values、controller identifiers、selection data hooks、empty-state hooks などの manifest-backed JavaScript constants について、`app/javascript/tree_view/index.d.ts` の literal shape を確認します。package-root export が足りない、または余分な場合は export-name guard を見ます。export は存在するが key、tuple、代表 literal value が `config/public_api_manifest.yml` とずれた場合は literal-shape guard を見ます。これは smoke guard であり、TypeScript compiler や declaration generator ではありません。
 
@@ -59,7 +59,7 @@ BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake
 
 Public API compatibility specsは、documented Ruby entry points、helper methods、helper option keys、grouped options、JavaScript package-root exportsが意図せず削除・renameされることを防ぐためのtestsです。JavaScript entrypoint smoke では、manifest-backed な controller registrations、public event names、documented `event.detail` key groups も確認します。これらのspecは、実装詳細を網羅するのではなく、APIの存在と代表的な互換挙動に絞ります。
 
-docs entrypoint smoke と public API docs signal smoke は、`npm run test:docs-entrypoints` の中で別の責務を持ちます。`script/test_docs_entrypoints.mjs` は docs の入口、link、広い feature-guide signal を守り、`script/test_public_api_docs_signals.mjs` は Public API docs と feature docs の代表 signal を守ります。public API manifest entry、package-root export、public helper surface、または docs signal を追加・rename する場合は、影響する英日 docs と一緒に public API docs signal smoke も見直して更新してください。
+docs entrypoint smoke と public API docs signal smoke は、`npm run test:docs-entrypoints` の中で別の責務を持ちます。`script/test_docs_entrypoints.mjs` は docs の入口、link、広い feature-guide signal を守り、`script/test_repository_only_maintainer_entrypoints.mjs` は `Product Profile.md`、`AGENTS.md`、`CHANGELOG.md`、`docs/i18n-audit.md` などの repository-only maintainer entry points が root docs map や言語別 README から消えないことを守ります。`script/test_public_api_docs_signals.mjs` は Public API docs と feature docs の代表 signal を守ります。public API manifest entry、package-root export、public helper surface、または docs signal を追加・rename する場合は、影響する英日 docs と一緒に public API docs signal smoke も見直して更新してください。
 
 意図的なbreaking changeを受け入れる場合は、public API docsとcompatibility specsを同時に更新し、documented contractとtest coverageを同期させます。
 
@@ -101,7 +101,7 @@ docs-only の entrypoint / signal checks は次で個別に確認できます。
 npm run test:docs-entrypoints
 ```
 
-この command は、docs entrypoint smoke、docs entrypoint signal smoke、README Quick Start signal、Public API docs signal、i18n parity checks を実行し、より広い entrypoint / CI policy checks は含めません。docs-only change が失敗したときは、`npm run test:entrypoints` や `npm run test:browser` に進む前の切り分けに使ってください。
+この command は、docs entrypoint smoke、repository-only maintainer entrypoint smoke、docs entrypoint signal smoke、README Quick Start signal、Public API docs signal、i18n parity checks を実行し、より広い entrypoint / CI policy checks は含めません。repository-only maintainer entrypoint smoke は、`Product Profile.md`、`AGENTS.md`、`CHANGELOG.md`、`docs/i18n-audit.md` など checkout 専用のファイルが `docs/README.md` と言語別 README から辿れることを守りますが、それらを gem 同梱の host-app API guide として扱うものではありません。docs-only change が失敗したときは、`npm run test:entrypoints` や `npm run test:browser` に進む前の切り分けに使ってください。
 
 Browser-level smoke testsはPlaywrightで実行します。
 


### PR DESCRIPTION
## 対応 Issue

Closes #1828

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/development.md` / `docs/ja/development.md` の `npm run test:docs-entrypoints` 説明に repository-only maintainer entrypoint smoke を追加しました。
- `script/test_repository_only_maintainer_entrypoints.mjs` が `Product Profile.md`、`AGENTS.md`、`CHANGELOG.md`、`docs/i18n-audit.md` など checkout 専用 maintainer files の入口を守ることを明記しました。
- checkout 専用ファイルを gem 同梱の host-app API guide として扱わない境界も補足しました。

## 変更範囲

- docs-only
- package script、CI workflow、docs smoke implementation、runtime Ruby / JavaScript は変更していません。
- full docs rewrite や docs entrypoint smoke の分割 refactor には広げていません。

## 確認内容

- Issue #1828 と current `package.json` の `test:docs-entrypoints` chain を確認しました。
- current `docs/README.md` の Maintainer entry points と矛盾しないことを確認しました。
- compare `main...docs/1828-maintainer-entrypoint-smoke`: `ahead_by:3` / `behind_by:0`
- changed files: `docs/en/development.md`, `docs/ja/development.md`
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。実装済み smoke の説明追従に限定しています。