### PR TITLE
mockup review flow と gallery 同期を smoke で守る

### DIFF
--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -27,9 +27,31 @@ function readmeMockupFiles() {
   return Array.from(new Set(Array.from(matches, (match) => match[1])))
 }
 
+function readmeReviewFlowMockupFiles() {
+  const readme = readFileSync(mockupsReadmePath, "utf8")
+  const reviewFlow = readme.split("## Recommended review flow")[1]?.split("## Demo boundary guidance")[0] || ""
+  const matches = reviewFlow.matchAll(/\[[^\]]+\]\(([^)#?]+\.html)\)/g)
+
+  return Array.from(new Set(Array.from(matches, (match) => match[1])))
+}
+
 function reviewGalleryMockupFiles() {
   const gallery = readFileSync(mockupPath("review-gallery.html"), "utf8")
   const matches = gallery.matchAll(/\b(?:href|src)="([^"#?]+\.html)"/g)
+
+  return Array.from(new Set(Array.from(matches, (match) => match[1])))
+}
+
+function reviewGalleryAnchorHrefs() {
+  const gallery = readFileSync(mockupPath("review-gallery.html"), "utf8")
+  const matches = gallery.matchAll(/\bhref="#([^"]+)"/g)
+
+  return Array.from(new Set(Array.from(matches, (match) => match[1])))
+}
+
+function reviewGalleryElementIds() {
+  const gallery = readFileSync(mockupPath("review-gallery.html"), "utf8")
+  const matches = gallery.matchAll(/\bid="([^"]+)"/g)
 
   return Array.from(new Set(Array.from(matches, (match) => match[1])))
 }
@@ -189,6 +211,16 @@ test.describe("docs mockup browser smoke", () => {
     const missingGalleryFiles = expectedFiles.filter((file) => !galleryFiles.includes(file))
 
     expect(missingGalleryFiles).toEqual([])
+  })
+
+  test("README review flow stays aligned with review gallery links and anchors", () => {
+    const reviewFlowFiles = readmeReviewFlowMockupFiles().filter((file) => file !== "review-gallery.html").sort()
+    const galleryFiles = reviewGalleryMockupFiles().sort()
+    const missingReviewFlowFiles = reviewFlowFiles.filter((file) => !galleryFiles.includes(file))
+    const staleGalleryAnchors = reviewGalleryAnchorHrefs().filter((anchor) => !reviewGalleryElementIds().includes(anchor))
+
+    expect(missingReviewFlowFiles).toEqual([])
+    expect(staleGalleryAnchors).toEqual([])
   })
 
   test("localized-row-labels.html preserves CJK and language exception signals", async ({ page }) => {


### PR DESCRIPTION
## 対応 Issue

Closes #2042

## Issue ごとの完了内容

- #2042: `docs/mockups/README.md` の Recommended review flow と `review-gallery.html` の link / anchor が drift した時に検出できる lightweight smoke を追加しました。

## 変更内容

- `test/browser/docs_mockups_smoke.spec.js` に README Recommended review flow の `.html` links を抽出する helper を追加しました。
- `review-gallery.html` の local `.html` links と `href="#..."` anchors / element ids を抽出する helper を追加しました。
- 新しい smoke で次を確認します。
  - Recommended review flow に出てくる focused mockup file が review gallery からも link されていること。
  - review gallery の in-page anchor href が実在する element id を指していること。

## 改善カテゴリ

- test
- docs smoke
- quality guard

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、helper behavior、mockup HTML/CSS、visual design は変更していません。
- 既存 browser smoke の対象リストや表示確認内容は維持し、静的な drift guard だけを追加しています。

## 実施した確認

- Issue #2042 の labels を直接確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- PR 前 compare: `main...quality/2042-mockup-review-flow-gallery-smoke` は `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local `npm run test:browser` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

- risk: low
- test-only で挙動変更なし。

## 補足事項

- Files table alignment、gallery local link check、focused sample region check は既存テストのまま残しています。
- review-gallery の visual redesign、dynamic filtering、screenshot baseline、individual mockup content には広げていません。