### PR TITLE
docs smoke で reader journey と empty colspan boundary を守る

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_quality_docs_smoke_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_quality_docs_smoke_signals.mjs
+++ b/script/test_quality_docs_smoke_signals.mjs
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const signalGroups = [
+  {
+    feature: "Decision guide and troubleshooting reader journey",
+    files: [
+      [
+        "README.md",
+        [
+          "If you already know the symptom and want a faster reverse-lookup entry point",
+          "docs/en/troubleshooting.md",
+          "docs/ja/troubleshooting.md"
+        ]
+      ],
+      [
+        "docs/README.md",
+        [
+          "choose APIs and options by use case",
+          "use caseからAPIやoptionを選ぶための入口",
+          "reverse-lookup entry point for common integration symptoms",
+          "よくある統合トラブルを症状から逆引きする入口"
+        ]
+      ],
+      [
+        "docs/en/decision-guide.md",
+        [
+          "Use this guide when you know what you want to build",
+          "Start from the use case",
+          "Troubleshooting](troubleshooting.md#toggle-links-do-not-expand-or-collapse)"
+        ]
+      ],
+      [
+        "docs/ja/decision-guide.md",
+        [
+          "何を作りたいか",
+          "やりたいことから選ぶ",
+          "Troubleshooting](troubleshooting.md#toggle-links-do-not-expand-or-collapse)"
+        ]
+      ],
+      [
+        "docs/en/troubleshooting.md",
+        [
+          "symptom-based entry point",
+          "already know what is going wrong",
+          "Read next:",
+          "Host App Extension Points"
+        ]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        [
+          "症状ベース",
+          "どの API 文書から読み直せばよいか",
+          "次に読む文書:",
+          "Host App 拡張ポイント"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Resource-table empty colspan boundary mockup",
+    files: [
+      [
+        "docs/mockups/README.md",
+        [
+          "resource-table-empty-colspan-boundary.html",
+          "broad `colspan=\"999\"` fallback",
+          "host-owned exact colspan",
+          "selection/action columns",
+          "TreeView empty-state wrapper boundaries"
+        ]
+      ],
+      [
+        "docs/mockups/resource-table-empty-colspan-boundary.html",
+        [
+          "data-tree-view-sample=\"resource-table-empty-colspan-boundary\"",
+          "colspan=\"999\"",
+          "exact colspan: 6",
+          "selection: host app",
+          "actions: host app",
+          "data-tree-view-empty-state=\"true\"",
+          "TreeView still only owns the reusable wrapper hook",
+          "Host apps own final recovery"
+        ]
+      ]
+    ]
+  }
+]
+
+signalGroups.forEach(({ feature, files }) => {
+  files.forEach(([sourcePath, signals]) => assertSignals(sourcePath, feature, signals))
+})


### PR DESCRIPTION
## 対応 Issue 一覧

- Closes #1884
- Closes #1886

## Issue ごとの完了内容

- #1884: `resource-table-empty-colspan-boundary.html` と mockup README の代表 signal を lightweight docs smoke で確認するようにしました。broad `colspan="999"` fallback、host-owned exact colspan、selection/action columns、TreeView empty-state wrapper boundary を guard します。
- #1886: Decision guide / Troubleshooting の reader journey を lightweight docs smoke で確認するようにしました。use-case selection と symptom reverse lookup の役割差、英日 docs の代表入口を guard します。

## 変更内容

- `script/test_quality_docs_smoke_signals.mjs` を追加しました。
- `npm run test:docs-entrypoints` の実行チェーンに新 smoke を追加しました。

## 改善カテゴリ

- test
- docs smoke
- regression guard

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、DB、認可、外部 API、UI behavior は変更していません。
- docs / mockup の代表 signal を確認するテスト追加のみです。

## 実施した確認

- Issue #1884 / #1886 の labels を個別確認し、`status:ready-for-agent`、`track:quality`、`agent:planned`、`risk:low` を満たすことを確認しました。
- branch は latest `main` `5a0e4c89df38414b14a2a711445fc0e51066f921` から作成しました。
- compare `main...quality/1884-1886-docs-smoke-signals`: `ahead_by:2` / `behind_by:0`、changed files 2。
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

- risk: low
- 既存 docs-entrypoint smoke に小さな代表 signal check を追加するだけで、挙動変更はありません。

## 補足事項

- final newline を保った内容で更新しています。