### PR TITLE
Installation から Styling state cues へ導線を追加する

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -68,7 +68,7 @@ Example:
 
 The packaged stylesheet is a quick-start baseline for TreeView's reusable structure and lightweight state cues. It covers common row states such as selected, current, collapsed, loading, error, and drop target rows, but the final theme, density, brand colors, and product wording remain host-app responsibilities.
 
-When the host app needs a different visual language, keep the import and override the documented row, toggle, and table selectors in the host app stylesheet after the TreeView import. Do not treat the packaged colors as a required public theme API; they are defaults that host apps may replace with their own class selector rules.
+When the host app needs a different visual language, keep the import and override the documented row, toggle, and table selectors in the host app stylesheet after the TreeView import. For the packaged stylesheet's small documented CSS custom property surface, see [Styling state cues](styling-state-cues.md). These tokens are host-app override guidance for state cue colors, not a complete theme system or a manifest-backed Ruby / JavaScript API.
 
 ## JavaScript / importmap
 

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -68,7 +68,7 @@ host app 側の stylesheet で TreeView 用CSSを読み込みます。
 
 同梱 stylesheet は、TreeView の再利用可能な構造と軽量な state cue をすぐ確認するための quick-start baseline です。selected、current、collapsed、loading、error、drop target など代表的な row state の見た目は含みますが、最終的な theme、density、brand color、product wording は host app 側の責務です。
 
-host app 側の見た目に合わせる場合も import は残し、TreeView import の後に host app の stylesheet で documented な row / toggle / table selector を上書きしてください。同梱色を必須の public theme API として扱う必要はありません。host app は class selector rules で独自の見た目へ置き換えられます。
+host app 側の見た目に合わせる場合も import は残し、TreeView import の後に host app の stylesheet で documented な row / toggle / table selector を上書きしてください。同梱 stylesheet の小さな documented CSS custom property surface は [State cue のスタイリング](styling-state-cues.md) で確認できます。これらの token は state cue color の host-app override guidance であり、complete theme system や manifest-backed Ruby / JavaScript API ではありません。
 
 ## JavaScript / importmap
 


### PR DESCRIPTION
## 対応 Issue

Closes #1901

## 分類

- `docs-sync`
- `docs-missing`

## 変更内容

- `docs/en/installation.md` の CSS import 節から [Styling state cues](docs/en/styling-state-cues.md) へ辿れるようにしました。
- `docs/ja/installation.md` の CSS 読み込み節から [State cue のスタイリング](docs/ja/styling-state-cues.md) へ辿れるようにしました。
- state cue token は host-app override guidance であり、complete theme system や manifest-backed Ruby / JavaScript API ではないことを短く明記しました。

## 対象範囲

- docs-only change です。
- runtime CSS、token 名、fallback 値、stylesheet behavior、mockup HTML/CSS、public API manifest schema は変更していません。
- `#1900` merge 後の current `main` を前提に、Installation の reader-facing discoverability だけを補強しています。

## 確認

- Issue #1901 と Planner handoff を確認しました。
- PR #1900 が 2026-06-13 に merge 済みで、current `main` に `docs/en|ja/styling-state-cues.md` と `docs/README.md` 導線があることを確認しました。
- PR 作成前 compare `main...docs/1901-styling-state-cues-installation`: `ahead_by=3`, `behind_by=0`。
- Changed files are docs only:
  - `docs/en/installation.md`
  - `docs/ja/installation.md`
- Local checkout/test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存 docs surface への導線追加と責務境界の短い補足だけで、実装や公開契約は変更していません。