### PR TITLE
manifest / package guard を release docs と optional arguments に追従する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -72,6 +72,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
   "Bilingual release docs" => %w[
     docs/en/release.md
     docs/ja/release.md
+  ],
+  "Release note candidate docs" => %w[
+    docs/en/release-note-candidates.md
+    docs/ja/release-note-candidates.md
   ]
 }.freeze
 

--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -265,6 +265,11 @@ assertObject(manifest.setup_generators, "setup_generators")
 assertObject(manifest.setup_generators.persisted_state_install, "setup_generators.persisted_state_install")
 assertString(manifest.setup_generators.persisted_state_install.name, "setup_generators.persisted_state_install.name")
 assertString(manifest.setup_generators.persisted_state_install.class_name, "setup_generators.persisted_state_install.class_name")
+assertEntries(
+  manifest.setup_generators.persisted_state_install.optional_arguments,
+  "setup_generators.persisted_state_install.optional_arguments",
+  ["name", "banner"]
+)
 assertUniqueStringList(
   manifest.setup_generators.persisted_state_install.generated_paths,
   "setup_generators.persisted_state_install.generated_paths"


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2117
Closes #2118

## Issue ごとの完了内容

- #2117: `script/test_public_api_manifest_structure.mjs` で `setup_generators.persisted_state_install.optional_arguments` を non-empty array として確認し、各 entry の `name` / `banner` を non-empty string として guard します。
- #2118: `script/check_gem_package_contents.rb` の representative packaged path group に `docs/en/release-note-candidates.md` / `docs/ja/release-note-candidates.md` を追加し、欠落時に `Release note candidate docs` group として分かるようにします。

## 変更内容

- 既存の `assertEntries` helper を再利用して、manifest structure smoke に setup generator optional argument の shape check を追加しました。
- gem package contents guard に release-note candidate collector docs の代表 path group を追加しました。

## 改善カテゴリ

- test / smoke guard 改善
- docs package verification guard 改善
- 小さな CI guard hardening

## 既存仕様への影響

- runtime Ruby / JavaScript、setup generator behavior、manifest schema、docs 本文、release-note candidate collector behavior は変更していません。
- 既存の packaged `docs/**/*` policy と矛盾しない representative guard の追加に閉じています。

## 実施した確認

- Issue #2117 / #2118 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- compare `main...quality/2117-2118-manifest-package-guards`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local clone / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 smoke / package guard の確認範囲を広げるだけで、公開API・generator・docs本文・runtime挙動は変更していません。

## 補足事項

- 複数 Issue はどちらも maintenance mode の guard hardening で、同じ review unit として扱えるため1 PRにまとめています。
- merge は行いません。