### PR TITLE
malformed selection params の troubleshooting 入口を追加する

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -307,6 +307,8 @@ Check these points.
 - Parse submitted values with `TreeView.parse_selection_params` on the server side.
 - In JavaScript, remember that TreeView only reports checked and enabled checkboxes.
 - Invalid JSON payloads are omitted from the selected payload array and reported through `tree-view-selection:invalid-payload`.
+- If a regular form submit raises `ArgumentError`, inspect the submitted checkbox values before changing the parser. `TreeView.parse_selection_params` skips `nil` and empty strings, accepts hash-like entries and JSON objects, and raises when a non-empty value is invalid JSON or parses to something other than a JSON object.
+- Decide in the host app whether malformed submitted values should be rescued, rejected, logged, or shown as validation copy. TreeView does not choose that request policy.
 - Use grouped `selection:` options for row payload generation, disabled-state decisions, and checkbox visibility.
 - If a user can check boxes but a regular HTML form submit sends no selection params, configure `data-tree-view-selection-hidden-input-name-value` on the `tree-view-selection` host element. Listening for `tree-view-selection:selected` or `tree-view-selection:change` alone does not create form params.
 - Hidden input sync writes one hidden input per valid checked payload to the nearest form. If the tree is outside the form, TreeView still dispatches selection events but does not create hidden inputs.

--- a/docs/ja/troubleshooting.md
+++ b/docs/ja/troubleshooting.md
@@ -307,6 +307,8 @@ selection checkbox の送信値は plain ID ではなく JSON string です。
 - server side では `TreeView.parse_selection_params` で parse する
 - JavaScript では checked かつ enabled な checkbox だけが対象になる
 - JSON が壊れている値は selected payload array から除外され、`tree-view-selection:invalid-payload` で通知される
+- 通常 form submit 後に `ArgumentError` が出る場合は、parser を変える前に送信された checkbox value を確認する。`TreeView.parse_selection_params` は `nil` と空文字列を skip し、hash-like entry と JSON object を受け付け、空でない値が不正な JSON または JSON object 以外に parse された場合に raise します
+- malformed submitted value を rescue するか、request を reject するか、記録するか、validation copy を表示するかは host app 側で決める。TreeView はその request policy を選びません
 - row payload 生成、disabled-state 判定、checkbox visibility は grouped `selection:` option 側で設定する
 - checkbox は見えているのに通常 form submit で selection params が送られない場合は、`tree-view-selection` host element に `data-tree-view-selection-hidden-input-name-value` を設定する。`tree-view-selection:selected` や `tree-view-selection:change` を listen するだけでは form params は作られません
 - hidden input 同期は、valid な checked payload ごとに hidden input を 1 つずつ最寄りの form に書き込みます。tree が form の外にある場合、TreeView は selection event だけを dispatch し、hidden input は生成しません


### PR DESCRIPTION
## 対応 Issue

Closes #2065

## 分類

- `code-ahead-of-docs`
- `docs-sync`

## 背景

`TreeView.parse_selection_params` は current code で次の server-side parser surface を持っています。

- `nil` / empty string は skip
- Hash-like entry と JSON object は受け付ける
- invalid JSON は `ArgumentError`
- JSON object 以外へ parse された値も `ArgumentError`

英日 `docs/en|ja/selection.md` にはこの parser surface と host-app-owned rescue / reject / log / validation copy boundary が既に説明されています。一方で、Troubleshooting の `Selection payloads` 章から regular form submit 後の malformed submitted values / invalid JSON へ辿る入口が薄かったため、症状別 entrypoint として短く同期しました。

## 変更内容

- `docs/en/troubleshooting.md`
  - regular form submit 後に `ArgumentError` が出る場合の確認ポイントを追加
  - parser behavior と host-app-owned request policy boundary を明記
- `docs/ja/troubleshooting.md`
  - 同内容を日本語側へ同期

## 変更範囲

Docs-only change です。runtime Ruby / JavaScript、selection controller、hidden input sync、parser behavior、Public API docs、browser event docs、spec は変更していません。

## 確認内容

- Issue #2065 の labels を確認: `status:ready-for-agent`, `track:docs`, `type:docs`, `risk:low`, `scope:maintenance`。
- 重複 open PR / Issue は `malformed selection params`, `parse_selection_params`, `invalid submitted checkbox values` で確認し、該当なし。
- Source of truth として以下を確認:
  - `lib/tree_view/selection_params.rb`
  - `spec/lib/tree_view/selection_params_spec.rb`
  - `docs/en/selection.md`
  - `docs/ja/selection.md`
  - `docs/en/troubleshooting.md`
  - `docs/ja/troubleshooting.md`
- PR 作成前 compare: `main...docs/2065-selection-params-troubleshooting` は `ahead_by:2` / `behind_by:1` / changed files 2。
- `behind_by:1` の main 側差分は `test/browser/docs_mockups_smoke.spec.js` で、今回の英日 Troubleshooting docs とは非重複でした。
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存実装と Selection docs に沿った症状別 entrypoint 追加のみです。

## 非対象

- `TreeView.parse_selection_params` behavior の変更
- lenient parsing mode の追加
- server-side validation UI / error copy の実装
- selection controller event payload の変更
- Troubleshooting 全体の rewrite