### PR TITLE
Ruby/version・manifest・package guard をまとめて強化する

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
     "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
-    "test:entrypoints": "script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
+    "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"
   },

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
+    "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
     "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
-    "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources",
+    "test:entrypoints": "script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"
   },

--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -3,50 +3,71 @@
 
 require "rubygems/package"
 
-# Keep representative English and Japanese files in this list so package
+# Keep representative English and Japanese files in these groups so package
 # verification covers the bilingual locale, public API, docs entrypoints,
-# release docs, and user-facing mockup entrypoints shipped by the gem.
-REQUIRED_PACKAGED_PATHS = %w[
-  app/helpers/tree_view_helper.rb
-  app/helpers/tree_view_helper/support.rb
-  app/helpers/tree_view_helper/rendering.rb
-  app/helpers/tree_view_helper/dom.rb
-  app/helpers/tree_view_helper/row_attributes.rb
-  app/helpers/tree_view_helper/selection.rb
-  app/helpers/tree_view_helper/transfer.rb
-  app/helpers/tree_view_helper/visuals.rb
-  app/helpers/tree_view_helper/render_scope.rb
-  app/helpers/tree_view_helper/lazy_loading.rb
-  app/helpers/tree_view_helper/toolbar.rb
-  app/helpers/tree_view_breadcrumb_helper.rb
-  app/views/tree_view/_tree_row.html.erb
-  app/assets/stylesheets/tree_view.scss
-  app/javascript/tree_view/index.js
-  app/javascript/tree_view/index.d.ts
-  app/javascript/tree_view/client_controller.js
-  app/javascript/tree_view/remote_state_controller.js
-  app/javascript/tree_view/selection_controller.js
-  app/javascript/tree_view/state_controller.js
-  app/javascript/tree_view/transfer_controller.js
-  config/importmap.tree_view.rb
-  config/public_api_manifest.yml
-  config/locales/tree_view.toolbar.en.yml
-  config/locales/tree_view.toolbar.ja.yml
-  CHANGELOG.md
-  README.md
-  docs/README.md
-  docs/mockups/README.md
-  docs/mockups/review-gallery.html
-  docs/mockups/default-tree.html
-  docs/mockups/default-tree.css
-  docs/mockups/assets/readme-default-tree.svg
-  docs/en/installation.md
-  docs/ja/installation.md
-  docs/en/public-api.md
-  docs/ja/public-api.md
-  docs/en/release.md
-  docs/ja/release.md
-].freeze
+# release docs, and user-facing mockup entrypoints shipped by the gem. The
+# groups are intentionally representative rather than a mirror of the gemspec
+# glob; add a path here when a new public-facing surface needs release-package
+# evidence beyond inclusion in `spec.files`.
+REQUIRED_PACKAGED_PATH_GROUPS = {
+  "Rails helpers" => %w[
+    app/helpers/tree_view_helper.rb
+    app/helpers/tree_view_helper/support.rb
+    app/helpers/tree_view_helper/rendering.rb
+    app/helpers/tree_view_helper/dom.rb
+    app/helpers/tree_view_helper/row_attributes.rb
+    app/helpers/tree_view_helper/selection.rb
+    app/helpers/tree_view_helper/transfer.rb
+    app/helpers/tree_view_helper/visuals.rb
+    app/helpers/tree_view_helper/render_scope.rb
+    app/helpers/tree_view_helper/lazy_loading.rb
+    app/helpers/tree_view_helper/toolbar.rb
+    app/helpers/tree_view_breadcrumb_helper.rb
+  ],
+  "Rails views and assets" => %w[
+    app/views/tree_view/_tree_row.html.erb
+    app/assets/stylesheets/tree_view.scss
+  ],
+  "JavaScript entrypoints" => %w[
+    app/javascript/tree_view/index.js
+    app/javascript/tree_view/index.d.ts
+    app/javascript/tree_view/client_controller.js
+    app/javascript/tree_view/remote_state_controller.js
+    app/javascript/tree_view/selection_controller.js
+    app/javascript/tree_view/state_controller.js
+    app/javascript/tree_view/transfer_controller.js
+  ],
+  "Configuration and locales" => %w[
+    config/importmap.tree_view.rb
+    config/public_api_manifest.yml
+    config/locales/tree_view.toolbar.en.yml
+    config/locales/tree_view.toolbar.ja.yml
+  ],
+  "Root docs" => %w[
+    CHANGELOG.md
+    README.md
+    docs/README.md
+  ],
+  "Mockup entrypoints" => %w[
+    docs/mockups/README.md
+    docs/mockups/review-gallery.html
+    docs/mockups/default-tree.html
+    docs/mockups/default-tree.css
+    docs/mockups/assets/readme-default-tree.svg
+  ],
+  "Bilingual setup and public API docs" => %w[
+    docs/en/installation.md
+    docs/ja/installation.md
+    docs/en/public-api.md
+    docs/ja/public-api.md
+  ],
+  "Bilingual release docs" => %w[
+    docs/en/release.md
+    docs/ja/release.md
+  ]
+}.freeze
+
+REQUIRED_PACKAGED_PATHS = REQUIRED_PACKAGED_PATH_GROUPS.values.flatten.freeze
 
 INSTALLATION_DOC_PATHS = %w[
   docs/en/installation.md
@@ -81,7 +102,10 @@ gem_path = ARGV.first || Dir[File.join(root, "tree_view-*.gem")].max_by { |path|
 abort "No built gem found. Run `gem build tree_view.gemspec` first." unless gem_path
 
 files = Gem::Package.new(gem_path).spec.files
-missing = REQUIRED_PACKAGED_PATHS.reject { |path| files.include?(path) }
+missing_by_group = REQUIRED_PACKAGED_PATH_GROUPS.transform_values do |paths|
+  paths.reject { |path| files.include?(path) }
+end.reject { |_group, paths| paths.empty? }
+missing = missing_by_group.values.flatten
 missing_installation_signals = INSTALLATION_DOC_PATHS.to_h do |path|
   content = File.read(File.join(root, path))
   [path, INSTALLATION_REQUIRED_SIGNALS.reject { |signal| content.include?(signal) }]
@@ -100,9 +124,9 @@ if missing.empty? && missing_installation_signals.empty? && forbidden_packaged_d
 else
   warn "Gem package contents verification failed: #{File.basename(gem_path)}"
 
-  unless missing.empty?
-    warn "Missing packaged files:"
-    missing.each { |path| warn "  - #{path}" }
+  missing_by_group.each do |group, paths|
+    warn "Missing packaged files for #{group}:"
+    paths.each { |path| warn "  - #{path}" }
   end
 
   missing_installation_signals.each do |path, signals|

--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -136,6 +136,48 @@ function assertTopLevelKeys(manifest) {
   })
 }
 
