### PR TITLE
CHANGELOG に CI policy workflow guard 追加を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Release preparation notes:
 - Added README orientation asset smoke coverage for the root README image, default-tree baseline mockup, and focused mockup review links.
 - Expanded package verification coverage for TreeViewHelper subfiles, the breadcrumb helper, representative Japanese toolbar locale, and Japanese release docs files.
 - Added docs smoke coverage for troubleshooting diagnostics reader journeys, toolbar contract source docs, public API hook signals, mockup review flow / gallery alignment, and docs entrypoint group selection.
+- Added CI changed-file policy guard coverage for workflow output key drift, docs entrypoint routing, and JavaScript npm command references.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / 背景

Refs #2090
Refs #2095
Refs #2097

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2097 が `script/test_ci_changed_files_policy.mjs` に workflow output key drift、`docs_entrypoint_sensitive` routing、JavaScript job の `npm run ...` command references を守る guard を追加して main に mergeされました。

`CHANGELOG.md` の `Unreleased > Tests` にはこの release-facing test evidence がまだ入っていなかったため、docs-only で1行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に CI changed-file policy guard coverage の1行を追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- CI workflow
- test script
- package scripts
- docs smoke policy の変更

## 確認内容

- latest main: `07e46e68a1dc38399937efe73c31f12348870f21`
- branch: `docs/changelog-ci-policy-workflow-guard`
- head: `5be8298af6b4111edc542dec27c78d501cd67f3a`
- compare `main...docs/changelog-ci-policy-workflow-guard`: `ahead_by:1` / `behind_by:0`
- changed files: `CHANGELOG.md` の1件のみ
- net diff: additions 1 / deletions 0

merge は行いません。