### PR TITLE
Add render log level docs reader journey smoke

### DIFF
--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -109,6 +109,46 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Render log level reader journey",
+    files: [
+      [
+        "README.md",
+        [
+          "docs/en/render-log-level.md",
+          "docs/ja/render-log-level.md",
+          "accepted values",
+          "host app's global Rails logger level"
+        ]
+      ],
+      [
+        "docs/README.md",
+        [
+          "en/render-log-level.md",
+          "ja/render-log-level.md",
+          "host app's global Rails logger level"
+        ]
+      ],
+      [
+        "docs/en/README.md",
+        [
+          "Render log level",
+          "render-log-level.md",
+          "Configure TreeView partial render log silencing",
+          "TreeView render log verbosity in host app logs"
+        ]
+      ],
+      [
+        "docs/ja/README.md",
+        [
+          "render log レベル",
+          "render-log-level.md",
+          "TreeView partial render log の抑制設定",
+          "host app log 上の TreeView render log"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Selection and children pagination unloaded descendants boundary",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue
- Closes #1869

## Issue ごとの完了内容
- #1869: README / docs entrypoint から render log level docs へ辿れる代表導線を `script/test_docs_reader_journey_signals.mjs` で guard しました。

## 変更内容
- `script/test_docs_reader_journey_signals.mjs` に `Render log level reader journey` group を追加。
- `README.md`, `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` の既存 signal を確認対象にしました。
- runtime Ruby、configuration behavior、public API manifest、docs 本文は変更していません。

## 改善カテゴリ
- test
- docs smoke
- maintenance

## 既存仕様への影響
- ありません。source-level docs smoke の追加のみで、公開 API / UI / runtime behavior / logging behavior は変更していません。

## 実施した確認
- Issue #1869 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch freshness: `main` commit `e02249643ae4f788818a8c033c1e00c4a87578b9` から branch 作成。
- 差分確認: `script/test_docs_reader_journey_signals.mjs` 1 file only, +40 / -0。
- source review: 追加した各 signal が current `README.md`, `docs/README.md`, `docs/en/README.md`, `docs/ja/README.md` に存在することを確認。

## ローカル確認について
- connector-only での最小変更です。現在の実行環境では repository checkout が GitHub 403 で取得できないため、`npm run test:docs-entrypoints` はローカル実行していません。PR CI で確認してください。

## リスク評価
- low。既存 docs smoke の signal group 追加のみで、挙動変更を含みません。

## 補足
- `docs/en|ja/render-log-level.md` 本文の `:warn` default、accepted values、`nil`、global Rails logger boundary は既存の `TreeView.configure option docs boundary` smoke が既に guard しているため、今回は reader journey 側の導線に絞りました。