### PR TITLE
Add code quality docs smoke signals

### DIFF
--- a/script/test_quality_docs_smoke_signals.mjs
+++ b/script/test_quality_docs_smoke_signals.mjs
@@ -112,6 +112,46 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Code quality docs command and checklist signals",
+    files: [
+      [
+        "docs/README.md",
+        [
+          "Code quality",
+          "en/code-quality.md",
+          "ja/code-quality.md",
+          "lint, tests, error message quality, and documentation quality policy"
+        ]
+      ],
+      [
+        "docs/en/code-quality.md",
+        [
+          "bundle exec standardrb",
+          "bundle exec rspec",
+          "npm run test:js",
+          "bundle exec rake build",
+          "Public API compatibility",
+          "Documentation quality",
+          "Review checklist",
+          "CHANGELOG.md"
+        ]
+      ],
+      [
+        "docs/ja/code-quality.md",
+        [
+          "bundle exec standardrb",
+          "bundle exec rspec",
+          "npm run test:js",
+          "bundle exec rake build",
+          "Public API compatibility",
+          "Documentation quality",
+          "Review checklist",
+          "CHANGELOG.md"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Resource-table empty colspan boundary mockup",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue
- Closes #2067

## Issue ごとの完了内容
- #2067: `script/test_quality_docs_smoke_signals.mjs` に Code quality docs の代表的な入口・command・review checklist signal を追加し、`docs/README.md`、`docs/en/code-quality.md`、`docs/ja/code-quality.md` の drift を軽量 smoke で検知できるようにしました。

## 変更内容
- 既存の quality docs smoke に `Code quality docs command and checklist signals` group を追加しました。
- 公開 API、UI、CI workflow、package contract には触れていません。

## 改善カテゴリ
- test
- docs drift guard

## 既存仕様への影響
- 既存仕様への影響はありません。docs smoke が確認する代表文字列を増やすだけの変更です。

## 実施した確認内容
- Connector-only で main の最新 SHA (`f3da488344eccf1dd5419054d9c736d3d77c74b6`) からブランチ作成済みです。
- PR 前に差分が `script/test_quality_docs_smoke_signals.mjs` の 1 ファイルだけであることを確認しました。
- ファイル末尾 newline を保持しています。
- ローカル実行環境は clone/network 制限のため未実行です。CI で `npm run test:docs-entrypoints` 相当の docs smoke 到達を確認してください。

## リスク評価
- risk: low
- 代表文字列ベースの smoke 追加のみで、実行時挙動や public contract を変更しません。

## 補足事項
- #2069 は CI workflow guard 側の独立 issue のため、この PR には混ぜていません。