### PR TITLE
release-note-candidates helper の output signal を docs smoke で守る

### DIFF
--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -74,3 +74,50 @@ const releaseDocs = [
 releaseDocs.forEach(([sourcePath, signals]) => {
   assertSignals(sourcePath, "Release checklist changelog policy", signals)
 })
+
+assertSignals("script/release_note_candidates.rb", "Release note candidate helper output", [
+  "# Release note candidates for #{repo}",
+  "Source: #{source}",
+  "This is a maintainer review aid. It does not rewrite CHANGELOG.md and does not decide the final release notes.",
+  "Merged pull requests",
+  "Closed issues",
+  "--since DATE",
+  "--since-tag TAG"
+])
+
+const releaseNoteCandidateDocs = [
+  [
+    "docs/en/release-note-candidates.md",
+    [
+      "script/release_note_candidates.rb",
+      "candidate collector only",
+      "It does not edit `CHANGELOG.md`.",
+      "It does not decide the final release notes.",
+      "--since 2026-06-01",
+      "--since-tag v0.1.0",
+      "# Release note candidates for matsuo-haruhito/tree_view-rails",
+      "## Merged pull requests",
+      "## Closed issues",
+      "release preparation notes, not committed as the final release text"
+    ]
+  ],
+  [
+    "docs/ja/release-note-candidates.md",
+    [
+      "script/release_note_candidates.rb",
+      "candidate collector に限定します",
+      "`CHANGELOG.md` は編集しません。",
+      "最終的な release notes を自動判断しません。",
+      "--since 2026-06-01",
+      "--since-tag v0.1.0",
+      "# Release note candidates for matsuo-haruhito/tree_view-rails",
+      "## Merged pull requests",
+      "## Closed issues",
+      "release preparation の確認メモへ貼るためのもの"
+    ]
+  ]
+]
+
+releaseNoteCandidateDocs.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Release note candidate docs", signals)
+})


### PR DESCRIPTION
## 対応 Issue

Closes #1875

## Issue ごとの完了内容

- #1875: `script/test_release_docs_signals.mjs` に release-note candidate collector 専用の代表 signal guard を追加しました。
- helper 本体の出力 heading / source line / section names / CLI option surface と、英日 `release-note-candidates.md` の boundary / output example が大きく drift した場合に検出できるようにしました。

## 変更内容

- `script/release_note_candidates.rb` の代表出力を docs smoke で確認します。
  - `# Release note candidates for ...`
  - `Source: ...`
  - `## Merged pull requests`
  - `## Closed issues`
  - `--since` / `--since-tag`
  - `CHANGELOG.md` を書き換えず、final release notes を自動判断しない境界
- `docs/en/release-note-candidates.md` / `docs/ja/release-note-candidates.md` の代表 signal を同じ smoke で確認します。
- 既存の release docs / CHANGELOG policy smoke に近い範囲へ追加し、#1709 系の汎用 docs entrypoint smokeとは分けています。

## 改善カテゴリ

- test
- docs drift guard
- release maintenance

## 既存仕様への影響

挙動変更はありません。GitHub API integration、release automation、GitHub Release 作成、tag 作成、gem publish、CHANGELOG category policy redesign は変更していません。

## 実施した確認

- Issue #1875 の labels を直接確認しました。
  - `status:ready-for-agent`
  - `track:quality`
  - `agent:planned`
  - `risk:low`
- Planner handoff を確認し、単独の low-risk maintainer-release smoke として扱いました。
- PR 前 compare `main...quality/1875-release-note-candidates-signals`: `ahead_by:1` / `behind_by:0` / changed files 1。
- final newline は connector fetch で末尾改行ありのテキストとして確認しました。
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS checkout が利用できないため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 release docs signal script への代表 signal 追加のみで、runtime Ruby/Rails behavior や public UI/API には触れていません。主なリスクは wording に寄りすぎることですが、全文一致ではなく短い代表 signal に限定しています。