### PR TITLE
Accessibility semantics docs から focused mockup への導線を追加する

### DIFF
--- a/docs/en/accessibility-semantics.md
+++ b/docs/en/accessibility-semantics.md
@@ -45,6 +45,8 @@ For a static comparison of no-root-items and no-results rows, the reusable empty
 
 Use that mockup as a visual companion to this policy; it does not redefine ARIA behavior, CTA copy, or filter-reset workflow.
 
+For a focused visual companion to the table-first ARIA policy, see [accessibility-semantics.html](../mockups/accessibility-semantics.html). It shows representative row-level ARIA placement, toggle `aria-expanded`, omitted `aria-controls`, and host-app-owned page-structure boundaries without redefining runtime behavior or promising a full treegrid model.
+
 ## Supported rendering examples
 
 ### Static table rows

--- a/docs/ja/accessibility-semantics.md
+++ b/docs/ja/accessibility-semantics.md
@@ -45,6 +45,8 @@ no-root-items と no-results row、再利用可能な empty-row wrapper hook、h
 
 この mockup は、この policy を視覚的に補うためのものです。ARIA behavior、CTA copy、filter-reset workflow を定義し直すものではありません。
 
+table-first ARIA policy を静的に見比べたい場合は [accessibility-semantics.html](../mockups/accessibility-semantics.html) を参照してください。この mockup は、row-level ARIA placement、toggle の `aria-expanded`、`aria-controls` 非採用、host-app-owned page structure boundary を確認する visual companion であり、runtime behavior を定義し直したり full treegrid model を約束したりするものではありません。
+
 ## 対応している描画例
 
 ### Static table rows


### PR DESCRIPTION
## 対応 Issue

Closes #1858

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- 英日 `docs/*/accessibility-semantics.md` から `docs/mockups/accessibility-semantics.html` へ辿れる短い導線を追加しました。
- focused mockup は table-first ARIA policy の visual companion であり、runtime behavior や full treegrid model を定義し直すものではないことを明記しました。
- 既存の empty-state mockup 導線、mockup README、review-gallery の役割とは重複しない範囲に閉じています。

## 変更範囲

- docs-only
- runtime Ruby / JavaScript、ARIA output、keyboard model、automated accessibility checker、mockup HTML / README / review-gallery は変更していません。

## 確認内容

- PR #1857 が 2026-06-11 19:15 UTC に merge 済みで、`docs/mockups/accessibility-semantics.html` と mockup README / review-gallery / browser smoke target が current `main` に入っていることを確認しました。
- compare `main...docs/1858-accessibility-semantics-mockup-link`: `ahead_by:2` / `behind_by:0`
- changed files: `docs/en/accessibility-semantics.md`, `docs/ja/accessibility-semantics.md` の 2 docs files only
- local checkout / local docs check は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存の merged mockup への discoverability を補うだけで、仕様追加や実装変更はありません。