### PR TITLE
ResourceTableRenderState で host row_data_builder を bridge hook と合成する

### DIFF
--- a/app/helpers/tree_view_helper/row_attributes.rb
+++ b/app/helpers/tree_view_helper/row_attributes.rb
@@ -4,16 +4,20 @@ module TreeViewHelper
       Array(builder&.call(item)).flatten.compact_blank
     end
 
-    def tree_row_data(item, builder = nil, tree: nil)
-      data = builder&.call(item)
+    def tree_row_data(item, builder = nil, tree: nil, row_context: nil)
+      data = if builder && tree_row_data_builder_accepts_context?(builder)
+        builder.call(item, row_context || {})
+      else
+        builder&.call(item)
+      end
       return {} if data.nil?
       return data.to_h if data.respond_to?(:to_h)
 
       raise ArgumentError, "row_data_builder must return a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
     end
 
-    def tree_render_row_data(item, tree, render_context, expanded:, depth:, transfer_data: nil)
-      data = tree_row_data(item, render_context.row_data_builder, tree: tree)
+    def tree_render_row_data(item, tree, render_context, expanded:, depth:, row_context: nil, transfer_data: nil)
+      data = tree_row_data(item, render_context.row_data_builder, tree: tree, row_context: row_context)
       if render_context.tree_instance_key.present?
         data = data.merge(tree_instance_key: render_context.tree_instance_key)
       end
@@ -67,6 +71,16 @@ module TreeViewHelper
       end
     rescue NoMethodError
       raise ArgumentError, "badge_builder must return text or a Hash-like object for #{tree_diagnostic_node_label(item, tree)}"
+    end
+
+    def tree_row_data_builder_accepts_context?(builder)
+      arity = if builder.respond_to?(:arity)
+        builder.arity
+      elsif builder.respond_to?(:method) && builder.respond_to?(:call)
+        builder.method(:call).arity
+      end
+
+      arity.nil? || arity.negative? || arity >= 2
     end
   end
 end

--- a/app/views/tree_view/_tree_row.html.erb
+++ b/app/views/tree_view/_tree_row.html.erb
@@ -17,7 +17,7 @@
 <% client_mode = mode == :client %>
 <% row_classes = tree_row_classes(item, render_context.row_class_builder) %>
 <% transfer_data = tree_row_transfer_data(item, tree, render_context.row_event_payload_builder) %>
-<% row_data = tree_render_row_data(item, tree, render_context, expanded: !effectively_collapsed, depth: depth, transfer_data: transfer_data) %>
+<% row_data = tree_render_row_data(item, tree, render_context, expanded: !effectively_collapsed, depth: depth, row_context: row_context, transfer_data: transfer_data) %>
 <% row_attrs = { id: tree_node_dom_id(item), class: row_classes.presence, data: row_data, aria: row_aria = { level: depth + 1, selected: tree_selection_checked?(item, tree, render_context.selection_selected_keys) } } %>
 <% row_attrs[:hidden] = true if hidden_by_client_parent %>
 <% row_attrs[:draggable] = true if transfer_data.present? %>

--- a/docs/en/resource-table-bridge.md
+++ b/docs/en/resource-table-bridge.md
@@ -42,6 +42,18 @@ The documented optional bridge keywords are:
 
 Other keyword options are accepted through `**render_options` and passed to `TreeView::RenderState`. Treat those options as the existing RenderState option surface, not as a separate resource-table-specific contract. For example, grouped options such as `initial_expansion:`, `selection:`, or `lazy_loading:` remain governed by the RenderState docs and manifest sections.
 
+### Row data composition
+
+`row_data_builder:` can be passed through `ResourceTableRenderState.call` when the host app needs extra row-level data for authorization hints, row state, or table-layer integration. The host builder may use the same one-argument shape as `RenderState`, or it may accept a second row context argument when it needs rendering context such as depth.
+
+Resource-table bridge data is reserved and remains TreeView-owned. Host data is merged first, then the bridge writes these keys last:
+
+- `rails_ui_row`
+- `tree_view_resource_table_row`
+- `rails_table_preferences_table_key`
+
+That precedence lets host apps add app-owned keys such as `resource_id`, `business_state`, or `can_edit`, while preventing bridge-owned hooks from being removed accidentally. If the host builder returns `nil`, it is treated as empty data. The bridge does not implement authorization, business actions, or table preference state; it only keeps the row data composition boundary stable.
+
 ## Intended integration with Rails Table Preferences
 
 A table preferences layer can infer columns from Active Record, merge saved table settings into a table state, and then pass that table state to TreeView:

