### PR TITLE
docs entrypoint smoke を suite runner に整理する

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoints.mjs && node script/test_repository_only_maintainer_entrypoints.mjs && node script/test_docs_entrypoint_signals.mjs && node script/test_public_setup_surface_docs_signals.mjs && node script/test_breadcrumb_docs_signals.mjs && node script/test_docs_reader_journey_signals.mjs && node script/test_decision_guide_signals.mjs && node script/test_quality_docs_smoke_signals.mjs && node script/test_release_docs_signals.mjs && node script/test_readme_quick_start_signal.mjs && node script/test_public_api_docs_signals.mjs && node script/test_localized_and_hook_docs_signals.mjs && npm run test:docs-i18n",
+    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -1,0 +1,103 @@
+import { spawnSync } from "node:child_process"
+
+const checks = [
+  {
+    group: "Foundational docs entrypoints",
+    command: "node",
+    args: ["script/test_docs_entrypoints.mjs"]
+  },
+  {
+    group: "Repository-only maintainer entrypoints",
+    command: "node",
+    args: ["script/test_repository_only_maintainer_entrypoints.mjs"]
+  },
+  {
+    group: "Docs entrypoint signals",
+    command: "node",
+    args: ["script/test_docs_entrypoint_signals.mjs"]
+  },
+  {
+    group: "Public setup surface docs signals",
+    command: "node",
+    args: ["script/test_public_setup_surface_docs_signals.mjs"]
+  },
+  {
+    group: "Breadcrumb docs signals",
+    command: "node",
+    args: ["script/test_breadcrumb_docs_signals.mjs"]
+  },
+  {
+    group: "Docs reader journey signals",
+    command: "node",
+    args: ["script/test_docs_reader_journey_signals.mjs"]
+  },
+  {
+    group: "Decision guide signals",
+    command: "node",
+    args: ["script/test_decision_guide_signals.mjs"]
+  },
+  {
+    group: "Quality docs smoke signals",
+    command: "node",
+    args: ["script/test_quality_docs_smoke_signals.mjs"]
+  },
+  {
+    group: "Release docs signals",
+    command: "node",
+    args: ["script/test_release_docs_signals.mjs"]
+  },
+  {
+    group: "README quick start signal",
+    command: "node",
+    args: ["script/test_readme_quick_start_signal.mjs"]
+  },
+  {
+    group: "Public API docs signals",
+    command: "node",
+    args: ["script/test_public_api_docs_signals.mjs"]
+  },
+  {
+    group: "Localized and hook docs signals",
+    command: "node",
+    args: ["script/test_localized_and_hook_docs_signals.mjs"]
+  },
+  {
+    group: "Docs i18n parity",
+    command: "npm",
+    args: ["run", "test:docs-i18n"]
+  }
+]
+
+function commandLine({ command, args }) {
+  return [command, ...args].join(" ")
+}
+
+for (const check of checks) {
+  console.log(`\n[docs-entrypoints] ${check.group}`)
+  console.log(`$ ${commandLine(check)}`)
+
+  const result = spawnSync(check.command, check.args, { stdio: "inherit" })
+
+  if (result.error) {
+    console.error(
+      `[docs-entrypoints] ${check.group} failed to start: ${result.error.message}`
+    )
+    process.exit(1)
+  }
+
+  if (result.signal) {
+    console.error(
+      `[docs-entrypoints] ${check.group} stopped by signal ${result.signal}: ${commandLine(check)}`
+    )
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    console.error(
+      `[docs-entrypoints] ${check.group} failed with exit code ${result.status}: ${commandLine(check)}`
+    )
+    process.exit(result.status ?? 1)
+  }
+}
+
+console.log("\n[docs-entrypoints] all checks passed")


### PR DESCRIPTION
## 対応 Issue

Closes #1978

## Issue ごとの完了内容

- #1978: `test:docs-entrypoints` の長い `&&` 直列を、新規 `script/test_docs_entrypoint_suite.mjs` の順序付き group runner に移しました。

## 変更内容

- `package.json` の `test:docs-entrypoints` を `node script/test_docs_entrypoint_suite.mjs` に短縮しました。
- runner script に既存 docs smoke / public API / setup / release / quality / i18n checks を従来と同じ順序で列挙しました。
- 各 check に group 名を付け、失敗時は group 名、実行 command、exit code または signal が分かるようにしました。

## 改善カテゴリ

- test / CI helper
- 小規模リファクタ
- maintenance

## 既存仕様への影響

- individual smoke script の assertion 内容は変更していません。
- 実行順は既存 `test:docs-entrypoints` と同じです。
- CI workflow、Node major version、依存関係、runtime Ruby / JavaScript、public API manifest、docs 本文は変更していません。
- #1825 の `script/test_docs_entrypoints.mjs` 内部 signal 配列分割は別 Issue として残しています。

## 実施した確認

- Issue #1978 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff を確認し、runner script 方式に限定しました。
- connector compare `main...quality/1978-docs-entrypoint-suite`: `ahead_by:2` / `behind_by:0` / changed files 2。
- 変更ファイルは `package.json` と `script/test_docs_entrypoint_suite.mjs` のみです。
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。
- GitHub Actions CI run 2608: all jobs success (`changes`, `pr_specs`, `lint`, `gem_package`, `docker_development_setup`, `javascript`, representative Rails matrix jobs; skipped matrix summary jobs are expected)。

## リスク評価

low。実行入口の整理のみで、docs smoke coverage と順序を維持しています。runner の exit code 伝播も CI で確認済みです。
