### PR TITLE
Installation から Public Setup Surface へ導線を追加する

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -100,6 +100,22 @@ registerTreeViewControllers(application)
 
 Use `registerTreeViewControllers(application)` as the quick-start path for JavaScript-powered TreeView features. Host apps that need selective registration or a custom boot order can use `TreeViewControllerIdentifiers` from the public JavaScript surface; see [Public API](public-api.md#javascript-surface).
 
+## Persisted-state setup generator
+
+When the host app enables persisted expansion state, run the persisted-state install generator after the gem is installed:
+
+```bash
+bin/rails generate tree_view:state:install
+```
+
+Pass an owner model name when the generated concern should be included in an existing owner model:
+
+```bash
+bin/rails generate tree_view:state:install User
+```
+
+The generator name, optional owner argument, and generated destination paths are documented as the [Public Setup Surface](public-setup-surface.md). That path-level contract tracks `db/migrate/*_create_tree_view_states.rb`, `app/models/tree_view_state.rb`, and `app/models/concerns/tree_view_state_owner.rb` without freezing the migration schema or generated template contents. Review the generated files in the host app, then continue with [Persisted State](persisted-state.md) for storage ownership, authorization, save timing, cleanup policy, controller actions, and UI wiring boundaries.
+
 ## Packaged files
 
 The gem package should include the files needed by Rails host apps:

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -100,6 +100,22 @@ registerTreeViewControllers(application)
 
 JavaScript-powered な TreeView 機能を使う場合は、quick-start として `registerTreeViewControllers(application)` を使ってください。controller を部分登録したい場合や custom boot order が必要な場合は、public JavaScript surface の `TreeViewControllerIdentifiers` を使えます。詳しくは [Public API](public-api.md#javascript-surface) を参照してください。
 
+## persisted-state setup generator
+
+persisted expansion state を有効にする host app では、gem の導入後に persisted-state install generator を実行します。
+
+```bash
+bin/rails generate tree_view:state:install
+```
+
+既存の owner model に generated concern を include したい場合は、owner model 名を渡します。
+
+```bash
+bin/rails generate tree_view:state:install User
+```
+
+generator 名、任意の owner 引数、生成先 path は [Public Setup Surface](public-setup-surface.md) に documented setup surface としてまとめています。この path-level contract は `db/migrate/*_create_tree_view_states.rb`、`app/models/tree_view_state.rb`、`app/models/concerns/tree_view_state_owner.rb` を追跡しますが、migration schema や生成 template 内容そのものを固定するものではありません。生成後のファイルは host app 側で確認し、storage ownership、認可、保存タイミング、cleanup policy、controller action、UI wiring の責務境界は [Persisted State](persisted-state.md) で確認してください。
+
 ## Packaged files
 
 TreeView gem package には、Rails host app で必要になる以下を含めます。


### PR DESCRIPTION
## 概要

Closes #1988

分類: `docs-missing` / `docs-sync`

`docs/README.md` と persisted-state docs には Public Setup Surface への入口がありますが、初回導入で最初に読む英日 Installation から persisted-state install generator の path-level contract へ辿る導線が不足していたため、小さな節を追加します。

## 更新内容

- `docs/en/installation.md`
  - `Persisted-state setup generator` 節を追加
  - `tree_view:state:install` と owner 引数つき実行例を掲載
  - `Public Setup Surface` と `Persisted State` へ導線を追加
- `docs/ja/installation.md`
  - 同じ内容を日本語側へ同期

## 確認観点

- docs-only change
- compare `main...docs/1988-public-setup-install-entry-v2`: `ahead_by:2` / `behind_by:0`
- changed files: `docs/en/installation.md` / `docs/ja/installation.md`
- `docs/en|ja/public-setup-surface.md` と `docs/en|ja/persisted-state.md` の current contract と矛盾しないことを確認
- local checkout / docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。generator name、optional owner argument、generated destination path contract への導線追加のみで、runtime Ruby、generator implementation、migration schema、public API manifest は変更していません。