### PR TITLE
Maintainer entrypoint docs の repository-only smoke を強化する

### DIFF
--- a/script/test_repository_only_maintainer_entrypoints.mjs
+++ b/script/test_repository_only_maintainer_entrypoints.mjs
@@ -83,6 +83,55 @@ const repositoryOnlyEntrypoints = [
         "Japanese docs README no longer exposes the repository-only maintainer table"
       ]
     ]
+  },
+  {
+    feature: "AGENTS maintainer first-read entrypoints",
+    links: [
+      ["AGENTS.md", "README.md"],
+      ["AGENTS.md", "docs/README.md"],
+      ["AGENTS.md", "Product Profile.md"],
+      ["AGENTS.md", "CHANGELOG.md"],
+      ["AGENTS.md", "docs/i18n-audit.md"]
+    ],
+    signals: [
+      [
+        "AGENTS.md",
+        /## First Read[\s\S]*1\. `AGENTS\.md`[\s\S]*2\. `README\.md`[\s\S]*3\. `docs\/README\.md`[\s\S]*4\. `Product Profile\.md`[\s\S]*docs\/i18n-audit\.md[\s\S]*CHANGELOG\.md/,
+        "AGENTS.md no longer preserves the maintainer first-read order and docs-change follow-up signals"
+      ],
+      [
+        "AGENTS.md",
+        /Use these files as the durable documentation source:[\s\S]*`README\.md`[\s\S]*`Product Profile\.md`[\s\S]*`docs\/README\.md`[\s\S]*`CHANGELOG\.md`[\s\S]*`docs\/i18n-audit\.md`/,
+        "AGENTS.md no longer lists the durable documentation source files"
+      ]
+    ]
+  },
+  {
+    feature: "Product Profile maintainer source-of-truth entrypoints",
+    links: [
+      ["Product Profile.md", "AGENTS.md"],
+      ["Product Profile.md", "README.md"],
+      ["Product Profile.md", "docs/README.md"],
+      ["Product Profile.md", "docs/en/README.md"],
+      ["Product Profile.md", "docs/ja/README.md"],
+      ["Product Profile.md", "docs/i18n-audit.md"],
+      ["Product Profile.md", "config/public_api_manifest.yml"],
+      ["Product Profile.md", "docs/en/release.md"],
+      ["Product Profile.md", "docs/ja/release.md"],
+      ["Product Profile.md", "CHANGELOG.md"]
+    ],
+    signals: [
+      [
+        "Product Profile.md",
+        /## Source of truth[\s\S]*Current code[\s\S]*Machine-readable public API contracts[\s\S]*Explicit decisions[\s\S]*Durable docs[\s\S]*Entry-point summaries[\s\S]*README\.md[\s\S]*docs\/README\.md[\s\S]*AGENTS\.md[\s\S]*this profile/,
+        "Product Profile no longer documents the source-of-truth order for maintainers"
+      ],
+      [
+        "Product Profile.md",
+        /## Recommended first reads[\s\S]*`AGENTS\.md`[\s\S]*`README\.md`[\s\S]*`docs\/README\.md`[\s\S]*`docs\/en\/README\.md` or `docs\/ja\/README\.md`[\s\S]*`docs\/i18n-audit\.md`[\s\S]*`config\/public_api_manifest\.yml`[\s\S]*`CHANGELOG\.md`/,
+        "Product Profile no longer preserves the recommended first-read maintainer path"
+      ]
+    ]
   }
 ]
 


### PR DESCRIPTION
## 対応 Issue

- Closes #1881

## Issue ごとの完了内容

- #1881: `docs/README.md` / language README の既存 maintainer entrypoint smoke に加えて、`AGENTS.md` と `Product Profile.md` 自身の maintainer 導線を smoke で確認するようにしました。

## 変更内容

- `script/test_repository_only_maintainer_entrypoints.mjs` に AGENTS first-read / durable documentation source のリンク・シグナル確認を追加しました。
- 同じ smoke に Product Profile の source-of-truth / recommended first reads のリンク・シグナル確認を追加しました。

## 改善カテゴリ

- docs entrypoint smoke 強化
- 回帰テスト追加

## 既存仕様への影響

- ドキュメント内容、gem public API、UI、DB、認可、外部契約は変更していません。
- 既存の docs entrypoint test lane に repository-only maintainer docs の欠落検知を足すだけです。

## 実施した確認

- Connector compare で branch が `main` から behind 0 / ahead 1 であることを確認しました。
- 差分対象が `script/test_repository_only_maintainer_entrypoints.mjs` のみであることを確認しました。
- `package.json` 上でこの script が `npm run test:docs-entrypoints` 経由の既存 lane に含まれていることを確認しました。
- ローカル checkout は環境の GitHub 接続制約で実行できなかったため、テスト実行は PR CI に委ねます。

## リスク評価

- risk: low
- repository-only docs のリンク・シグナル検査に限定しています。

## 補足事項

- final newline を保った内容で更新しています。