### PR TITLE
row_data_builder の row status data 境界を明文化する

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -257,7 +257,7 @@ render_state = TreeView::RenderState.new(
 )
 ```
 
-Use `row_data_builder` when host-app JavaScript needs stable metadata. If a row should be readonly or disabled for TreeView-level interaction, also see [Row status](row-status.md). Authorization decisions and business rules still belong in the host app.
+Use `row_data_builder` when host-app JavaScript needs stable metadata under host-owned keys. If a row should be readonly or disabled for TreeView-level interaction, also see [Row status](row-status.md); do not treat TreeView-owned status keys such as `tree_view_row_disabled` as app metadata to overwrite. Authorization decisions and business rules still belong in the host app.
 
 ## Stable name sorting
 

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -168,6 +168,8 @@ See [API reference](api.md), [Localized names](localized-names.md), and [Turbo F
 
 These keys are a key-surface contract only: `row_class_builder`, `row_data_builder`, `row_event_payload_builder`, `loading_builder`, `error_builder`, `depth_label_builder`, `badge_builder`, `icon_builder`, and `toggle_icon_builder` remain distinct from grouped option hashes, individual scalar options, and the declarative `toggle_icons` map. This contract does not change callback arity, return-value validation, row rendering, `NodePresenter` fallback behavior, or toggle icon lookup priority.
 
+`row_data_builder` stays inside that key-surface contract. Host-app data hash shape, merged row data attributes, and TreeView-owned row status keys are documented and guarded in [Row status](row-status.md) rather than promoted to a manifest-backed return-shape schema.
+
 ## Host app extension points
 
 Host apps are expected to provide these pieces:

--- a/docs/en/row-status.md
+++ b/docs/en/row-status.md
@@ -60,6 +60,8 @@ render_state = TreeView::RenderState.new(
 
 TreeView keeps existing host app classes and data, then adds the documented TreeView status class/data keys when `row_disabled_builder` or `row_readonly_builder` returns `true`. Disabled reasons are added when `row_disabled_reason_builder` returns a present value.
 
+`row_data_builder` is a host-app metadata hook. The public API manifest tracks the `row_data_builder` callback key as an initializer keyword and reader, but it does not make the callback's return shape or every merged row data attribute a manifest-backed schema. Keep host-app metadata under app-owned keys such as `document_id`; do not rely on overwriting TreeView-owned status keys like `tree_view_row_disabled`, `tree_view_row_readonly`, or `tree_view_row_disabled_reason`.
+
 ## Difference from selection disabled state
 
 `selection[:disabled_builder]` disables a checkbox.
@@ -79,6 +81,8 @@ Row status expresses state for the whole row.
 |---|---|---|
 | status builder invocation | yes | provides builders |
 | row class/data merge | yes | provides additional attributes |
+| TreeView-owned status data keys | yes | should not treat them as app-owned metadata |
+| host-app metadata keys from `row_data_builder` | preserves during merge | owns names, values, and JavaScript use |
 | business rule | no | yes |
 | authorization | no | yes |
 | action disabling | no | yes |

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -257,7 +257,7 @@ render_state = TreeView::RenderState.new(
 )
 ```
 
-host app JavaScriptが安定したmetadataを必要とする場合は `row_data_builder` を使います。TreeView levelのinteractionとしてreadonly / disabledを表したい場合は [Row status](row-status.md) も参照してください。authorization decisionや業務ruleは引き続きhost app側で扱います。
+host app JavaScriptが安定したmetadataを必要とする場合は、host app が所有する key に置く用途で `row_data_builder` を使います。TreeView levelのinteractionとしてreadonly / disabledを表したい場合は [Row status](row-status.md) も参照し、`tree_view_row_disabled` のような TreeView-owned status key を app metadata として上書き前提にしないでください。authorization decisionや業務ruleは引き続きhost app側で扱います。
 
 ## 名前順で安定ソートする
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -168,6 +168,8 @@ localized display-name helper は、利用できる場合に host app の Rails 
 
 対象 key は `row_class_builder`、`row_data_builder`、`row_event_payload_builder`、`loading_builder`、`error_builder`、`depth_label_builder`、`badge_builder`、`icon_builder`、`toggle_icon_builder` です。これは key surface の contract であり、grouped option hash、個別 scalar option、宣言的な `toggle_icons` map とは別の surface です。callback arity、return value validation、row rendering、`NodePresenter` fallback、toggle icon lookup priority は変更しません。
 
+`row_data_builder` もこの key-surface contract に留まります。host app の data hash shape、merge 後の row data attribute、TreeView-owned row status key との境界は [Row status](row-status.md) の docs/spec-level guidance で扱い、manifest-backed return-shape schema には昇格しません。
+
 ## Host app extension points
 
 host app が提供する主な拡張点は以下です。

