### PR TITLE
FilteredTree mode contract を Public API docs から辿れるようにする

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -59,6 +59,8 @@ Host apps may use these entry points directly:
 
 Use `TreeView::ResourceTableRenderState.call` when another table layer already owns column inference and table state, and TreeView should only build the hierarchical render state. See [Resource table bridge](resource-table-bridge.md).
 
+`TreeView::FilteredTree` is a stable public entry point for filtered tree results. Its mode set is also tracked in `config/public_api_manifest.yml` as the `filtered_tree_modes` contract; see [Filtered Trees: Modes](filtered-trees.md#modes) for the documented mode table and the host-app boundary for search query, ranking, authorization, and highlighting.
+
 ## Public error surface
 
 Host apps may rescue `TreeView::Error` to handle documented TreeView validation and configuration failures separately from unrelated application errors.

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -59,6 +59,8 @@ host app が直接使ってよい主な入口は以下です。
 
 `TreeView::ResourceTableRenderState.call` は、別の table layer が列推論や table state を持っていて、TreeView には階層 render state の組み立てだけを任せたい場合の公開入口です。詳細は [Resource table bridge](resource-table-bridge.md) を参照してください。
 
+`TreeView::FilteredTree` は filtered tree result 用の安定した公開入口です。mode set も `config/public_api_manifest.yml` の `filtered_tree_modes` contract として追跡されています。documented mode table と、search query、ranking、authorization、highlighting を host app 側に置く責務境界は [Filtered Trees: Modes](filtered-trees.md#modes) を参照してください。
+
 ## Public error surface
 
 host app は `TreeView::Error` を rescue することで、documented された TreeView の validation / configuration failure を、他の application error と分けて扱えます。


### PR DESCRIPTION
## 対応 Issue

Closes #1628

## 変更内容

- `docs/en/public-api.md` に、`TreeView::FilteredTree` の mode set が `config/public_api_manifest.yml` の `filtered_tree_modes` contract として追跡されていることを追記しました。
- `docs/ja/public-api.md` に同じ説明を同期しました。
- 詳細な mode table は既存の `docs/en|ja/filtered-trees.md#modes` に委譲し、Public API docs 側は discoverability と contract status の説明に留めています。

## 確認した根拠

- current `main` の `config/public_api_manifest.yml` に `filtered_tree_modes` が存在することを確認しました。
- current `docs/en/filtered-trees.md` が mode table と manifest-backed public contract の説明を持つことを確認しました。
- 以前の停止理由だった「#1622 相当が main にない」状態は解消済みです。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`

runtime Ruby / JavaScript、FilteredTree mode set、manifest schema、spec、smoke script、search query、ranking、authorization、highlighting、PathTree / ReverseTree の使い分けは変更していません。

## 確認

- compare `main...docs/1628-filtered-tree-public-api`: `ahead_by:3` / `behind_by:0`
- changed files: 2 docs files only
- GitHub HTTPS checkout は `CONNECT tunnel failed, response 403` のためローカル `npm run test:docs-entrypoints` は未実行です。PR CI を確認対象にします。

## 判定

- classification: `docs-sync` / `docs-stale`
- risk: low