### PR TITLE
Persisted State から Public Setup Surface へ導線を再適用する

### DIFF
--- a/docs/en/persisted-state.md
+++ b/docs/en/persisted-state.md
@@ -16,6 +16,8 @@ TreeView is responsible for:
 
 The host app remains responsible for storage ownership, authorization, save timing, cleanup policy, controller actions, and UI wiring.
 
+Use [Public Setup Surface](public-setup-surface.md) when you need the path-level contract for the persisted-state install generator. It tracks the generator name, optional owner argument, and generated destination paths without freezing the migration schema or generated template contents.
+
 For a static visual reference of the save/restore handoff, see [Persisted State boundary mockup](../mockups/persisted-state-boundary.html). The mockup shows representative before, changed, restored, save-failed, and retry cues without turning storage, save endpoints, authorization, or retry policy into gem-owned behavior.
 
 ## PersistedState.from normalization

--- a/docs/ja/persisted-state.md
+++ b/docs/ja/persisted-state.md
@@ -16,6 +16,8 @@ TreeView gem が担当するのは以下です。
 
 実際の保存先、owner model、認可、保存タイミング、cleanup policy、controller action、UI更新はhost app側で実装します。
 
+persisted-state install generator の生成先 path-level contract を確認したい場合は [Public Setup Surface](public-setup-surface.md) を参照してください。generator 名、任意の owner 引数、生成先 path を追跡しますが、migration schema や生成 template 内容そのものを固定するものではありません。
+
 保存・復元の受け渡しを静的な visual reference で確認したい場合は、[Persisted State boundary mockup](../mockups/persisted-state-boundary.html) を参照してください。この mockup は、保存前、変更後、復元後、保存失敗、retry の代表的な見え方を示しますが、storage、save endpoint、認可、retry policy を gem 側の責務として扱うものではありません。
 
 ## PersistedState.from の正規化境界


### PR DESCRIPTION
## 対応 Issue

Closes #1635
Supersedes #1834

## 判定分類

- `docs-sync`
- `docs-missing`
- `docs-stale`（旧 PR #1834 が latest `main` から `behind_by:46` になっていたため、current `main` 起点で再提案）

## 変更内容

- `docs/en/persisted-state.md` の Overview に Public Setup Surface への導線を追加しました。
- `docs/ja/persisted-state.md` に同じ粒度の日本語導線を追加しました。
- persisted-state install generator の generator 名、任意 owner 引数、生成先 path は Public Setup Surface が path-level contract として扱うことを明記しました。

## 変更範囲

- docs-only
- runtime Ruby / JavaScript、generator behavior、public API manifest schema、generated migration / model / concern template は変更していません。
- 旧 PR #1834 の意図だけを latest `main` `7a4e0c886e9971aa39d40322464ae40c32704e24` に再適用しています。

## 確認内容

- compare `main...docs/1635-persisted-state-public-setup-links-v2`: `ahead_by:2` / `behind_by:0`
- changed files: `docs/en/persisted-state.md`, `docs/ja/persisted-state.md` の 2 docs files only
- deletion hunk なし（2 行追加のみ）
- local checkout / local docs check は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認します。

## リスク

low。既存 docs page への相互導線追加のみで、setup contract の採用判断や実装挙動には触れていません。