### PR TITLE
Public API manifest structure smoke の nested group 検証を強化する

### DIFF
--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -121,6 +121,34 @@ function assertTopLevelKeys(manifest) {
   })
 }
 
+const requiredUiConfigBuilderOptionKeys = [
+  "build",
+  "build_turbo",
+  "build_static",
+  "build_client_side"
+]
+
+const requiredPathTreeBuilderNodeShapeKeys = ["folder_node", "record_node"]
+
+const requiredHelperOptionKeys = [
+  "tree_view_rows",
+  "tree_view_window",
+  "tree_view_breadcrumb",
+  "tree_view_toolbar"
+]
+
+const requiredGroupedOptionKeys = [
+  "initial_expansion",
+  "render_scope",
+  "toggle_scope",
+  "toggle_icons",
+  "selection",
+  "lazy_loading",
+  "row_status"
+]
+
+const requiredIntegrationHookKeys = ["state", "remote_state", "transfer"]
+
 const manifest = loadManifest()
 
 assertTopLevelKeys(manifest)
@@ -131,11 +159,13 @@ assertUniqueStringList(manifest.filtered_tree_modes, "filtered_tree_modes")
 assertObjectWithLists(manifest.visible_rows_row_metadata, "visible_rows_row_metadata", ["fields", "predicates"])
 assertUniqueStringList(manifest.node_presenter_builder_names, "node_presenter_builder_names")
 assertObjectWithLists(manifest.graph_adapter_initializer, "graph_adapter_initializer", ["required_keywords", "optional_keywords"])
-assertObjectWithLists(manifest.helper_option_keys, "helper_option_keys", Object.keys(manifest.helper_option_keys))
+assertObjectWithLists(manifest.ui_config_builder_option_keys, "ui_config_builder_option_keys", requiredUiConfigBuilderOptionKeys)
+assertObjectWithLists(manifest.path_tree_builder_node_shapes, "path_tree_builder_node_shapes", requiredPathTreeBuilderNodeShapeKeys)
+assertObjectWithLists(manifest.helper_option_keys, "helper_option_keys", requiredHelperOptionKeys)
 assertUniqueStringList(manifest.render_window_metadata, "render_window_metadata")
 assertStringMap(manifest.toolbar_actions, "toolbar_actions")
 assertObjectWithLists(manifest.toolbar_action_metadata, "toolbar_action_metadata", ["keys", "data_keys"])
-assertObjectWithLists(manifest.grouped_option_keys, "grouped_option_keys", Object.keys(manifest.grouped_option_keys))
+assertObjectWithLists(manifest.grouped_option_keys, "grouped_option_keys", requiredGroupedOptionKeys)
 assertObjectWithLists(manifest.resource_table_render_state_call, "resource_table_render_state_call", ["required_keywords", "optional_keywords"])
 assertString(manifest.resource_table_render_state_call.render_options_contract, "resource_table_render_state_call.render_options_contract")
 assertUniqueStringList(manifest.render_state_callback_builder_keys, "render_state_callback_builder_keys")
