### PR TITLE
docs smoke coverage for GraphAdapter and diagnostics entrypoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
+- [English Tree diagnostics](en/tree-diagnostics.md): inspect node keys, DOM IDs, orphan nodes, and cycles before rendering.
+- [日本語Tree diagnostics](ja/tree-diagnostics.md): node_key、DOM ID、orphan、cycle などの構造を描画前に確認する入口。
 - [English Accessibility Semantics](en/accessibility-semantics.md): table-first ARIA policy, empty-state wrapper hooks, keyboard helper boundary, and intentional automated-check allowances.
 - [日本語Accessibility Semantics](ja/accessibility-semantics.md): table-first ARIA 方針、empty-state wrapper hook、keyboard helper の責務境界、自動 accessibility check の意図的な許容事項。
 - [English Selection](en/selection.md): checkbox selection hooks, hidden input form sync, max-count limits, multi-tree form boundaries, unloaded-descendant boundaries, and submitted value parsing.

--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -150,7 +150,7 @@ const signalGroups = [
           "TreeView::Diagnostics.run",
           "pre-render validation",
           "Result",
-          "host-app data policy boundaries"
+          "data policy"
         ]
       ],
       [
@@ -159,7 +159,7 @@ const signalGroups = [
           "TreeView::Diagnostics.run",
           "pre-render validation",
           "Result",
-          "host-app data policy boundaries"
+          "data policy"
         ]
       ]
     ]

