### PR TITLE
mockup README の toolbar guidance を current contract へ同期する

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -161,7 +161,7 @@ Record deliberate copy or language exceptions in this list. Add a row when a moc
 
 - Use `toolbar-actions.html` to review visual action availability, current-path emphasis, disabled fallback, and missing-path fallback without treating the page as a public API manifest for `tree_view_toolbar_action_metadata`.
 - Keep route builders, authorization policy, final localized labels, and permission messages in the host app.
-- Use #1449 for helper return-shape / manifest-backed public contract decisions instead of expanding this mockup into API documentation.
+- Treat `docs/en/toolbar.md`, `docs/ja/toolbar.md`, `docs/en/public-api.md`, `docs/ja/public-api.md`, and `config/public_api_manifest.yml` as the helper metadata contract sources; use this mockup only as the visual review aid for those states.
 
 ## Drag/drop guidance
 


### PR DESCRIPTION
## 概要

Closes #1975

分類: docs-stale / docs-sync

`docs/mockups/README.md` の Toolbar guidance が、完了済み Issue #1449 を helper return-shape / manifest-backed public contract の判断先として案内していたため、current docs / manifest を正本として参照する表現へ更新します。

## 更新内容

- `docs/mockups/README.md`
  - `toolbar-actions.html` は visual review aid であり、helper metadata contract の正本ではない境界を維持
  - helper metadata contract の参照先を `docs/en|ja/toolbar.md`、`docs/en|ja/public-api.md`、`config/public_api_manifest.yml` に更新
  - runtime helper、manifest schema、toolbar mockup HTML は変更なし

## 確認観点

- docs-only change
- compare `main...docs/1975-toolbar-guidance-current-contract`: `ahead_by:1` / `behind_by:0`
- changed files: `docs/mockups/README.md` の1件のみ
- PR CI を確認対象にします

## リスク

low。完了済み Issue 番号への作業誘導を current contract docs への参照に置き換えるだけで、仕様や実装は変更しません。