### PR TITLE
Public API manifest の generator/localized root guard を追加する

### DIFF
--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -162,6 +162,12 @@ const requiredGroupedOptionKeys = [
   "row_status"
 ]
 
+const requiredLocalizedNameI18nKeyGroups = [
+  "model_names",
+  "attribute_names",
+  "node_type_names"
+]
+
 const requiredIntegrationHookKeys = ["state", "remote_state", "transfer"]
 
 const manifest = loadManifest()
@@ -185,7 +191,11 @@ assertObjectWithLists(manifest.resource_table_render_state_call, "resource_table
 assertString(manifest.resource_table_render_state_call.render_options_contract, "resource_table_render_state_call.render_options_contract")
 assertUniqueStringList(manifest.render_state_callback_builder_keys, "render_state_callback_builder_keys")
 
-assertObject(manifest.localized_name_i18n_keys, "localized_name_i18n_keys")
+assertRequiredObjectKeys(
+  manifest.localized_name_i18n_keys,
+  "localized_name_i18n_keys",
+  requiredLocalizedNameI18nKeyGroups
+)
 for (const [name, config] of Object.entries(manifest.localized_name_i18n_keys)) {
   assertObject(config, `localized_name_i18n_keys.${name}`)
   assertString(config.helper, `localized_name_i18n_keys.${name}.helper`)
@@ -204,6 +214,7 @@ assertString(
   "localized_name_i18n_keys.node_type_names.lookup_prefix"
 )
 
+assertObject(manifest.setup_generators, "setup_generators")
 assertObject(manifest.setup_generators.persisted_state_install, "setup_generators.persisted_state_install")
 assertString(manifest.setup_generators.persisted_state_install.name, "setup_generators.persisted_state_install.name")
 assertString(manifest.setup_generators.persisted_state_install.class_name, "setup_generators.persisted_state_install.class_name")


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2094

## Issue ごとの完了内容

- #2094: `setup_generators` 自体を object として明示検証し、`localized_name_i18n_keys` の required groups (`model_names`, `attribute_names`, `node_type_names`) を path 付きで検証するようにしました。

## 変更内容

- `script/test_public_api_manifest_structure.mjs` に `requiredLocalizedNameI18nKeyGroups` を追加しました。
- `localized_name_i18n_keys` の required group 欠落時に `localized_name_i18n_keys.<group>` の path で失敗するようにしました。
- `setup_generators` 親 root 欠落時に `setup_generators` の path で失敗するようにしました。
- 既存の `setup_generators.persisted_state_install` の `name` / `class_name` / `generated_paths` 検証は維持しています。

## 改善カテゴリ

- test / docs-entrypoint smoke hardening
- CI failure message の読みやすさ改善
- public API manifest guard の保守性改善

## 既存仕様への影響

挙動変更はありません。manifest values、runtime Ruby / JavaScript、setup generator behavior、localized-name fallback policy、docs 本文、CI workflow は変更していません。

## 実施した確認

- Issue #2094 の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- open PR 検索で #2094 の重複 PR がないことを確認しました。
- PR 前 compare `main...quality/2094-manifest-setup-localized-roots`: `ahead_by:1` / `behind_by:0` / changed files 1。
- 対象ファイルは `script/test_public_api_manifest_structure.mjs` のみです。
- CI run #2799: success。
  - `changes`, `pr_specs`, `lint`, `javascript`, `pr_rails_matrix` representative lanes: success。
  - `javascript` lane は `npm run test:js:core` まで到達して success。
  - `rails_matrix`, `ruby_matrix`, `docker_development_setup`, `gem_package`: PR path の条件により skip。
- local checkout / local focused test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク評価

low。test script 1ファイルの guard 強化のみです。

## 補足事項

- 先行の #2092 は merge 済みで、main 上の最新版に対して変更しました。
- merge は行いません。