### PR TITLE
docs entrypoint CI と public API manifest 構造 guard を強化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       browser_smoke_changed: ${{ steps.detect.outputs.browser_smoke_changed }}
       package_sensitive: ${{ steps.detect.outputs.package_sensitive }}
       docker_setup_sensitive: ${{ steps.detect.outputs.docker_setup_sensitive }}
+      docs_entrypoint_sensitive: ${{ steps.detect.outputs.docs_entrypoint_sensitive }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -28,6 +29,7 @@ jobs:
             echo "browser_smoke_changed=false" >> "$GITHUB_OUTPUT"
             echo "package_sensitive=true" >> "$GITHUB_OUTPUT"
             echo "docker_setup_sensitive=true" >> "$GITHUB_OUTPUT"
+            echo "docs_entrypoint_sensitive=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -147,17 +149,19 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true'
-        run: 'echo "Docs-only PR without mockup or browser-smoke changes: skipping JavaScript browser and entrypoint checks."'
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true' && needs.changes.outputs.docs_entrypoint_sensitive != 'true'
+        run: 'echo "Docs-only PR without package-facing docs, mockup, or browser-smoke changes: skipping JavaScript checks."'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
         uses: actions/checkout@v6
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
         run: npm install
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true' && needs.changes.outputs.docs_entrypoint_sensitive == 'true'
+        run: npm run test:docs-entrypoints
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js:core
       - if: github.event_name != 'pull_request' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'

--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -4,7 +4,8 @@ export function classifyChangedFiles(files) {
     mockups_changed: false,
     browser_smoke_changed: false,
     package_sensitive: false,
-    docker_setup_sensitive: false
+    docker_setup_sensitive: false,
+    docs_entrypoint_sensitive: false
   };
 
   for (const file of files.map((entry) => entry.trim()).filter(Boolean)) {
@@ -26,6 +27,10 @@ export function classifyChangedFiles(files) {
 
     if (isDockerSetupSensitivePath(file)) {
       result.docker_setup_sensitive = true;
+    }
+
+    if (isDocsEntrypointSensitivePath(file)) {
+      result.docs_entrypoint_sensitive = true;
     }
   }
 
@@ -61,6 +66,15 @@ function isPackageSensitivePath(file) {
     file.startsWith("app/assets/") ||
     file.startsWith("app/javascript/") ||
     file.startsWith("config/locales/")
+  );
+}
+
+function isDocsEntrypointSensitivePath(file) {
+  return (
+    file === "README.md" ||
+    file === "CHANGELOG.md" ||
+    file.startsWith("docs/") ||
+    file === "config/public_api_manifest.yml"
   );
 }
 

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -3,25 +3,27 @@ import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
 
 const cases = [
   {
-    name: "gem-packaged docs stay docs-only and request package guard",
+    name: "gem-packaged docs stay docs-only and request package and docs entrypoint guards",
     files: ["README.md", "docs/en/development.md", "docs/ja/development.md", "CHANGELOG.md"],
     expected: {
       docs_only: true,
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: false
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
     }
   },
   {
-    name: "repository-only docs stay docs-only without package guard",
+    name: "repository-only docs stay docs-only without package or docs entrypoint guard",
     files: ["Product Profile.md", "AGENTS.md"],
     expected: {
       docs_only: true,
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: false
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false
     }
   },
   {
@@ -32,7 +34,8 @@ const cases = [
       mockups_changed: true,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: false
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
     }
   },
   {
@@ -43,7 +46,8 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: true,
       package_sensitive: false,
-      docker_setup_sensitive: false
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false
     }
   },
   {
@@ -54,7 +58,20 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: false
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false
+    }
+  },
+  {
+    name: "public manifest changes request full JS and docs entrypoint guards",
+    files: ["config/public_api_manifest.yml"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
     }
   },
   {
@@ -65,7 +82,8 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: false
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
     }
   },
   {
@@ -76,7 +94,8 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: true
+      docker_setup_sensitive: true,
+      docs_entrypoint_sensitive: false
     }
   },
   {
@@ -87,7 +106,8 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: true
+      docker_setup_sensitive: true,
+      docs_entrypoint_sensitive: false
     }
   }
 ];

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -82,6 +82,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "Public API manifest structure",
+    command: "node",
+    args: ["script/test_public_api_manifest_structure.mjs"]
+  },
+  {
     group: "Public API entrypoint guard signals",
     command: "node",
     args: ["script/test_public_api_entrypoint_guard_signals.mjs"]

--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -1,0 +1,210 @@
+import { execFileSync } from "node:child_process"
+
+function loadManifest() {
+  try {
+    return JSON.parse(
+      execFileSync(
+        "ruby",
+        [
+          "-e",
+          [
+            'require "json"',
+            'require "yaml"',
+            'data = YAML.load_file("config/public_api_manifest.yml")',
+            "print JSON.generate(data)"
+          ].join("; ")
+        ],
+        { encoding: "utf8" }
+      )
+    )
+  } catch (error) {
+    const detail = [error.stdout, error.stderr]
+      .filter((output) => output && output.length > 0)
+      .join("\n")
+      .trim() || error.message
+
+    throw new Error(
+      [
+        "Could not load config/public_api_manifest.yml for the manifest structure smoke.",
+        "Run this command from the repository root with Ruby available, or inspect the manifest YAML syntax.",
+        `Loader output: ${detail}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function valueType(value) {
+  if (Array.isArray(value)) return "array"
+  if (value === null) return "null"
+
+  return typeof value
+}
+
+function assertObject(value, path) {
+  assert(
+    value && typeof value === "object" && !Array.isArray(value),
+    `${path} must be an object, got ${valueType(value)}`
+  )
+}
+
+function assertString(value, path) {
+  assert(typeof value === "string" && value.length > 0, `${path} must be a non-empty string`)
+}
+
+function assertUniqueStringList(value, path) {
+  assert(Array.isArray(value), `${path} must be an array, got ${valueType(value)}`)
+  assert(value.length > 0, `${path} must not be empty`)
+
+  const seenValues = new Set()
+
+  value.forEach((item, index) => {
+    assertString(item, `${path}[${index}]`)
+    assert(!seenValues.has(item), `${path} contains duplicate value: ${item}`)
+    seenValues.add(item)
+  })
+}
+
+function assertStringMap(value, path) {
+  assertObject(value, path)
+  Object.entries(value).forEach(([key, item]) => {
+    assertString(item, `${path}.${key}`)
+  })
+}
+
+function assertObjectWithLists(value, path, keys) {
+  assertObject(value, path)
+  keys.forEach((key) => assertUniqueStringList(value[key], `${path}.${key}`))
+}
+
+function assertEntries(value, path, requiredKeys) {
+  assert(Array.isArray(value), `${path} must be an array, got ${valueType(value)}`)
+  assert(value.length > 0, `${path} must not be empty`)
+
+  value.forEach((entry, index) => {
+    assertObject(entry, `${path}[${index}]`)
+    requiredKeys.forEach((key) => assertString(entry[key], `${path}[${index}].${key}`))
+  })
+}
+
+function assertTopLevelKeys(manifest) {
+  const expectedKeys = [
+    "module_methods",
+    "configuration_options",
+    "public_constants",
+    "localized_name_i18n_keys",
+    "filtered_tree_modes",
+    "visible_rows_row_metadata",
+    "node_presenter_builder_names",
+    "graph_adapter_initializer",
+    "ui_config_builder_option_keys",
+    "path_tree_builder_node_shapes",
+    "helper_methods",
+    "helper_option_keys",
+    "render_window_metadata",
+    "toolbar_actions",
+    "toolbar_action_metadata",
+    "setup_generators",
+    "grouped_option_keys",
+    "diagnostics",
+    "resource_table_render_state_call",
+    "render_state_callback_builder_keys",
+    "javascript_package_root"
+  ]
+
+  expectedKeys.forEach((key) => {
+    assert(key in manifest, `config/public_api_manifest.yml missing top-level key: ${key}`)
+  })
+}
+
+const manifest = loadManifest()
+
+assertTopLevelKeys(manifest)
+assertUniqueStringList(manifest.module_methods, "module_methods")
+assertObjectWithLists(manifest.configuration_options, "configuration_options", ["tree_view_configure"])
+assertUniqueStringList(manifest.public_constants, "public_constants")
+assertUniqueStringList(manifest.filtered_tree_modes, "filtered_tree_modes")
+assertObjectWithLists(manifest.visible_rows_row_metadata, "visible_rows_row_metadata", ["fields", "predicates"])
+assertUniqueStringList(manifest.node_presenter_builder_names, "node_presenter_builder_names")
+assertObjectWithLists(manifest.graph_adapter_initializer, "graph_adapter_initializer", ["required_keywords", "optional_keywords"])
+assertObjectWithLists(manifest.helper_option_keys, "helper_option_keys", Object.keys(manifest.helper_option_keys))
+assertUniqueStringList(manifest.render_window_metadata, "render_window_metadata")
+assertStringMap(manifest.toolbar_actions, "toolbar_actions")
+assertObjectWithLists(manifest.toolbar_action_metadata, "toolbar_action_metadata", ["keys", "data_keys"])
+assertObjectWithLists(manifest.grouped_option_keys, "grouped_option_keys", Object.keys(manifest.grouped_option_keys))
+assertObjectWithLists(manifest.resource_table_render_state_call, "resource_table_render_state_call", ["required_keywords", "optional_keywords"])
+assertString(manifest.resource_table_render_state_call.render_options_contract, "resource_table_render_state_call.render_options_contract")
+assertUniqueStringList(manifest.render_state_callback_builder_keys, "render_state_callback_builder_keys")
+
+assertObject(manifest.localized_name_i18n_keys, "localized_name_i18n_keys")
+for (const [name, config] of Object.entries(manifest.localized_name_i18n_keys)) {
+  assertObject(config, `localized_name_i18n_keys.${name}`)
+  assertString(config.helper, `localized_name_i18n_keys.${name}.helper`)
+  assertString(config.fallback, `localized_name_i18n_keys.${name}.fallback`)
+}
+assertUniqueStringList(
+  manifest.localized_name_i18n_keys.model_names.delegated_lookup_prefixes,
+  "localized_name_i18n_keys.model_names.delegated_lookup_prefixes"
+)
+assertUniqueStringList(
+  manifest.localized_name_i18n_keys.attribute_names.delegated_lookup_prefixes,
+  "localized_name_i18n_keys.attribute_names.delegated_lookup_prefixes"
+)
+assertString(
+  manifest.localized_name_i18n_keys.node_type_names.lookup_prefix,
+  "localized_name_i18n_keys.node_type_names.lookup_prefix"
+)
+
+assertObject(manifest.setup_generators.persisted_state_install, "setup_generators.persisted_state_install")
+assertString(manifest.setup_generators.persisted_state_install.name, "setup_generators.persisted_state_install.name")
+assertString(manifest.setup_generators.persisted_state_install.class_name, "setup_generators.persisted_state_install.class_name")
+assertUniqueStringList(
+  manifest.setup_generators.persisted_state_install.generated_paths,
+  "setup_generators.persisted_state_install.generated_paths"
+)
+
+assertObject(manifest.diagnostics, "diagnostics")
+assertUniqueStringList(manifest.diagnostics.accepted_checks, "diagnostics.accepted_checks")
+assertUniqueStringList(manifest.diagnostics.run_options, "diagnostics.run_options")
+assertObjectWithLists(manifest.diagnostics.result_surface, "diagnostics.result_surface", ["attributes", "methods"])
+
+const javascriptPackageRoot = manifest.javascript_package_root
+assertObject(javascriptPackageRoot, "javascript_package_root")
+assertUniqueStringList(javascriptPackageRoot.named_exports, "javascript_package_root.named_exports")
+assertEntries(javascriptPackageRoot.controller_registrations, "javascript_package_root.controller_registrations", ["key", "identifier", "export"])
+assertStringMap(javascriptPackageRoot.transfer_drop_positions, "javascript_package_root.transfer_drop_positions")
+assertStringMap(javascriptPackageRoot.transfer_data_mime_types, "javascript_package_root.transfer_data_mime_types")
+assertStringMap(javascriptPackageRoot.remote_state_values, "javascript_package_root.remote_state_values")
+assertStringMap(javascriptPackageRoot.remote_state_data_hooks, "javascript_package_root.remote_state_data_hooks")
+assertStringMap(javascriptPackageRoot.toolbar_data_hooks, "javascript_package_root.toolbar_data_hooks")
+assertStringMap(javascriptPackageRoot.integration_hooks.state, "javascript_package_root.integration_hooks.state")
+assertStringMap(javascriptPackageRoot.integration_hooks.remote_state, "javascript_package_root.integration_hooks.remote_state")
+assertStringMap(javascriptPackageRoot.integration_hooks.transfer, "javascript_package_root.integration_hooks.transfer")
+assertStringMap(javascriptPackageRoot.selection_data_hooks, "javascript_package_root.selection_data_hooks")
+assertStringMap(javascriptPackageRoot.selection_checkbox_hooks, "javascript_package_root.selection_checkbox_hooks")
+assertStringMap(javascriptPackageRoot.empty_state_hooks, "javascript_package_root.empty_state_hooks")
+
+assertObject(javascriptPackageRoot.event_names, "javascript_package_root.event_names")
+assertObject(javascriptPackageRoot.event_detail_keys, "javascript_package_root.event_detail_keys")
+assertObject(javascriptPackageRoot.event_names_without_detail, "javascript_package_root.event_names_without_detail")
+
+Object.entries(javascriptPackageRoot.event_names).forEach(([group, events]) => {
+  assertStringMap(events, `javascript_package_root.event_names.${group}`)
+})
+
+Object.entries(javascriptPackageRoot.event_detail_keys).forEach(([group, events]) => {
+  assertObject(events, `javascript_package_root.event_detail_keys.${group}`)
+  Object.entries(events).forEach(([eventName, keys]) => {
+    assertUniqueStringList(keys, `javascript_package_root.event_detail_keys.${group}.${eventName}`)
+  })
+})
+
+Object.entries(javascriptPackageRoot.event_names_without_detail).forEach(([group, eventNames]) => {
+  assertUniqueStringList(eventNames, `javascript_package_root.event_names_without_detail.${group}`)
+})
+
+console.log("Public API manifest structure smoke passed.")


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2079
Closes #2080

## Issue ごとの完了内容

- #2079: docs-only でも README / CHANGELOG / docs / `config/public_api_manifest.yml` のような package-facing docs 変更では、重い JS/browser lane ではなく `npm run test:docs-entrypoints` を CI で実行する条件を追加しました。
- #2080: `config/public_api_manifest.yml` の top-level key と代表 nested shape を確認する軽量 manifest structure smoke を追加し、docs entrypoint suite に接続しました。

## 変更内容

- `script/test_public_api_manifest_structure.mjs` を追加し、manifest の主要 section、list/map shape、JavaScript package-root event/detail hook shape を検証します。
- `script/test_docs_entrypoint_suite.mjs` に manifest structure smoke を追加しました。
- `script/ci_changed_files_policy.mjs` に `docs_entrypoint_sensitive` を追加しました。
- `.github/workflows/ci.yml` の `changes` output と `javascript` job を更新し、docs-only package-facing docs では Node install 後に `npm run test:docs-entrypoints` だけを走らせます。
- `script/test_ci_changed_files_policy.mjs` に代表ケースを追加・更新しました。

## 改善カテゴリ

- CI 改善
- テスト / smoke 追加
- docs/public API drift guard

## 既存仕様への影響

runtime Ruby / JavaScript、public API manifest の内容、docs 本文、browser smoke 条件、Rails compatibility lane の方針は変更していません。CI の docs-only 分岐に、package-facing docs の軽量 docs entrypoint guard を足すだけです。

## 実施した確認

- Issue #2079 / #2080 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:medium` / `risk:low`。
- compare `main...quality/2079-2080-docs-entrypoint-manifest-guards`: `ahead_by:5` / `behind_by:0` / changed files 5。
- 差分対象は `.github/workflows/ci.yml` と `script/` 配下の CI/docs smoke files のみです。
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

medium。workflow 条件を触りますが、対象は docs-only PR の軽量 guard 実行条件に限定し、full JS/browser/Rails matrix を無条件に広げていません。

## 補足事項

- `rails_table_preferences#1357` も eligible でしたが、対象の system spec が大きく、現環境では checkout が 403 のため完全ファイルを安全に再構成できませんでした。別途 checkout-capable 環境で扱うのが安全です。
- `rails_fields_kit` の確認候補は `status:needs-human` で、今回の実装対象外でした。
- merge は行いません。