### PR TITLE
CHANGELOG に maintenance guard 強化を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Release preparation notes:
 - Added docs smoke coverage for troubleshooting diagnostics reader journeys, toolbar contract source docs, public API hook signals, mockup review flow / gallery alignment, and docs entrypoint group selection.
 - Added CI changed-file policy guard coverage for workflow output key drift, docs entrypoint routing, and JavaScript npm command references.
 - Added package-sensitive CI guard coverage for `Gemfile` and `Gemfile.lock` changes so Ruby dependency updates reach gem package verification.
+- Added maintenance guard coverage for Ruby version source drift, grouped package contents verification, and Public API manifest event classification.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / 背景

Refs #2110
Refs #2104
Refs #2105
Refs #2108

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2110 が merge され、次の maintenance guard が main に入りました。

- Ruby version source drift guard
- grouped package contents verification
- Public API manifest event classification guard

`CHANGELOG.md` の `Unreleased > Tests` には Gemfile package-sensitive guard まで反映済みでしたが、#2110 の guard 強化はまだ release-facing summary に入っていなかったため、docs-only で1行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、Ruby version source drift / grouped package contents verification / Public API manifest event classification guard coverage の1行を追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- CI workflow
- package checker behavior
- manifest schema / values
- dependency version / lockfile

## 確認内容

- Default PR Check として #2030 / #2074 を確認しました。
  - #2030 は docs-only / CI success ですが、`TreeViewControllerEntries` の public API stance が human review待ちです。
  - #2074 は docs mockup PRですが、Mode E section の desktop / narrow viewport visual evidence が browser-capable review待ちです。
- #2110 が 2026-06-15 に merge済みであることを確認しました。
- current `CHANGELOG.md` の `Unreleased > Tests` を確認し、#2110 の3 guard summary が未反映であることを確認しました。
- compare `main...docs/changelog-maintenance-guard-groups`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` の1件のみ / additions 1 / deletions 0。

merge は行いません。