--- a/docs/ja/row-status.md
+++ b/docs/ja/row-status.md
@@ -60,6 +60,8 @@ render_state = TreeView::RenderState.new(
 
 TreeView は host app 側の class / data を残したうえで、`row_disabled_builder` または `row_readonly_builder` が `true` を返したときに documented な TreeView status class/data key を追加します。disabled reason は `row_disabled_reason_builder` が present な値を返したときに追加されます。
 
+`row_data_builder` は host app metadata 用の hook です。public API manifest が追跡するのは `row_data_builder` callback key が initializer keyword かつ reader として存在することまでで、callback の戻り値 shape や merge 後のすべての row data attribute を manifest-backed schema にするものではありません。host app metadata は `document_id` のような app-owned key に置き、`tree_view_row_disabled`、`tree_view_row_readonly`、`tree_view_row_disabled_reason` のような TreeView-owned status key を上書き前提で使わないでください。
+
 ## selectionとの違い
 
 selection の `disabled_builder` は checkbox を選択不可にします。
@@ -79,6 +81,8 @@ row status は行全体の見た目や状態を表すための hook です。
 |---|---|---|
 | status builder invocation | yes | provides builders |
 | row class/data merge | yes | provides additional attributes |
+| TreeView-owned status data keys | yes | app-owned metadata として扱わない |
+| `row_data_builder` 由来の host-app metadata key | merge 時に維持する | name、value、JavaScript 利用を所有する |
 | business rule | no | yes |
 | authorization | no | yes |
 | action disabling | no | yes |

--- a/spec/lib/tree_view/row_status_builder_spec.rb
+++ b/spec/lib/tree_view/row_status_builder_spec.rb
@@ -37,4 +37,22 @@ RSpec.describe "TreeView row status builders" do
     expect(state.row_data_builder.call(root)).to include(name: "root", tree_view_row_disabled: true, tree_view_row_disabled_reason: "locked")
     expect(state.row_data_builder.call(child)).to include(name: "child", tree_view_row_readonly: true)
   end
+
+  it "preserves host data while TreeView-owned status keys describe row status" do
+    state = TreeView::RenderState.new(
+      tree: tree,
+      root_items: tree.root_items,
+      row_partial: "items/tree_columns",
+      ui_config: ui_config,
+      row_data_builder: ->(item) { {name: item.name, tree_view_row_disabled: false, tree_view_row_disabled_reason: "host"} },
+      row_disabled_builder: ->(item) { item.locked },
+      row_disabled_reason_builder: ->(item) { item.locked ? "locked" : nil }
+    )
+
+    expect(state.row_data_builder.call(root)).to include(
+      name: "root",
+      tree_view_row_disabled: true,
+      tree_view_row_disabled_reason: "locked"
+    )
+  end
 end

--- a/spec/render_state_callback_builder_manifest_spec.rb
+++ b/spec/render_state_callback_builder_manifest_spec.rb
@@ -17,8 +17,12 @@ RENDER_STATE_CALLBACK_BUILDER_KEYS = %w[
 ].freeze
 
 RSpec.describe "RenderState callback builder public manifest" do
+  def public_api_manifest
+    YAML.safe_load_file(RENDER_STATE_CALLBACK_BUILDER_MANIFEST_PATH)
+  end
+
   def manifest_callback_builder_keys
-    YAML.safe_load_file(RENDER_STATE_CALLBACK_BUILDER_MANIFEST_PATH).fetch("render_state_callback_builder_keys")
+    public_api_manifest.fetch("render_state_callback_builder_keys")
   end
 
   it "keeps the flat callback builder key list aligned with RenderState" do
@@ -36,5 +40,11 @@ RSpec.describe "RenderState callback builder public manifest" do
     manifest_callback_builder_keys.each do |key|
       expect(state.public_send(key)).to eq(builders.fetch(key.to_sym)), "expected RenderState##{key} to keep the provided builder"
     end
+  end
+
+  it "keeps row_data_builder as a key-surface contract rather than a return-shape schema" do
+    expect(manifest_callback_builder_keys).to include("row_data_builder")
+    expect(public_api_manifest.keys.grep(/row_data_builder/)).to be_empty
+    expect(public_api_manifest.keys.grep(/row_data/)).to be_empty
   end
 end


### PR DESCRIPTION
`row_data_builder` は manifest-backed return-shape schema ではなく callback key surface として扱い、row status data key との責務境界を docs/spec で明文化します。

Closes #1838

## 変更内容

- Row status docs の英日ペアに、`row_data_builder` は host-app metadata hook であり、manifest は key-surface contract までであることを追記しました。
- `tree_view_row_disabled` / `tree_view_row_readonly` / `tree_view_row_disabled_reason` は TreeView-owned status keys として扱い、host app metadata とは分ける説明を追加しました。
- manifest spec に、`row_data_builder` を return-shape schema として昇格しないことの guard を追加しました。
- row status builder spec に、host data を維持しつつ TreeView-owned status keys が row status を表す representative case を追加しました。

## 受け入れ条件との対応

- `row_data_builder` return / merge surface は manifest-backed contract に含めず、docs/spec-level guidance に留める方針を明文化しました。
- manifest-backed contract は `row_data_builder` initializer keyword + reader の存在に限定されることを spec で守っています。
- row status docs が host app data と TreeView-owned row status data keys の responsibility boundary を説明しています。
- runtime behavior、row class/data merge algorithm、authorization / business state semantics は変更していません。
- private internal data attributes は public surface へ昇格していません。

## 変更範囲

- `docs/en/row-status.md`
- `docs/ja/row-status.md`
- `spec/render_state_callback_builder_manifest_spec.rb`
- `spec/lib/tree_view/row_status_builder_spec.rb`

## 実施した確認

- Issue #1838 の labels と Planner handoff を直接確認しました。
- #1838 を担当する既存 open PR がないことを確認しました。
- compare `main...feature/1838-row-data-builder-contract`: changed files 4 / behind_by 0。
- local checkout / local RSpec は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

medium。public contract wording と focused specs の変更に閉じ、runtime や manifest schema は変更していません。

## 未対応・補足

- public API manifest schema の追加、`RenderState` / row rendering runtime の変更、authorization / business state semantics の標準化、docs 全体 rewrite は行っていません。