### PR TITLE
Accessibility semantics mockup の reader journey signal を main 起点で追加する

### DIFF
--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -160,6 +160,40 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Accessibility semantics mockup reader journey",
+    files: [
+      [
+        "docs/en/accessibility-semantics.md",
+        [
+          "accessibility-semantics.html",
+          "table-first ARIA policy",
+          "toggle `aria-expanded`",
+          "omitted `aria-controls`",
+          "host-app-owned page-structure boundaries"
+        ]
+      ],
+      [
+        "docs/ja/accessibility-semantics.md",
+        [
+          "accessibility-semantics.html",
+          "table-first ARIA policy",
+          "toggle の `aria-expanded`",
+          "`aria-controls` 非採用",
+          "host-app-owned page structure boundary"
+        ]
+      ],
+      [
+        "docs/mockups/accessibility-semantics.html",
+        [
+          "data-tree-view-sample=\"accessibility-semantics\"",
+          "Table-first, not treegrid",
+          "aria-controls",
+          "host-app decisions"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Mockup README smoke and review policy",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue

Closes #1861
Supersedes #1864

## 置き換え理由

PR #1864 は #1858 / #1863 の stacked PR として作成されましたが、#1863 が main に squash merge された後も stacked base のままだったため、`main...quality/1861-accessibility-semantics-reader-journey` に #1863 由来の docs 差分が再び出ていました。

この PR は current `main` `ef10527b0f2b5b324e07416d4e46bd997f34e0e3` を親にして、#1861 の docs reader journey smoke 差分だけを載せ直します。

## Issue ごとの完了内容

- #1861: `script/test_docs_reader_journey_signals.mjs` に Accessibility semantics mockup reader journey の signal group を追加しました。
- 英日 `docs/*/accessibility-semantics.md` から `accessibility-semantics.html` への代表導線を確認します。
- mockup 側では `data-tree-view-sample="accessibility-semantics"`、table-first / not-treegrid boundary、`aria-controls`、host-app decision の代表 signal を確認します。

## 変更内容

- `script/test_docs_reader_journey_signals.mjs`
  - Accessibility semantics mockup reader journey group を追加
  - docs-to-mockup 導線と table-first ARIA policy の代表 signal を source path ごとに確認

## 改善カテゴリ

- test
- docs smoke
- docs reader journey guard

## 既存仕様への影響

なし。runtime Ruby / JavaScript、ARIA output、keyboard model、automated accessibility checker、mockup HTML、docs 本文は変更していません。

## 実施した確認

- compare `main...quality/1861-accessibility-semantics-reader-journey-main`:
  - `ahead_by:1`
  - `behind_by:0`
  - changed files: 1 (`script/test_docs_reader_journey_signals.mjs`)
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。source-level docs smoke の追加のみで、実装挙動や docs prose は変更していません。