### PR TITLE
Add lazy-loading handoff browser smoke coverage

### DIFF
--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -273,6 +273,33 @@ test.describe("docs mockup browser smoke", () => {
     await expect(page.getByRole("button", { name: "Download" })).toHaveAttribute("aria-disabled", "true")
   })
 
+  test("lazy-loading-handoff.html preserves placeholder, loaded, and retry handoff boundaries", async ({ page }) => {
+    await openMockup(page, "lazy-loading-handoff.html")
+
+    await expect(page.getByRole("heading", { name: "Responsibility boundary" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "TreeView-owned cues" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Host-app-owned slots" })).toBeVisible()
+    await expect(page.locator("code", { hasText: "tree_children_container_dom_id(node)" })).toBeVisible()
+    await expect(page.locator("code", { hasText: "tree_remote_state_placeholder_attributes(state:)" })).toBeVisible()
+
+    await expect(page.locator("#project_alpha[data-tree-remote-state='idle'][aria-expanded='false']")).toBeVisible()
+    await expect(page.locator("#project_alpha_children")).toContainText("Host app owns the placeholder content")
+    await expect(page.locator("#project_alpha_remote_state")).toContainText("remote-state placeholder is reserved")
+
+    await expect(page.locator("#project_delta[data-tree-remote-state='loading'][aria-busy='true']")).toBeVisible()
+    await expect(page.locator("#project_delta_children")).toContainText("Children are not committed yet")
+    await expect(page.locator("#project_delta_remote_state")).toContainText("Loading child rows...")
+
+    await expect(page.locator("#project_beta[data-tree-remote-state='loaded'][aria-expanded='true']")).toBeVisible()
+    await expect(page.locator("#project_beta_task_1[data-tree-parent-key='project:beta']")).toContainText("Loaded task one")
+    await expect(page.locator("#project_beta_task_2[data-tree-parent-key='project:beta']")).toContainText("Remote-state placeholder is cleared")
+
+    await expect(page.locator("#project_gamma[data-tree-remote-state='error'][aria-expanded='false']")).toBeVisible()
+    await expect(page.locator("#project_gamma_remote_state")).toContainText("Could not load children.")
+    await expect(page.getByRole("button", { name: "Retry loading" })).toBeVisible()
+    await expect(page.getByText("No real Turbo request, fetch controller, or retry implementation is included.", { exact: true })).toBeVisible()
+  })
+
   test("non-exempt focused mockups avoid document-level horizontal overflow at narrow width", async ({ page }) => {
     const overflowingMockups = []
     const checkedMockups = focusedMockupSmokeTargets.filter((mockup) => !narrowOverflowExpectedMockups.has(mockup.file))


### PR DESCRIPTION
## 対応 Issue
- Closes #1944

## Issue ごとの完了内容
- #1944: `lazy-loading-handoff.html` の placeholder / loaded / error-retry handoff 境界を Playwright smoke spec で確認するテストを追加しました。

## 変更内容
- `test/browser/docs_mockups_smoke.spec.js` に lazy-loading handoff 専用の代表 assertion を追加
- TreeView 側の helper/ARIA/state signal と、host app 側が所有する children / remote-state placeholder / retry slot の存在を確認
- 既存の viewport overflow smoke はそのまま維持

## 改善カテゴリ
- test
- docs mockup regression guard

## 既存仕様への影響
- テスト追加のみです。
- HTML、JavaScript、CSS、公開API、UI仕様、DB、認可、外部契約は変更していません。

## 実施した確認
- GitHub connector で `main` の最新 commit (`d51f8369fa57733c47a4dc78088a14e5e22e6aec`) からブランチ作成
- `main...quality/1944-lazy-loading-handoff-smoke` の差分確認: `test/browser/docs_mockups_smoke.spec.js` 1ファイル、27行追加のみ
- ブランチ上の更新後ファイルを再取得し、追加テスト内容と末尾改行相当を確認

## リスク評価
- low: 既存仕様に触れないテスト追加のみ

## 補足事項
- この実行環境ではリポジトリのローカル checkout / ブラウザ実行が安定して使えないため、ローカル Playwright 実行は未実施です。PR CI で `test/browser/docs_mockups_smoke.spec.js` の実行結果を確認してください。