### PR TITLE
Public API docs に hook export と callback boundary を追記する

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -170,6 +170,8 @@ See [API reference](api.md), [Localized names](localized-names.md), and [Turbo F
 
 These keys are a key-surface contract only: `row_class_builder`, `row_data_builder`, `row_event_payload_builder`, `loading_builder`, `error_builder`, `depth_label_builder`, `badge_builder`, `icon_builder`, and `toggle_icon_builder` remain distinct from grouped option hashes, individual scalar options, and the declarative `toggle_icons` map. This contract does not change callback arity, return-value validation, row rendering, `NodePresenter` fallback behavior, or toggle icon lookup priority.
 
+`loading_builder` and `error_builder` are row-level callback surfaces that let host apps render documented loading or error rows while keeping request lifecycle, retry UI, authorization-safe error copy, and response handling in the host app. See [Lazy Loading](lazy-loading.md) for the request-state boundary and the related interaction-state references.
+
 `row_data_builder` stays inside that key-surface contract. Host-app data hash shape, merged row data attributes, and TreeView-owned row status keys are documented and guarded in [Row status](row-status.md) rather than promoted to a manifest-backed return-shape schema.
 
 ## Host app extension points
@@ -201,8 +203,10 @@ Stable enough for host apps to use:
 - `TreeViewTransferDropPositions`
 - `TreeViewTransferDataMimeTypes`
 - `TreeViewRemoteStateValues`
+- `TreeViewRemoteStateDataHooks`
 - `TreeViewControllerIdentifiers`
 - `TreeViewIntegrationHooks`
+- `TreeViewToolbarDataHooks`
 - `TreeViewSelectionDataHooks`
 - `TreeViewSelectionCheckboxHooks`
 - `TreeViewEmptyStateHooks`
@@ -222,8 +226,10 @@ Stable enough for host apps to use:
 `TreeViewTransferDropPositions` exposes the documented coarse drop-position values for transfer events: `before`, `inside`, and `after`. `TreeViewEventNames.transfer.*` names transfer events, `TreeViewEventDetailKeys.transfer.*` lists the documented `event.detail` keys, and `TreeViewTransferDropPositions` carries the position values described in [Drag and Drop](drag-and-drop.md#drop-behavior).
 `TreeViewTransferDataMimeTypes` exposes the documented TreeView transfer MIME type values: `application/json` for the primary JSON payload and `text/plain` as the browser compatibility fallback. Use it when host-app JavaScript or tests need to read or assert TreeView transfer data without hand-copying MIME strings; drag/drop behavior, payload shape, and final business handling still live in [Drag and Drop](drag-and-drop.md#drop-behavior).
 `TreeViewRemoteStateValues` exposes the documented remote-state value set for lazy-loading rows: `loading`, `loaded`, and `error`. Use it when host-app JavaScript or tests need to compare `data-tree-remote-state` values without hand-copying strings; `TreeViewEventNames.remoteState.*` still names controller-emitted events, and `TreeViewEventDetailKeys.remoteState.*` still lists their `event.detail` keys.
+`TreeViewRemoteStateDataHooks` exposes the documented lazy-loading and remote-state data attribute names as a machine-readable package-root export. Use it when custom lazy-loading markup, tests, or copied host-app partials need to reference `data-tree-lazy`, `data-tree-children-url`, `data-tree-loaded`, or `data-tree-remote-state` without hand-copying strings; request dispatch, response handling, retry UI, and authorization-safe copy stay with the host app and [Lazy Loading](lazy-loading.md).
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
 `TreeViewIntegrationHooks` exposes documented integration hook attribute names as a machine-readable object for host-app JavaScript and tests that need to query or assert TreeView-owned wiring without hand-copying strings. Representative keys cover state row identity, remote-state children URLs, and transfer payload hooks; their detailed behavior still lives in the feature docs and [JavaScript event contract](js-events.md).
+`TreeViewToolbarDataHooks` exposes the documented toolbar container, action, and disabled data hook attribute names as a machine-readable package-root export. Use it when custom toolbar markup or tests need to reference TreeView-owned toolbar hooks without hand-copying strings; supported actions and metadata still come from the toolbar helpers, while action policy, labels, authorization copy, and final UI remain host-app responsibilities documented in [Toolbar](toolbar.md).
 `TreeViewSelectionDataHooks` exposes the documented `tree-view-selection` host-element value attribute names as a machine-readable object. Use it when JavaScript needs to author or query those host-owned attributes without hand-copying strings such as `TreeViewSelectionDataHooks.hiddenInputNameValue`.
 `TreeViewSelectionCheckboxHooks` exposes the rendered selection checkbox class and disabled-reason attribute emitted by TreeView's selection cell partial. Use it for browser-level tests or host-app JavaScript that needs to find TreeView-rendered checkbox elements, not for host-authored `tree-view-selection` controller values. See [Selection checkbox hooks](selection-checkbox-hooks.md).
 `TreeViewEmptyStateHooks` exposes the documented empty-state wrapper attribute and baseline row classes as a machine-readable object. Use it when host-app JavaScript, tests, or copied styling need to target the shipped empty-state reference pattern without hand-copying `data-tree-view-empty-state`, `.tree-view-empty-row__content`, or `.tree-view-empty-row__message`. The final empty-state copy, CTA, permission message, and filter-reset behavior stay host-app responsibilities.
@@ -248,6 +254,13 @@ Documented keys on `TreeViewRemoteStateValues`:
 - `loaded`
 - `error`
 
+Documented keys on `TreeViewRemoteStateDataHooks`:
+
+- `lazyAttribute`
+- `childrenUrlAttribute`
+- `loadedAttribute`
+- `remoteStateAttribute`
+
 Documented keys on `TreeViewControllerIdentifiers`:
 
 - `state`
@@ -262,6 +275,12 @@ Documented keys on `TreeViewIntegrationHooks`:
 - `state.nodeKey`
 - `remoteState.childrenUrl`
 - `transfer.payload`
+
+Documented keys on `TreeViewToolbarDataHooks`:
+
+- `toolbarAttribute`
+- `actionAttribute`
+- `disabledAttribute`
 
 Documented keys on `TreeViewSelectionDataHooks`:
 
@@ -290,7 +309,7 @@ The `tree-view-selection` controller's documented host-element value attributes 
 
 Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
-The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, transfer drop-position values, transfer data MIME type values, remote-state values, integration hook values, selection data hook values, selection checkbox hook values, and empty-state hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, transfer drop-position values, transfer data MIME type values, remote-state values, remote-state data hook values, toolbar data hook values, integration hook values, selection data hook values, selection checkbox hook values, and empty-state hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 
 Internal by default:
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -170,6 +170,8 @@ localized display-name helper は、利用できる場合に host app の Rails 
 
 対象 key は `row_class_builder`、`row_data_builder`、`row_event_payload_builder`、`loading_builder`、`error_builder`、`depth_label_builder`、`badge_builder`、`icon_builder`、`toggle_icon_builder` です。これは key surface の contract であり、grouped option hash、個別 scalar option、宣言的な `toggle_icons` map とは別の surface です。callback arity、return value validation、row rendering、`NodePresenter` fallback、toggle icon lookup priority は変更しません。
 
+`loading_builder` と `error_builder` は、host app が documented な loading / error row を描画するための row-level callback surface です。request lifecycle、retry UI、authorization-safe error copy、response handling は host app が所有します。request-state boundary と関連する interaction-state reference は [Lazy Loading](lazy-loading.md) を参照してください。
+
 `row_data_builder` もこの key-surface contract に留まります。host app の data hash shape、merge 後の row data attribute、TreeView-owned row status key との境界は [Row status](row-status.md) の docs/spec-level guidance で扱い、manifest-backed return-shape schema には昇格しません。
 
 ## Host app extension points
@@ -201,8 +203,10 @@ host app が使ってよい入口:
 - `TreeViewTransferDropPositions`
 - `TreeViewTransferDataMimeTypes`
 - `TreeViewRemoteStateValues`
+- `TreeViewRemoteStateDataHooks`
 - `TreeViewControllerIdentifiers`
 - `TreeViewIntegrationHooks`
+- `TreeViewToolbarDataHooks`
 - `TreeViewSelectionDataHooks`
 - `TreeViewSelectionCheckboxHooks`
 - `TreeViewEmptyStateHooks`
@@ -222,8 +226,10 @@ host app が使ってよい入口:
 `TreeViewTransferDropPositions` は transfer event の粗い drop-position value として、`before`、`inside`、`after` を公開します。`TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented な `event.detail` key、`TreeViewTransferDropPositions` は [Drag and Drop](drag-and-drop.md#drop処理) で説明している position value を表します。
 `TreeViewTransferDataMimeTypes` は documented な TreeView transfer MIME type value として、primary JSON payload 用の `application/json` と browser compatibility fallback 用の `text/plain` を公開します。host app の JavaScript や test が MIME string を写経せずに TreeView transfer data を読み取ったり assert したりしたい場合に使えます。drag/drop behavior、payload shape、最終的な業務処理は引き続き [Drag and Drop](drag-and-drop.md#drop処理) を正本にしてください。
 `TreeViewRemoteStateValues` は lazy-loading row の documented remote-state value set として、`loading`、`loaded`、`error` を公開します。host app の JavaScript や test が `data-tree-remote-state` の値を string の写経なしに照合したい場合に使えます。controller が emit する remote-state event 名は引き続き `TreeViewEventNames.remoteState.*`、その `event.detail` key は `TreeViewEventDetailKeys.remoteState.*` で扱います。
+`TreeViewRemoteStateDataHooks` は、documented された lazy-loading / remote-state data attribute names を machine-readable に参照するための package-root export です。custom lazy-loading markup、test、copied host-app partial が `data-tree-lazy`、`data-tree-children-url`、`data-tree-loaded`、`data-tree-remote-state` を写経せず参照したい場合に使えます。request dispatch、response handling、retry UI、authorization-safe copy は [Lazy Loading](lazy-loading.md) に沿って host app 側に残ります。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
 `TreeViewIntegrationHooks` は、documented integration hook attribute name を machine-readable object として公開します。host app の JavaScript や test が TreeView-owned wiring を query / assert するとき、raw string の写経を避けるために使えます。代表 key は state row identity、remote-state children URL、transfer payload hook を扱います。詳細な挙動は feature docs と [JavaScript event contract](js-events.md) を正本にしてください。
+`TreeViewToolbarDataHooks` は、documented された toolbar container、action、disabled data hook attribute names を machine-readable に参照するための package-root export です。custom toolbar markup や test が TreeView-owned toolbar hook を写経せず参照したい場合に使えます。supported action と metadata は toolbar helper から取得し、action policy、label、authorization copy、最終 UI は [Toolbar](toolbar.md) で説明している host app 側の責務です。
 `TreeViewSelectionDataHooks` は、documented された `tree-view-selection` host-element value attribute names を machine-readable object として公開します。JavaScript が host-owned attribute を author / query するとき、`TreeViewSelectionDataHooks.hiddenInputNameValue` のように使うことで string の写経を避けられます。
 `TreeViewSelectionCheckboxHooks` は、TreeView の selection cell partial が出力する rendered selection checkbox class と disabled-reason attribute を公開します。TreeView-rendered checkbox element を探す browser-level test や host-app JavaScript 向けであり、host-authored な `tree-view-selection` controller value には使いません。詳細は [Selection checkbox hooks](selection-checkbox-hooks.md) を参照してください。
 `TreeViewEmptyStateHooks` は、documented された empty-state wrapper attribute と baseline row class を machine-readable object として公開します。host app の JavaScript、test、copied styling が shipped empty-state reference pattern を target するとき、`data-tree-view-empty-state`、`.tree-view-empty-row__content`、`.tree-view-empty-row__message` の写経を避けられます。最終的な empty-state copy、CTA、permission message、filter-reset behavior は host app 側の責務です。
@@ -248,6 +254,13 @@ host app が使ってよい入口:
 - `loaded`
 - `error`
 
+`TreeViewRemoteStateDataHooks` の documented key:
+
+- `lazyAttribute`
+- `childrenUrlAttribute`
+- `loadedAttribute`
+- `remoteStateAttribute`
+
 `TreeViewControllerIdentifiers` の documented key:
 
 - `state`
@@ -262,6 +275,12 @@ host app が使ってよい入口:
 - `state.nodeKey`
 - `remoteState.childrenUrl`
 - `transfer.payload`
+
+`TreeViewToolbarDataHooks` の documented key:
+
+- `toolbarAttribute`
+- `actionAttribute`
+- `disabledAttribute`
 
 `TreeViewSelectionDataHooks` の documented key:
 
@@ -290,7 +309,7 @@ host app が使ってよい入口:
 
 これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する内部寄りの属性であり、host app が authoring する public hook ではありません。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
-package-root の JavaScript export、bundled controller identifier、transfer drop-position value、transfer data MIME type value、remote-state value、integration hook value、selection data hook value、selection checkbox hook value、empty-state hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+package-root の JavaScript export、bundled controller identifier、transfer drop-position value、transfer data MIME type value、remote-state value、remote-state data hook value、toolbar data hook value、integration hook value、selection data hook value、selection checkbox hook value、empty-state hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 
 内部扱い:
 


### PR DESCRIPTION
## 対応 Issue

- Closes #1940
- Closes #1945

## 判定分類

- #1940: `code-ahead-of-docs` / `docs-stale`
- #1945: `docs-stale` / `docs-sync`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の JavaScript surface list に `TreeViewRemoteStateDataHooks` と `TreeViewToolbarDataHooks` を追加しました。
- 両 export の用途を、lazy-loading / remote-state data hooks と toolbar data hooks の machine-readable package-root export として短く説明しました。
- documented key list に remote-state data hook keys と toolbar data hook keys を追加しました。
- `loading_builder` / `error_builder` が row-level callback surface であり、request lifecycle / retry UI / authorization-safe copy / response handling は host app responsibility であることを Public API docs に追記しました。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`

runtime JavaScript、TypeScript declaration、manifest、callback behavior、toolbar behavior、lazy-loading behavior は変更していません。

## 確認内容

- Connector preflight:
  - base: current `main` `d4d5d08223cb756caf794709890929f8c2b437df`
  - head: `ea15d509130a0761382ca55061bf7dd07becdf57`
  - compare `main...docs/1940-1945-public-api-hooks`: `ahead_by:3` / `behind_by:0`
  - changed files: `docs/en/public-api.md`, `docs/ja/public-api.md`
- local checkout / `npm run test:docs-entrypoints`: GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存公開 export と既存 callback key surface の docs discovery 補強に閉じています。