### PR TITLE
entrypoint smoke で hook export と manifest の同期を guard する

### DIFF
--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -288,12 +288,24 @@ assert(
 )
 assertFrozenObject(entrypointModule.TreeViewControllerIdentifiers, "TreeViewControllerIdentifiers")
 
+const expectedIntegrationHooks = deepCamelizeKeys(javascriptPackageManifest.integration_hooks)
+assertDeepEqualExport(entrypointModule.TreeViewIntegrationHooks, expectedIntegrationHooks, "TreeViewIntegrationHooks")
+assertFrozenObject(entrypointModule.TreeViewIntegrationHooks, "TreeViewIntegrationHooks", { deep: true })
+
 const expectedSelectionDataHooks = deepCamelizeKeys(javascriptPackageManifest.selection_data_hooks)
 assert(
   JSON.stringify(entrypointModule.TreeViewSelectionDataHooks) === JSON.stringify(expectedSelectionDataHooks),
   "TreeViewSelectionDataHooks export is out of sync"
 )
 assertFrozenObject(entrypointModule.TreeViewSelectionDataHooks, "TreeViewSelectionDataHooks")
+
+const expectedSelectionCheckboxHooks = deepCamelizeKeys(javascriptPackageManifest.selection_checkbox_hooks)
+assertDeepEqualExport(
+  entrypointModule.TreeViewSelectionCheckboxHooks,
+  expectedSelectionCheckboxHooks,
+  "TreeViewSelectionCheckboxHooks"
+)
+assertFrozenObject(entrypointModule.TreeViewSelectionCheckboxHooks, "TreeViewSelectionCheckboxHooks")
 
 const expectedEmptyStateHooks = deepCamelizeKeys(javascriptPackageManifest.empty_state_hooks)
 assert(


### PR DESCRIPTION
## 対応 Issue

Closes #2098

## Issue ごとの完了内容

- #2098: `TreeViewIntegrationHooks` の runtime export 値を `config/public_api_manifest.yml` の `javascript_package_root.integration_hooks` と比較する guard を追加しました。
- #2098: `TreeViewSelectionCheckboxHooks` の runtime export 値を `javascript_package_root.selection_checkbox_hooks` と比較する guard を追加しました。
- #2098: 既存の `assertDeepEqualExport` を使い、drift 時に export 名と nested path、expected / actual が出る形にしています。
- #2098: `TreeViewIntegrationHooks` は nested object として deep freeze、`TreeViewSelectionCheckboxHooks` は flat object として freeze を確認します。

## 変更内容

- `script/test_entrypoints.mjs` に manifest 由来の期待値と package-root runtime export の同期 assertion を追加しました。
- runtime JavaScript、TypeScript declaration、manifest values/schema、docs 本文、CI workflow は変更していません。

## 改善カテゴリ

- テスト追加・改善
- public API drift guard
- CI smoke hardening

## 既存仕様への影響

- 挙動変更はありません。
- public export の追加・rename・削除はしていません。
- manifest や `.d.ts` の public surface も変更していません。

## 実施した確認

- Issue #2098 のラベルを個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 open PR に #2098 を close するものがないことを確認しました。
- PR 作成前 compare `main...quality/2098-entrypoint-hook-manifest-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local Node test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 smoke に assertion を足すだけで、runtime / manifest / docs / workflow には触れていません。

## 補足事項

- #1688 の declaration literal / tuple shape guard はこの PR に含めていません。
- merge は行いません。