### PR TITLE
Add public API entrypoint docs signal guards

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -82,6 +82,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "Public API entrypoint guard signals",
+    command: "node",
+    args: ["script/test_public_api_entrypoint_guard_signals.mjs"]
+  },
+  {
     group: "Render window and resource table docs signals",
     command: "node",
     args: ["script/test_render_window_resource_table_docs_signals.mjs"]

--- a/script/test_public_api_entrypoint_guard_signals.mjs
+++ b/script/test_public_api_entrypoint_guard_signals.mjs
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const manifest = read("config/public_api_manifest.yml")
+const readme = read("README.md")
+
+const publicApiDocs = [
+  ["docs/en/public-api.md", read("docs/en/public-api.md")],
+  ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
+]
+
+const developmentDocs = [
+  ["docs/en/development.md", read("docs/en/development.md")],
+  ["docs/ja/development.md", read("docs/ja/development.md")]
+]
+
+const readmePackageRootExportSignals = [
+  "tree_view/index.js",
+  "TreeViewEventNames",
+  "TreeViewEventDetailKeys",
+  "documented data hook objects",
+  "docs/en/public-api.md#javascript-surface",
+  "docs/ja/public-api.md#javascript-surface",
+  "docs/en/js-events.md",
+  "docs/ja/js-events.md"
+]
+
+readmePackageRootExportSignals.forEach((signal) => {
+  assertIncludes(readme, signal, "README package-root export guidance")
+})
+
+assert(
+  /raw event names, data attributes, and controller identifiers/.test(readme),
+  "README package-root export guidance no longer states the raw hook-copying boundary"
+)
+
+const resourceTableManifestSignals = [
+  "resource_table_render_state_call:",
+  "required_keywords:",
+  "- records",
+  "- context",
+  "optional_keywords:",
+  "- row_partial",
+  "- table_key",
+  "- columns",
+  "- table_state",
+  "- ui_config",
+  "render_options_contract: render_state_pass_through"
+]
+
+resourceTableManifestSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest ResourceTableRenderState.call surface")
+})
+
+const resourceTableDocsSignals = [
+  "TreeView::ResourceTableRenderState.call",
+  "Resource table bridge"
+]
+
+publicApiDocs.forEach(([relativePath, document]) => {
+  resourceTableDocsSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} ResourceTableRenderState.call guidance`)
+  })
+
+  assert(
+    /another table layer already owns column inference and table state|別の table layer が列推論や table state を持っていて/.test(document),
+    `${relativePath}: ResourceTableRenderState.call docs no longer preserve the host-table-layer ownership boundary`
+  )
+})
+
+const developmentManifestSummarySignals = [
+  "config/public_api_manifest.yml",
+  "toolbar data hooks",
+  "toolbar action metadata",
+  "GraphAdapter initializer keywords",
+  "diagnostics accepted checks / run options / Result surface",
+  "PathTreeBuilder node shapes",
+  "ResourceTableRenderState call keywords"
+]
+
+developmentDocs.forEach(([relativePath, document]) => {
+  developmentManifestSummarySignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} public API manifest tracking summary`)
+  })
+})


### PR DESCRIPTION
## 対応 Issue
- Closes #2073
- Closes #2075
- Closes #2055

## Issue ごとの完了内容
- #2073: README の package-root export guidance が `tree_view/index.js`、event/detail key exports、data hook objects、英日 public API / JS event docs への導線を保っていることを docs entrypoint suite で検知する guard を追加しました。
- #2075: `TreeView::ResourceTableRenderState.call` の公開入口、manifest keyword surface、resource table bridge への導線、host table layer ownership boundary が落ちた場合に検知する guard を追加しました。
- #2055: development docs の public API manifest tracking summary が toolbar hooks/actions、GraphAdapter initializer、diagnostics surface、PathTreeBuilder、ResourceTableRenderState call keywords を含むことを検知する guard を追加しました。

## 変更内容
- `script/test_public_api_entrypoint_guard_signals.mjs` を追加し、README / public API docs / development docs / public API manifest の代表 signal を検証するようにしました。
- `script/test_docs_entrypoint_suite.mjs` に新しい guard を追加し、既存の docs entrypoint suite から実行されるようにしました。

## 改善カテゴリ
- test
- docs smoke / signal guard
- CI coverage reinforcement

## 既存仕様への影響
- runtime、公開 API、UI、DB、認可、外部サービス契約には触れていません。
- 既存ドキュメントと manifest の重要な記述が失われた場合に検知するテスト追加のみです。

## 実施した確認
- GitHub connector で main の最新 SHA を確認し、その SHA から branch を作成しました。
- `main...test/2073-public-api-doc-signals` の差分が `script/test_docs_entrypoint_suite.mjs` と `script/test_public_api_entrypoint_guard_signals.mjs` の2ファイルだけであることを確認しました。
- この実行環境では GitHub への git checkout が `CONNECT tunnel failed, response 403` で blocked されるため、ローカル test 実行はできませんでした。PR 作成後に GitHub Actions の結果を確認します。

## リスク評価
- risk: low
- 追加した guard は docs/manifest の文字列検証のみで、挙動変更はありません。

## 補足
- 3 Issue とも public API / docs signal guard の同系列改善として、1つの小さな docs entrypoint test 追加にまとめています。