### PR TITLE
CHANGELOG に public docs / package guard 追加を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ Release preparation notes:
 - Added CI changed-file policy guard coverage for workflow output key drift, docs entrypoint routing, and JavaScript npm command references.
 - Added package-sensitive CI guard coverage for `Gemfile` and `Gemfile.lock` changes so Ruby dependency updates reach gem package verification.
 - Added maintenance guard coverage for Ruby version source drift, grouped package contents verification, and Public API manifest event classification.
+- Added docs smoke and package verification coverage for grouped RenderState option docs signals, Public Setup Surface reader journeys, and README-linked public JavaScript / setup docs packaging.
+- Added setup generator optional-argument manifest guard coverage and release-note candidate docs package verification.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / 背景

Refs #2111
Refs #2112
Refs #2114
Refs #2117
Refs #2118

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2116 と #2119 が main に入り、次の maintenance guard が追加されました。

- grouped RenderState option docs signal
- Public Setup Surface reader journey signal
- README-linked public JavaScript / setup docs の package guard
- setup generator optional arguments の manifest structure guard
- release-note candidate docs の package guard

`CHANGELOG.md` の `Unreleased > Tests` には、これらの release-facing test / package verification evidence がまだ入っていなかったため、docs-only で2行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、#2116 と #2119 の docs smoke / package guard coverage を2行追加しました。

## 変更範囲

- `CHANGELOG.md` の2行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- CI workflow
- package checker behavior
- manifest schema / values
- docs 本文

## 確認内容

- Default PR Check として #1979 を確認しました。CI success / open / comments ありですが、残る gate は companion reference scope と browser-capable visual evidence の人間判断で、既存コメントと重複するため追加コメントしませんでした。
- #1409 は過去の停止理由どおり current public option surface が確認できず、未確認 docs を創作するリスクがあるため対象外にしました。
- #675 は依存していた interactive marker export が current main に存在しないため対象外にしました。
- #2116 と #2119 が 2026-06-15 に merge済みであることを確認しました。
- compare `main...docs/changelog-public-docs-package-guards-v2`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` の1件のみ / additions 2 / deletions 0。
- GitHub Actions CI #2847 / run `27530168087`: success。
  - `changes`, `lint`, `pr_specs`, `javascript` (`npm run test:docs-entrypoints`), `gem_package`: success。
  - representative Rails lanes: docs-only skip / success。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

merge は行いません。