### PR TITLE
Cookbook に Windowed Rendering の metadata 導線を追加する

### DIFF
--- a/docs/en/cookbook.md
+++ b/docs/en/cookbook.md
@@ -417,6 +417,8 @@ Use windowed rendering when many visible rows remain.
 <%= tree_view_rows(@render_state, window: { offset: 0, limit: 50 }) %>
 ```
 
+When the host app needs Previous / Next controls, summary counts, or an offset handoff across Turbo refreshes, start with `tree_view_window` instead of inventing pagination metadata in the partial. It exposes `total_count`, `before_count`, `after_count`, `previous?`, `next?`, `previous_offset`, and `next_offset`; the host app still chooses the route helper, query parameter name, disabled-button behavior, and whether the controls render as links, buttons, or a Turbo Frame toolbar. If the current row must stay visible, derive the anchored offset from `TreeView::VisibleRows` before rendering the window. The full recipe is in [Windowed Rendering](windowed-rendering.md#tree_view_window-helper), [Keep the current row inside the window](windowed-rendering.md#keep-the-current-row-inside-the-window), and [Hand off offset across Turbo updates](windowed-rendering.md#hand-off-offset-across-turbo-updates).
+
 Use lazy loading when children should be loaded only as needed.
 
 When the product needs scroll-position-driven DOM virtualization, keep that controller in the host app and use TreeView only for the HTML row slice it should render. `TreeView::RenderWindow` is useful for outputting a bounded list of already-visible rows, but it does not observe scroll position, reduce host-app queries, fetch pages, or preserve scroll anchoring.

--- a/docs/ja/cookbook.md
+++ b/docs/ja/cookbook.md
@@ -417,6 +417,8 @@ render_state = TreeView::RenderState.new(
 <%= tree_view_rows(@render_state, window: { offset: 0, limit: 50 }) %>
 ```
 
+Previous / Next control、summary count、Turbo refresh 時の offset handoff が必要な場合は、partial 内で paging metadata を組み立てず `tree_view_window` から始めます。`tree_view_window` は `total_count`、`before_count`、`after_count`、`previous?`、`next?`、`previous_offset`、`next_offset` を返します。route helper、query parameter 名、disabled button の扱い、link / button / Turbo Frame toolbar のどれで出すかは host app 側で決めます。現在行を window 内に残したい場合は、`TreeView::VisibleRows` から anchored offset を計算してから window を描画してください。詳しい recipe は [Windowed Rendering](windowed-rendering.md#tree_view_window-helper)、[current row を window 内に寄せる](windowed-rendering.md#current-row-を-window-内に寄せる)、[Turbo 更新時に offset を持ち回る](windowed-rendering.md#turbo-更新時に-offset-を持ち回る) を参照してください。
+
 子nodeを必要な分だけ読み込みたい場合は lazy loading を使います。
 
 product要件として scroll位置に応じたDOM仮想化が必要な場合は、そのcontrollerをhost app側に置き、TreeViewには描画すべきHTML row sliceだけを任せます。`TreeView::RenderWindow` は、すでにvisibleとして計算されたrowを小さく出力するには使えますが、scroll位置の監視、host app queryの削減、page取得、scroll anchoringの維持は行いません。


### PR DESCRIPTION
## 対応 Issue

Closes #1994

## 分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `docs/en/cookbook.md` の `Reduce initial HTML for large trees` recipe に、`tree_view_window` を使う場面を補足しました。
- `docs/ja/cookbook.md` の同じ recipe に日本語側の補足を追加しました。
- Previous / Next control、summary count、Turbo refresh 時の offset handoff、current-row anchoring の入口を Windowed Rendering docs の該当節へつなぎました。

## 対象範囲

- Cookbook の reader journey 補強だけです。
- runtime Ruby / JavaScript、`TreeView::RenderWindow`、`TreeView::VisibleRows`、`tree_view_window` API、mockup HTML、test / smoke script は変更していません。
- route helper、query parameter、disabled button、pagination UI、scroll observer、server-side pagination、data fetching は host app responsibility のままです。

## 確認

- Issue #1994 と Planner handoff を確認しました。
- current `main` の `docs/en|ja/cookbook.md` と `docs/en|ja/windowed-rendering.md` を確認しました。
- PR 作成前 compare `main...docs/1994-windowed-rendering-cookbook-recipe-v2`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / npm checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存 recipe への短い docs-only 追記で、API や動作は変更していません。