### PR TITLE
ActiveRecord repeated-query troubleshooting の docs smoke を追加する

### DIFF
--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -165,6 +165,49 @@ const signalGroups = [
     ]
   },
   {
+    feature: "ActiveRecord repeated-query troubleshooting reader journey",
+    files: [
+      [
+        "docs/en/troubleshooting.md",
+        [
+          "Tree rendering triggers repeated queries or high ActiveRecord time",
+          "ActiveRecord:",
+          "Views:",
+          "Document Load",
+          "DocumentVersion Load",
+          "CACHE",
+          "row partial calls helpers or associations that perform database work for every row",
+          "Return arrays, not lazy ActiveRecord relations, from `GraphAdapter` `children_resolver` callbacks",
+          "Cache child collections by parent id in the host app",
+          "Precompute authorization, version, or display metadata before the row partial renders",
+          "Cookbook: GraphAdapter and ActiveRecord performance",
+          "cookbook.md#graphadapter-and-activerecord-performance",
+          "Rendering Boundaries",
+          "Tree diagnostics"
+        ]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        [
+          "tree rendering 中に query が繰り返される / ActiveRecord time が大きい",
+          "ActiveRecord:",
+          "Views:",
+          "Document Load",
+          "DocumentVersion Load",
+          "CACHE",
+          "row partial から呼ぶ helper や association access が row ごとに DB work",
+          "`GraphAdapter` の `children_resolver` から lazy な ActiveRecord relation ではなく配列を返す",
+          "parent id ごとの children cache",
+          "authorization、version、表示用 metadata",
+          "Cookbook: GraphAdapter と ActiveRecord の性能",
+          "cookbook.md#graphadapter-と-activerecord-の性能",
+          "Rendering Boundaries",
+          "Tree diagnostics"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Render log level reader journey",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue
- Closes #2041

## Issue ごとの完了内容
- #2041: EN/JA troubleshooting の ActiveRecord repeated-query 導線について、症状、host-app-owned な query scope、row partial の DB work、authorization/cache 境界、関連 docs への read-next link を docs reader journey smoke で検出できるようにしました。

## 変更内容
- `script/test_docs_reader_journey_signals.mjs` に `ActiveRecord repeated-query troubleshooting reader journey` の signal group を追加しました。
- 既存 docs 本文には必要な signal が揃っていたため、本文や runtime code は変更していません。

## 改善カテゴリ
- test
- docs smoke coverage

## 既存仕様への影響
- なし。docs smoke の検出対象を追加するだけで、Ruby/JavaScript runtime、public API、UI、DB schema、認可、外部サービス契約は変更していません。

## 実施した確認
- Issue #2041 の labels を個別確認し、`status:ready-for-agent`、`track:quality`、`agent:planned`、`risk:low` を満たすことを確認しました。
- 着手前に対象3リポジトリの自分作成 open PR / review follow-up 候補を確認し、外部レビュー対応が必要な open PR は見当たらないことを確認しました。
- PR 前に `main` の最新 commit から branch を作成し、compare で `behind_by: 0` を確認しました。
- compare で差分が `script/test_docs_reader_journey_signals.mjs` のみに限定されていることを確認しました。
- 変更ファイルは final newline を維持しています。

## リスク評価
- low。既存 docs に含まれる代表文言を smoke で守るだけの変更です。

## 補足事項
- connector-only の変更のため、ローカルでは npm script を実行していません。PR 作成後の CI/check 状態を確認します。