### PR TITLE
selection submit error mockup を current main で再提案する

### DIFF
--- a/docs/mockups/selection-multi-tree-form.html
+++ b/docs/mockups/selection-multi-tree-form.html
@@ -109,6 +109,16 @@
   color: #047857;
 }
 
+.mock-selection-chip--error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.mock-selection-chip--warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
 .mock-selection-actions {
   display: inline-flex;
   flex-wrap: wrap;
@@ -185,6 +195,62 @@
 
 .mock-selection-tree-wrap .tree-view-table {
   min-width: 520px;
+}
+
+.mock-selection-alert {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border: 1px solid #fecaca;
+  border-left: 4px solid #dc2626;
+  border-radius: 12px;
+  background: #fff7f7;
+}
+
+.mock-selection-alert h3,
+.mock-selection-alert p {
+  margin: 0;
+}
+
+.mock-selection-alert--warning {
+  border-color: #fde68a;
+  border-left-color: #d97706;
+  background: #fffbeb;
+}
+
+.mock-selection-validation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.mock-selection-source-message {
+  display: grid;
+  gap: 8px;
+  padding: 13px 14px;
+  border: 1px solid #e4e7eb;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.mock-selection-source-message h3,
+.mock-selection-source-message p {
+  margin: 0;
+}
+
+.mock-selection-source-message--error {
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.mock-selection-source-message--warning {
+  border-color: #fde68a;
+  background: #fffbeb;
+}
+
+.mock-selection-source-message--success {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
 }
 
 @media (max-width: 720px) {
@@ -305,6 +371,56 @@
             <button class="mock-selection-button" type="button">Apply review action</button>
             <button class="mock-selection-button mock-selection-button--secondary" type="button">Clear visible selection</button>
           </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mock-section mock-selection-layout" aria-labelledby="submit-error-heading">
+      <div class="mock-selection-frame">
+        <div class="mock-selection-form-header">
+          <div class="mock-selection-form-header__copy">
+            <h2 id="submit-error-heading">Submit error and partial failure state</h2>
+            <p class="mock-selection-note">Static review lane for host-app validation after submit. TreeView keeps the checked rows and generated hidden inputs; the host app owns error placement, retry copy, and final business policy.</p>
+          </div>
+          <div class="mock-selection-chip-row" aria-label="Representative submit result">
+            <span class="mock-selection-chip mock-selection-chip--error">1 source blocked</span>
+            <span class="mock-selection-chip mock-selection-chip--warning">1 source needs retry</span>
+            <span class="mock-selection-chip mock-selection-chip--boundary">messages are host-app owned</span>
+          </div>
+        </div>
+
+        <div class="mock-selection-alert" role="status" aria-live="polite">
+          <h3>Bulk review could not be completed</h3>
+          <p>Fix the policy selection issue before retrying. Asset folders were accepted by the host app, but the action is not final until the whole form is submitted again.</p>
+        </div>
+
+        <div class="mock-selection-validation-grid">
+          <article class="mock-selection-source-message mock-selection-source-message--error" aria-labelledby="policy-error-heading">
+            <h3 id="policy-error-heading">Policy library issue</h3>
+            <p class="mock-selection-note">Escalation matrix is blocked by a host-app validation rule. Keep the selected row visible so the user can remove it or choose another policy.</p>
+            <div class="mock-selection-chip-row">
+              <span class="mock-selection-chip mock-selection-chip--error">source-level error</span>
+              <span class="mock-selection-chip mock-selection-chip--boundary">TreeView does not own error copy</span>
+            </div>
+          </article>
+
+          <article class="mock-selection-source-message mock-selection-source-message--success" aria-labelledby="asset-accepted-heading">
+            <h3 id="asset-accepted-heading">Asset folders accepted</h3>
+            <p class="mock-selection-note">Launch banners is valid for the action. This positive state is host-app feedback, not a TreeView selection controller state.</p>
+            <div class="mock-selection-chip-row">
+              <span class="mock-selection-chip mock-selection-chip--boundary">partial success boundary</span>
+              <span class="mock-selection-chip">selection still checked</span>
+            </div>
+          </article>
+
+          <article class="mock-selection-source-message mock-selection-source-message--warning" aria-labelledby="retry-boundary-heading">
+            <h3 id="retry-boundary-heading">Retry and recovery boundary</h3>
+            <p class="mock-selection-note">The host app decides whether to retry the whole form, preserve accepted rows, or ask the user to clear one source. TreeView only mirrors the current checked payloads.</p>
+            <div class="mock-selection-chip-row">
+              <span class="mock-selection-chip mock-selection-chip--warning">host-app retry policy</span>
+              <span class="mock-selection-chip mock-selection-chip--boundary">no server params change</span>
+            </div>
+          </article>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 対応Issue

- Closes #958
- Supersedes #1893
- Supersedes #1882

## 採用した方針

- PR #1893 の review:changes-requested は、差分内容ではなく latest main 追従と fresh CI / mergeability 確認が主因でした。
- 既存 PR branch は current main から `behind_by:1` / `status:diverged` になっていたため、旧 branch に追記せず current `main` `3d7505c865849e38d2b9bc0e8cf37f27cd7e299b` から clean replacement branch を作りました。
- 自動実行のため、最も低リスクで既存 mockup に沿う案として、既存 `selection-multi-tree-form.html` に focused section を追加する方針を維持しています。

## 比較した案

- 案A: PR #1893 branch を直接更新する
  - 変更意図は近い一方、この環境から git push ができず、connector-only の通常 file update では `behind_by` を解消できないため不採用。
- 案B: current main から replacement PR を作る
  - 採用。差分を `docs/mockups/selection-multi-tree-form.html` の1ファイルに保ち、`behind_by:0` を確認できます。
- 案C: 新規 mockup file / gallery inventory / browser smoke target を追加する
  - 不採用。#958 の review follow-up は mergeability refresh であり、inventory 追加まで広げると review scope が大きくなります。

## 変更内容

- `docs/mockups/selection-multi-tree-form.html` に `Submit error and partial failure state` section を追加しました。
- form-level status、policy source の blocked validation、asset source の accepted state、retry / recovery policy boundary を並べています。
- host app が error placement、retry copy、final business policy を所有し、TreeView は checked rows と generated hidden input を維持する境界を明記しました。

## 変更した画面・コンポーネント

- `docs/mockups/selection-multi-tree-form.html`

## 確認内容

- lint: PR CI で確認します。
- typecheck: runtime Ruby / JavaScript は変更していません。
- UI表示確認: 実ブラウザ確認は未実施です。static HTML fixture / QA handoff note で代替し、browser-capable review に残します。
- レスポンシブ確認: 実ブラウザ確認は未実施です。追加CSSは既存 mockup の grid / flex wrap 構成に閉じています。
- アクセシビリティ確認: static HTML 内で `role="status"` / `aria-live="polite"` / `aria-labelledby` を使っています。支援技術での確認は未実施です。
- 実ブラウザ確認の代替: static HTML fixture / QA handoff note。
- PR作成前 compare: `main...docs/958-selection-submit-error-state-v3` は `ahead_by:1` / `behind_by:0`、changed files は1件です。

## スクリーンショット

<!-- connector-only 実行のため未添付。desktop / narrow viewport で submit error section の折り返し、alert、source cards、chips が重ならないことを browser-capable review で確認してください。 -->

## リスク

- low

## 補足

- runtime Ruby / JavaScript、selection controller、params parser、authorization、business action behavior、server-side behavior は変更していません。
- PR #1893 は latest main refresh blocker のため、この PR で置き換えます。