--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -157,7 +157,7 @@ const signalGroups = [
         "docs/ja/tree-diagnostics.md",
         [
           "TreeView::Diagnostics.run",
-          "pre-render validation",
+          "描画前validation",
           "Result",
           "data policy"
         ]

--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -109,6 +109,62 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Tree diagnostics reader journey",
+    files: [
+      [
+        "README.md",
+        [
+          "Tree identity and diagnostics",
+          "docs/en/tree-diagnostics.md",
+          "docs/ja/tree-diagnostics.md"
+        ]
+      ],
+      [
+        "docs/README.md",
+        [
+          "en/tree-diagnostics.md",
+          "ja/tree-diagnostics.md"
+        ]
+      ],
+      [
+        "docs/en/README.md",
+        [
+          "Tree diagnostics",
+          "tree-diagnostics.md",
+          "Structure inspection APIs for node keys, DOM IDs, orphans, and cycles",
+          "Diagnose symptoms or responsibility boundaries"
+        ]
+      ],
+      [
+        "docs/ja/README.md",
+        [
+          "Tree diagnostics",
+          "tree-diagnostics.md",
+          "node_key、DOM ID、orphan、cycle などの構造確認 API",
+          "症状や責務境界から調べる"
+        ]
+      ],
+      [
+        "docs/en/tree-diagnostics.md",
+        [
+          "TreeView::Diagnostics.run",
+          "pre-render validation",
+          "Result",
+          "host-app data policy boundaries"
+        ]
+      ],
+      [
+        "docs/ja/tree-diagnostics.md",
+        [
+          "TreeView::Diagnostics.run",
+          "pre-render validation",
+          "Result",
+          "host-app data policy boundaries"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Render log level reader journey",
     files: [
       [

--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -29,6 +29,10 @@ const selectionDocs = [
   ["docs/en/selection.md", read("docs/en/selection.md")],
   ["docs/ja/selection.md", read("docs/ja/selection.md")]
 ]
+const graphAdapterDocs = [
+  ["docs/en/graph-adapter.md", read("docs/en/graph-adapter.md")],
+  ["docs/ja/graph-adapter.md", read("docs/ja/graph-adapter.md")]
+]
 const diagnosticsDocs = [
   ["docs/en/tree-diagnostics.md", read("docs/en/tree-diagnostics.md")],
   ["docs/ja/tree-diagnostics.md", read("docs/ja/tree-diagnostics.md")]
@@ -90,6 +94,19 @@ const emptyStateHookSignals = [
   "data-tree-view-empty-state"
 ]
 
+const graphAdapterInitializerSignals = [
+  "graph_adapter_initializer",
+  "roots",
+  "children_resolver",
+  "node_key_resolver"
+]
+
+const graphAdapterBoundarySignals = [
+  "authorization",
+  "query planning",
+  "host-app responsibility"
+]
+
 const diagnosticsAcceptedCheckSignals = [
   "node_keys",
   "dom_ids",
@@ -147,6 +164,7 @@ const manifestBackedDocsSignalSurfaces = [
   ["remote-state values", "remote_state_values:"],
   ["selection data hooks", "selection_data_hooks:"],
   ["empty-state hooks", "empty_state_hooks:"],
+  ["GraphAdapter initializer", "graph_adapter_initializer:"],
   ["diagnostics accepted checks", "diagnostics:"],
   ["diagnostics accepted checks", "accepted_checks:"],
   ["diagnostics run options", "run_options:"],
@@ -160,6 +178,10 @@ manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
 
 callbackBuilderSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest callback builder key surface")
+})
+
+graphAdapterInitializerSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest GraphAdapter initializer surface")
 })
 
 diagnosticsAcceptedCheckSignals.forEach((signal) => {
@@ -246,6 +268,28 @@ selectionDocs.forEach(([relativePath, document]) => {
   selectionDataHookSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} selection data hook docs`)
   })
+})
+
+graphAdapterDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeView::GraphAdapter", `${relativePath} GraphAdapter guide entrypoint docs`)
+
+  graphAdapterInitializerSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} GraphAdapter initializer manifest boundary docs`)
+  })
+
+  graphAdapterBoundarySignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} GraphAdapter host-app responsibility boundary docs`)
+  })
+
+  assert(
+    /constructor surface|constructor surface|constructor surface/.test(document),
+    `${relativePath}: GraphAdapter docs no longer identify the initializer constructor surface boundary`
+  )
+
+  assert(
+    /traversal semantics|traversal semantics|traversal semantics/.test(document),
+    `${relativePath}: GraphAdapter docs no longer separate traversal semantics from the manifest schema`
+  )
 })
 
 diagnosticsDocs.forEach(([relativePath, document]) => {


### PR DESCRIPTION
## 対応 Issue

- Closes #1955
- Closes #1957

## Issue ごとの完了内容

- #1955: GraphAdapter initializer の manifest/docs 境界が public API docs smoke で検知されるようにしました。`graph_adapter_initializer` と initializer 引数、host app 側責務の説明シグナルを確認します。
- #1957: Tree diagnostics の入口と reader journey が docs smoke で検知されるようにしました。root docs index から英日 diagnostics docs への導線と、diagnostics docs 内の主要シグナルを確認します。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に GraphAdapter initializer の manifest-backed docs signal と boundary signal を追加しました。
- `script/test_docs_reader_journey_signals.mjs` に Tree diagnostics の entrypoint/read journey signal を追加しました。
- `docs/README.md` に英日 Tree diagnostics への推奨入口を追加し、reader journey smoke が実際の導線を守るようにしました。

## 改善カテゴリ

- docs smoke test
- docs entrypoint regression guard
- public API / reader journey regression guard

## 既存仕様への影響

- 実行時 Ruby/JavaScript、公開 API、UI、manifest schema は変更していません。
- docs 導線と docs signal smoke の追加に限定しています。

## 確認内容

- Connector 上で `main...chore/1955-1957-docs-smoke-guards` を確認し、`ahead_by: 5` / `behind_by: 0` であることを確認しました。
- 差分対象は以下の 3 ファイルのみです。
  - `docs/README.md`
  - `script/test_public_api_docs_signals.mjs`
  - `script/test_docs_reader_journey_signals.mjs`
- PR CI #2578: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript` (`npm run test:js:core`): success
  - `gem_package`: success
  - representative `pr_rails_matrix` lanes: success
  - docs-only/full matrix jobs: skipped as intended

## リスク評価

- risk: low
- docs 導線と smoke test の確認対象追加のみで、公開契約や実行時挙動への変更はありません。

## 補足

- #1955 と #1957 はどちらも docs signal smoke の品質改善で、同じテスト層に対する回帰防止追加としてまとめています。