### PR TITLE
transfer data attribute hooks を package-root export に追加する

### DIFF
--- a/app/javascript/tree_view/index.js
+++ b/app/javascript/tree_view/index.js
@@ -87,6 +87,11 @@ export const TreeViewTransferDropPositions = Object.freeze({
   after: "after"
 })
 
+export const TreeViewTransferDataAttributes = Object.freeze({
+  payload: "data-tree-transfer-payload",
+  disabled: "data-tree-transfer-disabled"
+})
+
 export const TreeViewTransferDataMimeTypes = Object.freeze({
   applicationJson: "application/json",
   textPlain: "text/plain"

--- a/config/public_api_manifest.yml
+++ b/config/public_api_manifest.yml
@@ -304,6 +304,7 @@ javascript_package_root:
     - TreeViewRemoteStateDataHooks
     - TreeViewToolbarDataHooks
     - TreeViewTransferDropPositions
+    - TreeViewTransferDataAttributes
     - TreeViewTransferDataMimeTypes
     - TreeViewRemoteStateValues
     - TreeViewStateController
@@ -317,6 +318,9 @@ javascript_package_root:
     before: before
     inside: inside
     after: after
+  transfer_data_attributes:
+    payload: data-tree-transfer-payload
+    disabled: data-tree-transfer-disabled
   transfer_data_mime_types:
     application_json: application/json
     text_plain: text/plain

--- a/docs/en/drag-and-drop.md
+++ b/docs/en/drag-and-drop.md
@@ -39,7 +39,7 @@ render_state = TreeView::RenderState.new(
 
 The return value must be hash-like.
 
-TreeView renders the resulting payload on the documented `data-tree-transfer-payload` attribute. Host apps that already import the package root can use `TreeViewIntegrationHooks.transfer.payload` instead of hand-copying that attribute name in JavaScript, browser tests, or shared helper code. The export names the hook string only; payload shape, authorization, persistence, and final drop behavior remain host-app responsibilities.
+TreeView renders the resulting payload on the documented `data-tree-transfer-payload` attribute. Host apps that already import the package root can use `TreeViewTransferDataAttributes.payload` instead of hand-copying that attribute name in JavaScript, browser tests, or shared helper code. `TreeViewTransferDataAttributes.disabled` names the documented disabled-row transfer hook used by transfer boundary states. These exports name DOM wiring attributes only; payload shape, authorization, persistence, and final drop behavior remain host-app responsibilities. The broader `TreeViewIntegrationHooks.transfer.payload` export remains available for existing integrations that use the grouped integration-hook object.
 
 ## View example
 
@@ -80,7 +80,7 @@ Use `data-tree-view-ignore-drag="true"` when only drag start should be ignored a
 </td>
 ```
 
-These opt-out markers are documented DOM attributes. They are separate from `TreeViewIntegrationHooks.transfer.payload`, which points to the transfer payload attribute rather than to drag-safe control markers.
+These opt-out markers are documented DOM attributes. They are separate from `TreeViewTransferDataAttributes`, which points to transfer payload and disabled-row attributes rather than to drag-safe control markers.
 
 See [Usage](usage.md#interactive-controls-inside-rows) for keyboard and row interaction markers.
 

--- a/docs/ja/drag-and-drop.md
+++ b/docs/ja/drag-and-drop.md
@@ -39,7 +39,7 @@ render_state = TreeView::RenderState.new(
 
 戻り値はhash-like objectである必要があります。
 
-TreeView はこの payload を documented な `data-tree-transfer-payload` attribute に描画します。host app が package root をすでに import している場合、JavaScript、browser test、shared helper code では attribute 名を raw string で写経せず `TreeViewIntegrationHooks.transfer.payload` を使えます。この export は hook string を指すだけです。payload shape、authorization、保存、最終的な drop behavior は引き続き host app 側の責務です。
+TreeView はこの payload を documented な `data-tree-transfer-payload` attribute に描画します。host app が package root をすでに import している場合、JavaScript、browser test、shared helper code では attribute 名を raw string で写経せず `TreeViewTransferDataAttributes.payload` を使えます。`TreeViewTransferDataAttributes.disabled` は transfer boundary state で使う documented な disabled-row transfer hook を指します。これらの export は DOM wiring attribute 名だけを指します。payload shape、authorization、保存、最終的な drop behavior は引き続き host app 側の責務です。既存 integration が grouped integration-hook object を使っている場合、`TreeViewIntegrationHooks.transfer.payload` も引き続き利用できます。
 
 ## viewでの利用例
 
@@ -80,7 +80,7 @@ Drag startだけを無視し、他のTreeView動作は残したい場合は `dat
 </td>
 ```
 
-これらの opt-out marker は documented DOM attribute です。`TreeViewIntegrationHooks.transfer.payload` は transfer payload attribute を指すもので、drag-safe control marker を指すものではありません。
+これらの opt-out marker は documented DOM attribute です。`TreeViewTransferDataAttributes` は transfer payload と disabled-row attribute を指すもので、drag-safe control marker を指すものではありません。
 
 keyboardやrow interaction向けのmarkerは [使い方](usage.md#行内のinteractive-control) を参照してください。
 

--- a/spec/javascript/tree_view_transfer_drop_positions_spec.rb
+++ b/spec/javascript/tree_view_transfer_drop_positions_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "TreeView transfer drop position export" do
+RSpec.describe "TreeView transfer package-root exports" do
   let(:manifest) do
     YAML.safe_load_file(File.expand_path("../../config/public_api_manifest.yml", __dir__))
   end
@@ -12,14 +12,33 @@ RSpec.describe "TreeView transfer drop position export" do
     File.read(File.expand_path("../../app/javascript/tree_view/index.js", __dir__))
   end
 
-  it "keeps the package-root transfer drop position export aligned with the manifest" do
-    positions = manifest.fetch("javascript_package_root").fetch("transfer_drop_positions")
+  let(:javascript_package_root) do
+    manifest.fetch("javascript_package_root")
+  end
 
-    expect(manifest.fetch("javascript_package_root").fetch("named_exports")).to include("TreeViewTransferDropPositions")
+  it "keeps the package-root transfer drop position export aligned with the manifest" do
+    positions = javascript_package_root.fetch("transfer_drop_positions")
+
+    expect(javascript_package_root.fetch("named_exports")).to include("TreeViewTransferDropPositions")
     expect(positions).to eq({"before" => "before", "inside" => "inside", "after" => "after"})
     expect(entrypoint_source).to include("export const TreeViewTransferDropPositions = Object.freeze({")
 
     positions.each do |key, value|
+      expect(entrypoint_source).to include("#{key}: \"#{value}\"")
+    end
+  end
+
+  it "keeps the package-root transfer data attribute export aligned with the manifest" do
+    attributes = javascript_package_root.fetch("transfer_data_attributes")
+
+    expect(javascript_package_root.fetch("named_exports")).to include("TreeViewTransferDataAttributes")
+    expect(attributes).to eq({
+      "payload" => "data-tree-transfer-payload",
+      "disabled" => "data-tree-transfer-disabled"
+    })
+    expect(entrypoint_source).to include("export const TreeViewTransferDataAttributes = Object.freeze({")
+
+    attributes.each do |key, value|
       expect(entrypoint_source).to include("#{key}: \"#{value}\"")
     end
   end


### PR DESCRIPTION
Superseded by #2083. 作業中に main が進み、旧 branch が `behind_by:2` / `mergeable:false` になったため、latest main 起点の replacement PR へ同じ scoped diff を載せ直しました。