### PR TITLE
test: guard i18n audit maintenance signals

### DIFF
--- a/script/test_docs_policy_signal_guards.mjs
+++ b/script/test_docs_policy_signal_guards.mjs
@@ -111,6 +111,24 @@ const signalGroups = [
         ]
       ]
     ]
+  },
+  {
+    feature: "i18n audit maintenance checklist docs signal",
+    files: [
+      [
+        "docs/i18n-audit.md",
+        [
+          "Documentation maintenance checklist",
+          "Root-level prose docs should stay limited to intentional entry points, maintenance notes, or technical assets",
+          "## Update matrix",
+          "## Root-level docs policy",
+          "## Technical assets",
+          "docs/mockups/README.md` is the source of truth for the current static mockup file inventory",
+          "this checklist should describe responsibility rather than repeat every individual mockup HTML page",
+          "Update this technical-assets section only when the source-of-truth rule or asset-group responsibility changes"
+        ]
+      ]
+    ]
   }
 ]
 


### PR DESCRIPTION
## 対応 Issue

- Closes #2046

## Issue ごとの完了内容

- #2046: `docs/i18n-audit.md` の root-level docs policy、update matrix、technical assets rule、mockup inventory source-of-truth boundary を既存 docs policy smoke で確認する signal group を追加しました。

## 変更内容

- `script/test_docs_policy_signal_guards.mjs` に `i18n audit maintenance checklist docs signal` を追加
- `docs/i18n-audit.md` 本文や i18n page-set parity checker の責務は変更していません

## 改善カテゴリ

- docs smoke / test coverage
- maintenance checklist signal guard

## 既存仕様への影響

- runtime、public API、packaging、UI、docs本文の挙動変更はありません。
- `script/test_docs_i18n_parity.mjs` の page-set parity / exception metadata 責務にも触れていません。

## 実施した確認

- connector 上で `main...quality/2046-i18n-audit-signal-guard` を比較し、差分が `script/test_docs_policy_signal_guards.mjs` のみであることを確認
- connector 上で更新後ファイルを再取得し、対象 signal と failure message の形を確認

未実行:

- `node script/test_docs_policy_signal_guards.mjs`
- `npm run test:docs-entrypoints`
- `npm run test:docs-i18n`

この実行環境では GitHub checkout / raw fetch が 403 で失敗するため、実コマンドは PR の GitHub Actions で確認します。

## リスク評価

- risk: low
- 代表 phrase の smoke 追加のみで、通常の docs wording cleanup を妨げないように signal は policy boundary と source-of-truth 句に限定しています。

## 補足事項

- mockup inventory の二重管理は追加していません。`docs/mockups/README.md` が source of truth であることを guard するだけです。