+function assertEventClassification(javascriptPackageRoot) {
+  const requiredEventNameGroups = ["state", "selection", "remote_state", "host_lifecycle", "transfer"]
+  const requiredEventDetailGroups = ["state", "selection", "remote_state", "transfer"]
+  const requiredNoDetailGroups = ["host_lifecycle"]
+
+  assertRequiredObjectKeys(
+    javascriptPackageRoot.event_names,
+    "javascript_package_root.event_names",
+    requiredEventNameGroups
+  )
+  assertRequiredObjectKeys(
+    javascriptPackageRoot.event_detail_keys,
+    "javascript_package_root.event_detail_keys",
+    requiredEventDetailGroups
+  )
+  assertRequiredObjectKeys(
+    javascriptPackageRoot.event_names_without_detail,
+    "javascript_package_root.event_names_without_detail",
+    requiredNoDetailGroups
+  )
+
+  requiredNoDetailGroups.forEach((group) => {
+    const groupEvents = javascriptPackageRoot.event_names[group]
+    const noDetailEventNames = javascriptPackageRoot.event_names_without_detail[group]
+
+    assertStringMap(groupEvents, `javascript_package_root.event_names.${group}`)
+    assertUniqueStringList(noDetailEventNames, `javascript_package_root.event_names_without_detail.${group}`)
+
+    const validEventNames = new Set(Object.keys(groupEvents))
+    noDetailEventNames.forEach((eventName) => {
+      assert(
+        validEventNames.has(eventName),
+        `javascript_package_root.event_names_without_detail.${group} includes unknown event: ${eventName}`
+      )
+      assert(
+        !(javascriptPackageRoot.event_detail_keys[group] && javascriptPackageRoot.event_detail_keys[group][eventName]),
+        `javascript_package_root.event_names_without_detail.${group} overlaps detail-bearing event: ${eventName}`
+      )
+    })
+  })
+}
+
 const requiredUiConfigBuilderOptionKeys = [
   "build",
   "build_turbo",
@@ -237,6 +279,7 @@ assertStringMap(javascriptPackageRoot.empty_state_hooks, "javascript_package_roo
 assertObject(javascriptPackageRoot.event_names, "javascript_package_root.event_names")
 assertObject(javascriptPackageRoot.event_detail_keys, "javascript_package_root.event_detail_keys")
 assertObject(javascriptPackageRoot.event_names_without_detail, "javascript_package_root.event_names_without_detail")
+assertEventClassification(javascriptPackageRoot)
 
 Object.entries(javascriptPackageRoot.event_names).forEach(([group, events]) => {
   assertStringMap(events, `javascript_package_root.event_names.${group}`)

--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -86,6 +86,11 @@ function assertRequiredObjectKeys(value, path, keys) {
   keys.forEach((key) => assertObject(value[key], `${path}.${key}`))
 }
 
+function assertRequiredKeys(value, path, keys) {
+  assertObject(value, path)
+  keys.forEach((key) => assert(key in value, `${path} missing required key: ${key}`))
+}
+
 function assertPathTreeBuilderNodeShapes(value, path, keys) {
   assertRequiredObjectKeys(value, path, keys)
   keys.forEach((key) => {
@@ -151,7 +156,7 @@ function assertEventClassification(javascriptPackageRoot) {
     "javascript_package_root.event_detail_keys",
     requiredEventDetailGroups
   )
-  assertRequiredObjectKeys(
+  assertRequiredKeys(
     javascriptPackageRoot.event_names_without_detail,
     "javascript_package_root.event_names_without_detail",
     requiredNoDetailGroups

--- a/script/test_ruby_version_sources.mjs
+++ b/script/test_ruby_version_sources.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const read = (path) => readFileSync(join(repoRoot, path), "utf8");
+
+const minimumRubyVersion = "3.2";
+const currentRubyVersion = "3.3";
+const expectedReadmeSignal = `Ruby ${minimumRubyVersion} or later`;
+
+const readme = read("README.md");
+const gemspec = read("tree_view.gemspec");
+const workflow = read(".github/workflows/ci.yml");
+const englishDevelopment = read("docs/en/development.md");
+const japaneseDevelopment = read("docs/ja/development.md");
+const packageJson = JSON.parse(read("package.json"));
+
+function assertIncludes(content, signal, path) {
+  assert.ok(content.includes(signal), `${path} must include ${JSON.stringify(signal)}`);
+}
+
+assertIncludes(readme, expectedReadmeSignal, "README.md");
+assert.match(
+  gemspec,
+  /spec\.required_ruby_version\s*=\s*["']>= 3\.2["']/,
+  "tree_view.gemspec must keep required_ruby_version aligned with the README minimum Ruby version"
+);
+
+assertIncludes(workflow, 'ruby-version: "3.2"', ".github/workflows/ci.yml");
+assertIncludes(workflow, 'ruby-version: "3.3"', ".github/workflows/ci.yml");
+assertIncludes(workflow, '- "3.2"', ".github/workflows/ci.yml");
+assertIncludes(workflow, '- "3.3"', ".github/workflows/ci.yml");
+assertIncludes(workflow, "ruby_matrix:", ".github/workflows/ci.yml");
+assertIncludes(workflow, "rails_matrix:", ".github/workflows/ci.yml");
+
+assert.equal(
+  packageJson.scripts["test:ruby-version-sources"],
+  "node script/test_ruby_version_sources.mjs",
+  "package.json must expose the Ruby version source guard"
+);
+assert.ok(
+  packageJson.scripts["test:entrypoints"].includes("npm run test:ruby-version-sources"),
+  "npm run test:entrypoints must include the Ruby version source guard"
+);
+
+[
+  [englishDevelopment, "docs/en/development.md"],
+  [japaneseDevelopment, "docs/ja/development.md"]
+].forEach(([content, path]) => {
+  assertIncludes(content, "gemfiles/rails_7_0.gemfile", path);
+  assertIncludes(content, "gemfiles/rails_7_2.gemfile", path);
+  assertIncludes(content, "gemfiles/rails_8_0.gemfile", path);
+  assertIncludes(content, "Ruby version matrix", path);
+});
+
+console.log(
+  `Ruby version sources stay aligned with Ruby ${minimumRubyVersion}+ and representative Ruby ${minimumRubyVersion}/${currentRubyVersion} CI lanes.`
+);


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2104
Closes #2105
Closes #2108

## Issue ごとの完了内容

- #2104: README / gemspec / CI workflow / development docs / package script の Ruby version source を確認する `script/test_ruby_version_sources.mjs` を追加し、`npm run test:entrypoints` に接続しました。
- #2105: `script/check_gem_package_contents.rb` の required packaged paths を責務別 group に整理し、missing file report も group 名付きで出るようにしました。
- #2108: `script/test_public_api_manifest_structure.mjs` で event name group、detail-bearing group、intentional no-detail group を明示検証し、no-detail host lifecycle events が event_names に存在し detail-bearing entries と重ならないことを確認します。

## 変更内容

- Ruby minimum support と representative CI Ruby lanes の drift guard を追加しました。
- package contents checker の代表 path list を group 化し、gemspec glob と checker の責務差をコメントで明示しました。
- Public API manifest の event classification guard を path 付き failure message で強化しました。

## 改善カテゴリ

- test / smoke hardening
- devops / release package verification
- docs/public API drift guard の保守性改善

## 既存仕様への影響

挙動変更はありません。runtime Ruby / JavaScript、public API manifest values、docs 本文、CI workflow、gemspec package glob は変更していません。

## 実施した確認

- #2104 / #2105 / #2108 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 open PR #2103 を確認し、外部コメント / review thread は無いことを確認しました。#2103 は同じ manifest structure script の別 guard ですが、今回の3 Issue とは別PRとして current main から作成しています。
- compare `main...quality/2104-2105-2108-maintenance-guards`: `ahead_by:5` / `behind_by:0` / changed files 4。
- local checkout / local Node/Ruby checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存挙動を変えない smoke / checker 強化に閉じています。主なリスクは guard が意図より厳しすぎる場合の CI failure ですが、対象は既存 source-of-truth の代表 signal に限定しています。

## 補足事項

- #1357 は eligible ですが、大きい system spec の connector-only 編集が過去メモ上 unsafe なため今回のPRに含めていません。
- rails_fields_kit #1189 は current main の return shape と Issue 前提がズレており、既に停止コメント済みのため重複対応していません。
- merge は行いません。