### PR TITLE
Host App Extension Points の diagnostics signal を docs smoke で守る

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -17,6 +17,11 @@ const checks = [
     args: ["script/test_docs_entrypoint_signals.mjs"]
   },
   {
+    group: "Host app extension diagnostics signals",
+    command: "node",
+    args: ["script/test_host_app_extension_diagnostics_signals.mjs"]
+  },
+  {
     group: "Development docs Node version signals",
     command: "node",
     args: ["script/test_development_docs_node_version_signals.mjs"]

--- a/script/test_host_app_extension_diagnostics_signals.mjs
+++ b/script/test_host_app_extension_diagnostics_signals.mjs
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const hostAppExtensionDiagnosticsSignals = [
+  {
+    feature: "Host app extension diagnostics reverse lookup",
+    files: [
+      [
+        "docs/en/host-app-extension-points.md",
+        [
+          "Inspect tree data before rendering",
+          "TreeView::Diagnostics.run",
+          "validate_node_keys: true",
+          "RenderState#validate_unique_dom_ids!",
+          "cycle/orphan diagnostics",
+          "duplicate node key",
+          "tree-diagnostics.md",
+          "Public API"
+        ]
+      ],
+      [
+        "docs/ja/host-app-extension-points.md",
+        [
+          "描画前に tree data を確認する",
+          "TreeView::Diagnostics.run",
+          "validate_node_keys: true",
+          "RenderState#validate_unique_dom_ids!",
+          "cycle / orphan diagnostics",
+          "duplicate node key",
+          "tree-diagnostics.md",
+          "Public API"
+        ]
+      ]
+    ]
+  }
+]
+
+hostAppExtensionDiagnosticsSignals.forEach(({ feature, files }) => {
+  files.forEach(([sourcePath, signals]) => assertSignals(sourcePath, feature, signals))
+})


### PR DESCRIPTION
## 対応 Issue

Closes #1983

## Issue ごとの完了内容

- Host App Extension Points に landing 済みの diagnostics / pre-render validation reverse lookup entry を、専用の軽量 docs smoke で確認するようにしました。
- 英日 `docs/en|ja/host-app-extension-points.md` で `TreeView::Diagnostics.run`、`validate_node_keys: true`、`RenderState#validate_unique_dom_ids!`、cycle/orphan diagnostics、`tree-diagnostics.md` / Public API への導線が落ちた場合に検出できます。

## 変更内容

- `script/test_host_app_extension_diagnostics_signals.mjs` を追加しました。
- `script/test_docs_entrypoint_suite.mjs` に上記 smoke を接続しました。
- 既存の大きな `script/test_docs_entrypoint_signals.mjs` には触れず、diagnostics reverse lookup 専用の小さな guard として分けました。

## 改善カテゴリ

- test
- docs smoke
- docs entrypoint drift guard

## 既存仕様への影響

なし。docs の代表 signal を読むテスト追加のみです。runtime Ruby / JavaScript、Diagnostics behavior、manifest schema、docs 本文、UI、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- Issue #1983 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` の `docs/en|ja/host-app-extension-points.md` を確認し、diagnostics / pre-render validation entry が既に landing 済みであることを確認しました。
- current `main` の `script/test_docs_entrypoint_suite.mjs` を確認し、専用 smoke を suite に接続しました。
- PR 作成前 compare `main...test/1983-diagnostics-extension-smoke`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 docs にある diagnostics reverse lookup の代表シグナルを固定するだけで、実装・公開 API・docs prose は変更していません。

## 補足事項

- `package-lock` refresh や browser visual evidence が必要な open follow-up は、この connector-only 実行では停止対象として扱いました。
- merge は行いません。