### PR TITLE
test: mockup narrow overflow exceptions を分類して保守しやすくする

### DIFF
--- a/test/browser/docs_mockups_smoke.spec.js
+++ b/test/browser/docs_mockups_smoke.spec.js
@@ -108,38 +108,46 @@ const focusedMockupSmokeTargets = [
   { file: "empty-state.html", sample: "[data-tree-view-empty-state='true']", minimumCount: 2 }
 ]
 
+const narrowOverflowReasonCategories = new Set([
+  "wide-table-reference",
+  "side-by-side-comparison",
+  "inspectable-columns",
+  "long-label-stress",
+  "form-boundary-reference"
+])
+
 const narrowOverflowExpectedMockups = new Map([
-  ["default-tree.html", "wide baseline table columns are intentionally visible in the reference mockup"],
-  ["resource-table-bridge.html", "resource-table comparison keeps fuller columns visible for review"],
-  ["resource-table-empty-colspan-boundary.html", "resource-table colspan boundary keeps selection, metadata, and action columns visible for review"],
-  ["table-caption-context.html", "table caption reference keeps host-owned action and status columns visible"],
-  ["row-status-depth-labels.html", "status/depth table columns are intentionally preserved"],
-  ["toggle-icon-states.html", "toggle-state comparison uses a wide table matrix"],
-  ["interaction-states.html", "interaction-state table keeps multiple state columns visible"],
-  ["children-pagination.html", "children pagination examples keep branch page-state columns visible"],
-  ["reduced-motion-state-cues.html", "state-cue comparison keeps the table matrix visible"],
-  ["keyboard-focus-states.html", "focus samples include multiple side-by-side controls"],
-  ["accessibility-semantics.html", "table-first ARIA comparison keeps state and boundary columns visible"],
-  ["keyboard-current-row/index.html", "keyboard current-row comparison keeps focus/current/action columns visible"],
-  ["high-contrast-state-cues/index.html", "high-contrast state-cue panels stay side by side for comparison"],
-  ["direction-aware-cues/index.html", "direction-aware examples keep multiple writing directions visible for comparison"],
-  ["drop-positions.html", "drop-position comparison keeps before/inside/after states side by side"],
-  ["persisted-state-boundary.html", "persisted-state comparison keeps multiple state columns visible"],
-  ["turbo-frame-target.html", "Turbo Frame reference keeps target and row columns visible"],
-  ["drag-interactive-controls.html", "interactive-control rows keep native controls visible"],
-  ["interactive-marker-behaviors.html", "marker-behavior comparison keeps multiple controls visible"],
-  ["windowed-rendering.html", "window metadata columns are intentionally visible"],
-  ["breadcrumb-paths.html", "breadcrumb path examples keep long path segments inspectable"],
-  ["filtered-tree-modes.html", "filtered-mode comparison keeps mode columns visible"],
-  ["path-tree-builder-rows.html", "PathTreeBuilder examples keep generated path columns inspectable"],
-  ["node-presenter-row-partials.html", "NodePresenter partial examples keep host-owned columns visible"],
-  ["localized-row-labels.html", "localized label comparison keeps multilingual columns visible"],
-  ["form-editing-rows.html", "bulk-edit controls are intentionally visible in the reference"],
-  ["toolbar-actions.html", "toolbar action labels include long/localized stress cases"],
-  ["selection-max-count.html", "selection limit comparison keeps multiple state panels visible"],
-  ["selection-multi-tree-form.html", "multi-tree form comparison keeps source groups side by side"],
-  ["children-pagination-selection-boundary.html", "pagination selection boundary keeps rendered and unloaded state columns visible"],
-  ["empty-state.html", "empty-state comparison keeps table wrappers inspectable"]
+  ["default-tree.html", { category: "wide-table-reference", reason: "wide baseline table columns are intentionally visible in the reference mockup" }],
+  ["resource-table-bridge.html", { category: "inspectable-columns", reason: "resource-table comparison keeps fuller columns visible for review" }],
+  ["resource-table-empty-colspan-boundary.html", { category: "inspectable-columns", reason: "resource-table colspan boundary keeps selection, metadata, and action columns visible for review" }],
+  ["table-caption-context.html", { category: "inspectable-columns", reason: "table caption reference keeps host-owned action and status columns visible" }],
+  ["row-status-depth-labels.html", { category: "inspectable-columns", reason: "status/depth table columns are intentionally preserved" }],
+  ["toggle-icon-states.html", { category: "side-by-side-comparison", reason: "toggle-state comparison uses a wide table matrix" }],
+  ["interaction-states.html", { category: "side-by-side-comparison", reason: "interaction-state table keeps multiple state columns visible" }],
+  ["children-pagination.html", { category: "inspectable-columns", reason: "children pagination examples keep branch page-state columns visible" }],
+  ["reduced-motion-state-cues.html", { category: "side-by-side-comparison", reason: "state-cue comparison keeps the table matrix visible" }],
+  ["keyboard-focus-states.html", { category: "side-by-side-comparison", reason: "focus samples include multiple side-by-side controls" }],
+  ["accessibility-semantics.html", { category: "inspectable-columns", reason: "table-first ARIA comparison keeps state and boundary columns visible" }],
+  ["keyboard-current-row/index.html", { category: "inspectable-columns", reason: "keyboard current-row comparison keeps focus/current/action columns visible" }],
+  ["high-contrast-state-cues/index.html", { category: "side-by-side-comparison", reason: "high-contrast state-cue panels stay side by side for comparison" }],
+  ["direction-aware-cues/index.html", { category: "side-by-side-comparison", reason: "direction-aware examples keep multiple writing directions visible for comparison" }],
+  ["drop-positions.html", { category: "side-by-side-comparison", reason: "drop-position comparison keeps before/inside/after states side by side" }],
+  ["persisted-state-boundary.html", { category: "side-by-side-comparison", reason: "persisted-state comparison keeps multiple state columns visible" }],
+  ["turbo-frame-target.html", { category: "inspectable-columns", reason: "Turbo Frame reference keeps target and row columns visible" }],
+  ["drag-interactive-controls.html", { category: "inspectable-columns", reason: "interactive-control rows keep native controls visible" }],
+  ["interactive-marker-behaviors.html", { category: "side-by-side-comparison", reason: "marker-behavior comparison keeps multiple controls visible" }],
+  ["windowed-rendering.html", { category: "inspectable-columns", reason: "window metadata columns are intentionally visible" }],
+  ["breadcrumb-paths.html", { category: "long-label-stress", reason: "breadcrumb path examples keep long path segments inspectable" }],
+  ["filtered-tree-modes.html", { category: "side-by-side-comparison", reason: "filtered-mode comparison keeps mode columns visible" }],
+  ["path-tree-builder-rows.html", { category: "inspectable-columns", reason: "PathTreeBuilder examples keep generated path columns inspectable" }],
+  ["node-presenter-row-partials.html", { category: "inspectable-columns", reason: "NodePresenter partial examples keep host-owned columns visible" }],
+  ["localized-row-labels.html", { category: "long-label-stress", reason: "localized label comparison keeps multilingual columns visible" }],
+  ["form-editing-rows.html", { category: "form-boundary-reference", reason: "bulk-edit controls are intentionally visible in the reference" }],
+  ["toolbar-actions.html", { category: "long-label-stress", reason: "toolbar action labels include long/localized stress cases" }],
+  ["selection-max-count.html", { category: "side-by-side-comparison", reason: "selection limit comparison keeps multiple state panels visible" }],
+  ["selection-multi-tree-form.html", { category: "side-by-side-comparison", reason: "multi-tree form comparison keeps source groups side by side" }],
+  ["children-pagination-selection-boundary.html", { category: "inspectable-columns", reason: "pagination selection boundary keeps rendered and unloaded state columns visible" }],
+  ["empty-state.html", { category: "inspectable-columns", reason: "empty-state comparison keeps table wrappers inspectable" }]
 ])
 
 test.describe("docs mockup browser smoke", () => {
@@ -243,6 +251,9 @@ test.describe("docs mockup browser smoke", () => {
     const coveredFiles = focusedMockupSmokeTargets.map((mockup) => mockup.file)
     const staleExceptions = [...narrowOverflowExpectedMockups.keys()].filter((file) => !coveredFiles.includes(file))
     const uncheckedFiles = coveredFiles.filter((file) => !narrowOverflowExpectedMockups.has(file))
+    const invalidExceptions = [...narrowOverflowExpectedMockups.entries()].filter(([, exception]) =>
+      !narrowOverflowReasonCategories.has(exception.category) || !exception.reason
+    )
 
     expect(staleExceptions).toEqual([])
     expect(uncheckedFiles).toEqual([
@@ -251,6 +262,7 @@ test.describe("docs mockup browser smoke", () => {
       "current-branch-sidebar.html",
       "lazy-loading-handoff.html"
     ])
+    expect(invalidExceptions).toEqual([])
   })
 
   for (const mockup of focusedMockupSmokeTargets) {


### PR DESCRIPTION
## 対応 Issue

- Closes #1826

## Issue ごとの完了内容

- #1826: mockup browser smoke の narrow overflow 例外リストを、単なる理由文字列から `category` と `reason` を持つ明示的な構造に整理しました。
- 既存の例外対象 mockup は追加・削除せず、対象範囲を維持しました。
- stale な例外や focused smoke 対象外の例外を検出する既存ガードに加えて、未分類・理由なしの例外を検出する確認を追加しました。

## 変更内容

- narrow overflow 例外理由のカテゴリ集合を追加
- narrow overflow 例外データを `{ category, reason }` 形式に整理
- 例外リストのメンテナンス時にカテゴリ漏れと理由漏れを検出する assertion を追加

## 改善カテゴリ

- test
- 小さな内部整理
- 保守性改善

## 既存仕様への影響

- mockup HTML / CSS / runtime code は変更していません。
- narrow overflow の許容・検出ポリシーは変更していません。
- 例外対象ファイルの集合も変更していません。

## 実施した確認

- Issue #1826 の `status:ready-for-agent` / `track:quality` / `agent:planned` / `risk:low` ラベルを個別取得で確認しました。
- 作業ブランチは current main (`4590589c06046c09b19bb070cc2acfa8dc628055`) から作成し、PR 前に main から behind していないことを確認しました。
- compare で変更ファイルが browser smoke spec 1 ファイルだけであることを確認しました。
- ローカルでの `npm run test:browser` は、実行環境から GitHub HTTPS clone/fetch が 403 で通らないため未実行です。PR CI で確認します。

## リスク評価

- risk: low
- テストデータとテスト内 assertion の整理に限定しており、公開挙動への影響はありません。

## 補足事項

- docs/mockups README は既存の narrow-width smoke test 方針と矛盾していなかったため、今回の spec-only 整理では変更していません。