### PR TITLE
CHANGELOG に controller entries docs guard 追加を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Release preparation notes:
 - Added docs smoke and package verification coverage for grouped RenderState option docs signals, Public Setup Surface reader journeys, and README-linked public JavaScript / setup docs packaging.
 - Added setup generator optional-argument manifest guard coverage and release-note candidate docs package verification.
 - Added CI changed-file detection workflow signal and configuration docs signal coverage for base-ref diff routing and `TreeView.configure` option docs.
+- Added controller entries contract smoke and `tree_view_rows` / Windowed Rendering docs signal coverage to the docs entrypoint suite.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue

Closes #2133

## 分類

- `code-ahead-of-docs`
- `docs-sync`

## 背景

#2131 が main に入り、次の maintenance guard が追加されました。

- `TreeViewControllerEntries` の manifest-backed controller registration contract smoke
- `tree_view_rows` helper option / Windowed Rendering docs signal smoke
- docs entrypoint suite 上の configuration docs / tree_view_rows docs signal group 可観測性

`CHANGELOG.md` の `Unreleased > Tests` にこの release-facing test evidence がまだ入っていなかったため、docs-only で1行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、controller entries contract smoke と `tree_view_rows` / Windowed Rendering docs signal coverage の1行を追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- CI workflow
- public API docs 本文
- public API manifest

## 確認内容

- Default PR Check として #2030 を確認し、`behind_by:0` / CI success / docs-only だが `TreeViewControllerEntries` の public API stance が human review gate のため追加修正しませんでした。
- #2131 が 2026-06-15 に merge済みであることを確認しました。
- #2133 の内容と current `CHANGELOG.md` を確認し、#2131 の guard coverage が未反映であることを確認しました。
- 重複 open PR は `controller entries` / `tree_view_rows` / `CHANGELOG` で見当たりませんでした。
- compare `main...docs/2133-changelog-controller-entries-tree-view-rows`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` の1件のみ / additions 1 / deletions 0。

merge は行いません。