### PR TITLE
Accessibility semantics mockup の reader journey signal を追加する

### DIFF
--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -160,6 +160,40 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Accessibility semantics mockup reader journey",
+    files: [
+      [
+        "docs/en/accessibility-semantics.md",
+        [
+          "accessibility-semantics.html",
+          "table-first ARIA policy",
+          "toggle `aria-expanded`",
+          "omitted `aria-controls`",
+          "host-app-owned page-structure boundaries"
+        ]
+      ],
+      [
+        "docs/ja/accessibility-semantics.md",
+        [
+          "accessibility-semantics.html",
+          "table-first ARIA policy",
+          "toggle の `aria-expanded`",
+          "`aria-controls` 非採用",
+          "host-app-owned page structure boundary"
+        ]
+      ],
+      [
+        "docs/mockups/accessibility-semantics.html",
+        [
+          "data-tree-view-sample=\"accessibility-semantics\"",
+          "Table-first, not treegrid",
+          "aria-controls",
+          "host-app decisions"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Mockup README smoke and review policy",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue

Refs #1861
Depends on #1863 / #1858

## stacked にした理由

#1861 は #1858 の docs 導線 landing 後に扱う quality smoke です。現時点で #1858 は PR #1863 として open / mergeable / CI success ですが、まだ `main` には入っていません。

Planner handoff が「#1858 が未mergeなら PR head に stack 可」としているため、current `main` の事実として先取りせず、#1863 head `a9f0154d806823fb1989c9eb8d61f8054970c32c` を base にした stacked PR として作成します。

## Issue ごとの完了内容

- #1861: `script/test_docs_reader_journey_signals.mjs` に Accessibility semantics mockup reader journey の signal group を追加しました。
- 英日 `docs/*/accessibility-semantics.md` から `accessibility-semantics.html` への導線を確認します。
- mockup 側では `data-tree-view-sample="accessibility-semantics"`、table-first / not-treegrid boundary、`aria-controls`、host-app decision の代表 signal を確認します。

## 変更内容

- `script/test_docs_reader_journey_signals.mjs`
  - `Accessibility semantics mockup reader journey` group を追加
  - docs-to-mockup 導線と table-first ARIA policy の代表 signal を source path ごとに確認

## 改善カテゴリ

- test
- docs smoke
- docs reader journey guard

## 既存仕様への影響

なし。runtime Ruby / JavaScript、ARIA output、keyboard model、automated accessibility checker、mockup HTML、docs 本文は変更していません。

## 実施した確認

- base PR #1863 は open / `mergeable:true` / head `a9f0154d806823fb1989c9eb8d61f8054970c32c`
- compare `docs/1858-accessibility-semantics-mockup-link...quality/1861-accessibility-semantics-reader-journey`:
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1 (`script/test_docs_reader_journey_signals.mjs`)
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。#1858 の docs 導線を前提にした source-level docs smoke の追加のみです。#1863 が merge された後は、この PR を `main` 向けに retarget するか、同等差分を main 起点で再提案してください。

## 補足事項

- この stacked PR では Issue close keyword を使っていません。#1863 merge 後に main 向け PR として扱う段階で `Closes #1861` に切り替えるのが安全です。