### PR TITLE
root README から Styling state cues docs へ導線を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Key documents:
 | Tree identity and diagnostics | [Node keys](docs/en/node-keys.md) and [Tree diagnostics](docs/en/tree-diagnostics.md) | [Node key 設計](docs/ja/node-keys.md) and [Tree diagnostics](docs/ja/tree-diagnostics.md) |
 | Large tree rendering strategy | [Render Scale](docs/en/render-scale.md), [Lazy Loading](docs/en/lazy-loading.md), [Children Pagination](docs/en/children-pagination.md), [Windowed Rendering](docs/en/windowed-rendering.md), [Rendering Boundaries](docs/en/rendering-boundaries.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [Lazy Loading](docs/ja/lazy-loading.md), [Children Pagination](docs/ja/children-pagination.md), [Windowed Rendering](docs/ja/windowed-rendering.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
 | Styling and direction-aware boundary | [Direction-aware styling boundary](docs/en/direction-aware-styling.md) | [Direction-aware styling boundary](docs/ja/direction-aware-styling.md) |
+| Packaged stylesheet state cues | [Styling state cues](docs/en/styling-state-cues.md) | [State cue のスタイリング](docs/ja/styling-state-cues.md) |
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
 | GraphAdapter | [GraphAdapter](docs/en/graph-adapter.md) | [GraphAdapter](docs/ja/graph-adapter.md) |
 | API reference | [API reference](docs/en/api.md) | [API仕様](docs/ja/api.md) |


### PR DESCRIPTION
## 対応 Issue

Closes #2010

## 分類

- code-ahead-of-docs / docs-sync

## 変更内容

- root `README.md` の Key documents に `Packaged stylesheet state cues` 行を追加しました。
- 英日 `docs/en|ja/styling-state-cues.md` へ直接辿れるようにし、packaged stylesheet の state cue / CSS custom property override / host-app theme boundary の入口を補いました。

## 確認内容

- Issue #2010 の labels を確認: `status:ready-for-agent`, `track:docs`, `type:docs`, `risk:low`, `scope:maintenance`。
- 重複 open PR 検索では、同じ root README Key documents 追加を扱う open PR は見当たりませんでした。
- current main の `README.md` / `docs/README.md` / `docs/en|ja/styling-state-cues.md` を確認し、`docs/README.md` 側の Recommended entry point と矛盾しない表現にしました。
- PR 作成前 compare `main...docs/2010-styling-state-cues-readme`: `ahead_by:1` / `behind_by:0` / changed files 1 (`README.md`)。
- local checkout / local test は GitHub HTTPS と raw fetch が `CONNECT tunnel failed, response 403` / 403 のため未実行です。PR CI を確認対象にします。

## リスク

low。README の discoverability 追加のみで、runtime Ruby / JavaScript、stylesheet token 名、public API manifest、docs index の構造には触れていません。