### PR TITLE
development docs の CI policy signal を smoke で守る

### DIFF
--- a/script/test_quality_docs_smoke_signals.mjs
+++ b/script/test_quality_docs_smoke_signals.mjs
@@ -81,6 +81,37 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Development docs CI policy and drift recovery",
+    files: [
+      [
+        "docs/en/development.md",
+        [
+          "Docs-only pull requests that touch only",
+          "docs/mockups/**",
+          "Pull requests that change `test/browser/**`",
+          ".github/workflows/**",
+          "A green check suite does not by itself mean a pull request is ready to merge after `main` has moved",
+          "known public-contract drift",
+          "not as permission to widen the pull request automatically",
+          "drift owner issue or pull request"
+        ]
+      ],
+      [
+        "docs/ja/development.md",
+        [
+          "docs-only Pull Request",
+          "`docs/mockups/**`",
+          "`test/browser/**` を変更する Pull Request",
+          "`.github/workflows/**`",
+          "green checks だけでは merge ready と判断しません",
+          "既知 drift の recovery",
+          "Pull Request scope を自動で広げないでください",
+          "drift を所有する Pull Request"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Resource-table empty colspan boundary mockup",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue

Closes #1928

## Issue ごとの完了内容

- #1928: 英日 development docs にある CI policy / known drift recovery の代表 signal を、既存の quality docs smoke で確認するようにしました。

## 変更内容

- `script/test_quality_docs_smoke_signals.mjs` に `Development docs CI policy and drift recovery` group を追加しました。
- 英語 docs では docs-only shortcut、mockup docs browser smoke、`test/browser/**`、workflow changes、main 進行後の green CI 過信防止、known public-contract drift、drift owner の代表文言を確認します。
- 日本語 docs でも同じ境界を代表 signal として確認します。

## 改善カテゴリ

- test
- docs drift guard
- small maintainability improvement

## 既存仕様への影響

- runtime Ruby / JavaScript、CI workflow、package install policy、public API manifest は変更していません。
- 既存 docs の文言を guard するだけで、docs 本文の意味や CI policy は変えていません。

## 実施した確認

- Issue #1928 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
- current `main` `eb6f5e435527a55a996542d6aee7bc3348af687c` から branch を作成
- PR前 compare `main...test/1928-development-docs-ci-policy-smoke`: `ahead_by:1` / `behind_by:0`
- changed files: 1 (`script/test_quality_docs_smoke_signals.mjs`)
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS 制約のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 docs signal の smoke guard 追加のみです。

## 補足事項

- `.github/workflows/ci.yml`、`package-lock.json`、runtime code、docs prose は変更していません。