### PR TITLE
PathTreeBuilder の documents 向け cookbook recipe を補う

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -41,6 +41,60 @@ Start with `row_partial` for business columns, then use `row_class_builder`, `ro
 
 TreeView owns the rendering slots and reusable row-state hooks. The host app owns the status vocabulary, permission model, action availability, persistence, route targets, and final badge or action copy. Use [row-status-depth-labels.html](../mockups/row-status-depth-labels.html) for status + depth-label composition and [resource-table-bridge.html](../mockups/resource-table-bridge.html) when business columns need to sit beside TreeView hierarchy controls.
 
+### Documents and attachments from path-like records
+
+Use [PathTreeBuilder](path-tree-builder.md) when documents, attachments, generated artifacts, or export files are stored as flat records with a path-like value but the host app does not have separate folder records. The builder supplies generated folder nodes and record-backed leaf nodes; the host app keeps the query, permission scope, download route, preview behavior, and final business copy.
+
+```ruby
+builder = TreeView::PathTreeBuilder.new(
+  records: current_project.documents.visible_to(current_user),
+  path_resolver: ->(document) { document.source_relative_path },
+  id_resolver: ->(document) { TreeView.node_key(:document, document.id) },
+  label_resolver: ->(document) { document.title },
+  sort: { folders_first: true }
+)
+
+render_state = TreeView::RenderState.new(
+  tree: builder.tree,
+  root_items: builder.root_items,
+  row_partial: "documents/tree_columns",
+  row_actions_partial: "documents/tree_actions",
+  ui_config: tree_ui
+)
+```
+
+Keep the row partial split small: folder rows describe generated grouping context, while record rows unwrap `item.record` for host-app metadata and actions.
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<% if item.folder_node? %>
+  <td><%= item.label %></td>
+  <td><%= item.path %></td>
+  <td>Generated folder</td>
+<% elsif item.record_node? %>
+  <% document = item.record %>
+  <td><%= item.label %></td>
+  <td><%= item.path %></td>
+  <td><%= document.owner_name %></td>
+  <td><%= document.review_state %></td>
+<% end %>
+```
+
+```erb
+<!-- app/views/documents/_tree_actions.html.erb -->
+<% if item.record_node? %>
+  <% document = item.record %>
+  <td>
+    <%= link_to "Preview", document_path(document) %>
+    <%= link_to "Download", download_document_path(document) %>
+  </td>
+<% else %>
+  <td></td>
+<% end %>
+```
+
+TreeView owns generated folder shape, record node wrapping, row rendering slots, and the reusable hierarchy cue. The host app owns which records are included, permission checks before rendering or downloading, path normalization policy, preview availability, file-size or status metadata, and final action labels. Use the [PathTreeBuilder row mockup](../mockups/path-tree-builder-rows.html) when reviewing long path segments or folder-versus-record row composition.
+
 ## Add a breadcrumb for the current item
 
 Use [Breadcrumb](breadcrumb.md) when the page already has a records-mode tree and a current item, and the UI needs a compact path from the root to that item. TreeView looks up the ancestor path with `tree.path_for(item)` and renders the standard breadcrumb markup through `tree_view_breadcrumb`.

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -41,6 +41,60 @@ TreeView は checkbox state、selected values、selected payloads、disabled rea
 
 TreeView は rendering slot と再利用可能な row-state hook を担当します。status vocabulary、permission model、action availability、保存、route target、最終的な badge / action copy は host app 側の責務です。status + depth label の組み合わせは [row-status-depth-labels.html](../mockups/row-status-depth-labels.html)、業務列と TreeView hierarchy control を並べる場合は [resource-table-bridge.html](../mockups/resource-table-bridge.html) を参照してください。
 
+### path らしい record から documents / attachments を表示する
+
+Database 上に folder record はないが、documents、attachments、generated artifacts、export file などが path らしい値を持つ場合は [PathTreeBuilder](path-tree-builder.md) を使います。builder は生成 folder node と record-backed leaf node を提供し、query、permission scope、download route、preview behavior、最終的な業務copy は host app 側に残します。
+
+```ruby
+builder = TreeView::PathTreeBuilder.new(
+  records: current_project.documents.visible_to(current_user),
+  path_resolver: ->(document) { document.source_relative_path },
+  id_resolver: ->(document) { TreeView.node_key(:document, document.id) },
+  label_resolver: ->(document) { document.title },
+  sort: { folders_first: true }
+)
+
+render_state = TreeView::RenderState.new(
+  tree: builder.tree,
+  root_items: builder.root_items,
+  row_partial: "documents/tree_columns",
+  row_actions_partial: "documents/tree_actions",
+  ui_config: tree_ui
+)
+```
+
+row partial の分岐は小さく保ちます。folder row は生成された grouping context を説明し、record row は `item.record` を取り出して host app 固有の metadata や action を描画します。
+
+```erb
+<!-- app/views/documents/_tree_columns.html.erb -->
+<% if item.folder_node? %>
+  <td><%= item.label %></td>
+  <td><%= item.path %></td>
+  <td>Generated folder</td>
+<% elsif item.record_node? %>
+  <% document = item.record %>
+  <td><%= item.label %></td>
+  <td><%= item.path %></td>
+  <td><%= document.owner_name %></td>
+  <td><%= document.review_state %></td>
+<% end %>
+```
+
+```erb
+<!-- app/views/documents/_tree_actions.html.erb -->
+<% if item.record_node? %>
+  <% document = item.record %>
+  <td>
+    <%= link_to "Preview", document_path(document) %>
+    <%= link_to "Download", download_document_path(document) %>
+  </td>
+<% else %>
+  <td></td>
+<% end %>
+```
+
+TreeView は generated folder shape、record node wrapping、row rendering slot、再利用可能な hierarchy cue を担当します。どの record を含めるか、描画や download 前の permission check、path normalization policy、preview availability、file size / status metadata、最終的な action label は host app 側の責務です。長い path segment や folder / record row の組み合わせを確認する場合は [PathTreeBuilder row mockup](../mockups/path-tree-builder-rows.html) を参照してください。
+
 ## 現在itemのbreadcrumbを追加する
 
 records mode のtreeと現在itemがあり、rootからそのitemまでの短いpathをUIに出したい場合は [Breadcrumb](breadcrumb.md) を使います。TreeView は `tree.path_for(item)` で祖先pathを解決し、`tree_view_breadcrumb` で標準的なbreadcrumb markupを描画します。


### PR DESCRIPTION
## Summary

Closes #1914

Classification: `docs-missing`

- Added an English/Japanese Cookbook recipe for documents, attachments, generated artifacts, and export files that are stored as flat records with path-like values.
- Showed the docs-only integration boundary for `PathTreeBuilder`, including `path_resolver`, `id_resolver`, `label_resolver`, `row_partial`, and `row_actions_partial`.
- Clarified that TreeView owns generated folder shape and row rendering slots, while the host app owns record queries, permission checks, downloads, preview behavior, metadata, and final action copy.

## Scope

- Updated only `docs/en/cookbook.md` and `docs/ja/cookbook.md`.
- Did not change runtime Ruby, JavaScript, API shape, manifests, mockups, or release scripts.
- Kept #1913 static mockup work and #1915 smoke/script work out of scope.

## Verification

- Rechecked the branch against current `main`: ahead by 2, behind by 0.
- Reviewed the inserted English/Japanese sections and later Cookbook sections to ensure the long docs were not truncated.
- Local checkout-based checks were not run from this environment because direct GitHub HTTPS access from the container returned a 403 tunnel error; PR CI should provide the repository checks.