### PR TITLE
test: guard docs reader journey signals

### DIFF
--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -64,6 +64,102 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Language README user journey",
+    files: [
+      [
+        "docs/en/README.md",
+        [
+          "For users",
+          "Goal-based shortcuts",
+          "Set up TreeView for the first time",
+          "Choose the right API or rendering mode",
+          "Render large or partial trees",
+          "Diagnose symptoms or responsibility boundaries",
+          "Installation",
+          "Minimal usage",
+          "Usage",
+          "Decision guide",
+          "Troubleshooting",
+          "FAQ",
+          "Visual reference mockups",
+          "Demo application boundary",
+          "Reading order"
+        ]
+      ],
+      [
+        "docs/ja/README.md",
+        [
+          "利用者向け",
+          "目的別ショートカット",
+          "初めて TreeView を導入する",
+          "使う API や描画方式を選ぶ",
+          "大きな tree や一部描画を扱う",
+          "症状や責務境界から調べる",
+          "導入手順",
+          "最小利用例",
+          "使い方",
+          "API判断ガイド",
+          "トラブルシューティング",
+          "FAQ",
+          "視覚リファレンス mockup",
+          "Demo application boundary",
+          "読む順番"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Selection and children pagination unloaded descendants boundary",
+    files: [
+      [
+        "docs/en/selection.md",
+        [
+          "DOM-based",
+          "rendered rows only",
+          "unloaded descendants",
+          "server-side intent or query filter",
+          "Children Pagination",
+          "children-pagination-selection-boundary.html"
+        ]
+      ],
+      [
+        "docs/ja/selection.md",
+        [
+          "DOMベース",
+          "描画済み行だけ",
+          "unloaded descendants",
+          "server-side intent",
+          "Children Pagination",
+          "children-pagination-selection-boundary.html"
+        ]
+      ],
+      [
+        "docs/en/children-pagination.md",
+        [
+          "Selection and drag/drop interactions",
+          "unloaded descendants",
+          "server-side selection intent",
+          "query-backed actions",
+          "DOM-submitted checkbox values",
+          "Selection](selection.md#linked-checkbox-behavior)",
+          "children-pagination-selection-boundary.html"
+        ]
+      ],
+      [
+        "docs/ja/children-pagination.md",
+        [
+          "selection / drag-drop との相互作用",
+          "unloaded descendants",
+          "server-side selection intent",
+          "query-backed action",
+          "DOMから送られるcheckbox値",
+          "Selection](selection.md#連動checkbox挙動)",
+          "children-pagination-selection-boundary.html"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Mockup README smoke and review policy",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue

- Closes #1833
- Closes #1842

## Issue ごとの完了内容

- #1833: language README の goal-based shortcuts、導入/判断/トラブルシューティング/FAQ/読む順番の主要導線が docs reader journey smoke で検出されるようにしました。
- #1842: Selection と Children Pagination の unloaded descendants 境界、server-side intent / query-backed actions、相互リンク、関連 mockup 参照が docs reader journey smoke で検出されるようにしました。

## 変更内容

- `script/test_docs_reader_journey_signals.mjs` に以下の signal group を追加しました。
  - `Language README user journey`
  - `Selection and children pagination unloaded descendants boundary`

## 改善カテゴリ

- docs smoke test の強化
- docs drift guard の追加

## 既存仕様への影響

- ランタイムコード、Ruby/JS 実装、公開 API、UI、DB、認可、状態遷移には触れていません。
- docs 本文も変更せず、既存ドキュメントの重要な読者導線を検出する smoke test のみを追加しています。

## 確認内容

- `node --check` で更新後スクリプトの構文確認を実施しました。
- PR 前に `main...quality/1833-1842-docs-reader-journey-smoke` を確認し、branch は main から ahead 1 / behind 0 でした。
- 差分は `script/test_docs_reader_journey_signals.mjs` のみに限定されていることを確認しました。

## リスク評価

- risk: low
- docs smoke の検出対象を増やすだけのため、既存仕様への影響はありません。

## 補足事項

- connector-only 作業のため、ローカル checkout での full npm script 実行ではなく、構文確認と branch freshness / 差分範囲確認を行っています。CI で docs smoke 全体の実行結果を確認します。