### PR TITLE
development docs の Node 22 signal smoke を追加する

### DIFF
--- a/script/test_development_docs_node_version_signals.mjs
+++ b/script/test_development_docs_node_version_signals.mjs
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const nodeVersionSourceSignals = [
+  {
+    feature: "English development docs Node 22 version-source guard",
+    sourcePath: "docs/en/development.md",
+    signals: [
+      "Node 22",
+      ".nvmrc",
+      "`engines.node`",
+      "workflow `node-version`",
+      "Dockerfile",
+      "script/test_node_version_sources.mjs",
+      "npm run test:node-version-sources",
+      "npm run test:entrypoints",
+      "without changing the current install policy"
+    ]
+  },
+  {
+    feature: "Japanese development docs Node 22 version-source guard",
+    sourcePath: "docs/ja/development.md",
+    signals: [
+      "Node 22",
+      ".nvmrc",
+      "`engines.node`",
+      "workflow の `node-version`",
+      "Dockerfile",
+      "script/test_node_version_sources.mjs",
+      "npm run test:node-version-sources",
+      "npm run test:entrypoints",
+      "現在の install policy を変えずに確認します"
+    ]
+  }
+]
+
+nodeVersionSourceSignals.forEach(({ feature, sourcePath, signals }) => {
+  assertSignals(sourcePath, feature, signals)
+})
+
+const nodeVersionSourceFiles = [
+  [".nvmrc", "22"],
+  ["package.json", "\"node\": \"22.x\""],
+  [".github/workflows/ci.yml", "node-version: \"22\""],
+  ["Dockerfile", "ARG NODE_MAJOR=22"],
+  ["script/test_node_version_sources.mjs", "NODE_MAJOR"]
+]
+
+nodeVersionSourceFiles.forEach(([sourcePath, signal]) => {
+  assertSignals(sourcePath, "Node 22 source file inventory", [signal])
+})

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -17,6 +17,11 @@ const checks = [
     args: ["script/test_docs_entrypoint_signals.mjs"]
   },
   {
+    group: "Development docs Node version signals",
+    command: "node",
+    args: ["script/test_development_docs_node_version_signals.mjs"]
+  },
+  {
     group: "Public setup surface docs signals",
     command: "node",
     args: ["script/test_public_setup_surface_docs_signals.mjs"]


### PR DESCRIPTION
## 対応 Issue

Closes #1986
Refs #1825

## Issue ごとの完了内容

- #1986: development docs が Node 22、`.nvmrc`、`package.json` `engines.node`、workflow `node-version`、Dockerfile、`test_node_version_sources` guard への導線を維持していることを軽量 smoke で確認するようにしました。
- #1825: 既存の大きな `test_docs_entrypoints.mjs` に新しい signal を追加せず、docs-entrypoint suite に独立した domain-specific smoke を追加しました。ただし #1825 の既存配列分割全体はこの PR では close しません。

## 変更内容

- `script/test_development_docs_node_version_signals.mjs` を追加し、英日 development docs の Node 22 / version-source guard 導線と、関連 source file の代表 signal を確認します。
- `script/test_docs_entrypoint_suite.mjs` に新しい smoke を追加し、既存 `npm run test:docs-entrypoints` の実行導線から走るようにしました。

## 改善カテゴリ

- test
- docs smoke
- small maintainability split

## 既存仕様への影響

runtime Ruby / JavaScript、Node version policy、Docker image behavior、CI install policy、package manager / lockfile policy は変更していません。既存 docs と source の drift guard 追加だけです。

## 実施した確認

- Issue #1986 の labels を直接確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 近接 Issue #1825 の labels も確認しましたが、今回は close せず related maintainability として扱います。
- review follow-up 候補を確認し、tree_view-rails #1985 は visual evidence / human review 対象のため、この quality PR には混ぜていません。
- compare `main...test/1986-development-node-docs-signals`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs-entrypoint smoke の追加だけで、公開 API、UI、DB、認可、外部サービス契約、状態遷移には触れていません。

## 補足事項

- #1825 の「既存の大きな signal 配列を分割する」作業は、別 PR で既存配列の移動・重複整理として扱うのが安全です。
- merge は行いません。