### PR TITLE
CI と configuration docs の drift guard を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs",
+    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
+    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs && node script/test_configuration_docs_signals.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs"
+
+const workflowPath = ".github/workflows/ci.yml"
+const workflowSource = readFileSync(workflowPath, "utf8")
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+function workflowJobBlock(workflowSource, jobName) {
+  const marker = `  ${jobName}:\n`
+  const start = workflowSource.indexOf(marker)
+  assert(start !== -1, `${workflowPath} must define jobs.${jobName}`)
+
+  const bodyStart = start + marker.length
+  const remainingWorkflow = workflowSource.slice(bodyStart)
+  const nextJobOffset = remainingWorkflow.search(/\n  [a-z_]+:\n/)
+
+  return nextJobOffset === -1 ? remainingWorkflow : remainingWorkflow.slice(0, nextJobOffset + 1)
+}
+
+function assertOrdered(source, earlier, later, label) {
+  const earlierIndex = source.indexOf(earlier)
+  const laterIndex = source.indexOf(later)
+
+  assert(earlierIndex !== -1, `${label}: missing ${earlier}`)
+  assert(laterIndex !== -1, `${label}: missing ${later}`)
+  assert(earlierIndex < laterIndex, `${label}: expected ${earlier} before ${later}`)
+}
+
+const changesJob = workflowJobBlock(workflowSource, "changes")
+
+const changedFileDetectionSignals = [
+  ["base ref fetch", 'git fetch origin "${{ github.base_ref }}" --depth=1'],
+  ["merge-base branch", 'git merge-base "origin/${{ github.base_ref }}" HEAD'],
+  ["three-dot diff", 'git diff --name-only "origin/${{ github.base_ref }}"...HEAD'],
+  ["fallback diff", 'git diff --name-only "origin/${{ github.base_ref }}" HEAD'],
+  ["policy invocation", 'node script/ci_changed_files_policy.mjs <<EOF >> "$GITHUB_OUTPUT"'],
+  ["changed files heredoc", "$changed_files"]
+]
+
+changedFileDetectionSignals.forEach(([label, signal]) => {
+  assertIncludes(changesJob, signal, `${workflowPath} jobs.changes changed-file detection ${label}`)
+})
+
+assertOrdered(
+  changesJob,
+  'git fetch origin "${{ github.base_ref }}" --depth=1',
+  'git merge-base "origin/${{ github.base_ref }}" HEAD',
+  `${workflowPath} jobs.changes must fetch the base ref before merge-base detection`
+)
+
+assertOrdered(
+  changesJob,
+  'git merge-base "origin/${{ github.base_ref }}" HEAD',
+  'git diff --name-only "origin/${{ github.base_ref }}"...HEAD',
+  `${workflowPath} jobs.changes must try merge-base before the three-dot diff`
+)
+
+assertOrdered(
+  changesJob,
+  'git diff --name-only "origin/${{ github.base_ref }}"...HEAD',
+  'git diff --name-only "origin/${{ github.base_ref }}" HEAD',
+  `${workflowPath} jobs.changes must keep a fallback diff after the three-dot diff path`
+)
+
+assertOrdered(
+  changesJob,
+  'git diff --name-only "origin/${{ github.base_ref }}" HEAD',
+  'node script/ci_changed_files_policy.mjs <<EOF >> "$GITHUB_OUTPUT"',
+  `${workflowPath} jobs.changes must pass the collected file list into the policy script`
+)
+
+console.log("Checked CI changed-file detection workflow signals.")

