### PR TITLE
README から JavaScript Public API への導線を補う

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Add the importmap pin when needed:
 pin "tree_view", to: "tree_view/index.js"
 ```
 
+Host apps that write tests or custom renderers against TreeView browser hooks can avoid raw event names, data attributes, and controller identifiers by using the package-root exports from `tree_view/index.js`, such as `TreeViewEventNames`, `TreeViewEventDetailKeys`, and the documented data hook objects. See the [Public API JavaScript surface](docs/en/public-api.md#javascript-surface) / [日本語](docs/ja/public-api.md#javascript-surface) and the [JavaScript event contract](docs/en/js-events.md) / [日本語](docs/ja/js-events.md).
+
 See [Installation](docs/en/installation.md) for details.
 
 日本語の導入手順は [docs/ja/installation.md](docs/ja/installation.md) を参照してください。


### PR DESCRIPTION
## 対応 Issue

Closes #2005

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `README.md` の importmap pin 直後に、`tree_view/index.js` の package-root exports へ進む短い導線を追加しました。
- `TreeViewEventNames`、`TreeViewEventDetailKeys`、documented data hook objects のような代表 surface から、英日 Public API JavaScript surface と JavaScript event contract へ辿れるようにしました。

## 確認した根拠

- `app/javascript/tree_view/index.js` は `TreeViewEventNames` / `TreeViewEventDetailKeys` / `TreeViewRemoteStateDataHooks` / `TreeViewToolbarDataHooks` / `TreeViewSelectionDataHooks` などを package-root export として公開しています。
- `docs/en/public-api.md` / `docs/ja/public-api.md` は JavaScript surface と package-root exports の用途を説明済みです。
- README は controller 登録や browser integration hooks を案内している一方、package-root exports への近い導線が薄かったため、Installation 付近に最小追記しました。

## 非対象

- runtime Ruby / JavaScript behavior
- export set の追加・rename
- TypeScript declaration
- public API manifest schema
- README 全体の再構成

## 確認

- compare `main...docs/2005-readme-js-public-api-link`: `ahead_by:1` / `behind_by:0`
- changed files: `README.md` のみ
- GitHub Actions CI #2643 success on head `8cb971cdeefc961a8844017faa2054984215e888`
  - `changes`, `lint`, `pr_specs`, `gem_package`: success
  - docs-only PR として representative Rails lanes / JavaScript browser checks は shortcut success
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。既存 export と既存 docs への discoverability 追加に閉じています。