### PR TITLE
CHANGELOG に status-heavy row mockup 追加を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Release preparation notes:
 - Added render log level docs in Japanese and English.
 - Added JavaScript event contract docs in Japanese and English for public Stimulus events and payload details.
 - Clarified JavaScript event contract docs that `TreeViewEventDetailKeys` mirrors documented detail key names for machine-readable test assertions without changing event payload shape.
-- Clarified release checklist guidance for documented JavaScript wiring surfaces, including `data-tree_view-*` integration hooks and selection controller host-element value attributes, alongside machine-readable package-root exports.
+- Clarified release checklist guidance for documented JavaScript wiring surfaces, including `data-tree-view-*` integration hooks and selection controller host-element value attributes, alongside machine-readable package-root exports.
 - Added migration guides in Japanese and English to summarize compatibility promises, deprecations, rename handling, and release-note expectations.
 - Clarified the CI policy split between pull request Ruby checks and broader `main` / release checks.
 - Clarified development docs for the Ruby-backed `npm run test:entrypoints` manifest loader path and setup expectations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Release preparation notes:
 - Added render log level docs in Japanese and English.
 - Added JavaScript event contract docs in Japanese and English for public Stimulus events and payload details.
 - Clarified JavaScript event contract docs that `TreeViewEventDetailKeys` mirrors documented detail key names for machine-readable test assertions without changing event payload shape.
-- Clarified release checklist guidance for documented JavaScript wiring surfaces, including `data-tree-view-*` integration hooks and selection controller host-element value attributes, alongside machine-readable package-root exports.
+- Clarified release checklist guidance for documented JavaScript wiring surfaces, including `data-tree_view-*` integration hooks and selection controller host-element value attributes, alongside machine-readable package-root exports.
 - Added migration guides in Japanese and English to summarize compatibility promises, deprecations, rename handling, and release-note expectations.
 - Clarified the CI policy split between pull request Ruby checks and broader `main` / release checks.
 - Clarified development docs for the Ruby-backed `npm run test:entrypoints` manifest loader path and setup expectations.
@@ -93,6 +93,7 @@ Release preparation notes:
 - Added transfer disabled / invalid boundary states to the drop-position mockup and updated the mockup review guidance.
 - Added static mockup references for multi-tree selection forms, toggle icon states, high-contrast state cues, reduced-motion state cues, and localized row labels.
 - Added focused mockup references for RenderWindow boundary metadata and direction-aware visual cue boundaries.
+- Added a status-heavy row composition mockup section for dense business columns, row status cues, and host-app-owned action availability.
 - Added a current-branch sidebar breadcrumb mockup for reviewing route context and row-local hierarchy cues in narrow panes.
 - Added direction-aware styling boundary docs for host-app-owned RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing overrides.
 - Added Decision guide guidance for choosing Static, Turbo, or Client-side toggle mode before tuning render depth or loading strategy.


### PR DESCRIPTION
## 対応 Issue / 背景

Refs #1845

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#1845 が `docs/mockups/row-status-depth-labels.html` に `Status-heavy table composition` section を追加しました。`docs/mockups/README.md` は既に `row-status-depth-labels.html` を row-wide status cues / depth labels の focused mockup として案内しており、追加 section は同ページ内の release-facing documentation update として `CHANGELOG.md` にだけ未反映でした。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に status-heavy row composition mockup section の1行を追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- static mockup HTML / CSS
- `docs/mockups/README.md`
- browser smoke / CI workflow / test script
- release note category redesign

## 確認内容

- latest main: `07e46e68a1dc38399937efe73c31f12348870f21`
- branch: `docs/changelog-status-heavy-row-composition`
- head: `453c3388616780c54466519c5ca571e9482c0d96`
- compare `main...docs/changelog-status-heavy-row-composition`: `ahead_by:2` / `behind_by:0`
- changed files: `CHANGELOG.md` の1件のみ
- net diff: additions 1 / deletions 0
- GitHub Actions CI #2806 / run `27520045075`: success
  - `changes`, `lint`, `pr_specs`, `gem_package`: success
  - `javascript`: `npm run test:docs-entrypoints` success
  - representative Rails lanes: docs-only skip / success

merge は行いません。