### PR TITLE
Gemfile / Gemfile.lock 変更を package-sensitive CI guard に含める

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -52,6 +52,8 @@ function isPackageSensitivePath(file) {
     file === "README.md" ||
     file === "CHANGELOG.md" ||
     file.startsWith("docs/") ||
+    file === "Gemfile" ||
+    file === "Gemfile.lock" ||
     file === "tree_view.gemspec" ||
     file === "package.json" ||
     file === "package-lock.json" ||

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -91,6 +91,18 @@ const cases = [
     }
   },
   {
+    name: "Ruby dependency files are package-sensitive full CI changes",
+    files: ["Gemfile", "Gemfile.lock"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false
+    }
+  },
+  {
     name: "package and Node metadata are package-sensitive full CI changes",
     files: ["package.json", "package-lock.json", ".nvmrc"],
     expected: {


### PR DESCRIPTION
## 対応 Issue

- Closes #2102

## Issue ごとの完了内容

- #2102: `Gemfile` と `Gemfile.lock` を CI changed-files policy の `package_sensitive` 対象に追加しました。
- #2102: `Gemfile` / `Gemfile.lock` の変更で `package_sensitive: true` になる regression test を追加しました。

## 変更内容

- `script/ci_changed_files_policy.mjs`
  - Ruby dependency lockfile / manifest changes を package-sensitive な変更として扱うようにしました。
- `script/test_ci_changed_files_policy.mjs`
  - `Gemfile` と `Gemfile.lock` の変更が full CI / gem package guard に到達することを確認するケースを追加しました。

## 改善カテゴリ

- CI guard 改善
- テスト追加

## 既存仕様への影響

- Runtime code、public API、gemspec、dependency version、workflow job 定義は変更していません。
- 変更ファイル分類の抜けを補うだけで、既存の公開挙動や gem の仕様には影響しません。

## 実施した確認

- Issue #2102 の label を個別確認し、`status:ready-for-agent`、`track:quality`、`agent:planned`、`risk:low` を満たすことを確認しました。
- 既存 open PR / review follow-up を確認し、#2102 と重複する実装 PR がないことを確認しました。
- ローカルの一時 workspace で `node script/test_ci_changed_files_policy.mjs` を実行し、成功しました。
  - `Checked 10 CI changed-file policy cases.`
  - `Checked 6 workflow output keys and 2 JavaScript npm commands.`
- `main...quality/2102-gemfile-package-sensitive` の差分が意図した 2 ファイルだけであることを確認しました。
- branch は `main` から `ahead_by: 2` / `behind_by: 0` であることを確認しました。

## リスク評価

- risk: low
- CI changed-files policy とそのテストに限定した変更です。
- 依存バージョン、DB、認可、API、UI、外部サービス契約には触れていません。

## 補足

- #2104 / #2105 は同じ repository の quality issue ですが、Planner コメント上の観点が異なるため、この PR には混ぜていません。
- マージは行いません。