### PR TITLE
Node version source guard に Dockerfile を含める

### DIFF
--- a/script/test_node_version_sources.mjs
+++ b/script/test_node_version_sources.mjs
@@ -7,11 +7,15 @@ const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.ur
 const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
 const nvmrc = readFileSync(join(repoRoot, ".nvmrc"), "utf8").trim();
 const workflow = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+const dockerfile = readFileSync(join(repoRoot, "Dockerfile"), "utf8");
 
 const workflowNodeVersions = Array.from(workflow.matchAll(/node-version:\s*["']?(\d+)["']?/g), (match) => match[1]);
+const dockerNodeMajorMatch = dockerfile.match(/^ARG\s+NODE_MAJOR=(\d+)\s*$/m);
 
 assert.equal(nvmrc, "22", ".nvmrc must keep Node 22 as the local source of truth");
 assert.equal(packageJson.engines.node, "22.x", "package.json engines.node must stay aligned with .nvmrc");
 assert.deepEqual(workflowNodeVersions, ["22"], "CI workflow node-version values must stay aligned with .nvmrc");
+assert.ok(dockerNodeMajorMatch, "Dockerfile must declare ARG NODE_MAJOR so Docker development setup stays aligned with .nvmrc");
+assert.equal(dockerNodeMajorMatch[1], nvmrc, "Dockerfile ARG NODE_MAJOR must stay aligned with .nvmrc");
 
 console.log("Node version sources stay aligned with Node 22.");


### PR DESCRIPTION
## 対応 Issue

- Closes #1923

## Issue ごとの完了内容

- #1923: 既存の Node version source guard に Dockerfile の `ARG NODE_MAJOR` を追加し、`.nvmrc` とずれた場合に検知できるようにしました。

## 変更内容

- `script/test_node_version_sources.mjs` で `Dockerfile` を読み込むようにしました。
- `ARG NODE_MAJOR=<major>` を抽出し、宣言が存在することと `.nvmrc` の値に一致することを検証します。
- 既存の `.nvmrc`、`package.json`、CI workflow の Node version 検証は維持しています。

## 改善カテゴリ

- test
- CI / devops guard

## 既存仕様への影響

- Docker build、base image、npm policy、lockfile、CI workflow の挙動は変更していません。
- 既存の公開 API、UI、DB、認可、状態遷移には影響しません。

## 実施した確認

- Issue #1923 の eligibility label を個別確認しました: `status:ready-for-agent`、`track:quality`、`agent:planned`、`risk:low`。
- 既存 open PR に #1923 対応の重複がないことを確認しました。
- `main` の最新 commit `bc786b7c421e5ae3d7cafc28a78baa71a96ecfc5` からブランチを作成しました。
- PR 前比較で `behind_by: 0`、差分が `script/test_node_version_sources.mjs` の 1 ファイルのみであることを確認しました。
- connector-only 作業のため、ローカルで `npm run test:node-version-sources` / `npm run test:entrypoints` は実行していません。PR CI で確認します。

## リスク評価

- risk: low
- 既存仕様を変えず、Node version drift を検知するテストガードのみを拡張する変更です。

## 補足

- Dockerfile 側の `ARG NODE_MAJOR=22` 自体は変更していません。