### PR TITLE
Add toolbar contract source docs smoke guard

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -33,6 +33,8 @@ const toolbarDocs = [
   ["docs/en/toolbar.md", read("docs/en/toolbar.md")],
   ["docs/ja/toolbar.md", read("docs/ja/toolbar.md")]
 ]
+const toolbarBoundaryNote = read("docs/toolbar_action_html_boundary.md")
+const mockupDocsReadme = read("docs/mockups/README.md")
 const graphAdapterDocs = [
   ["docs/en/graph-adapter.md", read("docs/en/graph-adapter.md")],
   ["docs/ja/graph-adapter.md", read("docs/ja/graph-adapter.md")]
@@ -131,6 +133,25 @@ const toolbarActionMetadataSignals = [
   "tree_view_toolbar_disabled",
   "path: nil",
   "disabled: true"
+]
+
+const toolbarHelperOptionKeySignals = [
+  "helper_option_keys:",
+  "tree_view_toolbar:",
+  "- actions",
+  "- labels",
+  "- class_name",
+  "- button_class_name",
+  "- html",
+  "- action_html"
+]
+
+const toolbarContractSourceSignals = [
+  ["visual companion link", "../mockups/toolbar-actions.html"],
+  ["HTML boundary note link", "../toolbar_action_html_boundary.md"],
+  ["action-state manifest key", "toolbar_actions"],
+  ["action metadata manifest key", "toolbar_action_metadata"],
+  ["helper option-key contract", "tree_view_toolbar"]
 ]
 
 const emptyStateHookSignals = [
@@ -245,6 +266,10 @@ toolbarDataHookSignals.forEach((signal) => {
 
 toolbarActionMetadataSignals.slice(0, 10).forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest toolbar action metadata surface")
+})
+
+toolbarHelperOptionKeySignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest tree_view_toolbar helper option-key surface")
 })
 
 diagnosticsAcceptedCheckSignals.forEach((signal) => {
@@ -382,6 +407,10 @@ toolbarDocs.forEach(([relativePath, document]) => {
     assertIncludes(document, signal, `${relativePath} toolbar action metadata docs`)
   })
 
+  toolbarContractSourceSignals.forEach(([label, signal]) => {
+    assertIncludes(document, signal, `${relativePath} toolbar contract source ${label}`)
+  })
+
   assert(
     /Authorization, route availability, and final fallback copy still belong to the host app|authorization、route availability、fallback copy の最終判断は引き続き host app 側の責務/.test(document),
     `${relativePath}: toolbar action metadata docs no longer preserve the host-app-owned fallback boundary`
@@ -397,6 +426,24 @@ toolbarDocs.forEach(([relativePath, document]) => {
     `${relativePath}: toolbar action metadata docs no longer point readers at the manifest-backed integration contract`
   )
 })
+
+toolbarDataHookSignals.slice(1).forEach((signal) => {
+  assertIncludes(toolbarBoundaryNote, signal, "docs/toolbar_action_html_boundary.md toolbar owned hook boundary")
+})
+
+assert(
+  /Host-app attributes may be added|host app 側/.test(toolbarBoundaryNote),
+  "docs/toolbar_action_html_boundary.md: toolbar boundary note no longer separates host-app-owned attributes from TreeView-owned hooks"
+)
+
+assertIncludes(mockupDocsReadme, "toolbar-actions.html", "docs/mockups/README.md toolbar visual companion inventory")
+assertIncludes(mockupDocsReadme, "docs/en/toolbar.md", "docs/mockups/README.md toolbar helper contract source guidance")
+assertIncludes(mockupDocsReadme, "docs/ja/toolbar.md", "docs/mockups/README.md toolbar helper contract source guidance")
+assertIncludes(mockupDocsReadme, "config/public_api_manifest.yml", "docs/mockups/README.md toolbar manifest source guidance")
+assert(
+  /helper metadata contract sources|helper metadata contract sources/.test(mockupDocsReadme),
+  "docs/mockups/README.md: toolbar guidance no longer separates manifest/docs contract sources from the visual mockup responsibility boundary"
+)
 
 graphAdapterDocs.forEach(([relativePath, document]) => {
   assertIncludes(document, "TreeView::GraphAdapter", `${relativePath} GraphAdapter guide entrypoint docs`)


### PR DESCRIPTION
## 対応 Issue

- Closes #2050

## Issue ごとの完了内容

- #2050: Toolbar docs / manifest / visual companion / boundary note / mockup README の代表 signal を `script/test_public_api_docs_signals.mjs` で検出する lightweight guard を追加しました。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に `docs/toolbar_action_html_boundary.md` と `docs/mockups/README.md` の読み込みを追加
- Toolbar docs から以下の代表導線が落ちた場合に検出する check を追加
  - `../mockups/toolbar-actions.html`
  - `../toolbar_action_html_boundary.md`
  - `toolbar_actions`
  - `toolbar_action_metadata`
  - `tree_view_toolbar`
- `config/public_api_manifest.yml` の `tree_view_toolbar` helper option-key surface を代表 signal として確認
- toolbar boundary note と mockup README が、TreeView-owned hooks / host-app-owned attributes / visual mockup と manifest/docs contract source の責務差を示していることを確認

## 改善カテゴリ

- test
- docs smoke guard
- maintenance

## 既存仕様への影響

ありません。runtime Ruby / JavaScript、helper behavior、toolbar markup、visual mockup、public API manifest、docs本文は変更していません。

## 実施した確認

- Issue #2050 のラベルを個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`
- 同じ Issue を close する open PR がないことを確認しました。
- branch freshness: `main` は `147578efc68390d9de2e177cf9565c39b44045ae` と一致し、そこから作成しました。
- compare `main...quality/2050-toolbar-contract-docs-smoke`: `ahead_by:1`, `behind_by:0`
- changed files は `script/test_public_api_docs_signals.mjs` のみです。
- local checkout / `node script/test_public_api_docs_signals.mjs` / `npm run test:docs-entrypoints -- --only "Public API docs signals"` は、この実行環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` になるため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存の docs signal smoke に代表 signal を足すだけで、公開挙動や契約は変えません。主なリスクは wording cleanup に対して signal が細かすぎることですが、Issue の受け入れ条件に沿って contract source / boundary / manifest key の代表語に絞っています。

## 補足事項

#2055 も同系統の quality issue ですが、Planner handoff が #2054 docs本文同期の merge 後または stack を条件にしていました。#2054 の PR #2058 は open のため、この PR には含めていません。