### PR TITLE
Decision guide の flowchart / common combinations signal を docs smoke で守る

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_public_setup_surface_docs_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_quality_docs_smoke_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_public_setup_surface_docs_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_decision_guide_signals.mjs && node script/test_quality_docs_smoke_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && npm run test:docs-i18n",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_decision_guide_signals.mjs
+++ b/script/test_decision_guide_signals.mjs
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const decisionGuideSignals = [
+  {
+    feature: "Decision guide flowchart and loading boundary",
+    files: [
+      [
+        "docs/en/decision-guide.md",
+        [
+          "## Flowchart",
+          "flowchart TD",
+          "Render controls",
+          "Data-loading controls",
+          "Static rendering: Tree + RenderState + tree_view_rows",
+          "Turbo rendering: UiConfigBuilder#build_turbo with show/hide path builders",
+          "Client-side rendering: UiConfigBuilder#build_client_side",
+          "Lazy Loading or Children Pagination",
+          "RenderWindow or window: offset/limit",
+          "Host-app JavaScript or external virtualization library",
+          "GraphAdapter with host-app roots, children_resolver, and node_key_resolver"
+        ]
+      ],
+      [
+        "docs/ja/decision-guide.md",
+        [
+          "## Flowchart",
+          "flowchart TD",
+          "描画制御",
+          "データ読み込み制御",
+          "Static rendering: Tree + RenderState + tree_view_rows",
+          "Turbo rendering: UiConfigBuilder#build_turbo と show/hide path builders",
+          "Client-side rendering: UiConfigBuilder#build_client_side",
+          "Lazy Loading または Children Pagination",
+          "RenderWindow または window: offset/limit",
+          "host app JavaScript または外部virtualization library",
+          "GraphAdapter と host-app roots / children_resolver / node_key_resolver"
+        ]
+      ]
+    ]
+  },
+  {
+    feature: "Decision guide common combinations",
+    files: [
+      [
+        "docs/en/decision-guide.md",
+        [
+          "## Common combinations",
+          "Small admin taxonomy",
+          "Large folder browser",
+          "Heterogeneous project workspace",
+          "Large scrolling browser",
+          "Bulk action page",
+          "Tree-wide action toolbar",
+          "Row action menu",
+          "Localized row display",
+          "Reorderable hierarchy"
+        ]
+      ],
+      [
+        "docs/ja/decision-guide.md",
+        [
+          "## よくある組み合わせ",
+          "小さな管理用taxonomy",
+          "大きなfolder browser",
+          "異種nodeを含むproject workspace",
+          "大きなscrolling browser",
+          "bulk action page",
+          "tree全体のaction toolbar",
+          "row action menu",
+          "localized row display",
+          "並び替え可能な階層"
+        ]
+      ]
+    ]
+  }
+]
+
+decisionGuideSignals.forEach(({ feature, files }) => {
+  files.forEach(([sourcePath, signals]) => assertSignals(sourcePath, feature, signals))
+})


### PR DESCRIPTION
## 対応 Issue

Closes #1925

## Issue ごとの完了内容

- #1925: Decision guide の flowchart、render controls / data-loading controls、common combinations の代表 signal を軽量 docs smoke で確認できるようにしました。

## 変更内容

- `script/test_decision_guide_signals.mjs` を追加しました。
  - 英日 `docs/*/decision-guide.md` の flowchart signal を確認します。
  - Static / Turbo / Client-side、Lazy Loading / Children Pagination、RenderWindow、host-app virtualization、GraphAdapter の代表 signal を確認します。
  - 英日 common combinations の代表 scenario を確認します。
- `npm run test:docs-entrypoints` に新しい smoke script を接続しました。

## 改善カテゴリ

- test
- docs smoke
- maintainability

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、docs 本文、mockup、CI workflow は変更していません。
- Decision guide の既存内容を守る source-level smoke の追加だけです。

## 実施した確認

- Issue #1925 の eligibility label を個別確認しました: `status:ready-for-agent`、`track:quality`、`agent:planned`、`risk:low`。
- 既存 open PR に #1925 対応の重複がないことを確認しました。
- current main: `f2ae865286b08c92092fb4005d76a7adc869094a`
- compare `main...quality/1925-decision-guide-smoke`: `ahead_by:2` / `behind_by:0`
- changed files: 2 (`package.json`, `script/test_decision_guide_signals.mjs`)
- ローカルでは checkout が GitHub HTTPS `CONNECT tunnel failed, response 403` で利用できないため、追加 script の `node --check` と `package.json` の JSON 構文確認のみ実施しました。`npm run test:docs-entrypoints` は PR CI で確認します。

## リスク評価

low。既存 docs の代表 signal を確認するテスト追加のみで、挙動変更はありません。

## 補足事項

- full markdown parser、Mermaid rendering test、visual regression、docs rewrite には広げていません。