### PR TITLE
public API / docs guard の可観測性を補強する

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs && node script/test_configuration_docs_signals.mjs",
-    "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
+    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
+    "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"
   },

--- a/script/test_controller_entries_contract.mjs
+++ b/script/test_controller_entries_contract.mjs
@@ -1,0 +1,111 @@
+import { execFileSync } from "node:child_process"
+
+function loadJavascriptPackageManifest() {
+  try {
+    return JSON.parse(
+      execFileSync(
+        "ruby",
+        [
+          "-e",
+          [
+            'require "json"',
+            'require "yaml"',
+            'data = YAML.load_file("config/public_api_manifest.yml")',
+            'print JSON.generate(data.fetch("javascript_package_root"))'
+          ].join("; ")
+        ],
+        { encoding: "utf8" }
+      )
+    )
+  } catch (error) {
+    const rubyOutput = [error.stdout, error.stderr]
+      .filter((output) => output && output.length > 0)
+      .join("\n")
+      .trim()
+    const detail = rubyOutput || error.message
+
+    throw new Error(
+      [
+        "Could not load config/public_api_manifest.yml for the controller entries contract smoke.",
+        "Run this command from the repository root with Ruby available, or inspect javascript_package_root.controller_registrations.",
+        `Loader output: ${detail}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertControllerEntry(entry, expected, index) {
+  const label = `TreeViewControllerEntries[${index}] (${expected.key})`
+
+  assert(entry && typeof entry === "object" && !Array.isArray(entry), `${label} must be an object entry`)
+  assert(Object.isFrozen(entry), `${label} is not frozen`)
+  assert(entry.key === expected.key, `${label} key drift: expected ${expected.key}, actual ${entry.key}`)
+  assert(
+    entry.identifier === expected.identifier,
+    `${label} identifier drift: expected ${expected.identifier}, actual ${entry.identifier}`
+  )
+  assert(
+    entry.controller === expected.controller,
+    `${label} controller drift: expected ${expected.exportName}, actual controller reference changed`
+  )
+}
+
+const javascriptPackageManifest = loadJavascriptPackageManifest()
+const entrypointModule = await import(new URL("../app/javascript/tree_view/index.js", import.meta.url).href)
+
+const expectedEntries = javascriptPackageManifest.controller_registrations.map(
+  ({ key, identifier, export: exportName }) => {
+    assert(exportName in entrypointModule, `${exportName} export is missing for controller entry ${key}`)
+
+    return {
+      key,
+      identifier,
+      exportName,
+      controller: entrypointModule[exportName]
+    }
+  }
+)
+
+const actualEntries = entrypointModule.TreeViewControllerEntries
+assert(Array.isArray(actualEntries), "TreeViewControllerEntries must be an array")
+assert(Object.isFrozen(actualEntries), "TreeViewControllerEntries array is not frozen")
+assert(
+  actualEntries.length === expectedEntries.length,
+  `TreeViewControllerEntries count drift: expected ${expectedEntries.length}, actual ${actualEntries.length}`
+)
+
+expectedEntries.forEach((expected, index) => {
+  assertControllerEntry(actualEntries[index], expected, index)
+})
+
+const application = {
+  calls: [],
+  register(identifier, controller) {
+    this.calls.push([identifier, controller])
+  }
+}
+
+entrypointModule.registerTreeViewControllers(application)
+assert(
+  application.calls.length === actualEntries.length,
+  `registerTreeViewControllers call count drift: expected ${actualEntries.length}, actual ${application.calls.length}`
+)
+
+actualEntries.forEach((entry, index) => {
+  const [identifier, controller] = application.calls[index] || []
+  const label = `registerTreeViewControllers call ${index + 1} (${entry.key})`
+
+  assert(
+    identifier === entry.identifier,
+    `${label} identifier drift: expected ${entry.identifier}, actual ${identifier}`
+  )
+  assert(
+    controller === entry.controller,
+    `${label} controller drift: expected TreeViewControllerEntries.${entry.key}.controller`
+  )
+})

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -32,6 +32,11 @@ const checks = [
     args: ["script/test_public_setup_surface_docs_signals.mjs"]
   },
   {
+    group: "Configuration docs signals",
+    command: "node",
+    args: ["script/test_configuration_docs_signals.mjs"]
+  },
+  {
     group: "Breadcrumb docs signals",
     command: "node",
     args: ["script/test_breadcrumb_docs_signals.mjs"]
@@ -80,6 +85,11 @@ const checks = [
     group: "Public API docs signals",
     command: "node",
     args: ["script/test_public_api_docs_signals.mjs"]
+  },
+  {
+    group: "tree_view_rows helper docs signals",
+    command: "node",
+    args: ["script/test_tree_view_rows_docs_signals.mjs"]
   },
   {
     group: "RenderState grouped option docs signals",

--- a/script/test_tree_view_rows_docs_signals.mjs
+++ b/script/test_tree_view_rows_docs_signals.mjs
@@ -1,0 +1,118 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function loadTreeViewRowsOptionKeys() {
+  try {
+    return JSON.parse(
+      execFileSync(
+        "ruby",
+        [
+          "-e",
+          [
+            'require "json"',
+            'require "yaml"',
+            'data = YAML.load_file("config/public_api_manifest.yml")',
+            'print JSON.generate(data.fetch("helper_option_keys").fetch("tree_view_rows"))'
+          ].join("; ")
+        ],
+        { encoding: "utf8" }
+      )
+    )
+  } catch (error) {
+    const rubyOutput = [error.stdout, error.stderr]
+      .filter((output) => output && output.length > 0)
+      .join("\n")
+      .trim()
+    const detail = rubyOutput || error.message
+
+    throw new Error(
+      [
+        "Could not load helper_option_keys.tree_view_rows from config/public_api_manifest.yml.",
+        "The docs signal smoke expects the manifest to track mode, collapsed, and window as the public tree_view_rows option keys.",
+        `Loader output: ${detail}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const treeViewRowsOptionKeys = loadTreeViewRowsOptionKeys()
+const expectedOptionKeys = ["mode", "collapsed", "window"]
+
+expectedOptionKeys.forEach((key) => {
+  assert(
+    treeViewRowsOptionKeys.includes(key),
+    `config/public_api_manifest.yml helper_option_keys.tree_view_rows is missing ${key}`
+  )
+})
+
+assert(
+  treeViewRowsOptionKeys.length === new Set(treeViewRowsOptionKeys).size,
+  "config/public_api_manifest.yml helper_option_keys.tree_view_rows contains duplicate keys"
+)
+
+const publicApiDocs = [
+  ["docs/en/public-api.md", read("docs/en/public-api.md")],
+  ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
+]
+
+publicApiDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "tree_view_rows(render_state)", `${relativePath} stable helper entrypoint`)
+  assertIncludes(
+    document,
+    "tree_view_rows(render_state, window: { offset:, limit: })",
+    `${relativePath} windowed tree_view_rows entrypoint`
+  )
+  assertIncludes(
+    document,
+    "tree_view_rows(render_state, window: nil)",
+    `${relativePath} public helper surface option signature`
+  )
+  assertIncludes(
+    document,
+    "tree_view_window(render_state, offset:, limit:)",
+    `${relativePath} companion metadata helper entrypoint`
+  )
+})
+
+const windowedRenderingDocs = [
+  ["docs/en/windowed-rendering.md", read("docs/en/windowed-rendering.md")],
+  ["docs/ja/windowed-rendering.md", read("docs/ja/windowed-rendering.md")]
+]
+
+windowedRenderingDocs.forEach(([relativePath, document]) => {
+  assertIncludes(
+    document,
+    "tree_view_rows(@render_state, window: { offset: 0, limit: 50 })",
+    `${relativePath} tree_view_rows window usage`
+  )
+  assertIncludes(
+    document,
+    "tree_view_window(@render_state, offset: 0, limit: 50)",
+    `${relativePath} tree_view_window metadata usage`
+  )
+  assert(
+    /route helper|URL parameter|pagination controls|pagination policy|route や UI policy|route helper、URL parameter、disabled button/.test(document),
+    `${relativePath}: windowed rendering docs no longer separate tree_view_rows row rendering from host-app pagination and route ownership`
+  )
+  assert(
+    /virtual scrolling in the host app|host app側でvirtual scrolling/.test(document),
+    `${relativePath}: windowed rendering docs no longer keep virtual scrolling outside the tree_view_rows option surface`
+  )
+})


### PR DESCRIPTION
## 対応 Issue

Closes #2127
Closes #2128
Closes #2129

## Issue ごとの完了内容

- #2127: `TreeViewControllerEntries` の frozen array / frozen entries / `key` / `identifier` / `controller` を manifest-backed registrations と比較する focused smoke を追加しました。`registerTreeViewControllers(application)` の登録順・identifier・controller class も同じ entries と比較します。
- #2128: `helper_option_keys.tree_view_rows` の `mode` / `collapsed` / `window` と、英日 Public API / Windowed Rendering docs の代表 signal を確認する focused docs smoke を追加しました。
- #2129: `script/test_configuration_docs_signals.mjs` を docs entrypoint suite の通常 group に追加し、`--list` / `--only` から見えるようにしました。`package.json` 側の直列実行は外し、suite 経由で一度だけ実行します。

## 変更内容

- `script/test_controller_entries_contract.mjs` を追加
- `script/test_tree_view_rows_docs_signals.mjs` を追加
- `script/test_docs_entrypoint_suite.mjs` に configuration docs / tree_view_rows docs の group を追加
- `package.json` の `test:entrypoints` / `test:docs-entrypoints` を smoke 追加と重複排除に合わせて更新

## 改善カテゴリ

- test / docs smoke hardening
- public API drift guard
- CI/docs suite observability

## 既存仕様への影響

runtime Ruby / JavaScript、public API manifest schema、controller identifiers、registration behavior、helper behavior、docs 本文は変更していません。既存 contract を検出しやすくする smoke と実行導線の整理だけです。

## 実施した確認

- Issue #2127 / #2128 / #2129 の labels を個別取得で確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- compare `main...quality/2127-entrypoint-docs-guards`: `ahead_by:4` / `behind_by:0` / changed files 4。
- 変更ファイルが `package.json`, `script/test_docs_entrypoint_suite.mjs`, `script/test_controller_entries_contract.mjs`, `script/test_tree_view_rows_docs_signals.mjs` に限定されることを確認しました。
- local checkout / local Node test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 contract の smoke 強化と suite 接続のみで、公開挙動・UI・API・DB・認可・外部サービス契約には触れていません。

## 補足事項

- `tree_view_rows` docs signal は既存 docs の代表文字列を確認し、full markdown parser や全文一致には広げていません。
- merge は行いません。