### PR TITLE
mockup docs / README asset の代表シグナルをguardする

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -67,6 +67,11 @@ const checks = [
     args: ["script/test_readme_quick_start_signal.mjs"]
   },
   {
+    group: "Mockup docs and asset signals",
+    command: "node",
+    args: ["script/test_mockup_docs_asset_signals.mjs"]
+  },
+  {
     group: "Public API docs signals",
     command: "node",
     args: ["script/test_public_api_docs_signals.mjs"]

--- a/script/test_mockup_docs_asset_signals.mjs
+++ b/script/test_mockup_docs_asset_signals.mjs
@@ -1,0 +1,81 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+function assertFileExists(relativePath, feature) {
+  assert(
+    existsSync(path.join(repoRoot, relativePath)),
+    `${feature}: expected ${relativePath} to exist`
+  )
+}
+
+assertSignals("README.md", "README orientation mockup asset", [
+  "![Static TreeView mockup showing expanded and collapsed hierarchy rows with selection checkboxes, badges, and row actions.](docs/mockups/assets/readme-default-tree.svg)",
+  "single orientation asset derived from the `default-tree.html` baseline rows",
+  "review-gallery.html",
+  "default-tree.html"
+])
+
+assertFileExists(
+  "docs/mockups/assets/readme-default-tree.svg",
+  "README orientation mockup asset"
+)
+
+assertSignals("docs/mockups/assets/readme-default-tree.svg", "README orientation mockup asset", [
+  "role=\"img\"",
+  "aria-labelledby=\"title desc\"",
+  "Default TreeView rendering mock",
+  "expanded and collapsed hierarchy rows",
+  "selection checkboxes",
+  "badges",
+  "row actions",
+  "TREE_VIEW-RAILS"
+])
+
+assertSignals("docs/mockups/README.md", "README/default-tree mockup routing", [
+  "[default-tree.html](default-tree.html)",
+  "Default table/tree output, checkbox selection, expanded/collapsed rows, badges, depth labels, row actions, and baseline CSS.",
+  "[review-gallery.html](review-gallery.html)",
+  "Single-surface comparison hub for the current baseline and focused mockup references",
+  "broken HTML, blank pages, missing review links, and missing representative regions without adding screenshot baselines or visual diff review"
+])
+
+assertSignals("docs/mockups/README.md", "table caption context mockup routing", [
+  "[table-caption-context.html](table-caption-context.html)",
+  "Focused table caption and surrounding page structure reference showing host-app-owned heading, caption, summary, and actions around TreeView-owned row cues.",
+  "Use [table-caption-context.html](table-caption-context.html) when review needs to compare host-app-owned heading, caption, summary, and adjacent actions around TreeView-owned row hierarchy cues."
+])
+
+assertSignals("docs/mockups/table-caption-context.html", "table caption context boundary", [
+  "Table caption context mock",
+  "Host app actions",
+  "Host-owned summary: 4 visible nodes",
+  "Host-owned table caption describing the current workspace hierarchy and review context.",
+  "tree-depth-label",
+  "tree-toggle__hidden-count",
+  "tree-node-badge tree-node-badge--info",
+  "Host app owns page heading, caption copy, summary text, action labels, routes, authorization, and final business wording.",
+  "TreeView owns row hierarchy cues such as branch lines, toggle affordances, depth labels, hidden counts, and selection payload hooks.",
+  "This mock does not introduce a caption helper, treegrid semantics, CRUD flow, route policy, or public API option."
+])


### PR DESCRIPTION
## 対応 Issue

Closes #2026
Closes #1816

## Issue ごとの完了内容

- #2026: root README の orientation SVG 参照、`default-tree.html` baseline rows 由来説明、SVG 本体の title / desc / role / representative state signal を軽量 docs smoke で確認できるようにしました。
- #1816: `table-caption-context.html` の mockup index 導線と、host-app-owned heading / caption / summary / actions と TreeView-owned row hierarchy cues の代表 boundary signal を軽量 docs smoke で確認できるようにしました。

## 変更内容

- `script/test_mockup_docs_asset_signals.mjs` を追加し、README、mockup index、orientation SVG、table-caption mockup の代表 signal を検査します。
- `script/test_docs_entrypoint_suite.mjs` に `Mockup docs and asset signals` を追加し、既存の `npm run test:docs-entrypoints` から実行されるようにしました。

## 改善カテゴリ

- test
- docs smoke
- mockup/docs asset drift guard

## 既存仕様への影響

- runtime Ruby / JavaScript、mockup HTML 本体、SVG 本体、public API、DB、認可、外部サービス契約は変更していません。
- screenshot baseline / visual diff / visual redesign は追加していません。
- 既存 docs-entrypoint suite に小さな read-only signal check を足すだけです。

## 実施した確認

- Issue #2026 / #1816 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 open PR の review follow-up を確認し、Design/Feature 系の browser evidence / human review 待ちは Quality Fixer の自動対応対象外と判断しました。
- branch 作成前に current `main` を確認しました: `c462b9cc2ae49d0867a6ed11d0bb32d176758760`。
- PR前 compare `main...quality/2026-mockup-docs-asset-signals`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local `npm run test:docs-entrypoints -- --only "Mockup docs and asset signals"` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存ファイルを読むだけの docs smoke 追加で、ユーザー向け挙動や公開契約は変えません。

## 補足事項

- 複数 Issue をまとめた理由: どちらも static mockup / README asset の reader-facing drift を防ぐ軽量 signal guard であり、同じ docs-entrypoint suite に置けるためです。
- merge は行いません。