@@ -181,9 +211,10 @@ assertStringMap(javascriptPackageRoot.transfer_data_mime_types, "javascript_pack
 assertStringMap(javascriptPackageRoot.remote_state_values, "javascript_package_root.remote_state_values")
 assertStringMap(javascriptPackageRoot.remote_state_data_hooks, "javascript_package_root.remote_state_data_hooks")
 assertStringMap(javascriptPackageRoot.toolbar_data_hooks, "javascript_package_root.toolbar_data_hooks")
-assertStringMap(javascriptPackageRoot.integration_hooks.state, "javascript_package_root.integration_hooks.state")
-assertStringMap(javascriptPackageRoot.integration_hooks.remote_state, "javascript_package_root.integration_hooks.remote_state")
-assertStringMap(javascriptPackageRoot.integration_hooks.transfer, "javascript_package_root.integration_hooks.transfer")
+assertObject(javascriptPackageRoot.integration_hooks, "javascript_package_root.integration_hooks")
+requiredIntegrationHookKeys.forEach((key) => {
+  assertStringMap(javascriptPackageRoot.integration_hooks[key], `javascript_package_root.integration_hooks.${key}`)
+})
 assertStringMap(javascriptPackageRoot.selection_data_hooks, "javascript_package_root.selection_data_hooks")
 assertStringMap(javascriptPackageRoot.selection_checkbox_hooks, "javascript_package_root.selection_checkbox_hooks")
 assertStringMap(javascriptPackageRoot.empty_state_hooks, "javascript_package_root.empty_state_hooks")

--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -81,6 +81,21 @@ function assertObjectWithLists(value, path, keys) {
   keys.forEach((key) => assertUniqueStringList(value[key], `${path}.${key}`))
 }
 
+function assertRequiredObjectKeys(value, path, keys) {
+  assertObject(value, path)
+  keys.forEach((key) => assertObject(value[key], `${path}.${key}`))
+}
+
+function assertPathTreeBuilderNodeShapes(value, path, keys) {
+  assertRequiredObjectKeys(value, path, keys)
+  keys.forEach((key) => {
+    const shape = value[key]
+    assertString(shape.constant, `${path}.${key}.constant`)
+    assertUniqueStringList(shape.fields, `${path}.${key}.fields`)
+    assertUniqueStringList(shape.predicates, `${path}.${key}.predicates`)
+  })
+}
+
 function assertEntries(value, path, requiredKeys) {
   assert(Array.isArray(value), `${path} must be an array, got ${valueType(value)}`)
   assert(value.length > 0, `${path} must not be empty`)
@@ -160,7 +175,7 @@ assertObjectWithLists(manifest.visible_rows_row_metadata, "visible_rows_row_meta
 assertUniqueStringList(manifest.node_presenter_builder_names, "node_presenter_builder_names")
 assertObjectWithLists(manifest.graph_adapter_initializer, "graph_adapter_initializer", ["required_keywords", "optional_keywords"])
 assertObjectWithLists(manifest.ui_config_builder_option_keys, "ui_config_builder_option_keys", requiredUiConfigBuilderOptionKeys)
-assertObjectWithLists(manifest.path_tree_builder_node_shapes, "path_tree_builder_node_shapes", requiredPathTreeBuilderNodeShapeKeys)
+assertPathTreeBuilderNodeShapes(manifest.path_tree_builder_node_shapes, "path_tree_builder_node_shapes", requiredPathTreeBuilderNodeShapeKeys)
 assertObjectWithLists(manifest.helper_option_keys, "helper_option_keys", requiredHelperOptionKeys)
 assertUniqueStringList(manifest.render_window_metadata, "render_window_metadata")
 assertStringMap(manifest.toolbar_actions, "toolbar_actions")


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2087
Closes #2091

## Issue ごとの完了内容

- #2087: `javascript_package_root.integration_hooks` 自体と required nested groups (`state`, `remote_state`, `transfer`) を path 付きで明示検証するようにしました。
- #2091: `helper_option_keys` / `grouped_option_keys` / 関連 nested groups を required group list で検証し、group 自体が消えた場合も意図した path で失敗するようにしました。

## 変更内容

- `script/test_public_api_manifest_structure.mjs` に required nested group lists を追加しました。
- `ui_config_builder_option_keys`, `helper_option_keys`, `grouped_option_keys`, `javascript_package_root.integration_hooks` を明示的な required group として検証します。
- `path_tree_builder_node_shapes` は `constant` / `fields` / `predicates` を持つ nested object として検証します。
- 既存 manifest values、public API docs、runtime Ruby / JavaScript、CI workflow は変更していません。

## 改善カテゴリ

- test / docs-entrypoint smoke hardening
- CI failure message の読みやすさ改善
- public API manifest guard の保守性改善

## 既存仕様への影響

挙動変更はありません。manifest schema や public surface は変えず、既存 smoke test の検証粒度だけを強めています。

## 実施した確認

- Issue #2087 / #2091 の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- compare `main...quality/2087-manifest-structure-groups`: `ahead_by:2` / `behind_by:0` / changed files 1。
- CI run #2786: success。
  - `changes`, `pr_specs`, `lint`, `javascript`, `pr_rails_matrix` representative lanes: success。
  - `rails_matrix`, `ruby_matrix`, `docker_development_setup`, `gem_package`: PR path の条件により skip。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク評価

low。test script 1ファイルの guard 強化のみです。

## 補足事項

- #2090 は CI workflow wiring guard で、今回の manifest structure guard とは別ファイル・別責務のため含めていません。
- merge は行いません。