### PR TITLE
selection controller に selected count target を追加する

### DIFF
--- a/app/javascript/tree_view/selection_controller.js
+++ b/app/javascript/tree_view/selection_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
 export class TreeViewSelectionController extends Controller {
+  static targets = ["selectedCount"]
+
   static values = {
     cascade: Boolean,
     indeterminate: Boolean,
@@ -74,6 +76,7 @@ export class TreeViewSelectionController extends Controller {
 
   dispatchSelectionChanged(detail = this.selectionDetail()) {
     this.syncHiddenInputs(detail.selectedPayloads)
+    this.syncSelectedCountTargets(detail.selectedCount)
 
     this.dispatch("change", {
       detail
@@ -95,6 +98,14 @@ export class TreeViewSelectionController extends Controller {
     return Array.from(
       this.element.querySelectorAll(".tree-selection-checkbox:checked:not(:disabled)")
     )
+  }
+
+  syncSelectedCountTargets(count) {
+    if (!this.hasSelectedCountTarget) return
+
+    this.selectedCountTargets.forEach((target) => {
+      target.textContent = String(count)
+    })
   }
 
   parsePayload(checkbox) {

--- a/app/javascript/tree_view/selection_controller.test.js
+++ b/app/javascript/tree_view/selection_controller.test.js
@@ -75,6 +75,99 @@ describe("TreeViewSelectionController", () => {
     ])
   })
 
+  it("syncs selected count targets on connect and checkbox changes", async () => {
+    document.body.innerHTML = `
+      <table>
+        <tbody
+          data-controller="tree-view-selection"
+          data-action="change->tree-view-selection#toggle">
+          <tr data-tree-depth="0">
+            <td>
+              <span id="count" data-tree-view-selection-target="selectedCount">pending</span>
+              <span id="toolbar-count" data-tree-view-selection-target="selectedCount">pending</span>
+            </td>
+            <td>
+              <input
+                id="node-1"
+                class="tree-selection-checkbox"
+                type="checkbox"
+                checked
+                value='{"id":1}'>
+            </td>
+          </tr>
+          <tr data-tree-depth="0">
+            <td></td>
+            <td>
+              <input
+                id="node-2"
+                class="tree-selection-checkbox"
+                type="checkbox"
+                value='{"id":2}'>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `
+
+    await flush()
+
+    expect(document.getElementById("count").textContent).toBe("1")
+    expect(document.getElementById("toolbar-count").textContent).toBe("1")
+
+    const second = document.getElementById("node-2")
+    second.checked = true
+    second.dispatchEvent(new Event("change", { bubbles: true }))
+
+    await flush()
+
+    expect(document.getElementById("count").textContent).toBe("2")
+    expect(document.getElementById("toolbar-count").textContent).toBe("2")
+  })
+
+  it("keeps selected count targets aligned after max-count rollback", async () => {
+    document.body.innerHTML = `
+      <table>
+        <tbody
+          data-controller="tree-view-selection"
+          data-action="change->tree-view-selection#toggle"
+          data-tree-view-selection-max-count-value="1">
+          <tr data-tree-depth="0">
+            <td><span id="count" data-tree-view-selection-target="selectedCount">pending</span></td>
+            <td>
+              <input
+                id="node-1"
+                class="tree-selection-checkbox"
+                type="checkbox"
+                checked
+                value='{"id":1}'>
+            </td>
+          </tr>
+          <tr data-tree-depth="0">
+            <td></td>
+            <td>
+              <input
+                id="node-2"
+                class="tree-selection-checkbox"
+                type="checkbox"
+                value='{"id":2}'>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    `
+
+    await flush()
+
+    const second = document.getElementById("node-2")
+    second.checked = true
+    second.dispatchEvent(new Event("change", { bubbles: true }))
+
+    await flush()
+
+    expect(second.checked).toBe(false)
+    expect(document.getElementById("count").textContent).toBe("1")
+  })
+
   it("skips disabled and invalid payloads when syncing hidden inputs", async () => {
     document.body.innerHTML = `
       <form id="bulk-form">

--- a/docs/en/selection.md
+++ b/docs/en/selection.md
@@ -117,6 +117,27 @@ document.addEventListener(TreeViewEventNames.selection.change, (event) => {
 
 Only checked and enabled `.tree-selection-checkbox` elements are included. Invalid JSON values are skipped and reported through the same documented invalid-payload event (`TreeViewEventNames.selection.invalidPayload` or raw `tree-view-selection:invalid-payload`).
 
+### Selected count target
+
+When the host app only needs the current selected count as text, add an optional `selectedCount` target inside the `tree-view-selection` controller.
+
+```erb
+<p>
+  Selected nodes:
+  <strong data-tree-view-selection-target="selectedCount">0</strong>
+</p>
+
+<tbody
+  data-controller="tree-view-selection"
+  data-action="change->tree-view-selection#toggle">
+  <%= tree_view_rows(@render_state) %>
+</tbody>
+```
+
+The controller writes the numeric `selectedCount` into every `selectedCount` target on connect and after selection changes. If the target is omitted, existing event-only usage is unchanged.
+
+The target owns the number only. Surrounding copy, bulk action enable/disable, max-count messages, and business-specific behavior remain host-app responsibility. The `tree-view-selection:change` event still carries the full `selectedCount`, `selectedValues`, and `selectedPayloads` detail for richer integrations.
+
 ## Hidden input sync for regular form submit
 
 When the tree sits inside a normal HTML form, the same controller can mirror checked payloads into hidden inputs on the nearest form.
@@ -214,6 +235,7 @@ See [Children Pagination](children-pagination.md#selection-and-dragdrop-interact
 | Rendering checkboxes | yes | no |
 | JSON payload generation | yes | optional customization |
 | Submitted value parsing and hidden input sync | helper provided, optional form bridge | owns controller placement and business action |
+| Selected count target | syncs the numeric count when the optional target is present | owns surrounding copy, action state, and messages |
 | Cascade / indeterminate | rendered DOM only | decides unloaded/server-side semantics |
 | Max count event | dispatches event | shows message or blocks business action |
 | Delete / move / relate / API calls | no | yes |

--- a/docs/ja/selection.md
+++ b/docs/ja/selection.md
@@ -117,6 +117,27 @@ document.addEventListener(TreeViewEventNames.selection.change, (event) => {
 
 対象になるのは、checked かつ enabled な `.tree-selection-checkbox` だけです。不正なJSON値はskipされ、同じ documented invalid-payload event (`TreeViewEventNames.selection.invalidPayload` または raw `tree-view-selection:invalid-payload`) で通知されます。
 
+### selected count target
+
+host app が現在の選択数だけを text として表示したい場合は、`tree-view-selection` controller の内側に optional な `selectedCount` target を置けます。
+
+```erb
+<p>
+  選択中:
+  <strong data-tree-view-selection-target="selectedCount">0</strong>
+</p>
+
+<tbody
+  data-controller="tree-view-selection"
+  data-action="change->tree-view-selection#toggle">
+  <%= tree_view_rows(@render_state) %>
+</tbody>
+```
+
+controller は connect 時と selection 変更後に、すべての `selectedCount` target へ数値の `selectedCount` を書き込みます。target を置かない既存の event-only 利用では挙動は変わりません。
+
+target が担当するのは数値だけです。周辺文言、bulk action の enable / disable、max count message、業務固有の挙動は host app 側で実装します。より細かい連携が必要な場合は、従来どおり `tree-view-selection:change` event の `selectedCount`、`selectedValues`、`selectedPayloads` detail を使ってください。
+
 ## 通常form送信用の hidden input 同期
 
 tree が通常の HTML form の中にある場合、同じ controller で checked payload を最寄りの form に hidden input としてミラーできます。
@@ -214,6 +235,7 @@ pagination 固有の境界は [Children Pagination](children-pagination.md#selec
 | Rendering checkboxes | yes | no |
 | JSON payload generation | yes | optional customization |
 | Submitted value parsing と hidden input sync | helper 提供、form bridge は optional | controller の配置と業務 action を決める |
+| Selected count target | optional target がある場合に数値だけ同期 | 周辺文言、action state、message を決める |
 | Cascade / indeterminate | rendered DOM only | decides unloaded/server-side semantics |
 | Max count event | dispatches event | shows message or blocks business action |
 | Delete / move / relate / API calls | no | yes |


### PR DESCRIPTION
selection controller で選択数だけを optional target に同期できるようにします。

Closes #932

## 変更内容

- `tree-view-selection` に optional target `selectedCount` を追加しました。
- controller connect / selection change / manual refresh 後に、既存 `selectionDetail().selectedCount` と同じ数値を target の `textContent` へ同期します。
- target がない既存利用では no-op のままです。
- selected-count target の focused Vitest を追加しました。
- 英日 selection docs に、target は数値だけを同期し、周辺文言・bulk action enable/disable・max-count message は host app responsibility であることを追記しました。

## 受け入れ条件との対応

- connect 時と checkbox change 後に checked enabled checkbox 数が selectedCount target へ反映されます。
- 複数 selectedCount target に同じ数値を同期します。
- target がない既存利用では挙動を変えません。
- max-count 超過で attempted checkbox が戻された後も、表示 count は実際の selected count と一致します。
- `tree-view-selection:change` event の名前・detail field・意味は変更していません。

## 変更範囲

- `app/javascript/tree_view/selection_controller.js`
- `app/javascript/tree_view/selection_controller.test.js`
- `docs/en/selection.md`
- `docs/ja/selection.md`

bulk action toolbar、button disabled 切り替え、aria-live 文言生成、limit-exceeded message、hidden input sync、payload schema、Rails params parsing、cascade / indeterminate behavior、DB、認可、外部 API は変更していません。

## 実施した確認

- Issue #932 の labels と Planner handoff を直接確認しました。
- #932 を担当する既存 open PR がないことを確認しました。
- PR 前 compare `main...feature/932-selection-count-target`: `ahead_by:5` / `behind_by:0` / changed files 4。
- local checkout / `npm test` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

medium。public JavaScript controller target の additive expansion です。required target は増やさず、表示責務を数値同期だけに限定しています。

## 未対応・補足

- final copy、bulk action enable/disable、上限超過メッセージは host app responsibility のままです。
- merge は行いません。