### PR TITLE
CHANGELOG に Gemfile package-sensitive guard を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ Release preparation notes:
 - Expanded package verification coverage for TreeViewHelper subfiles, the breadcrumb helper, representative Japanese toolbar locale, and Japanese release docs files.
 - Added docs smoke coverage for troubleshooting diagnostics reader journeys, toolbar contract source docs, public API hook signals, mockup review flow / gallery alignment, and docs entrypoint group selection.
 - Added CI changed-file policy guard coverage for workflow output key drift, docs entrypoint routing, and JavaScript npm command references.
+- Added package-sensitive CI guard coverage for `Gemfile` and `Gemfile.lock` changes so Ruby dependency updates reach gem package verification.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / 背景

Related to #2102

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2107 が merge され、`Gemfile` / `Gemfile.lock` の変更が CI changed-files policy の `package_sensitive` 対象になりました。これにより Ruby dependency update が gem package verification に到達するようになっています。

`CHANGELOG.md` の `Unreleased > Tests` には CI changed-file policy guard coverage の記録はありましたが、#2107 の Ruby dependency package-sensitive guard 追加はまだ release-facing summary に反映されていなかったため、docs-only で1行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、`Gemfile` / `Gemfile.lock` 変更が gem package verification に到達する guard coverage の1行を追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- CI workflow
- changed-files policy script
- test script
- dependency version / lockfile

## 確認内容

- Default PR Check として open PR #1793 を確認し、draft / review:changes-requested / inventory sequencing が人間判断待ちで、既存コメントと重複するため追加コメントしない判断にしました。
- #2107 が 2026-06-15 に merge 済みで、#2102 が completed であることを確認しました。
- 重複 open PR は `Gemfile package-sensitive CHANGELOG` で見当たりませんでした。
- 作成時 compare: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` の1件のみ / net diff additions 1 / deletions 0。
- PR 作成直後に #2110 が main へ merge されたため、current compare は `ahead_by:1` / `behind_by:1` / changed files `CHANGELOG.md` の1件のみです。main 側の進行は quality guard 変更で、この PR の CHANGELOG 1行とは非重複です。
- GitHub Actions CI #2825: success。
  - `changes`, `lint`, `pr_specs`, `javascript` (`npm run test:docs-entrypoints`), `gem_package`, representative Rails lanes: success。

merge は行いません。