### PR TITLE
Add Docker Ruby base image source guard

### DIFF
--- a/script/test_ruby_version_sources.mjs
+++ b/script/test_ruby_version_sources.mjs
@@ -13,6 +13,7 @@ const expectedReadmeSignal = `Ruby ${minimumRubyVersion} or later`;
 const readme = read("README.md");
 const gemspec = read("tree_view.gemspec");
 const workflow = read(".github/workflows/ci.yml");
+const dockerfile = read("Dockerfile");
 const englishDevelopment = read("docs/en/development.md");
 const japaneseDevelopment = read("docs/ja/development.md");
 const packageJson = JSON.parse(read("package.json"));
@@ -35,6 +36,18 @@ assertIncludes(workflow, '- "3.3"', ".github/workflows/ci.yml");
 assertIncludes(workflow, "ruby_matrix:", ".github/workflows/ci.yml");
 assertIncludes(workflow, "rails_matrix:", ".github/workflows/ci.yml");
 
+const dockerRubyBaseImage = dockerfile.match(/^FROM ruby:(?<version>\d+\.\d+(?:\.\d+)?)-slim$/m);
+assert.ok(
+  dockerRubyBaseImage,
+  "Dockerfile must use a ruby:<major.minor[.patch]>-slim base image for development setup"
+);
+const [dockerRubyMajor, dockerRubyMinor] = dockerRubyBaseImage.groups.version.split(".");
+assert.equal(
+  `${dockerRubyMajor}.${dockerRubyMinor}`,
+  minimumRubyVersion,
+  `Dockerfile Ruby base image must stay on the minimum supported Ruby ${minimumRubyVersion}.x line for development setup; found ${dockerRubyBaseImage.groups.version}`
+);
+
 assert.equal(
   packageJson.scripts["test:ruby-version-sources"],
   "node script/test_ruby_version_sources.mjs",
@@ -56,5 +69,5 @@ assert.ok(
 });
 
 console.log(
-  `Ruby version sources stay aligned with Ruby ${minimumRubyVersion}+ and representative Ruby ${minimumRubyVersion}/${currentRubyVersion} CI lanes.`
+  `Ruby version sources stay aligned with Ruby ${minimumRubyVersion}+ and representative Ruby ${minimumRubyVersion}/${currentRubyVersion} CI lanes, plus Docker Ruby ${dockerRubyBaseImage.groups.version}.`
 );


### PR DESCRIPTION
## 対応 Issue
- Closes #2132

## Issue ごとの完了内容
- #2132: `script/test_ruby_version_sources.mjs` が `Dockerfile` の `FROM ruby:<major.minor[.patch]>-slim` を読み取り、development Docker image の Ruby base image が minimum supported Ruby 3.2 系から drift していないことを guard するようにしました。

## 変更内容
- 既存 Ruby version source guard に `Dockerfile` 読み取りを追加
- Docker base image の Ruby major/minor が `minimumRubyVersion` と一致することを検証
- failure message から `Dockerfile` と期待 Ruby policy が分かるように整理

## 改善カテゴリ
- test
- devops guard hardening

## 既存仕様への影響
- Dockerfile、Ruby support policy、gemspec、CI matrix、package scripts は変更していません。
- 既存の公開挙動・API・UI・DB・認可には影響しません。

## 実施した確認
- GitHub connector で `main` との差分確認: `script/test_ruby_version_sources.mjs` のみ変更、branch behind 0
- Node ES module syntax check: pass

補足: この実行環境では GitHub への `git ls-remote` が `CONNECT tunnel failed, response 403` で通らないため、ローカル checkout での `npm run test:ruby-version-sources` は実行できませんでした。差分は connector 上で確認しています。

## リスク評価
Low。既存 guard に Dockerfile の代表 signal を追加するだけで、Docker image policy や supported Ruby minimum は変更していません。