### PR TITLE
Public Setup Surface docs signal smoke を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_quality_docs_smoke_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_public_setup_surface_docs_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_quality_docs_smoke_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_public_setup_surface_docs_signals.mjs
+++ b/script/test_public_setup_surface_docs_signals.mjs
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertRelativeLink(sourcePath, href, feature) {
+  const source = read(sourcePath)
+  const target = href.split("#", 1)[0]
+  const resolvedTarget = path.resolve(path.dirname(path.join(repoRoot, sourcePath)), target)
+
+  assert(
+    source.includes(href),
+    `${feature}: ${sourcePath} does not link to ${href}`
+  )
+  assert(
+    resolvedTarget.startsWith(repoRoot) && existsSync(resolvedTarget),
+    `${feature}: ${sourcePath} links to missing local target ${href}`
+  )
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const feature = "Public Setup Surface docs"
+
+;[
+  ["docs/README.md", "en/public-setup-surface.md"],
+  ["docs/README.md", "ja/public-setup-surface.md"]
+].forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
+
+assertSignals("docs/en/public-setup-surface.md", feature, [
+  "bin/rails generate tree_view:state:install",
+  "bin/rails generate tree_view:state:install User",
+  "config/public_api_manifest.yml",
+  "db/migrate/*_create_tree_view_states.rb",
+  "app/models/tree_view_state.rb",
+  "app/models/concerns/tree_view_state_owner.rb",
+  "review the generated files in the host app",
+  "Storage ownership, authorization, save timing, controller actions, and UI wiring remain host-app responsibilities"
+])
+
+assertSignals("docs/ja/public-setup-surface.md", feature, [
+  "bin/rails generate tree_view:state:install",
+  "bin/rails generate tree_view:state:install User",
+  "config/public_api_manifest.yml",
+  "db/migrate/*_create_tree_view_states.rb",
+  "app/models/tree_view_state.rb",
+  "app/models/concerns/tree_view_state_owner.rb",
+  "生成後のファイルは host app 側で確認してください",
+  "storage ownership、認可、保存タイミング、controller action、UI wiring は host app 側の責務です"
+])


### PR DESCRIPTION
## 対応 Issue

Closes #1891

## Issue ごとの完了内容

- #1891: Public Setup Surface docs の代表 entrypoint と generator/setup surface signal を `npm run test:docs-entrypoints` 経路で検出できるようにしました。

## 変更内容

- `script/test_public_setup_surface_docs_signals.mjs` を追加し、以下を確認します。
  - `docs/README.md` から英日 Public Setup Surface docs への相対リンク
  - generator name `bin/rails generate tree_view:state:install`
  - optional owner argument `User`
  - generated destination paths
  - host-app review / ownership responsibility boundary
- `package.json` の `test:docs-entrypoints` に新しい smoke を接続しました。

## 改善カテゴリ

- test 改善
- docs smoke guard

## 既存仕様への影響

- runtime Ruby / JavaScript、generator behavior、generated templates、migration files、public API manifest schema、release automation は変更していません。
- docs 本文も変更せず、既存 docs signal の regression guard のみに閉じています。

## 実施した確認

- Issue #1891 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 open PR に #1891 / Public Setup Surface docs smoke の重複がないことを確認しました。
- branch freshness: `main...test/1891-public-setup-surface-signals` は `behind_by:0`。
- compare changed files: 2 件のみ。
- connector-only 作業のため、ローカル `npm run test:docs-entrypoints` は未実行です。ローカル checkout は GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗しました。PR CI を確認対象にします。
- 更新した text files は末尾改行ありの内容で作成・更新しています。

## リスク評価

low。Node 標準 API だけを使う docs smoke の追加で、既存仕様には影響しません。

## 補足事項

- #1890 の docs discoverability 本体には踏み込まず、今回の PR は regression guard に限定しています。