### PR TITLE
FAQ responsibility boundary を reader journey smoke で guard する

### DIFF
--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -109,6 +109,46 @@ const signalGroups = [
     ]
   },
   {
+    feature: "FAQ responsibility-boundary reader journey",
+    files: [
+      [
+        "docs/en/faq.md",
+        [
+          "Why does persisted state save as soon as the page loads?",
+          "tree-view-state:state-changed",
+          "initial connect",
+          "not proof that the user changed the tree",
+          "host app should save only user-initiated changes",
+          "dirty-state policy in the host app",
+          "Does TreeView infer breadcrumbs for resolver or adapter mode?",
+          "GraphAdapter",
+          "host app choose the breadcrumb trail",
+          "Does selecting a parent include descendants that have not loaded yet?",
+          "rendered DOM",
+          "unloaded descendants",
+          "host-app-owned server-side intent or query filter"
+        ]
+      ],
+      [
+        "docs/ja/faq.md",
+        [
+          "persisted state が画面表示直後に保存されるのはなぜですか？",
+          "tree-view-state:state-changed",
+          "初回 connect",
+          "ユーザーが tree を変更した証拠ではありません",
+          "host app 側の dirty-state policy",
+          "resolver mode や adapter mode でも TreeView が breadcrumb を推測しますか？",
+          "GraphAdapter",
+          "host app 側で breadcrumb trail を選び",
+          "parent を選択すると、まだ読み込まれていない descendants も含まれますか？",
+          "描画済み DOM",
+          "unloaded descendants",
+          "host app 側の server-side intent や query filter"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Tree diagnostics reader journey",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue

Closes #2052

## Issue ごとの完了内容

- #2052: 英日 FAQ の persisted-state initial `state-changed`、GraphAdapter / resolver mode の breadcrumb 境界、selection と unloaded descendants の host-app-owned boundary を既存 reader journey smoke の代表 signal として固定しました。

## 変更内容

- `script/test_docs_reader_journey_signals.mjs` に `FAQ responsibility-boundary reader journey` group を追加しました。
- FAQ 本文に既に存在する responsibility-boundary answer の代表 signal だけを確認します。
- runtime Ruby / JavaScript、public API manifest、FAQ 本文、full-site link checker は変更していません。

## 改善カテゴリ

- test
- docs smoke
- regression guard

## 既存仕様への影響

- 挙動変更はありません。
- 公開 API、UI 仕様、DB スキーマ、認可、状態遷移、外部サービス契約への変更はありません。
- 既存 docs の reader journey signal を追加で守るだけの変更です。

## 実施した確認

- Issue #2052 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR 前に current `main` との差分を確認: `ahead_by:1`, `behind_by:0`。
- 変更ファイルは `script/test_docs_reader_journey_signals.mjs` の1件のみ。
- local checkout / local `npm run test:docs-entrypoints -- --only "Docs reader journey signals"` は GitHub HTTPS / raw fetch が 403 のため未実行です。PR CI を確認対象にします。

## リスク評価

- risk: low
- 既存 docs smoke の signal 追加だけで、実行対象も既存 suite 内です。

## 補足事項

- #2050 と #2042 も eligible ですが、今回の変更とは別の docs/mockup/manifest smoke surface です。共通性の薄い bundle にせず、#2052 の FAQ reader journey guard に絞りました。