--- a/script/test_configuration_docs_signals.mjs
+++ b/script/test_configuration_docs_signals.mjs
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const manifest = read("config/public_api_manifest.yml")
+const publicApiDocs = [
+  ["docs/en/public-api.md", read("docs/en/public-api.md")],
+  ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
+]
+const renderLogLevelDocs = [
+  ["docs/en/render-log-level.md", read("docs/en/render-log-level.md")],
+  ["docs/ja/render-log-level.md", read("docs/ja/render-log-level.md")]
+]
+
+const configurationOptionSignals = ["initial_state", "render_log_level"]
+const configurationEntrypointSignals = [
+  "TreeView.configure",
+  "TreeView.configuration",
+  "TreeView.reset_configuration!"
+]
+
+assertIncludes(manifest, "configuration_options:", "public API manifest configuration option surface")
+assertIncludes(manifest, "tree_view_configure:", "public API manifest TreeView.configure option surface")
+configurationOptionSignals.forEach((signal) => {
+  assertIncludes(manifest, `- ${signal}`, "public API manifest TreeView.configure option names")
+})
+
+publicApiDocs.forEach(([relativePath, document]) => {
+  configurationEntrypointSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} configuration entrypoint docs`)
+  })
+
+  configurationOptionSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} configuration option docs`)
+  })
+
+  assertIncludes(document, "render-log-level.md", `${relativePath} render_log_level docs link`)
+  assertIncludes(document, "config/public_api_manifest.yml", `${relativePath} manifest-backed configuration docs`)
+  assertIncludes(document, "accepted value", `${relativePath} configuration accepted-value boundary docs`)
+
+  assert(
+    /manifest.*option names|manifest.*option 名|option names.*manifest|option 名.*manifest/.test(document),
+    `${relativePath}: configuration docs must say the manifest tracks option names rather than a separate value schema`
+  )
+})
+
+renderLogLevelDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeView.configure", `${relativePath} configuration entrypoint docs`)
+  assertIncludes(document, "config/public_api_manifest.yml", `${relativePath} manifest-backed option docs`)
+
+  configurationOptionSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} configuration option docs`)
+  })
+
+  ;[":expanded", ":collapsed", ":debug", ":info", ":warn", ":error", ":fatal", ":unknown", "nil"].forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} accepted configuration value docs`)
+  })
+
+  assertIncludes(document, "Rails.logger.level", `${relativePath} host-app logging boundary docs`)
+  assertIncludes(document, "TreeView::ConfigurationError", `${relativePath} invalid initial_state boundary docs`)
+})
+
+console.log("Checked configuration option manifest and docs signals.")


### PR DESCRIPTION
## 対応 Issue

Closes #2124
Closes #2125

## Issue ごとの完了内容

- #2124: `.github/workflows/ci.yml` の `changes` job が base ref fetch、merge-base 判定、three-dot diff、fallback diff、changed-file policy script 呼び出しを保つことを軽量 smoke で確認するようにしました。
- #2125: `config/public_api_manifest.yml` の `TreeView.configure` option names と、英日 Public API / Render log level docs の代表 signal が同期していることを専用 smoke で確認するようにしました。

## 変更内容

- `script/test_ci_workflow_changed_file_detection_signals.mjs` を追加しました。
- `script/test_configuration_docs_signals.mjs` を追加しました。
- `package.json` の既存 npm scripts へ接続し、`npm run test:ci-policy` と `npm run test:docs-entrypoints` の通常導線で実行されるようにしました。

## 改善カテゴリ

- テスト追加
- CI drift guard
- docs/public API signal guard

## 既存仕様への影響

runtime Ruby / JavaScript、CI workflow の実行条件、public API manifest schema、docs 本文は変更していません。既存の挙動を変えず、現在の contract が落ちた時に検出する guard 追加だけです。

## 実施した確認

- Issue #2124 / #2125 の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- #2124 / #2125 を担当する既存 open PR がないことを確認しました。
- compare `main...chore/2124-configuration-ci-guards`: `ahead_by:3` / `behind_by:0` / changed files 3。
- PR metadata: `mergeable:true`。
- GitHub Actions CI #2851 / run `27533296092`: success。
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success (`npm run test:js:core`)
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `gem_package`: success
  - `docker_development_setup`: success
  - `ruby_matrix` / `rails_matrix`: push-to-main only のため skipped
- local checkout / local npm test は、この環境から GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認済みです。

## リスク評価

low。新規 smoke script と npm script 接続のみで、既存の workflow behavior や docs content は変更していません。

## 補足事項

- rails_fields_kit #1189 は eligible labels を持ちますが、既に current main の helper return shape と Issue 前提が合わないことをコメント済みだったため、重複 PR / 重複コメントは作成していません。
- merge は行いません。