### PR TITLE
toolbar actions mockup の boundary smoke を追加する

### DIFF
--- a/test/browser/toolbar_actions_mockup_signals.spec.js
+++ b/test/browser/toolbar_actions_mockup_signals.spec.js
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test"
+import { pathToFileURL } from "node:url"
+import path from "node:path"
+
+const repoRoot = path.resolve(import.meta.dirname, "../..")
+
+function mockupUrl(name) {
+  return pathToFileURL(path.join(repoRoot, "docs/mockups", name)).href
+}
+
+test.describe("toolbar actions mockup focused signals", () => {
+  test("keeps collapse-to-current, fallback, localization, and host boundary signals visible", async ({ page }) => {
+    await page.goto(mockupUrl("toolbar-actions.html"))
+
+    await expect(page.locator("[data-mock-state='expand-enabled']")).toBeVisible()
+    await expect(page.locator("[data-mock-state='collapse-enabled']")).toBeVisible()
+    await expect(page.locator("[data-mock-state='current-path-enabled']")).toBeVisible()
+    await expect(page.locator("[data-mock-state='current-path-current'][data-mock-boundary='current-path-active']")).toBeVisible()
+    await expect(page.locator("[data-mock-state='localized-current-path-current'][data-mock-boundary='localized-current-path-active']")).toBeVisible()
+
+    await expect(page.locator("[data-mock-boundary='metadata-missing-path-fallback']")).toBeVisible()
+    await expect(page.locator("[data-mock-boundary='metadata-disabled-fallback']")).toHaveCount(2)
+
+    await expect(page.getByText("すべての部署とチームを展開", { exact: true })).toBeVisible()
+    await expect(page.getByText("現在の申請ルートだけを表示", { exact: true })).toBeVisible()
+    await expect(page.getByText("全階層を折りたたむ", { exact: true })).toBeVisible()
+
+    await expect(page.getByText("Host app owns", { exact: true })).toBeVisible()
+    await expect(page.getByText("Route generation, authorization policy, final permission copy, localization, and business-specific action names.", { exact: true })).toBeVisible()
+    await expect(page.getByText("Action availability and fallback state stay visible without making this mockup a contract", { exact: false })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## 対応 Issue

- Closes #1904

## Issue ごとの完了内容

- #1904: toolbar actions mockup の collapse-to-current-path、disabled fallback、missing-path fallback、localized/long label、host-app responsibility boundary を browser smoke で代表確認できるようにしました。

## 変更内容

- `test/browser/toolbar_actions_mockup_signals.spec.js` を追加
  - `docs/mockups/toolbar-actions.html` を直接開く Playwright smoke
  - expand / collapse / current-path state hooks の可視性を確認
  - current-path active と localized current-path active の data hook を確認
  - missing-path fallback と disabled fallback count を確認
  - 日本語ラベルと host-app responsibility copy を確認

## 改善カテゴリ

- test
- docs mockup smoke coverage

## 既存仕様への影響

- なし。static mockup の確認 spec 追加のみです。
- runtime Ruby / JavaScript、public API、UI仕様、DB、認可、外部サービス契約には触れていません。

## 確認内容

- connector compare: `main...quality/1904-toolbar-mockup-signals`
  - `ahead_by: 1`
  - `behind_by: 0`
  - changed files: `test/browser/toolbar_actions_mockup_signals.spec.js` のみ
- `package.json` で `test:browser` が `playwright test` であることを確認しました。
- connector-only 作業のため local Playwright は未実行です。PR CI で browser smoke の実行結果を確認してください。

## リスク評価

- low
- 既存 mockup HTML は変更せず、既存 data hook / copy を読むだけの spec です。

## 補足事項

- 既存 `test/browser/docs_mockups_smoke.spec.js` にも近い確認はありますが、#1904 の受け入れ条件に沿って toolbar actions の representative signals を専用 spec として分けました。