### PR TITLE
docs smoke の単独実行と localized label guard を強化する

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -98,30 +98,107 @@ function formatDuration(milliseconds) {
   return `${(milliseconds / 1000).toFixed(1)}s`
 }
 
-function printCheckList() {
-  console.log(`[docs-entrypoints] ${checks.length} checks configured`)
+function formatAvailableGroups() {
+  return checks.map((check, index) => `  ${index + 1}. ${check.group}`).join("\n")
+}
 
-  checks.forEach((check, index) => {
+function printCheckList(selectedChecks = checks) {
+  console.log(`[docs-entrypoints] ${selectedChecks.length} checks configured`)
+
+  selectedChecks.forEach((check, index) => {
     console.log(
       `[docs-entrypoints] ${index + 1}. ${check.group}: ${commandLine(check)}`
     )
   })
 }
 
-if (process.argv.includes("--list")) {
+function usage() {
+  console.error("[docs-entrypoints] usage: node script/test_docs_entrypoint_suite.mjs [--list] [--only <group>]")
+  console.error("[docs-entrypoints] use --list to show available groups")
+}
+
+function resolveOnlyGroup(groupName) {
+  const exactMatches = checks.filter((check) => check.group === groupName)
+  if (exactMatches.length === 1) return exactMatches[0]
+
+  const normalizedGroupName = groupName.toLowerCase()
+  const caseInsensitiveExactMatches = checks.filter(
+    (check) => check.group.toLowerCase() === normalizedGroupName
+  )
+  if (caseInsensitiveExactMatches.length === 1) return caseInsensitiveExactMatches[0]
+
+  const partialMatches = checks.filter((check) =>
+    check.group.toLowerCase().includes(normalizedGroupName)
+  )
+
+  if (partialMatches.length === 1) return partialMatches[0]
+
+  if (partialMatches.length > 1) {
+    console.error(`[docs-entrypoints] ambiguous --only group: ${groupName}`)
+    console.error("[docs-entrypoints] matching groups:")
+    console.error(partialMatches.map((check) => `  - ${check.group}`).join("\n"))
+  } else {
+    console.error(`[docs-entrypoints] unknown --only group: ${groupName}`)
+  }
+
+  console.error("[docs-entrypoints] available groups:")
+  console.error(formatAvailableGroups())
+  console.error("[docs-entrypoints] run with --list to inspect commands")
+  process.exit(1)
+}
+
+function parseArgs(argv) {
+  const options = { list: false, only: null }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+
+    if (arg === "--list") {
+      options.list = true
+      continue
+    }
+
+    if (arg === "--only") {
+      const groupName = argv[index + 1]
+
+      if (!groupName || groupName.startsWith("--")) {
+        console.error("[docs-entrypoints] --only requires a group name")
+        usage()
+        console.error("[docs-entrypoints] available groups:")
+        console.error(formatAvailableGroups())
+        process.exit(1)
+      }
+
+      options.only = resolveOnlyGroup(groupName)
+      index += 1
+      continue
+    }
+
+    console.error(`[docs-entrypoints] unknown argument: ${arg}`)
+    usage()
+    process.exit(1)
+  }
+
+  return options
+}
+
+const options = parseArgs(process.argv.slice(2))
+
+if (options.list) {
   printCheckList()
   process.exit(0)
 }
 
+const selectedChecks = options.only ? [options.only] : checks
 const suiteStartedAt = Date.now()
 const passedChecks = []
 
-printCheckList()
+printCheckList(selectedChecks)
 
-for (const [index, check] of checks.entries()) {
+for (const [index, check] of selectedChecks.entries()) {
   const checkStartedAt = Date.now()
 
-  console.log(`\n[docs-entrypoints] ${index + 1}/${checks.length} ${check.group}`)
+  console.log(`\n[docs-entrypoints] ${index + 1}/${selectedChecks.length} ${check.group}`)
   console.log(`$ ${commandLine(check)}`)
 
   const result = spawnSync(check.command, check.args, { stdio: "inherit" })
@@ -132,7 +209,7 @@ for (const [index, check] of checks.entries()) {
       `[docs-entrypoints] ${check.group} failed to start after ${formatDuration(elapsed)}: ${result.error.message}`
     )
     console.error(
-      `[docs-entrypoints] summary: ${passedChecks.length}/${checks.length} checks passed before failure`
+      `[docs-entrypoints] summary: ${passedChecks.length}/${selectedChecks.length} checks passed before failure`
     )
     process.exit(1)
   }
@@ -142,7 +219,7 @@ for (const [index, check] of checks.entries()) {
       `[docs-entrypoints] ${check.group} stopped by signal ${result.signal} after ${formatDuration(elapsed)}: ${commandLine(check)}`
     )
     console.error(
-      `[docs-entrypoints] summary: ${passedChecks.length}/${checks.length} checks passed before failure`
+      `[docs-entrypoints] summary: ${passedChecks.length}/${selectedChecks.length} checks passed before failure`
     )
     process.exit(1)
   }
@@ -152,7 +229,7 @@ for (const [index, check] of checks.entries()) {
       `[docs-entrypoints] ${check.group} failed with exit code ${result.status} after ${formatDuration(elapsed)}: ${commandLine(check)}`
     )
     console.error(
-      `[docs-entrypoints] summary: ${passedChecks.length}/${checks.length} checks passed before failure`
+      `[docs-entrypoints] summary: ${passedChecks.length}/${selectedChecks.length} checks passed before failure`
     )
     process.exit(result.status ?? 1)
   }
@@ -164,5 +241,5 @@ for (const [index, check] of checks.entries()) {
 }
 
 console.log(
-  `\n[docs-entrypoints] all ${checks.length} checks passed in ${formatDuration(Date.now() - suiteStartedAt)}`
+  `\n[docs-entrypoints] all ${selectedChecks.length} checks passed in ${formatDuration(Date.now() - suiteStartedAt)}`
 )

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -191,6 +191,22 @@ test.describe("docs mockup browser smoke", () => {
     expect(missingGalleryFiles).toEqual([])
   })
 
+  test("localized-row-labels.html preserves CJK and language exception signals", async ({ page }) => {
+    await openMockup(page, "localized-row-labels.html")
+
+    await expect(page.getByText("Deliberate CJK width stress sample", { exact: true })).toBeVisible()
+    await expect(page.locator("table[lang='ja'].tree-view-table")).toBeVisible()
+    await expect(page.getByText("四半期契約レビューの地域別確認資料と承認経路一覧", { exact: true })).toBeVisible()
+    await expect(page.getByText("確認資料タイプ", { exact: true })).toBeVisible()
+    await expect(page.locator("#localized_cjk_node_2[aria-current='page']")).toBeVisible()
+    await expect(page.getByText("current", { exact: true })).toBeVisible()
+    await expect(page.getByText("tooltip cue: primary link title に全文を保持", { exact: true })).toBeVisible()
+
+    const readme = readFileSync(mockupsReadmePath, "utf8")
+    expect(readme).toContain("localized-row-labels.html` intentionally uses long localized-style English labels and a deliberate CJK / Japanese-width sample")
+    expect(readme).toContain("| `localized-row-labels.html` | Long localized-style row labels and metadata, plus deliberate CJK / Japanese-width sample text |")
+  })
+
   test("narrow overflow exceptions stay explicit and attached to focused smoke targets", () => {
     const coveredFiles = focusedMockupSmokeTargets.map((mockup) => mockup.file)
     const staleExceptions = [...narrowOverflowExpectedMockups.keys()].filter((file) => !coveredFiles.includes(file))

--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -199,7 +199,7 @@ test.describe("docs mockup browser smoke", () => {
     await expect(page.getByText("四半期契約レビューの地域別確認資料と承認経路一覧", { exact: true })).toBeVisible()
     await expect(page.getByText("確認資料タイプ", { exact: true })).toBeVisible()
     await expect(page.locator("#localized_cjk_node_2[aria-current='page']")).toBeVisible()
-    await expect(page.getByText("current", { exact: true })).toBeVisible()
+    await expect(page.locator("#localized_cjk_node_2 .tree-node-badge")).toContainText("current")
     await expect(page.getByText("tooltip cue: primary link title に全文を保持", { exact: true })).toBeVisible()
 
     const readme = readFileSync(mockupsReadmePath, "utf8")


### PR DESCRIPTION
## 対応 Issue

Closes #2020
Closes #2021

## Issue ごとの完了内容

- #2020: `script/test_docs_entrypoint_suite.mjs` に `--only <group>` を追加し、既存 `checks` / `--list` を source of truth にして docs entrypoint group を単独実行できるようにしました。
- #2020: 完全一致、case-insensitive 一致、unique partial match を許容し、missing / ambiguous group は非 0 終了で available groups と `--list` 案内を出すようにしました。
- #2021: 既存 browser smoke に `localized-row-labels.html` の CJK / language exception signal guard を追加しました。
- #2021: `lang="ja"` table、CJK sample text、type badge、current cue、tooltip cue、README exception row / policy text を確認対象にしました。

## 変更内容

- docs entrypoint suite runner の arg parsing を追加しました。
- no-arg 実行と `--list` は既存の全件 runner / listing behavior を維持します。
- localized row labels mockup の代表シグナルを browser smoke の narrow coverage に追加しました。

## 改善カテゴリ

- test
- dev workflow
- docs smoke guard
- 小さな内部整理

## 既存仕様への影響

runtime Ruby / JavaScript、helper API、UI mockup HTML、公開 docs contract は変更していません。docs/test runner と browser smoke assertion のみです。

## 確認内容

- Issue #2020 / #2021 の labels と Planner handoff を個別確認しました。
- `docs/mockups/localized-row-labels.html` と `docs/mockups/README.md` の現行 signal を確認しました。
- compare `main...test/2020-2021-docs-smoke`: `ahead_by:2` / `behind_by:0`
- changed files: 2 (`script/test_docs_entrypoint_suite.mjs`, `test/browser/docs_mockups_smoke.spec.js`)
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` で利用できないため未実行です。PR CI を確認対象にします。

## リスク評価

low。実行対象の絞り込みと smoke assertion 追加のみで、product behavior や公開 API には触れていません。`--only` の unknown / ambiguous path は明示的に失敗させ、既存の全件実行を維持しています。