### PR TITLE
CHANGELOG に直近 docs 同期を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ Release preparation notes:
 - Corrected Windowed Rendering docs examples and metadata tables to use the implemented `TreeView::RenderWindow#previous?` / `#next?` API names.
 - Clarified mockup copy and language policy exception recording for deliberate review stress cases.
 - Clarified that `docs/mockups/README.md` is the source of truth for mockup technical asset inventory.
+- Added root docs index entry points for the English and Japanese Rendering Boundaries guides.
+- Added malformed selection params troubleshooting guidance in English and Japanese, including `TreeView.parse_selection_params` error boundaries and host-app-owned request policy.
 
 ### Tests
 
@@ -128,6 +130,7 @@ Release preparation notes:
 - Added browser smoke coverage for representative docs mockup pages and the review gallery.
 - Added docs entrypoint guard coverage for keeping README feature links and docs index targets aligned.
 - Expanded package verification coverage for TreeViewHelper subfiles, the breadcrumb helper, representative Japanese toolbar locale, and Japanese release docs files.
+- Added docs smoke coverage for troubleshooting diagnostics reader journeys, toolbar contract source docs, public API hook signals, mockup review flow / gallery alignment, and docs entrypoint group selection.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

直近で main に入った docs / docs-smoke 系の変更に対して、`CHANGELOG.md` の `Unreleased` がまだ追従していませんでした。

確認した merge 済み変更:

- #2062: root docs index に Rendering Boundaries の入口を追加
- #2066: malformed selection params の Troubleshooting entrypoint を英日 docs に追加
- #2060 / #2059 / #2040 / #2063 など: docs reader journey / toolbar contract / public API hook / mockup review flow の smoke signal

## 変更内容

- `CHANGELOG.md` の `Unreleased` / `Documentation` に Rendering Boundaries index entry と malformed selection params troubleshooting を追記
- `CHANGELOG.md` の `Unreleased` / `Tests` に直近 docs-smoke coverage の要約を追記

## 変更範囲

Docs-only change です。runtime Ruby / JavaScript、spec、CI workflow、docs smoke 実装、README、docs index、AGENTS、Product Profile は変更していません。

## 確認内容

- open PR / Issue で同じ CHANGELOG 追従候補がないことを検索しました。
- latest main `30a7798b15023ab237b6fae31767660259128c9b` から branch を作成しました。
- compare: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` only / deletions 0。
- local checkout は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。release-facing summary の追記のみで、仕様や実装は変更していません。