### PR TITLE
mockup boundary signals を browser smoke で守る

### DIFF
--- a/test/browser/docs_mockup_boundary_signals.spec.js
+++ b/test/browser/docs_mockup_boundary_signals.spec.js
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const mockupsRoot = path.join(repoRoot, "docs/mockups")
+
+function mockupUrl(file) {
+  return pathToFileURL(path.join(mockupsRoot, file)).toString()
+}
+
+async function openMockup(page, file) {
+  await page.goto(mockupUrl(file))
+  await expect(page.locator("main.mock-page")).toBeVisible()
+}
+
+test.describe("docs mockup boundary signals", () => {
+  test("breadcrumb-paths.html preserves current-row, long-path, and host-owned boundary signals", async ({ page }) => {
+    await openMockup(page, "breadcrumb-paths.html")
+
+    await expect(page.getByRole("heading", { name: "Shallow path with current item at the end" })).toBeVisible()
+    await expect(page.locator(".mock-breadcrumb-pill--current[aria-current='page']", { hasText: "Admin UI" })).toBeVisible()
+    await expect(page.locator("#breadcrumb_current[aria-current='page'] .tree-node-badge--current", { hasText: "current row" })).toBeVisible()
+
+    await expect(page.getByRole("heading", { name: "Long labels in a narrow breadcrumb frame" })).toBeVisible()
+    await expect(page.locator(".mock-breadcrumb-frame--narrow")).toBeVisible()
+    await expect(page.locator(".mock-breadcrumb-path--stress .mock-breadcrumb-pill--stress", { hasText: "Current review item with a deliberately long label" })).toBeVisible()
+
+    await expect(page.getByText("Exact URLs, truncation rules, and permission-aware labels still belong to the host app.", { exact: true })).toBeVisible()
+    await expect(page.getByText("Real route helpers, final labels, authorization-aware visibility, and Turbo navigation.", { exact: true })).toBeVisible()
+  })
+
+  test("localized-row-labels.html preserves CJK review samples and identity boundary signals", async ({ page }) => {
+    await openMockup(page, "localized-row-labels.html")
+
+    await expect(page.getByText("Deliberate CJK width stress sample", { exact: true })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Japanese-width label stress sample" })).toBeVisible()
+    await expect(page.locator("table[lang='ja']")).toBeVisible()
+    await expect(page.locator("table[lang='ja'] .mock-localized-type--accent", { hasText: "確認資料タイプ" })).toBeVisible()
+    await expect(page.getByText("It is not final product copy.", { exact: false })).toBeVisible()
+
+    await expect(page.getByRole("heading", { name: "Node key and DOM ID boundary note" })).toBeVisible()
+    await expect(page.locator("[data-tree-node-key='localized-cjk:invoice']")).toHaveCount(3)
+    await expect(page.locator("code", { hasText: "workspace_tree_localized_cjk_invoice" })).toBeVisible()
+    await expect(page.locator("code", { hasText: "picker_tree_localized_cjk_invoice" })).toBeVisible()
+    await expect(page.getByText("Use the node key for data identity; use the DOM ID only for this rendered browser target.", { exact: true })).toBeVisible()
+  })
+})

--- a/test/browser/docs_mockup_boundary_signals.spec.js
+++ b/test/browser/docs_mockup_boundary_signals.spec.js
@@ -26,8 +26,8 @@ test.describe("docs mockup boundary signals", () => {
     await expect(page.locator(".mock-breadcrumb-frame--narrow")).toBeVisible()
     await expect(page.locator(".mock-breadcrumb-path--stress .mock-breadcrumb-pill--stress", { hasText: "Current review item with a deliberately long label" })).toBeVisible()
 
-    await expect(page.getByText("Exact URLs, truncation rules, and permission-aware labels still belong to the host app.", { exact: true })).toBeVisible()
-    await expect(page.getByText("Real route helpers, final labels, authorization-aware visibility, and Turbo navigation.", { exact: true })).toBeVisible()
+    await expect(page.getByText("Exact URLs, truncation rules, and permission-aware labels still belong to the host app.", { exact: false })).toBeVisible()
+    await expect(page.getByText("Real route helpers, final labels, authorization-aware visibility, and Turbo navigation.", { exact: false })).toBeVisible()
   })
 
   test("localized-row-labels.html preserves CJK review samples and identity boundary signals", async ({ page }) => {
@@ -45,4 +45,4 @@ test.describe("docs mockup boundary signals", () => {
     await expect(page.locator("code", { hasText: "picker_tree_localized_cjk_invoice" })).toBeVisible()
     await expect(page.getByText("Use the node key for data identity; use the DOM ID only for this rendered browser target.", { exact: true })).toBeVisible()
   })
-})
+}

--- a/test/browser/docs_mockup_boundary_signals.spec.js
+++ b/test/browser/docs_mockup_boundary_signals.spec.js
@@ -45,4 +45,4 @@ test.describe("docs mockup boundary signals", () => {
     await expect(page.locator("code", { hasText: "picker_tree_localized_cjk_invoice" })).toBeVisible()
     await expect(page.getByText("Use the node key for data identity; use the DOM ID only for this rendered browser target.", { exact: true })).toBeVisible()
   })
-}
+})


### PR DESCRIPTION
## 対応 Issue

Closes #2007
Closes #2008

## Issue ごとの完了内容

### #2007 breadcrumb mockup

- `breadcrumb-paths.html` の current breadcrumb item と current tree row cue を dedicated browser smoke で確認します。
- long-label / narrow-frame stress state を `mock-breadcrumb-frame--narrow` と `mock-breadcrumb-path--stress` の代表 signal で確認します。
- exact URLs / truncation / permission-aware labels / route helpers / Turbo navigation が host-app-owned boundary として残っていることを確認します。

### #2008 localized row labels mockup

- deliberate CJK / Japanese-width stress sample を dedicated browser smoke で確認します。
- `table[lang="ja"]` と CJK badge / sample heading を確認し、final product copy ではない review-purpose sample であることも確認します。
- `Node key and DOM ID boundary note`、同一 node key と tree instance ごとの DOM ID の代表 signal を確認します。

## 変更内容

- `test/browser/docs_mockup_boundary_signals.spec.js` を追加しました。
- 既存 HTML / docs 本文 / runtime Ruby / JavaScript は変更していません。
- 既存の大きな `docs_mockups_smoke.spec.js` inventory には触れず、同じ Playwright browser smoke 配下の focused spec として追加しています。

## 改善カテゴリ

- test
- docs/mockup drift guard
- browser smoke hardening

## 既存仕様への影響

なし。静的 mockup の代表 signal を読むテスト追加のみです。`tree_view_breadcrumb` helper、LocalizedNames behavior、runtime Ruby / JavaScript、public API、manifest、browser visual baseline は変更していません。

## 実施した確認

- Issue #2007 / #2008 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff を確認し、同一 PR にまとめる場合も test block と完了説明を Issue ごとに分ける条件に合わせました。
- 対象既存 open PR 検索で #2007 / #2008 を直接 close する重複 PR がないことを確認しました。
- compare `main...test/2007-2008-mockup-boundary-smoke`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local Playwright は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。追加 spec は既存 mockup HTML 内の stable heading / aria attribute / boundary text / CSS class を読むだけで、仕様変更や UI 変更はありません。主なリスクは signal が過度に brittle になることですが、全文一致は避け、mockup の責務境界を示す代表要素に絞っています。

## 補足

- #2007 と #2008 は同じ smoke surface の品質改善なので、1 PR にまとめています。
- merge は行いません。