### PR TITLE
Add installation entrypoint smoke guard

### DIFF
--- a/spec/docs/installation_entrypoint_signals_spec.rb
+++ b/spec/docs/installation_entrypoint_signals_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "installation entrypoint signal docs" do
+  def read_repo_file(path)
+    File.read(File.expand_path("../../#{path}", __dir__))
+  end
+
+  let(:english_installation) { read_repo_file("docs/en/installation.md") }
+  let(:japanese_installation) { read_repo_file("docs/ja/installation.md") }
+
+  it "keeps CSS import, importmap pin, and controller registration signals visible" do
+    {
+      "docs/en/installation.md" => english_installation,
+      "docs/ja/installation.md" => japanese_installation
+    }.each do |path, document|
+      expect(document).to include(
+        '@import "tree_view";',
+        'pin "tree_view", to: "tree_view/index.js"',
+        'import { registerTreeViewControllers } from "tree_view"',
+        "registerTreeViewControllers(application)"
+      ), "#{path} lost one of the representative installation entrypoint signals"
+    end
+  end
+
+  it "keeps Propshaft and Sprockets setup signals separate from the quick-start path" do
+    expect(english_installation).to include(
+      "## Propshaft",
+      "explicitly import CSS and add the importmap pin",
+      "## Sprockets",
+      "explicit CSS/importmap setup in the host app remains the recommended integration path"
+    )
+
+    expect(japanese_installation).to include(
+      "## Propshaft",
+      "CSS / importmap を明示的に読み込む構成を推奨します",
+      "## Sprockets",
+      "導入の中心はhost app側でCSS / importmapを明示的に読み込む運用です"
+    )
+  end
+end


### PR DESCRIPTION
## 対応 Issue

- Closes #1964

## Issue ごとの完了内容

- #1964: Installation docs の CSS import、importmap pin、Stimulus controller registration の代表 signal を RSpec smoke で guard しました。
- Propshaft / Sprockets の説明が quick-start signal と混ざらず残っていることも確認対象にしました。

## 変更内容

- `spec/docs/installation_entrypoint_signals_spec.rb` を追加
- `docs/en/installation.md` と `docs/ja/installation.md` の代表導入 signal を検査

## 改善カテゴリ

- test
- docs drift guard

## 既存仕様への影響

- ありません。runtime、UI、API、DB、認可、状態遷移は変更していません。
- ドキュメント本文も変更しておらず、既存導入手順の drift guard のみ追加しています。

## 確認内容

- connector-only で main が `8dbae3bf034971cdca38e61bfaba8738caaffad8` から進んでいないことを確認
- 差分が `spec/docs/installation_entrypoint_signals_spec.rb` の追加だけであることを確認
- ローカル checkout は GitHub raw/git access が 403 のため実行できず、テスト実行は PR CI に委ねます。

## リスク評価

- low。RSpec の source/docs smoke 追加のみで、公開挙動には影響しません。

## 補足事項

- 新しい導入経路や package script は追加していません。既存 RSpec 実行に乗る最小 guard です。