### PR TITLE
RenderWindow / ResourceTableRenderState docs signal を軽量 smoke で守る

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -72,6 +72,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "Render window and resource table docs signals",
+    command: "node",
+    args: ["script/test_render_window_resource_table_docs_signals.mjs"]
+  },
+  {
     group: "Localized and hook docs signals",
     command: "node",
     args: ["script/test_localized_and_hook_docs_signals.mjs"]

--- a/script/test_render_window_resource_table_docs_signals.mjs
+++ b/script/test_render_window_resource_table_docs_signals.mjs
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${JSON.stringify(needle)}`)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => assertIncludes(source, signal, `${feature} (${sourcePath})`))
+}
+
+const manifest = read("config/public_api_manifest.yml")
+
+const renderWindowMetadataSignals = [
+  "render_window_metadata:",
+  "rows",
+  "offset",
+  "limit",
+  "total_count",
+  "before_count",
+  "after_count",
+  "start_index",
+  "end_index",
+  "previous?",
+  "next?",
+  "previous_offset",
+  "next_offset",
+  "empty?"
+]
+
+const resourceTableCallSignals = [
+  "resource_table_render_state_call:",
+  "required_keywords:",
+  "records",
+  "context",
+  "optional_keywords:",
+  "row_partial",
+  "parent_id_method",
+  "id_method",
+  "table_key",
+  "columns",
+  "table_state",
+  "ui_config",
+  "render_options_contract: render_state_pass_through"
+]
+
+renderWindowMetadataSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest RenderWindow metadata surface")
+})
+
+resourceTableCallSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest ResourceTableRenderState call surface")
+})
+
+const windowedRenderingDocs = [
+  [
+    "docs/en/windowed-rendering.md",
+    [
+      "tree_view_window",
+      "TreeView::RenderWindow",
+      "render_window_metadata",
+      "before_count",
+      "after_count",
+      "previous_offset",
+      "next_offset",
+      "route helper",
+      "URL parameters",
+      "disabled button behavior",
+      "infinite scroll",
+      "virtual scrolling",
+      "host-app decisions"
+    ]
+  ],
+  [
+    "docs/ja/windowed-rendering.md",
+    [
+      "tree_view_window",
+      "TreeView::RenderWindow",
+      "render_window_metadata",
+      "before_count",
+      "after_count",
+      "previous_offset",
+      "next_offset",
+      "route helper",
+      "URL parameter",
+      "disabled button",
+      "infinite scroll",
+      "virtual scrolling",
+      "host app 側で決めます"
+    ]
+  ]
+]
+
+const resourceTableBridgeDocs = [
+  [
+    "docs/en/resource-table-bridge.md",
+    [
+      "ResourceTableRenderState.call",
+      "manifest-backed public bridge",
+      "required keywords are `records:` and `context:`",
+      "documented optional bridge keywords",
+      "columns:",
+      "table_state:",
+      "visible_columns",
+      "**render_options",
+      "RenderState option surface",
+      "row_data_builder:",
+      "bridge writes these keys last",
+      "column inference",
+      "saved table state"
+    ]
+  ],
+  [
+    "docs/ja/resource-table-bridge.md",
+    [
+      "ResourceTableRenderState.call",
+      "manifest-backed な public bridge",
+      "required keyword は `records:` と `context:`",
+      "optional bridge keyword",
+      "columns:",
+      "table_state:",
+      "visible_columns",
+      "**render_options",
+      "RenderState option surface",
+      "row_data_builder:",
+      "bridge が次の key を最後に書き込みます",
+      "カラム推論",
+      "保存済みtable state"
+    ]
+  ]
+]
+
+windowedRenderingDocs.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "RenderWindow metadata docs signal", signals)
+})
+
+resourceTableBridgeDocs.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "ResourceTableRenderState bridge docs signal", signals)
+})


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2016
Closes #2017

## Issue ごとの完了内容

- #2016: `render_window_metadata` の manifest surface と英日 `windowed-rendering.md` の代表 metadata / host-app-owned pagination boundary signal を軽量 smoke で確認します。
- #2017: `resource_table_render_state_call` の manifest surface と英日 `resource-table-bridge.md` の required / optional keyword、`**render_options` boundary、row data composition signal を軽量 smoke で確認します。

## 変更内容

- `script/test_render_window_resource_table_docs_signals.mjs` を追加しました。
- `script/test_docs_entrypoint_suite.mjs` に新しい docs signal smoke を登録しました。
- runtime Ruby / JavaScript、manifest content、docs 本文、mockup HTML は変更していません。

## 改善カテゴリ

- test
- docs signal drift guard
- public API docs smoke

## 既存仕様への影響

なし。既存 docs / manifest にある代表 signal を読む smoke 追加だけです。`RenderWindow` / `VisibleRows` / `ResourceTableRenderState.call` の API、metadata、helper behavior、table preferences integration、route/query/pagination policy は変更していません。

## 実施した確認内容

- Issue #2016 / #2017 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- review follow-up: tree_view-rails には browser-capable visual evidence が必要な open PR follow-up が残っていますが、この環境では実ブラウザ証跡を生成できないため新規 quality issue のうち実装可能な docs smoke を優先しました。
- current `main` の対象 docs / manifest / docs entrypoint suite を確認しました。
- compare `main...test/2016-2017-public-docs-signals`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local Node 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs smoke の代表 signal 追加のみで、public behavior や docs prose には触れていません。

## 補足事項

- #1992 は npm registry / lockfile policy 依存が強く、今回の docs signal smoke bundleとは別単位にしました。
- merge は行いません。