### PR TITLE
Troubleshooting diagnostics reader journey signals を追加する

### DIFF
--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -259,7 +259,7 @@ const signalGroups = [
           "Tree diagnostics",
           "Node keys",
           "GraphAdapter rows look duplicated, incomplete, or shaped differently than expected",
-          "nil becomes an empty child list",
+          "`nil` becomes an empty child list",
           "node_key_resolver:",
           "cycles or duplicate keys",
           "Duplicate node keys, orphan records, DOM ID collisions, or cycles appear",

--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -248,6 +248,49 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Troubleshooting diagnostics reader journey",
+    files: [
+      [
+        "docs/en/troubleshooting.md",
+        [
+          "Row partial output looks broken or table cells do not line up",
+          "tree node keys and UI DOM IDs",
+          "tree.node_key_for(item)",
+          "Tree diagnostics",
+          "Node keys",
+          "GraphAdapter rows look duplicated, incomplete, or shaped differently than expected",
+          "nil becomes an empty child list",
+          "node_key_resolver:",
+          "cycles or duplicate keys",
+          "Duplicate node keys, orphan records, DOM ID collisions, or cycles appear",
+          "validate_node_keys: true",
+          "orphan_strategy:",
+          "render_state.validate_unique_dom_ids!",
+          "TreeView::CycleDiagnostics.new(tree).report"
+        ]
+      ],
+      [
+        "docs/ja/troubleshooting.md",
+        [
+          "row partial の表示が崩れる / table cell 数が合わない",
+          "tree node key と UI DOM ID",
+          "tree.node_key_for(item)",
+          "Tree diagnostics",
+          "Node keys",
+          "GraphAdapter の行が重複する / 足りない / 想定と違う形になる",
+          "nil は空の child list",
+          "node_key_resolver:",
+          "cycle や duplicate key",
+          "duplicate node key / orphan / DOM ID collision / cycle が出る",
+          "validate_node_keys: true",
+          "orphan_strategy:",
+          "render_state.validate_unique_dom_ids!",
+          "TreeView::CycleDiagnostics.new(tree).report"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Render log level reader journey",
     files: [
       [

--- a/script/test_docs_reader_journey_signals.mjs
+++ b/script/test_docs_reader_journey_signals.mjs
@@ -278,7 +278,7 @@ const signalGroups = [
           "Tree diagnostics",
           "Node keys",
           "GraphAdapter の行が重複する / 足りない / 想定と違う形になる",
-          "nil は空の child list",
+          "`nil` は空の child list",
           "node_key_resolver:",
           "cycle や duplicate key",
           "duplicate node key / orphan / DOM ID collision / cycle が出る",


### PR DESCRIPTION
## 対応 Issue

- Closes #1831

## Issue ごとの完了内容

- #1831: Troubleshooting から Tree diagnostics / Node keys / GraphAdapter / row partial symptom へ辿る代表 signal を既存 docs reader journey smoke に追加しました。
- 英日 Troubleshooting の両方で、source path と missing signal が failure message に出る既存仕組みを利用しています。

## 変更内容

- `script/test_docs_reader_journey_signals.mjs` に `Troubleshooting diagnostics reader journey` group を追加。
- row partial、GraphAdapter、duplicate/orphan/DOM/cycle diagnostics の代表語を英日で確認します。

## 改善カテゴリ

- test
- docs smoke

## 既存仕様への影響

- docs 本文、runtime Ruby / JavaScript、public API は変更していません。
- 既存 docs の reader journey drift を検知する smoke guard の追加のみです。

## 確認内容

- GitHub connector で `main` の先頭を確認してからブランチを作成しました。
- PR 前に compare し、変更ファイルが `script/test_docs_reader_journey_signals.mjs` のみであることを確認しました。
- ローカル checkout がない connector-only 作業のため、手元で `npm run test:docs-entrypoints` は未実行です。CI で docs entrypoint smoke の結果を確認してください。

## リスク評価

- risk: low
- test script の signal 追加のみで挙動変更なし。

## 補足

- #2042 も eligible でしたが、browser smoke 側の mockup review flow guard で別の確認軸のため、この PR には混ぜていません。