### PR TITLE
README Quick Start smoke を代表 assertion に分割する

### DIFF
--- a/script/test_readme_quick_start_signal.mjs
+++ b/script/test_readme_quick_start_signal.mjs
@@ -9,7 +9,71 @@ function assert(condition, message) {
   if (!condition) throw new Error(message)
 }
 
-assert(
-  /## Quick Start[\s\S]*Controller:[\s\S]*TreeView::Tree[\s\S]*TreeView::UiConfigBuilder[\s\S]*build_static[\s\S]*TreeView::RenderState[\s\S]*row_partial:\s*"projects\/tree_columns"[\s\S]*View:[\s\S]*tree_view_rows\(@render_state\)[\s\S]*Row partial:[\s\S]*app\/views\/projects\/_tree_columns\.html\.erb/.test(rootReadme),
-  "README.md Quick Start no longer exposes the representative controller/view/row-partial path"
+function extractSection(source, heading) {
+  const sectionPattern = new RegExp(`^## ${heading}\\n([\\s\\S]*?)(?=^## |\\z)`, "m")
+  const match = source.match(sectionPattern)
+
+  assert(match, `README.md is missing the ${heading} section`)
+
+  return match[1]
+}
+
+function assertQuickStartSignal(signal, pattern, message) {
+  assert(pattern.test(quickStart), `README.md Quick Start ${signal}: ${message}`)
+}
+
+const quickStart = extractSection(rootReadme, "Quick Start")
+
+assertQuickStartSignal(
+  "controller label",
+  /Controller:/,
+  "missing the controller example label"
+)
+
+assertQuickStartSignal(
+  "TreeView::Tree",
+  /TreeView::Tree/,
+  "missing the representative tree construction signal"
+)
+
+assertQuickStartSignal(
+  "UiConfigBuilder static build",
+  /TreeView::UiConfigBuilder[\s\S]*build_static/,
+  "missing the representative TreeView::UiConfigBuilder#build_static signal"
+)
+
+assertQuickStartSignal(
+  "RenderState",
+  /TreeView::RenderState/,
+  "missing the representative render state construction signal"
+)
+
+assertQuickStartSignal(
+  "row partial option",
+  /row_partial:\s*"projects\/tree_columns"/,
+  "missing the row_partial option path"
+)
+
+assertQuickStartSignal(
+  "view label",
+  /View:/,
+  "missing the view example label"
+)
+
+assertQuickStartSignal(
+  "tree_view_rows call",
+  /tree_view_rows\(@render_state\)/,
+  "missing the representative tree_view_rows(@render_state) call"
+)
+
+assertQuickStartSignal(
+  "row partial label",
+  /Row partial:/,
+  "missing the row partial example label"
+)
+
+assertQuickStartSignal(
+  "row partial file path",
+  /app\/views\/projects\/_tree_columns\.html\.erb/,
+  "missing the row partial file path"
 )

--- a/script/test_readme_quick_start_signal.mjs
+++ b/script/test_readme_quick_start_signal.mjs
@@ -10,7 +10,7 @@ function assert(condition, message) {
 }
 
 function extractSection(source, heading) {
-  const sectionPattern = new RegExp(`^## ${heading}\\n([\\s\\S]*?)(?=^## |\\z)`, "m")
+  const sectionPattern = new RegExp(`^## ${heading}\\n([\\s\\S]*?)(?=^## |$)`, "m")
   const match = source.match(sectionPattern)
 
   assert(match, `README.md is missing the ${heading} section`)

--- a/script/test_readme_quick_start_signal.mjs
+++ b/script/test_readme_quick_start_signal.mjs
@@ -10,12 +10,18 @@ function assert(condition, message) {
 }
 
 function extractSection(source, heading) {
-  const sectionPattern = new RegExp(`^## ${heading}\\n([\\s\\S]*?)(?=^## |$)`, "m")
-  const match = source.match(sectionPattern)
+  const headingLine = `## ${heading}`
+  const headingStart = source.indexOf(`${headingLine}\n`)
 
-  assert(match, `README.md is missing the ${heading} section`)
+  assert(headingStart >= 0, `README.md is missing the ${heading} section`)
 
-  return match[1]
+  const sectionStart = headingStart + headingLine.length + 1
+  const nextHeadingStart = source.indexOf("\n## ", sectionStart)
+
+  return source.slice(
+    sectionStart,
+    nextHeadingStart === -1 ? undefined : nextHeadingStart
+  )
 }
 
 function assertQuickStartSignal(signal, pattern, message) {


### PR DESCRIPTION
## 対応 Issue

Closes #1822

## Issue ごとの完了内容

- #1822: `script/test_readme_quick_start_signal.mjs` の Quick Start guard を、巨大な単一正規表現から controller / view / row partial の代表 signal ごとの assertion に分割しました。

## 変更内容

- README の `## Quick Start` section を heading boundary で切り出す helper を追加しました。
- `Controller:`、`TreeView::Tree`、`TreeView::UiConfigBuilder#build_static`、`TreeView::RenderState`、`row_partial`、`tree_view_rows(@render_state)`、row partial path などを個別 assertion にしました。
- 失敗時に欠落した signal が分かるよう、error message を signal 単位にしました。

## 改善カテゴリ

- test maintainability
- docs smoke guard readability

## 既存仕様への影響

- README 本文、runtime Ruby / JavaScript、public API、mockup、CI workflow は変更していません。
- 既存の Quick Start guard が見ていた代表 signal は維持し、検査粒度だけを細かくしています。

## 実施した確認

- Issue #1822 の labels を直接確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- #1822 を担当する既存 open PR がないことを確認しました。
- 直近 open PR #1874 / #1879 は外部コメントを確認し、最終状態が `review:needs-human` のため、この Fixer run では新規修正対象にしませんでした。
- compare `main...quality/1822-docs-smoke-assertions`: `ahead_by:2`, `behind_by:0`, changed files 1。
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs smoke script の内部整理のみで、公開挙動や docs 内容は変えません。

## 補足事項

- #1825 も docs smoke maintainability ですが、`script/test_docs_entrypoints.mjs` 全体の大きな整理になるため、このPRには混ぜていません。