### PR TITLE
Public API / setup docs の guard を追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -61,6 +61,14 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/public-api.md
     docs/ja/public-api.md
   ],
+  "README-linked public JavaScript docs" => %w[
+    docs/en/js-events.md
+    docs/ja/js-events.md
+  ],
+  "Public setup surface docs" => %w[
+    docs/en/public-setup-surface.md
+    docs/ja/public-setup-surface.md
+  ],
   "Bilingual release docs" => %w[
     docs/en/release.md
     docs/ja/release.md

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -82,6 +82,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "RenderState grouped option docs signals",
+    command: "node",
+    args: ["script/test_grouped_option_docs_signals.mjs"]
+  },
+  {
     group: "Public API manifest structure",
     command: "node",
     args: ["script/test_public_api_manifest_structure.mjs"]

--- a/script/test_grouped_option_docs_signals.mjs
+++ b/script/test_grouped_option_docs_signals.mjs
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assertIncludes(source, signal, `${feature}: ${sourcePath}`)
+  })
+}
+
+const feature = "RenderState grouped option docs"
+const manifest = read("config/public_api_manifest.yml")
+
+const groupedOptionSignals = [
+  "grouped_option_keys:",
+  "initial_expansion:",
+  "render_scope:",
+  "toggle_scope:",
+  "toggle_icons:",
+  "selection:",
+  "lazy_loading:",
+  "row_status:",
+  "auto_expand_ancestors",
+  "max_leaf_distance",
+  "payload_builder",
+  "disabled_reason_builder",
+  "row_readonly_builder"
+]
+
+assertSignals("config/public_api_manifest.yml", feature, groupedOptionSignals)
+
+const publicApiDocSignals = [
+  "### RenderState grouped option keys",
+  "config/public_api_manifest.yml",
+  "spec/public_api_compatibility_spec.rb",
+  "initial_expansion",
+  "render_scope",
+  "toggle_scope",
+  "toggle_icons",
+  "selection",
+  "lazy_loading",
+  "row_status",
+  "auto_expand_ancestors",
+  "max_leaf_distance",
+  "payload_builder",
+  "disabled_reason_builder",
+  "row_readonly_builder"
+]
+
+;["docs/en/public-api.md", "docs/ja/public-api.md"].forEach((sourcePath) => {
+  assertSignals(sourcePath, feature, publicApiDocSignals)
+})
+
+assert(
+  /grouped_option_keys:\n(?:.|\n)*initial_expansion:\n(?:.|\n)*selection:\n(?:.|\n)*lazy_loading:\n(?:.|\n)*row_status:/.test(manifest),
+  `${feature}: config/public_api_manifest.yml grouped option groups are missing or unexpectedly reordered`
+)

--- a/script/test_public_setup_surface_docs_signals.mjs
+++ b/script/test_public_setup_surface_docs_signals.mjs
@@ -42,7 +42,9 @@ const feature = "Public Setup Surface docs"
 
 ;[
   ["docs/README.md", "en/public-setup-surface.md"],
-  ["docs/README.md", "ja/public-setup-surface.md"]
+  ["docs/README.md", "ja/public-setup-surface.md"],
+  ["docs/en/persisted-state.md", "public-setup-surface.md"],
+  ["docs/ja/persisted-state.md", "public-setup-surface.md"]
 ].forEach(([sourcePath, href]) => assertRelativeLink(sourcePath, href, feature))
 
 assertSignals("docs/en/public-setup-surface.md", feature, [
@@ -65,4 +67,24 @@ assertSignals("docs/ja/public-setup-surface.md", feature, [
   "app/models/concerns/tree_view_state_owner.rb",
   "生成後のファイルは host app 側で確認してください",
   "storage ownership、認可、保存タイミング、controller action、UI wiring は host app 側の責務です"
+])
+
+assertSignals("docs/en/persisted-state.md", feature, [
+  "Public Setup Surface",
+  "public-setup-surface.md",
+  "path-level contract",
+  "generator name",
+  "optional owner argument",
+  "generated destination paths",
+  "without freezing the migration schema or generated template contents"
+])
+
+assertSignals("docs/ja/persisted-state.md", feature, [
+  "Public Setup Surface",
+  "public-setup-surface.md",
+  "path-level contract",
+  "generator 名",
+  "任意の owner 引数",
+  "生成先 path",
+  "migration schema や生成 template 内容そのものを固定するものではありません"
 ])


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2111
Closes #2112
Closes #2114

## Issue ごとの完了内容

- #2111: `RenderState grouped option keys` の manifest / 英日 Public API docs signal を専用 smoke で確認するようにしました。
- #2112: Public Setup Surface docs signal で、英日 persisted-state docs から `public-setup-surface.md` への導線と代表説明を確認するようにしました。
- #2114: README 直リンク先の JavaScript event docs と Public Setup Surface docs を gem package contents guard の representative packaged docs に追加しました。

## 変更内容

- `script/test_grouped_option_docs_signals.mjs` を追加しました。
- `script/test_docs_entrypoint_suite.mjs` に grouped option docs signal を接続しました。
- `script/test_public_setup_surface_docs_signals.mjs` に persisted-state docs から Public Setup Surface への reader journey signal を追加しました。
- `script/check_gem_package_contents.rb` に README-linked public JavaScript docs / Public setup surface docs の packaged path group を追加しました。

## 改善カテゴリ

- test / docs smoke hardening
- package contents guard
- failure message clarity

## 既存仕様への影響

挙動変更はありません。runtime Ruby / JavaScript、public API manifest values/schema、docs 本文、CI workflow behavior、generator implementation、migration schema、gemspec packaging policy は変更していません。

## 実施した確認

- Issues #2111 / #2112 / #2114 の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- Default PR Check として自分作成の open PR を確認し、今回の対象に優先すべき actionable review follow-up がないことを確認しました。
- 既存 open PR #2115 は `CHANGELOG.md` のみで、この PR の4ファイルとは非重複です。
- compare `main...quality/2111-public-docs-package-guards`: `ahead_by:4` / `behind_by:0` / changed files 4。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs/test/package guard のみで、既存公開挙動や契約値は変更していません。

## 補足事項

- #2111 は既存の大きな `test_public_api_docs_signals.mjs` へ直接追記せず、専用小スクリプトとして分けました。失敗時に grouped option docs の欠落だと分かりやすくするためです。
- merge は行いません。