### PR TITLE
CI ポリシーの workflow drift guard を追加

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -74,7 +74,7 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: true,
+      docker_setup_sensitive: false,
       docs_entrypoint_sensitive: true
     }
   },
@@ -86,7 +86,7 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: true,
+      docker_setup_sensitive: false,
       docs_entrypoint_sensitive: true
     }
   },

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -123,11 +123,20 @@ function workflowChangesOutputs(workflowSource) {
   return [...outputsBlock.groups.body.matchAll(/^      (?<key>[a-z_]+): /gm)].map((match) => match.groups.key).sort();
 }
 
-function workflowJavaScriptJob(workflowSource) {
-  const jobBlock = workflowSource.match(/^  javascript:\n(?<body>(?:    .*\n)+?)(?=^  [a-z_]+:\n|$)/m);
-  assert.ok(jobBlock, `${workflowPath} must define jobs.javascript`);
+function workflowJobBlock(workflowSource, jobName) {
+  const marker = `  ${jobName}:\n`;
+  const start = workflowSource.indexOf(marker);
+  assert.notEqual(start, -1, `${workflowPath} must define jobs.${jobName}`);
 
-  return jobBlock.groups.body;
+  const bodyStart = start + marker.length;
+  const remainingWorkflow = workflowSource.slice(bodyStart);
+  const nextJobOffset = remainingWorkflow.search(/\n  [a-z_]+:\n/);
+
+  return nextJobOffset === -1 ? remainingWorkflow : remainingWorkflow.slice(0, nextJobOffset + 1);
+}
+
+function workflowJavaScriptJob(workflowSource) {
+  return workflowJobBlock(workflowSource, "javascript");
 }
 
 function npmRunScripts(workflowSource) {

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
+
+const workflowPath = ".github/workflows/ci.yml";
+const packagePath = "package.json";
 
 const cases = [
   {
@@ -70,7 +74,7 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: false,
+      docker_setup_sensitive: true,
       docs_entrypoint_sensitive: true
     }
   },
@@ -82,7 +86,7 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: false,
+      docker_setup_sensitive: true,
       docs_entrypoint_sensitive: true
     }
   },
@@ -112,8 +116,63 @@ const cases = [
   }
 ];
 
+function workflowChangesOutputs(workflowSource) {
+  const outputsBlock = workflowSource.match(/^  changes:\n(?:    .*\n)*?    outputs:\n(?<body>(?:      [a-z_]+: .*\n)+)/m);
+  assert.ok(outputsBlock, `${workflowPath} must define jobs.changes.outputs`);
+
+  return [...outputsBlock.groups.body.matchAll(/^      (?<key>[a-z_]+): /gm)].map((match) => match.groups.key).sort();
+}
+
+function workflowJavaScriptJob(workflowSource) {
+  const jobBlock = workflowSource.match(/^  javascript:\n(?<body>(?:    .*\n)+?)(?=^  [a-z_]+:\n|\z)/m);
+  assert.ok(jobBlock, `${workflowPath} must define jobs.javascript`);
+
+  return jobBlock.groups.body;
+}
+
+function npmRunScripts(workflowSource) {
+  return [...workflowJavaScriptJob(workflowSource).matchAll(/run: npm run (?<script>[\w:-]+)/g)]
+    .map((match) => match.groups.script)
+    .sort();
+}
+
+function assertSameMembers(actual, expected, message) {
+  assert.deepEqual([...actual].sort(), [...expected].sort(), message);
+}
+
 for (const testCase of cases) {
   assert.deepEqual(classifyChangedFiles(testCase.files), testCase.expected, testCase.name);
 }
 
+const policyKeys = Object.keys(classifyChangedFiles([])).sort();
+const workflowSource = readFileSync(workflowPath, "utf8");
+const packageScripts = JSON.parse(readFileSync(packagePath, "utf8")).scripts;
+const workflowOutputKeys = workflowChangesOutputs(workflowSource);
+
+assertSameMembers(
+  workflowOutputKeys,
+  policyKeys,
+  `${workflowPath} jobs.changes.outputs must match classifyChangedFiles result keys`
+);
+
+const javascriptJob = workflowJavaScriptJob(workflowSource);
+assert.match(
+  javascriptJob,
+  /needs\.changes\.outputs\.docs_entrypoint_sensitive == 'true'/,
+  `${workflowPath} jobs.javascript must keep docs_entrypoint_sensitive in its package-facing docs condition`
+);
+assert.match(
+  javascriptJob,
+  /run: npm run test:docs-entrypoints/,
+  `${workflowPath} jobs.javascript must still run docs entrypoint checks for docs_entrypoint_sensitive changes`
+);
+
+for (const scriptName of npmRunScripts(workflowSource)) {
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(packageScripts, scriptName),
+    `${workflowPath} jobs.javascript runs npm script "${scriptName}", but ${packagePath} scripts does not define it`
+  );
+}
+
 console.log(`Checked ${cases.length} CI changed-file policy cases.`);
+console.log(`Checked ${workflowOutputKeys.length} workflow output keys and ${npmRunScripts(workflowSource).length} JavaScript npm commands.`);

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -124,7 +124,7 @@ function workflowChangesOutputs(workflowSource) {
 }
 
 function workflowJavaScriptJob(workflowSource) {
-  const jobBlock = workflowSource.match(/^  javascript:\n(?<body>(?:    .*\n)+?)(?=^  [a-z_]+:\n|\z)/m);
+  const jobBlock = workflowSource.match(/^  javascript:\n(?<body>(?:    .*\n)+?)(?=^  [a-z_]+:\n|$)/m);
   assert.ok(jobBlock, `${workflowPath} must define jobs.javascript`);
 
   return jobBlock.groups.body;


### PR DESCRIPTION
## 対応 Issue

- Closes #2090
- Closes #2095

## Issue ごとの完了内容

- #2090: `classifyChangedFiles` が返すキー集合と `.github/workflows/ci.yml` の `jobs.changes.outputs` がずれた場合に検出できる guard を追加しました。あわせて `docs_entrypoint_sensitive` が JavaScript job の条件と `npm run test:docs-entrypoints` に接続され続けることも確認します。
- #2095: JavaScript job 内で実行している `npm run ...` コマンドを抽出し、`package.json` の `scripts` に存在することを確認する guard を追加しました。

## 変更内容

- `script/test_ci_changed_files_policy.mjs` に workflow / package scripts の軽量な整合性チェックを追加
- workflow、package scripts、CI ポリシー本体の挙動は変更していません

## 改善カテゴリ

- CI 改善
- テストガード追加
- workflow drift の早期検知

## 既存仕様への影響

既存の分類仕様、CI 実行条件、npm script 定義は変更していません。今回の変更はテスト用スクリプトの検証範囲追加のみです。

## 実施した確認

- GitHub connector 上で branch freshness を確認: `main` から `behind_by: 0`
- 差分対象を確認: `script/test_ci_changed_files_policy.mjs` のみ
- GitHub Actions CI #2790: success
- ローカル checkout は GitHub HTTPS 接続が 403 で取得できないため未実行です。CI で `javascript` job と既存 Ruby/lint job の成功を確認しました。

## リスク評価

低リスクです。CI ポリシーの公開挙動には触れず、既存テストスクリプトに drift 検出を追加するだけの変更です。