### PR TITLE
Styling token docs parity を stylesheet spec で守る

### DIFF
--- a/spec/assets/tree_view_stylesheet_source_spec.rb
+++ b/spec/assets/tree_view_stylesheet_source_spec.rb
@@ -4,6 +4,21 @@ require "spec_helper"
 
 RSpec.describe "tree_view stylesheet source" do
   let(:stylesheet_source) { File.read(File.expand_path("../../app/assets/stylesheets/tree_view.scss", __dir__)) }
+  let(:english_styling_docs) { File.read(File.expand_path("../../docs/en/styling-state-cues.md", __dir__)) }
+  let(:japanese_styling_docs) { File.read(File.expand_path("../../docs/ja/styling-state-cues.md", __dir__)) }
+
+  def tree_view_tokens(source)
+    source.scan(/--tree-view-[a-z0-9-]+/).uniq.sort
+  end
+
+  it "keeps documented styling token lists aligned with stylesheet token usage" do
+    stylesheet_tokens = tree_view_tokens(stylesheet_source)
+
+    aggregate_failures do
+      expect(tree_view_tokens(english_styling_docs)).to eq(stylesheet_tokens)
+      expect(tree_view_tokens(japanese_styling_docs)).to eq(stylesheet_tokens)
+    end
+  end
 
   it "adds a distinct focus-visible state for tree toggle actions" do
     aggregate_failures do


### PR DESCRIPTION
## 対応 Issue

Closes #2032

## Issue ごとの完了内容

- #2032: 英日 `styling-state-cues.md` に documented token として現れる `--tree-view-*` token set が、`app/assets/stylesheets/tree_view.scss` の token usage と一致することを既存 stylesheet source spec で固定しました。

## 変更内容

- `spec/assets/tree_view_stylesheet_source_spec.rb` に docs/source token parity guard を追加しました。
- stylesheet source、英語 docs、日本語 docs から `--tree-view-*` token を抽出し、片側だけの追加・削除を検出できるようにしました。

## 改善カテゴリ

- test
- docs/source drift guard

## 既存仕様への影響

- runtime Ruby / JavaScript、stylesheet CSS、docs prose、public API manifest、CSS token 名、fallback value は変更していません。
- CSS custom property token を manifest-backed public contract に昇格する判断は #2012 に残しています。
- screenshot baseline、visual regression、theme system には広げていません。

## 実施した確認

- Issue #2032 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 同 Issue を close する既存 open PR がないことを確認しました。
- connector compare `main...quality/2032-styling-token-parity`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local RSpec は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 spec に representative parity guard を追加するだけで、挙動・UI・API・CSS出力は変えません。

## 補足事項

#2029 も label 条件を満たす低リスク候補として確認しましたが、英日 Development docs の全文更新が必要で、今回の one-file token parity guard とは root cause が別のため、この PR には混ぜていません。