--- a/docs/ja/resource-table-bridge.md
+++ b/docs/ja/resource-table-bridge.md
@@ -42,6 +42,18 @@ default row partialは `tree_view/resource_table_row` です。`table_state["vis
 
 その他の keyword option は `**render_options` として受け取り、`TreeView::RenderState` に渡します。これらは resource-table 専用 contract ではなく、既存の RenderState option surface として扱ってください。たとえば `initial_expansion:`、`selection:`、`lazy_loading:` のような grouped option は RenderState 側の docs と manifest section が責務を持ちます。
 
+### row data composition
+
+host app が authorization hint、row state、table layer integration 用の追加 data を行に持たせたい場合は、`ResourceTableRenderState.call` に `row_data_builder:` を渡せます。host builder は既存 `RenderState` と同じ1引数の形でも使えますし、depth などの描画contextが必要な場合は第2引数の row context も受け取れます。
+
+resource-table bridge の data は予約済みで、TreeView が所有します。host data を先に merge し、その後で bridge が次の key を最後に書き込みます。
+
+- `rails_ui_row`
+- `tree_view_resource_table_row`
+- `rails_table_preferences_table_key`
+
+この優先順位により、host app は `resource_id`、`business_state`、`can_edit` のような app-owned key を追加できます。一方で、bridge-owned hook が host data によって誤って消えることはありません。host builder が `nil` を返した場合は空 data として扱います。bridge は authorization、business action、table preference state を実装せず、row data composition の境界だけを安定させます。
+
 ## Rails Table Preferencesとの連携
 
 Rails Table Preferencesのようなtable layerがActive Recordからカラムを推論し、保存済み設定を `table_state` にmergeしてからTreeViewへ渡す想定です。

--- a/lib/tree_view/resource_table_render_state.rb
+++ b/lib/tree_view/resource_table_render_state.rb
@@ -33,14 +33,17 @@ module TreeView
     end
 
     def call
+      options = render_options.dup
+      host_row_data_builder = options.delete(:row_data_builder)
+
       RenderState.new(
         tree: tree,
         root_items: tree.root_items,
         row_partial: row_partial,
         ui_config: resolved_ui_config,
         row_locals: row_locals,
-        row_data_builder: row_data_builder,
-        **render_options
+        row_data_builder: row_data_builder(host_row_data_builder),
+        **options
       )
     end
 
@@ -79,14 +82,44 @@ module TreeView
       }.compact
     end
 
-    def row_data_builder
-      lambda do |_item, _row_context = {}|
-        {
-          rails_ui_row: true,
-          tree_view_resource_table_row: true,
-          rails_table_preferences_table_key: table_key
-        }.compact
+    def row_data_builder(host_row_data_builder = nil)
+      lambda do |item, row_context = {}|
+        host_row_data(item, host_row_data_builder, row_context).merge(bridge_row_data)
       end
+    end
+
+    def host_row_data(item, builder, row_context)
+      return {} if builder.nil?
+
+      data = if builder_accepts_row_context?(builder)
+        builder.call(item, row_context)
+      else
+        builder.call(item)
+      end
+      return {} if data.nil?
+      return data.to_h if data.respond_to?(:to_h)
+
+      raise ArgumentError, "row_data_builder must return a Hash-like object for ResourceTableRenderState rows"
+    end
+
+    def builder_accepts_row_context?(builder)
+      arity = builder_arity(builder)
+      arity.nil? || arity.negative? || arity >= 2
+    end
+
+    def builder_arity(builder)
+      return builder.arity if builder.respond_to?(:arity)
+      return builder.method(:call).arity if builder.respond_to?(:method) && builder.respond_to?(:call)
+
+      nil
+    end
+
+    def bridge_row_data
+      {
+        rails_ui_row: true,
+        tree_view_resource_table_row: true,
+        rails_table_preferences_table_key: table_key
+      }.compact
     end
   end
 end

--- a/spec/lib/tree_view/resource_table_render_state_spec.rb
+++ b/spec/lib/tree_view/resource_table_render_state_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+ResourceTableRenderStateSpecNode = Struct.new(:id, :parent_id, :name, keyword_init: true)
+
+RSpec.describe TreeView::ResourceTableRenderState do
+  let(:root) { ResourceTableRenderStateSpecNode.new(id: 1, parent_id: nil, name: "root") }
+  let(:child) { ResourceTableRenderStateSpecNode.new(id: 2, parent_id: 1, name: "child") }
+  let(:records) { [root, child] }
+  let(:context) { Object.new }
+  let(:ui_config) { instance_double(TreeView::UiConfig) }
+
+  def build_state(**options)
+    described_class.call(
+      records: records,
+      context: context,
+      parent_id_method: :parent_id,
+      table_key: "projects_tree",
+      ui_config: ui_config,
+      **options
+    )
+  end
+
+  it "keeps the bridge-owned row data hooks without a host builder" do
+    state = build_state
+
+    expect(state.row_data_builder.call(root)).to include(
+      rails_ui_row: true,
+      tree_view_resource_table_row: true,
+      rails_table_preferences_table_key: "projects_tree"
+    )
+  end
+
+  it "adds host row data while preserving bridge-owned hooks" do
+    state = build_state(
+      row_data_builder: ->(item, row_context = {}) { {resource_name: item.name, row_depth: row_context.fetch(:depth)} }
+    )
+
+    expect(state.row_data_builder.call(root, {depth: 0})).to include(
+      resource_name: "root",
+      row_depth: 0,
+      rails_ui_row: true,
+      tree_view_resource_table_row: true,
+      rails_table_preferences_table_key: "projects_tree"
+    )
+  end
+
+  it "keeps bridge-owned hooks when host data uses reserved keys" do
+    state = build_state(
+      row_data_builder: ->(_item) {
+        {
+          rails_ui_row: false,
+          tree_view_resource_table_row: false,
+          rails_table_preferences_table_key: "host_value",
+          host_row_state: "locked"
+        }
+      }
+    )
+
+    expect(state.row_data_builder.call(root)).to include(
+      host_row_state: "locked",
+      rails_ui_row: true,
+      tree_view_resource_table_row: true,
+      rails_table_preferences_table_key: "projects_tree"
+    )
+  end
+
+  it "treats nil host row data as empty data" do
+    state = build_state(row_data_builder: ->(_item, _row_context = {}) { nil })
+
+    expect(state.row_data_builder.call(root, {depth: 0})).to eq(
+      rails_ui_row: true,
+      tree_view_resource_table_row: true,
+      rails_table_preferences_table_key: "projects_tree"
+    )
+  end
+
+  it "keeps one-argument host row_data_builder callables compatible" do
+    state = build_state(row_data_builder: ->(item) { {resource_name: item.name} })
+
+    expect(state.row_data_builder.call(child, {depth: 1})).to include(
+      resource_name: "child",
+      tree_view_resource_table_row: true
+    )
+  end
+end

--- a/spec/lib/tree_view/resource_table_render_state_spec.rb
+++ b/spec/lib/tree_view/resource_table_render_state_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe TreeView::ResourceTableRenderState do
   end
 
   it "treats nil host row data as empty data" do
-    state = build_state(row_data_builder: ->(_item, _row_context = {}) { nil })
+    state = build_state(row_data_builder: ->(_item, _row_context = {}) {})
 
     expect(state.row_data_builder.call(root, {depth: 0})).to eq(
       rails_ui_row: true,


### PR DESCRIPTION
ResourceTableRenderState の bridge-owned data hook を守りながら、host app の row_data_builder を追加できるようにします。

Closes #947

## 変更内容

- `ResourceTableRenderState.call(..., row_data_builder:)` で host supplied builder を受け取り、resource-table bridge の row data hook と合成するようにしました。
- host data を先に取り込み、`rails_ui_row` / `tree_view_resource_table_row` / `rails_table_preferences_table_key` は bridge-owned reserved key として最後に上書きします。
- host builder が `nil` を返す場合は空 data として扱います。
- 既存の1引数 `row_data_builder` は壊さず、2引数対応 builder には rendering 時の row context を渡せるようにしました。
- ResourceTableRenderState 専用 spec と英日 `resource-table-bridge` docs を追加・更新しました。

## 受け入れ条件との対応

- host supplied `row_data_builder` と bridge-owned hook が両立します。
- host data の追加 key は残り、reserved bridge key は host data で消えないことを spec で確認しています。
- host builder の1引数互換、2引数 row context、nil return、merge precedence を spec/docs で固定しています。
- column inference、table preference state、authorization implementation、business action には広げていません。

## 変更範囲

- `lib/tree_view/resource_table_render_state.rb`
- `app/helpers/tree_view_helper/row_attributes.rb`
- `app/views/tree_view/_tree_row.html.erb`
- `spec/lib/tree_view/resource_table_render_state_spec.rb`
- `docs/en/resource-table-bridge.md`
- `docs/ja/resource-table-bridge.md`

## 実施した確認

- Issue #947 の labels と Planner handoff を直接確認しました。
- #947 を担当する既存 open PR がないことを確認しました。
- compare `main...feature/947-resource-table-row-data-builder`: `ahead_by:6` / `behind_by:0` / changed files 6。
- local checkout / local `bundle exec rspec spec/lib/tree_view/resource_table_render_state_spec.rb` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

medium。public rendering option と bridge-owned data hook の境界に触れますが、既存1引数 builder を維持し、ResourceTableRenderState の reserved key precedence に閉じています。

## 未対応・補足

- ResourceTableRenderState 全体 redesign、default row partial visual redesign、column value formatting API、Rails Table Preferences direct dependency、host app authorization / business action は扱っていません。