### PR TITLE
CI/declaration smoke の quality guard を強化する

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -157,8 +157,29 @@ function npmRunScripts(workflowSource) {
     .sort();
 }
 
+function escapeRegExp(value) {
+  return String(value).replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+function workflowActionVersions(workflowSource, actionName) {
+  const pattern = new RegExp(`uses: ${escapeRegExp(actionName)}@(?<version>[^\\s]+)`, "g");
+  return [...new Set([...workflowSource.matchAll(pattern)].map((match) => match.groups.version))].sort();
+}
+
 function assertSameMembers(actual, expected, message) {
   assert.deepEqual([...actual].sort(), [...expected].sort(), message);
+}
+
+function assertWorkflowActionVersions(workflowSource, actionName, expectedVersions) {
+  assertSameMembers(
+    workflowActionVersions(workflowSource, actionName),
+    expectedVersions,
+    `${workflowPath} must use ${actionName}@${expectedVersions.join(" or ")} for its representative setup surface`
+  );
+}
+
+function assertJobMatches(jobBlock, pattern, message) {
+  assert.match(jobBlock, pattern, message);
 }
 
 for (const testCase of cases) {
@@ -176,6 +197,21 @@ assertSameMembers(
   `${workflowPath} jobs.changes.outputs must match classifyChangedFiles result keys`
 );
 
+assertWorkflowActionVersions(workflowSource, "actions/checkout", ["v6"]);
+assertWorkflowActionVersions(workflowSource, "actions/setup-node", ["v6"]);
+assertWorkflowActionVersions(workflowSource, "ruby/setup-ruby", ["v1"]);
+
+const changesJob = workflowJobBlock(workflowSource, "changes");
+assertJobMatches(
+  changesJob,
+  /uses: actions\/checkout@v6[\s\S]*fetch-depth: 0/,
+  `${workflowPath} jobs.changes must keep a full checkout for changed-file detection`
+);
+
+const lintJob = workflowJobBlock(workflowSource, "lint");
+assertJobMatches(lintJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.lint must keep Ruby 3.3`);
+assertJobMatches(lintJob, /bundler-cache: true/, `${workflowPath} jobs.lint must keep bundler-cache enabled`);
+
 const javascriptJob = workflowJavaScriptJob(workflowSource);
 assert.match(
   javascriptJob,
@@ -187,6 +223,13 @@ assert.match(
   /run: npm run test:docs-entrypoints/,
   `${workflowPath} jobs.javascript must still run docs entrypoint checks for docs_entrypoint_sensitive changes`
 );
+assertJobMatches(javascriptJob, /uses: actions\/setup-node@v6/, `${workflowPath} jobs.javascript must keep setup-node v6`);
+assertJobMatches(javascriptJob, /node-version: "22"/, `${workflowPath} jobs.javascript must keep the Node 22 CI lane`);
+assertJobMatches(javascriptJob, /cache: npm/, `${workflowPath} jobs.javascript must keep npm cache enabled`);
+
+const gemPackageJob = workflowJobBlock(workflowSource, "gem_package");
+assertJobMatches(gemPackageJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.gem_package must keep Ruby 3.3`);
+assertJobMatches(gemPackageJob, /bundler-cache: true/, `${workflowPath} jobs.gem_package must keep bundler-cache enabled`);
 
 for (const scriptName of npmRunScripts(workflowSource)) {
   assert.ok(
@@ -197,3 +240,4 @@ for (const scriptName of npmRunScripts(workflowSource)) {
 
 console.log(`Checked ${cases.length} CI changed-file policy cases.`);
 console.log(`Checked ${workflowOutputKeys.length} workflow output keys and ${npmRunScripts(workflowSource).length} JavaScript npm commands.`);
+console.log("Checked representative CI workflow setup surfaces.");

--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -106,19 +106,14 @@ function assertDeclarationShape(block, expectedValue, path = []) {
 
 const manifest = loadJavascriptPackageManifest()
 const declarationSource = readFileSync("app/javascript/tree_view/index.d.ts", "utf8")
-const expectedManifestLiteralGroups = [
-  "event_names",
-  "event_detail_keys",
-  "remote_state_values",
-  "remote_state_data_hooks",
-  "toolbar_data_hooks",
-  "transfer_drop_positions",
-  "transfer_data_mime_types",
-  "integration_hooks",
-  "selection_data_hooks",
-  "selection_checkbox_hooks",
-  "empty_state_hooks"
-]
+const nonLiteralManifestGroups = new Set([
+  "named_exports",
+  "controller_registrations",
+  "event_names_without_detail"
+])
+const expectedManifestLiteralGroups = Object.keys(manifest)
+  .filter((manifestGroup) => !nonLiteralManifestGroups.has(manifestGroup))
+  .sort()
 const literalExportsByManifestGroup = {
   event_names: {
     exportName: "TreeViewEventNames",

--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -55,6 +55,22 @@ function assertBlockContains(block, pattern, message) {
   assert(pattern.test(block), message)
 }
 
+function assertSameMembers(actual, expected, message) {
+  const actualSet = new Set(actual)
+  const expectedSet = new Set(expected)
+  const missing = expected.filter((item) => !actualSet.has(item))
+  const unexpected = actual.filter((item) => !expectedSet.has(item))
+
+  assert(
+    missing.length === 0 && unexpected.length === 0,
+    [
+      message,
+      missing.length > 0 ? `Missing: ${missing.join(", ")}` : null,
+      unexpected.length > 0 ? `Unexpected: ${unexpected.join(", ")}` : null
+    ].filter(Boolean).join("\n")
+  )
+}
+
 function assertDeclarationShape(block, expectedValue, path = []) {
   Object.entries(expectedValue).forEach(([key, value]) => {
     const currentPath = [...path, key]
@@ -90,22 +106,73 @@ function assertDeclarationShape(block, expectedValue, path = []) {
 
 const manifest = loadJavascriptPackageManifest()
 const declarationSource = readFileSync("app/javascript/tree_view/index.d.ts", "utf8")
-const literalExports = {
-  TreeViewEventNames: deepCamelizeKeys(manifest.event_names),
-  TreeViewEventDetailKeys: deepCamelizeKeys(manifest.event_detail_keys),
-  TreeViewRemoteStateValues: manifest.remote_state_values,
-  TreeViewRemoteStateDataHooks: deepCamelizeKeys(manifest.remote_state_data_hooks),
-  TreeViewToolbarDataHooks: deepCamelizeKeys(manifest.toolbar_data_hooks),
-  TreeViewTransferDropPositions: manifest.transfer_drop_positions,
-  TreeViewTransferDataMimeTypes: deepCamelizeKeys(manifest.transfer_data_mime_types),
-  TreeViewControllerIdentifiers: Object.fromEntries(
-    manifest.controller_registrations.map(({ key, identifier }) => [key, identifier])
-  ),
-  TreeViewSelectionDataHooks: deepCamelizeKeys(manifest.selection_data_hooks),
-  TreeViewEmptyStateHooks: deepCamelizeKeys(manifest.empty_state_hooks)
+const expectedManifestLiteralGroups = [
+  "event_names",
+  "event_detail_keys",
+  "remote_state_values",
+  "remote_state_data_hooks",
+  "toolbar_data_hooks",
+  "transfer_drop_positions",
+  "transfer_data_mime_types",
+  "integration_hooks",
+  "selection_data_hooks",
+  "selection_checkbox_hooks",
+  "empty_state_hooks"
+]
+const literalExportsByManifestGroup = {
+  event_names: {
+    exportName: "TreeViewEventNames",
+    expectedShape: deepCamelizeKeys(manifest.event_names)
+  },
+  event_detail_keys: {
+    exportName: "TreeViewEventDetailKeys",
+    expectedShape: deepCamelizeKeys(manifest.event_detail_keys)
+  },
+  remote_state_values: {
+    exportName: "TreeViewRemoteStateValues",
+    expectedShape: manifest.remote_state_values
+  },
+  remote_state_data_hooks: {
+    exportName: "TreeViewRemoteStateDataHooks",
+    expectedShape: deepCamelizeKeys(manifest.remote_state_data_hooks)
+  },
+  toolbar_data_hooks: {
+    exportName: "TreeViewToolbarDataHooks",
+    expectedShape: deepCamelizeKeys(manifest.toolbar_data_hooks)
+  },
+  transfer_drop_positions: {
+    exportName: "TreeViewTransferDropPositions",
+    expectedShape: manifest.transfer_drop_positions
+  },
+  transfer_data_mime_types: {
+    exportName: "TreeViewTransferDataMimeTypes",
+    expectedShape: deepCamelizeKeys(manifest.transfer_data_mime_types)
+  },
+  integration_hooks: {
+    exportName: "TreeViewIntegrationHooks",
+    expectedShape: deepCamelizeKeys(manifest.integration_hooks)
+  },
+  selection_data_hooks: {
+    exportName: "TreeViewSelectionDataHooks",
+    expectedShape: deepCamelizeKeys(manifest.selection_data_hooks)
+  },
+  selection_checkbox_hooks: {
+    exportName: "TreeViewSelectionCheckboxHooks",
+    expectedShape: deepCamelizeKeys(manifest.selection_checkbox_hooks)
+  },
+  empty_state_hooks: {
+    exportName: "TreeViewEmptyStateHooks",
+    expectedShape: deepCamelizeKeys(manifest.empty_state_hooks)
+  }
 }
 
-Object.entries(literalExports).forEach(([exportName, expectedShape]) => {
+assertSameMembers(
+  Object.keys(literalExportsByManifestGroup),
+  expectedManifestLiteralGroups,
+  "script/test_declaration_literal_shapes.mjs must cover every javascript_package_root literal export group"
+)
+
+Object.values(literalExportsByManifestGroup).forEach(({ exportName, expectedShape }) => {
   assertDeclarationShape(declarationBlock(declarationSource, exportName), expectedShape, [exportName])
 })
 

--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -160,6 +160,11 @@ const literalExportsByManifestGroup = {
     expectedShape: deepCamelizeKeys(manifest.empty_state_hooks)
   }
 }
+const controllerRegistrationExports = {
+  TreeViewControllerIdentifiers: Object.fromEntries(
+    manifest.controller_registrations.map(({ key, identifier }) => [key, identifier])
+  )
+}
 
 assertSameMembers(
   Object.keys(literalExportsByManifestGroup),
@@ -168,6 +173,10 @@ assertSameMembers(
 )
 
 Object.values(literalExportsByManifestGroup).forEach(({ exportName, expectedShape }) => {
+  assertDeclarationShape(declarationBlock(declarationSource, exportName), expectedShape, [exportName])
+})
+
+Object.entries(controllerRegistrationExports).forEach(([exportName, expectedShape]) => {
   assertDeclarationShape(declarationBlock(declarationSource, exportName), expectedShape, [exportName])
 })
 


### PR DESCRIPTION
## 対応 Issue

Closes #2120
Closes #2121

## Issue ごとの完了内容

- #2120: `script/test_declaration_literal_shapes.mjs` が `javascript_package_root` の literal export group を manifest から逆算し、declaration smoke 対象に漏れがあれば失敗するようにしました。
- #2120: 既存の `TreeViewControllerIdentifiers` guard は維持しつつ、未guardだった `TreeViewIntegrationHooks` と `TreeViewSelectionCheckboxHooks` の declaration literal shape も確認対象に追加しました。
- #2121: `script/test_ci_changed_files_policy.mjs` に workflow setup surface の代表 guard を追加し、`actions/checkout@v6`、`actions/setup-node@v6`、`ruby/setup-ruby@v1`、changed-file detection の `fetch-depth: 0`、Node 22 / npm cache / Ruby 3.3 / bundler-cache の drift を検出できるようにしました。

## 変更内容

- declaration literal smoke の manifest coverage check を追加
- CI changed-file policy smoke に workflow action/setup signal check を追加
- runtime Ruby / JavaScript、public API manifest、TypeScript declaration 本体、CI workflow 本体、docs 本文は変更していません

## 改善カテゴリ

- test / CI guard hardening
- public API declaration drift prevention
- workflow setup drift prevention

## 既存仕様への影響

既存仕様への影響はありません。既存の workflow と declaration surface を変更せず、現在の期待状態を smoke script でより明確に守るだけです。

## 実施した確認

- Issue #2120 / #2121 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch 作成前の current `main`: `2c10888f812e138dbce1fad68b0dc40dc065340f`。
- PR前 compare `main...quality/2120-2121-ci-declaration-guards`: `ahead_by:4` / `behind_by:0`、changed files 2件のみ。
- GitHub HTTPS checkout はこの環境で `CONNECT tunnel failed, response 403` のため不可。ローカル test は実行できず、PR CI を確認対象にします。
- Node regex smoke はローカルで最小確認済みです。

## リスク評価

low。2つの Node smoke script のみの変更です。workflow topology、test matrix、manifest schema、runtime behavior、public API surface は変更していません。

## 補足

- action SHA pinning や CI workflow redesign は扱っていません。現状の major tag policy を代表 signal として守る範囲に閉じています。
- TypeScript declaration generator の導入や新しい export の追加は扱っていません。