### PR TITLE
Guard Docker development setup workflow wiring

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -227,6 +227,32 @@ assertJobMatches(javascriptJob, /uses: actions\/setup-node@v6/, `${workflowPath}
 assertJobMatches(javascriptJob, /node-version: "22"/, `${workflowPath} jobs.javascript must keep the Node 22 CI lane`);
 assertJobMatches(javascriptJob, /cache: npm/, `${workflowPath} jobs.javascript must keep npm cache enabled`);
 
+const dockerDevelopmentSetupJob = workflowJobBlock(workflowSource, "docker_development_setup");
+assertJobMatches(
+  dockerDevelopmentSetupJob,
+  /if: github\.event_name == 'pull_request' && needs\.changes\.outputs\.docker_setup_sensitive == 'true'/,
+  `${workflowPath} jobs.docker_development_setup must stay gated by docker_setup_sensitive pull request changes`
+);
+assertJobMatches(
+  dockerDevelopmentSetupJob,
+  /needs: changes/,
+  `${workflowPath} jobs.docker_development_setup must depend on changed-file detection`
+);
+assertJobMatches(
+  dockerDevelopmentSetupJob,
+  /run: docker compose build app/,
+  `${workflowPath} jobs.docker_development_setup must keep the Docker app build smoke`
+);
+assertJobMatches(
+  dockerDevelopmentSetupJob,
+  /run: docker compose run --rm app/,
+  `${workflowPath} jobs.docker_development_setup must keep the Docker app setup smoke`
+);
+assert.ok(
+  dockerDevelopmentSetupJob.includes('node --version | grep -E "^v22\\." && npm --version && npm install'),
+  `${workflowPath} jobs.docker_development_setup must keep the representative Node/npm setup smoke`
+);
+
 const gemPackageJob = workflowJobBlock(workflowSource, "gem_package");
 assertJobMatches(gemPackageJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.gem_package must keep Ruby 3.3`);
 assertJobMatches(gemPackageJob, /bundler-cache: true/, `${workflowPath} jobs.gem_package must keep bundler-cache enabled`);


### PR DESCRIPTION
## 対応 Issue
- Closes #2134

## Issue ごとの完了内容
- #2134: `script/test_ci_changed_files_policy.mjs` が `.github/workflows/ci.yml` の `docker_development_setup` job wiring を監視するようにしました。

## 変更内容
- `docker_development_setup` job block の存在を既存 helper で取得
- `docker_setup_sensitive` pull request gate、`needs: changes`、`docker compose build app`、`docker compose run --rm app`、Node/npm setup smoke の代表 signal を guard
- workflow 実装や changed-file policy の分類ロジックは変更なし

## 改善カテゴリ
- test
- CI guard hardening

## 既存仕様への影響
- `.github/workflows/ci.yml`、Dockerfile、docker-compose、Ruby/Node version、npm install policy は変更していません。
- 既存の公開挙動・API・UI・DB・認可には影響しません。

## 実施した確認
- GitHub connector で `main` との差分確認: `script/test_ci_changed_files_policy.mjs` のみ変更、branch behind 0
- Node ES module syntax check: pass

補足: この実行環境では GitHub への `git ls-remote` が `CONNECT tunnel failed, response 403` で通らないため、ローカル checkout での `node script/test_ci_changed_files_policy.mjs` / `npm run test:entrypoints` は実行できませんでした。差分は connector 上で確認しています。

## リスク評価
Low。既存 workflow parser helper に focused assertions を追加するだけで、CI topology や Docker setup の実行内容は変更していません。