### PR TITLE
root docs index に Rendering Boundaries の入口を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@
 - [日本語PathTreeBuilder](ja/path-tree-builder.md): pathらしいrecord値から生成folder行とrecord行を作る入口。
 - [English FAQ](en/faq.md): quick answers about responsibility boundaries and common misunderstandings.
 - [日本語FAQ](ja/faq.md): 責務境界とよくある誤解を短く確認する入口。
+- [English Rendering Boundaries](en/rendering-boundaries.md): check which rendering responsibilities belong to TreeView and which remain in the host app.
+- [日本語描画責務の境界](ja/rendering-boundaries.md): TreeView が担う描画責務と host app 側に残す責務を確認する入口。
 - [English troubleshooting](en/troubleshooting.md): reverse-lookup entry point for common integration symptoms.
 - [日本語Troubleshooting](ja/troubleshooting.md): よくある統合トラブルを症状から逆引きする入口。
 - [English Tree diagnostics](en/tree-diagnostics.md): inspect node keys, DOM IDs, orphan nodes, and cycles before rendering.


### PR DESCRIPTION
## 対応 Issue

Closes #2061

## 変更内容

- `docs/README.md` の Recommended entry points に英日 Rendering Boundaries / 描画責務の境界への入口を追加しました。
- 追加文言は、TreeView が担う描画責務と host app 側に残す責務を確認する入口として短く説明する範囲に留めています。

## 判定分類

- docs-sync
- docs-missing

## 確認内容

- 着手前に Default PR Check として open PR #2060 を確認し、current head の CI success と追加修正不要を PR comment に残しました。
- 重複 open PR がないことを検索しました。
- current `main` は `8626eed8a92d2ddf13d9c9edcaccd7e7a6fcf518` と確認しました。
- 作成直後に main が進んだため、latest main を追加親にした refresh commit `6a289ec01ef54fae5968d3e58d67553946bceabd` で追従しました。
- compare `main...docs/2061-rendering-boundaries-index-entry`: `ahead_by:2` / `behind_by:0` / changed files 1。
- PR metadata: `mergeable:true`。
- file patch は `docs/README.md` の 2 行追加のみで、削除 hunk はありません。
- runtime Ruby / JavaScript / public API manifest は変更していません。

## CI

- GitHub Actions CI #2738 / run `27496967541`: success
- `lint`, `pr_specs`, `changes`, `gem_package`: success
- `javascript`: success（docs-only 判定で browser / JS core checks は skipped）
- representative Rails lanes 7.0 / 7.2 / 8.0: success（docs-only skip）

## リスク

- risk: low
- root docs index の discoverability 追加のみです。Rendering Boundaries 本文、英日 language README、FAQ / Troubleshooting の再構成には広げていません。