### PR TITLE
docs entrypoint suite の出力を追いやすくする

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -77,32 +77,77 @@ function commandLine({ command, args }) {
   return [command, ...args].join(" ")
 }
 
-for (const check of checks) {
-  console.log(`\n[docs-entrypoints] ${check.group}`)
+function formatDuration(milliseconds) {
+  if (milliseconds < 1000) return `${milliseconds}ms`
+
+  return `${(milliseconds / 1000).toFixed(1)}s`
+}
+
+function printCheckList() {
+  console.log(`[docs-entrypoints] ${checks.length} checks configured`)
+
+  checks.forEach((check, index) => {
+    console.log(
+      `[docs-entrypoints] ${index + 1}. ${check.group}: ${commandLine(check)}`
+    )
+  })
+}
+
+if (process.argv.includes("--list")) {
+  printCheckList()
+  process.exit(0)
+}
+
+const suiteStartedAt = Date.now()
+const passedChecks = []
+
+printCheckList()
+
+for (const [index, check] of checks.entries()) {
+  const checkStartedAt = Date.now()
+
+  console.log(`\n[docs-entrypoints] ${index + 1}/${checks.length} ${check.group}`)
   console.log(`$ ${commandLine(check)}`)
 
   const result = spawnSync(check.command, check.args, { stdio: "inherit" })
+  const elapsed = Date.now() - checkStartedAt
 
   if (result.error) {
     console.error(
-      `[docs-entrypoints] ${check.group} failed to start: ${result.error.message}`
+      `[docs-entrypoints] ${check.group} failed to start after ${formatDuration(elapsed)}: ${result.error.message}`
+    )
+    console.error(
+      `[docs-entrypoints] summary: ${passedChecks.length}/${checks.length} checks passed before failure`
     )
     process.exit(1)
   }
 
   if (result.signal) {
     console.error(
-      `[docs-entrypoints] ${check.group} stopped by signal ${result.signal}: ${commandLine(check)}`
+      `[docs-entrypoints] ${check.group} stopped by signal ${result.signal} after ${formatDuration(elapsed)}: ${commandLine(check)}`
+    )
+    console.error(
+      `[docs-entrypoints] summary: ${passedChecks.length}/${checks.length} checks passed before failure`
     )
     process.exit(1)
   }
 
   if (result.status !== 0) {
     console.error(
-      `[docs-entrypoints] ${check.group} failed with exit code ${result.status}: ${commandLine(check)}`
+      `[docs-entrypoints] ${check.group} failed with exit code ${result.status} after ${formatDuration(elapsed)}: ${commandLine(check)}`
+    )
+    console.error(
+      `[docs-entrypoints] summary: ${passedChecks.length}/${checks.length} checks passed before failure`
     )
     process.exit(result.status ?? 1)
   }
+
+  passedChecks.push(check.group)
+  console.log(
+    `[docs-entrypoints] ${check.group} passed in ${formatDuration(elapsed)}`
+  )
 }
 
-console.log("\n[docs-entrypoints] all checks passed")
+console.log(
+  `\n[docs-entrypoints] all ${checks.length} checks passed in ${formatDuration(Date.now() - suiteStartedAt)}`
+)


### PR DESCRIPTION
## 対応 Issue

Closes #1997

## Issue ごとの完了内容

- #1997: `npm run test:docs-entrypoints` の runner に、実行対象一覧、group 番号、所要時間、失敗時 summary を追加しました。

## 変更内容

- `script/test_docs_entrypoint_suite.mjs` に `--list` option を追加し、group と command の一覧だけを exit 0 で確認できるようにしました。
- 通常実行の開始時にも configured checks を表示し、どの docs smoke が走るかを先に読めるようにしました。
- 各 group の成功時に duration を出し、失敗時には failed group / command / exit code または signal / passed count summary を最後にも出すようにしました。
- 既存 `checks` の対象 script、実行順、個別 assertion 内容、`npm run test:docs-entrypoints` の入口は変更していません。

## 改善カテゴリ

- test runner maintainability
- docs smoke failure output improvement
- small internal refactor

## 既存仕様への影響

runtime Ruby / JavaScript behavior、docs 本文、CI workflow、required check name、package manager / Node policy は変更していません。runner の出力補助だけの変更です。

## 実施した確認

- Issue #1997 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- #1997 を担当する既存 open PR がないことを確認しました。
- ローカル scratch で `node --check` 相当の構文確認を実施。
- ローカル scratch で `node script/test_docs_entrypoint_suite.mjs --list` 相当の一覧出力が exit 0 になることを確認。
- compare `main...chore/1997-docs-entrypoint-suite-output`: `ahead_by:1` / `behind_by:0` / changed files 1。

## 未実行の確認

- `npm run test:docs-entrypoints` はローカル checkout が GitHub HTTPS `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。実行対象と exit status の基本経路は維持し、出力の可読性だけを改善しています。

## 補足事項

- parallel execution は導入していません。
- 個別 docs smoke coverage の追加や docs rewrite は行っていません。