### PR TITLE
CHANGELOG に CI / configuration guard 追加を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ Release preparation notes:
 - Added maintenance guard coverage for Ruby version source drift, grouped package contents verification, and Public API manifest event classification.
 - Added docs smoke and package verification coverage for grouped RenderState option docs signals, Public Setup Surface reader journeys, and README-linked public JavaScript / setup docs packaging.
 - Added setup generator optional-argument manifest guard coverage and release-note candidate docs package verification.
+- Added CI changed-file detection workflow signal and configuration docs signal coverage for base-ref diff routing and `TreeView.configure` option docs.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / 背景

Refs #2124
Refs #2125
Refs #2126

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2126 が main に入り、次の guard が追加されました。

- CI changes job の changed-file detection workflow signal guard
- `configuration_options` manifest と英日 configuration docs signal の同期 guard

`CHANGELOG.md` の `Unreleased > Tests` には #2126 の release-facing test evidence がまだ入っていなかったため、docs-only で1行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、CI changed-file detection workflow signal と configuration docs signal coverage の1行を追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- CI workflow
- public API manifest schema / values
- configuration behavior
- docs 本文

## 確認内容

- Default PR Check として #2030 / #2074 を確認し、latest main 追従を実施しました。
  - #2030: head `2455cfd2ae8411fc30495ce9563c93573701cc16`、compare `ahead_by:13` / `behind_by:0`、CI #2858 success。残る gate は `TreeViewControllerEntries` の public API stance human review です。
  - #2074: head `49c3ee9a613eccb2bd6c3a17fbf1735698b2378e`、compare `ahead_by:9` / `behind_by:0`、CI #2859 success。残る gate は Mode E section の desktop / narrow viewport browser-capable visual evidence です。
- #2124 / #2125 が #2126 で completed close 済みであることを確認しました。
- compare `main...docs/changelog-ci-config-guards`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` の1件のみ / additions 1 / deletions 0。

merge は行いません。