### PR TITLE
Selection docs から checkbox hook export へ導線を足す

### DIFF
--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -77,6 +77,8 @@ selection: {
 
 The return value from `disabled_reason_builder` is rendered as the checkbox `title` and `data-tree-selection-disabled-reason`.
 
+If host-app JavaScript or browser tests need to find rendered selection checkboxes or the disabled-reason attribute without hand-copying raw strings, use `TreeViewSelectionCheckboxHooks.checkboxClass` and `TreeViewSelectionCheckboxHooks.disabledReasonAttribute` from the package root. The raw `.tree-selection-checkbox` class and `data-tree-selection-disabled-reason` attribute remain the documented DOM contract; the export is a machine-readable reference to those names. See [Selection checkbox hooks](selection-checkbox-hooks.md).
+
 ## JavaScript selection API
 
 `tree-view-selection` can collect checked node payloads from rendered selection checkboxes.

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -77,6 +77,8 @@ selection: {
 
 `disabled_reason_builder` の戻り値は、checkboxの `title` と `data-tree-selection-disabled-reason` に出力されます。
 
+host app の JavaScript や browser test で、描画済み selection checkbox や disabled reason attribute を raw string の写経なしで参照したい場合は、package root の `TreeViewSelectionCheckboxHooks.checkboxClass` と `TreeViewSelectionCheckboxHooks.disabledReasonAttribute` を使えます。raw `.tree-selection-checkbox` class と `data-tree-selection-disabled-reason` attribute は引き続き documented DOM contract であり、export はそれらの名前を machine-readable に参照するためのものです。詳しくは [Selection checkbox hooks](selection-checkbox-hooks.md) を参照してください。
+
 ## JavaScript selection API
 
 `tree-view-selection` は、描画済みselection checkboxからchecked node payloadを収集できます。


### PR DESCRIPTION
## 対応 Issue

Closes #664

## 分類

- `code-ahead-of-docs`

## 変更内容

- `docs/en/selection.md` / `docs/ja/selection.md` の disabled checkbox 説明に、`TreeViewSelectionCheckboxHooks.checkboxClass` と `TreeViewSelectionCheckboxHooks.disabledReasonAttribute` への導線を追加しました。
- raw `.tree-selection-checkbox` class と `data-tree-selection-disabled-reason` attribute は引き続き documented DOM contract であり、package-root export はそれらの machine-readable reference であることを明記しました。
- 詳細は既存の `selection-checkbox-hooks.md` に委譲し、selection controller behavior、event payload、hidden input sync、business action guidance は変更していません。

## 確認内容

- current `main` の `app/javascript/tree_view/index.js` に `TreeViewSelectionCheckboxHooks` export が存在することを確認しました。
- current `docs/en|ja/public-api.md` と `docs/en|ja/selection-checkbox-hooks.md` が同 export を説明済みであることを確認しました。
- compare `main...docs/664-selection-checkbox-hooks-entrypoint`: changed files 2 / `behind_by:0`。
- ローカル checkout は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存 public export への docs 導線追加だけで、runtime Ruby / JavaScript、public API manifest、selection controller behavior は変更していません。