### PR TITLE
Public API docs から GraphAdapter / Diagnostics guide へ導線を足す

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -61,6 +61,10 @@ Use `TreeView::ResourceTableRenderState.call` when another table layer already o
 
 `TreeView::FilteredTree` is a stable public entry point for filtered tree results. Its mode set is also tracked in `config/public_api_manifest.yml` as the `filtered_tree_modes` contract; see [Filtered Trees: Modes](filtered-trees.md#modes) for the documented mode table and the host-app boundary for search query, ranking, authorization, and highlighting.
 
+`TreeView::GraphAdapter` is the adapter-mode entry point for heterogeneous or graph-like nodes that do not fit one parent-id column. See [GraphAdapter](graph-adapter.md) and [API overview: adapter mode](api-overview.md#adapter-mode) for the host-app traversal, authorization, query planning, and node-key boundaries.
+
+`TreeView::Diagnostics` is the aggregate pre-render validation entry point for node key, DOM ID, orphan, and cycle checks. See [Tree diagnostics](tree-diagnostics.md) for the `TreeView::Diagnostics.run` flow, `Result` surface, and host-app data correction boundary.
+
 ## Public error surface
 
 Host apps may rescue `TreeView::Error` to handle documented TreeView validation and configuration failures separately from unrelated application errors.

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -61,6 +61,10 @@ host app が直接使ってよい主な入口は以下です。
 
 `TreeView::FilteredTree` は filtered tree result 用の安定した公開入口です。mode set も `config/public_api_manifest.yml` の `filtered_tree_modes` contract として追跡されています。documented mode table と、search query、ranking、authorization、highlighting を host app 側に置く責務境界は [Filtered Trees: Modes](filtered-trees.md#modes) を参照してください。
 
+`TreeView::GraphAdapter` は、単一の parent-id column では表せない heterogeneous / graph-like nodes のための adapter-mode 入口です。host app 側の traversal、authorization、query planning、node-key 境界は [GraphAdapter](graph-adapter.md) と [API概要: adapter mode](api-overview.md#adapter-mode) を参照してください。
+
+`TreeView::Diagnostics` は、node key、DOM ID、orphan、cycle をまとめて確認する pre-render validation 入口です。`TreeView::Diagnostics.run` の流れ、`Result` surface、host-app data correction boundary は [Tree diagnostics](tree-diagnostics.md) を参照してください。
+
 ## Public error surface
 
 host app は `TreeView::Error` を rescue することで、documented された TreeView の validation / configuration failure を、他の application error と分けて扱えます。


### PR DESCRIPTION
## 対応 Issue

- Closes #1954
- Closes #1958

## 判定分類

- #1954: `docs-sync` / `docs-missing`
- #1958: `docs-sync` / `docs-missing`

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` の stable public entry points section に、`TreeView::GraphAdapter` から GraphAdapter guide / API overview adapter mode へ辿る短い説明を追加しました。
- 同じ section に、`TreeView::Diagnostics` から Tree diagnostics guide へ辿る短い説明を追加しました。
- records mode / adapter mode / diagnostics Result surface の責務境界を広げず、既存 feature guide への discovery 補強に留めました。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`

runtime Ruby、GraphAdapter behavior、Diagnostics behavior、public API manifest schema、docs smoke には触れていません。

## 確認内容

- base: current `main` `34fccaed779c677d28d7df308f4f4285264ff306`
- compare `main...docs/1954-1958-public-api-entrypoints`: `ahead_by:2` / `behind_by:0`
- changed files: `docs/en/public-api.md`, `docs/ja/public-api.md`
- diff: additions 4 / deletions 0
- local checkout / `npm run test:docs-entrypoints`: GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存 public entrypoint の reader-facing guide discovery 補強だけで、実装や manifest contract は変更していません。