### PR TITLE
README orientation asset の drift guard を追加する

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -72,6 +72,11 @@ const checks = [
     args: ["script/test_mockup_docs_asset_signals.mjs"]
   },
   {
+    group: "README orientation asset signals",
+    command: "node",
+    args: ["script/test_readme_orientation_asset_signals.mjs"]
+  },
+  {
     group: "Public API docs signals",
     command: "node",
     args: ["script/test_public_api_docs_signals.mjs"]

--- a/script/test_readme_orientation_asset_signals.mjs
+++ b/script/test_readme_orientation_asset_signals.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+const readme = read("README.md")
+const orientationAsset = read("docs/mockups/assets/readme-default-tree.svg")
+const defaultTreeMockup = read("docs/mockups/default-tree.html")
+
+const readmeSignals = [
+  "docs/mockups/assets/readme-default-tree.svg",
+  "Static TreeView mockup showing expanded and collapsed hierarchy rows",
+  "single orientation asset derived from the `default-tree.html` baseline rows",
+  "linked mockups for full static review paths and focused state comparisons",
+  "docs/mockups/default-tree.html"
+]
+
+readmeSignals.forEach((signal) => {
+  assert(
+    readme.includes(signal),
+    `README orientation asset signal is missing ${JSON.stringify(signal)}`
+  )
+})
+
+assert(
+  orientationAsset.trim().startsWith("<svg"),
+  "README orientation asset should remain a non-empty SVG file"
+)
+
+assert(
+  defaultTreeMockup.includes("tree-view-table"),
+  "default-tree.html should remain the baseline mockup source for the README orientation asset"
+)


### PR DESCRIPTION
## 対応 Issue

Closes #1862

## Issue ごとの完了内容

- #1862: README の orientation asset が `docs/mockups/assets/readme-default-tree.svg` を参照し続けることを lightweight docs smoke で確認します。
- #1862: alt text、`default-tree.html` baseline rows 由来の説明、full static review paths への誘導、SVG 実体の存在を代表 signal として固定します。

## 変更内容

- `script/test_readme_orientation_asset_signals.mjs` を追加しました。
- `script/test_docs_entrypoint_suite.mjs` に README orientation asset signals group を追加しました。
- 画像生成、screenshot baseline、visual diff、README/mockup redesign は行っていません。

## 改善カテゴリ

- test
- docs smoke
- maintenance guard

## 既存仕様への影響

挙動変更はありません。README と static mockup asset の drift を検出する test-only 変更です。runtime Ruby / JavaScript、public API、mockup HTML/CSS、UI 仕様、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- Issue #1862 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 open PR 検索で #1862 / `readme-default-tree` / orientation asset 対応の重複 PR がないことを確認しました。
- compare `main...quality/1862-readme-orientation-asset-guard`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs smoke の代表 signal 追加に限定しています。README 文言を全文固定せず、orientation asset の維持に必要な最小 signal と asset existence に閉じています。