### PR TITLE
gem package verification と release docs の代表 signal を守る

### DIFF
--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -75,6 +75,60 @@ releaseDocs.forEach(([sourcePath, signals]) => {
   assertSignals(sourcePath, "Release checklist changelog policy", signals)
 })
 
+const packageContentsVerificationSignals = [
+  [
+    "script/check_gem_package_contents.rb",
+    [
+      "REQUIRED_PACKAGED_PATHS",
+      "INSTALLATION_REQUIRED_SIGNALS",
+      "app/helpers/tree_view_helper.rb",
+      "app/views/tree_view/_tree_row.html.erb",
+      "app/assets/stylesheets/tree_view.scss",
+      "app/javascript/tree_view/index.js",
+      "config/importmap.tree_view.rb",
+      "config/locales/tree_view.toolbar.en.yml",
+      "config/locales/tree_view.toolbar.ja.yml",
+      "config/public_api_manifest.yml",
+      "docs/en/release.md",
+      "docs/ja/release.md",
+      "docs/mockups/review-gallery.html",
+      "Gem package contents verification failed"
+    ]
+  ],
+  [
+    "docs/en/release.md",
+    [
+      "ruby script/check_gem_package_contents.rb tree_view-*.gem",
+      "representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, and public API manifest",
+      "Package-sensitive PR paths include `tree_view.gemspec`",
+      "Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`",
+      "config/importmap.tree_view.rb",
+      "config/public_api_manifest.yml",
+      "config/locales/**",
+      "docs/en/release.md",
+      "docs/ja/release.md"
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "ruby script/check_gem_package_contents.rb tree_view-*.gem",
+      "Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest",
+      "package-sensitive path には、`tree_view.gemspec`",
+      "Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`",
+      "config/importmap.tree_view.rb",
+      "config/public_api_manifest.yml",
+      "config/locales/**",
+      "docs/en/release.md",
+      "docs/ja/release.md"
+    ]
+  ]
+]
+
+packageContentsVerificationSignals.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Gem package release docs category signal", signals)
+})
+
 assertSignals("script/release_note_candidates.rb", "Release note candidate helper output", [
   "# Release note candidates for #{repo}",
   "Source: #{source}",


### PR DESCRIPTION
## 対応 Issue

Closes #1909

## Issue ごとの完了内容

- #1909: `script/check_gem_package_contents.rb` と英日 release docs の packaged-file category signal を、既存 release docs smoke で代表的に確認するようにしました。

## 変更内容

- `script/test_release_docs_signals.mjs` に gem package release docs category signal の確認を追加しました。
- package verifier script 側では `REQUIRED_PACKAGED_PATHS` / `INSTALLATION_REQUIRED_SIGNALS`、Rails helper / view / stylesheet / JS entrypoint / importmap / locale / public API manifest / release docs / mockup gallery の代表 path を確認します。
- 英日 `docs/*/release.md` 側では `check_gem_package_contents.rb` 実行導線、package-sensitive path、代表 file family の説明が落ちていないことを確認します。

## 改善カテゴリ

- test
- docs drift guard
- release/package verification guard

## 既存仕様への影響

- ありません。source-level smoke の追加のみです。
- `tree_view.gemspec`、package contents script の実行挙動、release automation、tag/publish flow、runtime Ruby / JavaScript、public API manifest schema は変更していません。
- exact file list の完全同期や full gem build の重複実行には広げていません。

## 実施した確認

- Issue #1909 の labels を直接確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 open PR を確認し、#1909 を直接 close する PR がないことを確認しました。
- PR 前に latest `main` `26974a0d6ccafcbe2d221e57c957cbbb71c81fe7` から branch を作成し、PR 前 compare が `ahead_by:1` / `behind_by:0` / changed files 1 であることを確認しました。
- 更新後の `script/test_release_docs_signals.mjs` は connector fetch で末尾改行ありの full content を確認しました。
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

- low
- docs wording / package verifier path naming の変更時に、代表 signal の意図的な更新が必要になります。

## 補足事項

- #1915 は current main の `test/browser/docs_mockups_smoke.spec.js` で既に `path-tree-builder-rows.html preserves generated-folder and record-row boundary signals` として満たされているため、別途 evidence comment で close します。