### PR TITLE
RemoteState / Toolbar hooks の declaration literal guard を追加する

### DIFF
--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -94,6 +94,8 @@ const literalExports = {
   TreeViewEventNames: deepCamelizeKeys(manifest.event_names),
   TreeViewEventDetailKeys: deepCamelizeKeys(manifest.event_detail_keys),
   TreeViewRemoteStateValues: manifest.remote_state_values,
+  TreeViewRemoteStateDataHooks: deepCamelizeKeys(manifest.remote_state_data_hooks),
+  TreeViewToolbarDataHooks: deepCamelizeKeys(manifest.toolbar_data_hooks),
   TreeViewTransferDropPositions: manifest.transfer_drop_positions,
   TreeViewTransferDataMimeTypes: deepCamelizeKeys(manifest.transfer_data_mime_types),
   TreeViewControllerIdentifiers: Object.fromEntries(


### PR DESCRIPTION
## 対応 Issue

- Closes #1939

## Issue ごとの完了内容

- #1939: `script/test_declaration_literal_shapes.mjs` の literal export guard に `TreeViewRemoteStateDataHooks` と `TreeViewToolbarDataHooks` を追加し、`config/public_api_manifest.yml` と `app/javascript/tree_view/index.d.ts` の同期崩れを smoke test で検出できるようにしました。

## 変更内容

- `TreeViewRemoteStateDataHooks` を `manifest.remote_state_data_hooks` から検証するよう追加
- `TreeViewToolbarDataHooks` を `manifest.toolbar_data_hooks` から検証するよう追加

## 改善カテゴリ

- test
- quality guard

## 既存仕様への影響

- runtime、manifest、型宣言そのものは変更していません。
- 既存の公開 API / UI / 状態遷移 / DB / 認可には影響しません。
- 既存仕様を変えず、既に存在する declaration と manifest の同期確認範囲だけを広げています。

## 実施した確認

- GitHub connector 上で main との差分を確認し、対象差分が `script/test_declaration_literal_shapes.mjs` の 1 ファイルのみであることを確認しました。
- branch は main に対して `behind_by: 0`、`ahead_by: 1` であることを確認しました。
- GitHub Actions CI #2550: success
- ローカル checkout は GitHub HTTPS 接続が 403 で失敗するため、この環境では `npm run test:entrypoints` は実行できていません。CI で確認済みです。

## リスク評価

- risk: low
- テストスクリプトの検証対象を追加するだけで、実行時挙動には影響しません。

## 補足

- docs-only sibling の #1940 はこの PR には含めていません。