### PR TITLE
package-lock refresh の release handoff を明文化する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -52,6 +52,18 @@ Minimum release conditions:
 
 The committed `package-lock.json` is not yet in sync with `package.json`, so both local setup and CI still use `npm install` for the JavaScript lane. Switch these release checks back to `npm ci` after the lockfile refresh work lands.
 
+### Lockfile refresh handoff
+
+When a registry-enabled lockfile refresh lands, review these release-facing points before switching the JavaScript lane back to `npm ci`:
+
+- Confirm `package-lock.json` was refreshed against the current `package.json` without bundling unrelated dependency upgrades.
+- Update the setup wording in `docs/en/development.md` and `docs/ja/development.md` if `npm ci` becomes the current local and Docker install path.
+- Update this release checklist and any CI wording that still describes the `npm install` exception.
+- Keep the Node 22 source guard separate: `.nvmrc`, `package.json` `engines.node`, workflow `node-version`, and `script/test_node_version_sources.mjs` confirm the Node major, while the lockfile refresh decides whether `npm ci` is safe again.
+- Observe fresh PR or main-push CI after the switch so the JavaScript lane proves the refreshed lockfile works in CI.
+
+Do not change `package-lock.json`, workflow setup, dependency versions, or the Node major from this checklist alone; those belong in the lockfile refresh or CI change PR that owns the actual switch.
+
 Local checks:
 
 ```bash

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -52,6 +52,18 @@ GitHub Release notes を書く前に、[Release note candidate collector](releas
 
 committed `package-lock.json` はまだ `package.json` と同期していないため、JavaScript lane は local setup / CI ともに現時点では `npm install` 前提です。lockfile refresh 作業が入ったら、release checks も `npm ci` 前提へ戻します。
 
+### Lockfile refresh handoff
+
+registry-enabled な環境で lockfile refresh が入ったら、JavaScript lane を `npm ci` に戻す前に、release-facing な確認点を見直してください。
+
+- `package-lock.json` が current `package.json` に対して refresh され、関係ない dependency upgrade を同じ PR に混ぜていないことを確認する。
+- `npm ci` が現在の local / Docker install path になる場合は、`docs/en/development.md` と `docs/ja/development.md` の setup 説明も同期する。
+- この release checklist と、`npm install` 例外を説明している CI wording を更新する。
+- Node 22 source guard とは責務を分ける。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version`、`script/test_node_version_sources.mjs` は Node major の整合を確認し、lockfile refresh は `npm ci` に戻して安全かどうかを判断する。
+- 切り替え後は fresh な PR CI または main-push CI を観測し、refreshed lockfile が CI の JavaScript lane で動くことを確認する。
+
+この checklist だけを根拠に `package-lock.json`、workflow setup、dependency version、Node major を変更しないでください。実際の切り替えは、lockfile refresh または CI 変更を担当する PR に閉じます。
+
 ローカル確認:
 
 ```bash


### PR DESCRIPTION
## 対応 Issue

Closes #1937

## 変更内容

- `docs/en/release.md` に `Lockfile refresh handoff` を追加し、lockfile refresh 後に `npm ci` へ戻す前の確認点を整理しました。
- `docs/ja/release.md` に同じ内容を同期しました。
- `npm install` 継続理由、`npm ci` 復帰条件、development docs / CI wording の見直し対象、Node 22 source guard との責務差を release-facing に追えるようにしました。

## 変更範囲

- `docs/en/release.md`
- `docs/ja/release.md`

`package-lock.json`、`.github/workflows/**`、`package.json`、`.nvmrc`、dependency version、Node major、CI workflow は変更していません。

## 確認

- Issue #1937 と Planner handoff を確認しました。
- compare `main...docs/1937-lockfile-refresh-release-docs`: `ahead_by:2` / `behind_by:0`
- changed files: 2 docs files only
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## 判定

- classification: `docs-sync` / `docs-missing`
- risk: low