### PR TITLE
Development docs に version / CI policy guard の導線を追加する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -35,10 +35,11 @@ npm test
 npm run test:entrypoints
 npm run test:docs-entrypoints
 npm run test:node-version-sources
+npm run test:ruby-version-sources
 npm run test:browser
 ```
 
-Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, repository-only maintainer entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use `npm run test:node-version-sources` when you only need to confirm that `.nvmrc`, `package.json` `engines.node`, and CI workflow `node-version` still agree on Node 22. Use the individual npm commands when you are narrowing a failure.
+Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, repository-only maintainer entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use `npm run test:node-version-sources` when you only need to confirm that `.nvmrc`, `package.json` `engines.node`, and CI workflow `node-version` still agree on Node 22. Use `npm run test:ruby-version-sources` when you only need to confirm that the README, gemspec, CI workflow, Dockerfile Ruby base image, Development docs, and package script still agree on the supported Ruby sources and representative Ruby version matrix. Use the individual npm commands when you are narrowing a failure.
 
 For docs entrypoint suite triage, run `npm run test:docs-entrypoints -- --list` to print the numbered groups and commands. Then run `npm run test:docs-entrypoints -- --only <group-or-index>` with the 1-based number from that list, an exact group name, a case-insensitive group name, or a unique partial group name. Unknown, ambiguous, or out-of-range values exit non-zero and print the available groups plus the `--list` hint.
 

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -34,12 +34,13 @@ npm run test:js
 npm test
 npm run test:entrypoints
 npm run test:docs-entrypoints
+npm run test:ci-policy
 npm run test:node-version-sources
 npm run test:ruby-version-sources
 npm run test:browser
 ```
 
-Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, repository-only maintainer entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use `npm run test:node-version-sources` when you only need to confirm that `.nvmrc`, `package.json` `engines.node`, and CI workflow `node-version` still agree on Node 22. Use `npm run test:ruby-version-sources` when you only need to confirm that the README, gemspec, CI workflow, Dockerfile Ruby base image, Development docs, and package script still agree on the supported Ruby sources and representative Ruby version matrix. Use the individual npm commands when you are narrowing a failure.
+Use `npm run test:js` when you want the same JavaScript entrypoint, unit, and browser smoke coverage as the CI JavaScript lane. Use `npm run test:docs-entrypoints` when you are narrowing docs-only failures across docs entrypoints, repository-only maintainer entrypoints, README Quick Start signals, Public API docs signals, and i18n parity before running the broader `npm run test:entrypoints` or browser smoke checks. Use `npm run test:ci-policy` when you only need to confirm changed-file classification and workflow detection signals before the broader entrypoint suite. Use `npm run test:node-version-sources` when you only need to confirm that `.nvmrc`, `package.json` `engines.node`, and CI workflow `node-version` still agree on Node 22. Use `npm run test:ruby-version-sources` when you only need to confirm that the README, gemspec, CI workflow, Dockerfile Ruby base image, Development docs, and package script still agree on the supported Ruby sources and representative Ruby version matrix. Use the individual npm commands when you are narrowing a failure.
 
 For docs entrypoint suite triage, run `npm run test:docs-entrypoints -- --list` to print the numbered groups and commands. Then run `npm run test:docs-entrypoints -- --only <group-or-index>` with the 1-based number from that list, an exact group name, a case-insensitive group name, or a unique partial group name. Unknown, ambiguous, or out-of-range values exit non-zero and print the available groups plus the `--list` hint.
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -35,10 +35,11 @@ npm test
 npm run test:entrypoints
 npm run test:docs-entrypoints
 npm run test:node-version-sources
+npm run test:ruby-version-sources
 npm run test:browser
 ```
 
-CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、repository-only maintainer entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。`.nvmrc`、`package.json` の `engines.node`、CI workflow の `node-version` が Node 22 でそろっていることだけを確認したい場合は `npm run test:node-version-sources` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
+CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、repository-only maintainer entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。`.nvmrc`、`package.json` の `engines.node`、CI workflow の `node-version` が Node 22 でそろっていることだけを確認したい場合は `npm run test:node-version-sources` を使います。README、gemspec、CI workflow、Dockerfile の Ruby base image、Development docs、package script が supported Ruby sources と代表 Ruby version matrix に沿っていることだけを確認したい場合は `npm run test:ruby-version-sources` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
 
 Docs entrypoint suite を切り分ける場合は、`npm run test:docs-entrypoints -- --list` で番号付きの group と command を表示します。その後、`npm run test:docs-entrypoints -- --only <group-or-index>` に `--list` の 1-based 番号、完全一致の group 名、大文字小文字を問わない group 名、または一意に絞れる部分一致の group 名を渡すと、該当 group だけを実行できます。unknown、ambiguous、範囲外の値は非 0 終了し、available groups と `--list` の案内を表示します。
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -34,12 +34,13 @@ npm run test:js
 npm test
 npm run test:entrypoints
 npm run test:docs-entrypoints
+npm run test:ci-policy
 npm run test:node-version-sources
 npm run test:ruby-version-sources
 npm run test:browser
 ```
 
-CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、repository-only maintainer entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。`.nvmrc`、`package.json` の `engines.node`、CI workflow の `node-version` が Node 22 でそろっていることだけを確認したい場合は `npm run test:node-version-sources` を使います。README、gemspec、CI workflow、Dockerfile の Ruby base image、Development docs、package script が supported Ruby sources と代表 Ruby version matrix に沿っていることだけを確認したい場合は `npm run test:ruby-version-sources` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
+CI の JavaScript lane と同じ entrypoint、unit、browser smoke coverage をまとめて確認したい場合は `npm run test:js` を使います。docs-only failure を、docs entrypoints、repository-only maintainer entrypoints、README Quick Start signal、Public API docs signal、i18n parity の範囲で先に切り分けたい場合は `npm run test:docs-entrypoints` を使います。その後、より広い `npm run test:entrypoints` や browser smoke checks に進んでください。changed-file classification と workflow detection signal だけを確認したい場合は `npm run test:ci-policy` を使います。`.nvmrc`、`package.json` の `engines.node`、CI workflow の `node-version` が Node 22 でそろっていることだけを確認したい場合は `npm run test:node-version-sources` を使います。README、gemspec、CI workflow、Dockerfile の Ruby base image、Development docs、package script が supported Ruby sources と代表 Ruby version matrix に沿っていることだけを確認したい場合は `npm run test:ruby-version-sources` を使います。失敗箇所を切り分ける場合は個別の npm command を使ってください。
 
 Docs entrypoint suite を切り分ける場合は、`npm run test:docs-entrypoints -- --list` で番号付きの group と command を表示します。その後、`npm run test:docs-entrypoints -- --only <group-or-index>` に `--list` の 1-based 番号、完全一致の group 名、大文字小文字を問わない group 名、または一意に絞れる部分一致の group 名を渡すと、該当 group だけを実行できます。unknown、ambiguous、範囲外の値は非 0 終了し、available groups と `--list` の案内を表示します。
 


### PR DESCRIPTION
## Summary
- Add `npm run test:ruby-version-sources` to the English and Japanese Development docs command lists.
- Add `npm run test:ci-policy` to the same Common commands list and describe it as the focused changed-file policy / workflow detection signal guard.
- Keep the update docs-only; no guard script, package script, CI workflow, Dockerfile, Ruby support policy, or CI path classification is changed.

Closes #2139
Closes #2142

## Classification
- `code-ahead-of-docs`: `package.json` already exposes `test:ruby-version-sources` and `test:ci-policy`, and `test:entrypoints` already includes both guards.
- `docs-sync`: this PR documents existing maintenance commands without changing behavior.

## Scope
- Updated:
  - `docs/en/development.md`
  - `docs/ja/development.md`
- Not changed:
  - `script/test_ruby_version_sources.mjs`
  - `script/test_ci_changed_files_policy.mjs`
  - `script/test_ci_workflow_changed_file_detection_signals.mjs`
  - `package.json`
  - GitHub Actions workflow
  - Dockerfile / Ruby base image
  - Ruby support policy, CI matrix, or CI path classification

## Verification
- Confirmed current `package.json` includes `test:ruby-version-sources` and `test:ci-policy`, and runs both from `test:entrypoints`.
- Confirmed `test:ci-policy` maps to `script/test_ci_changed_files_policy.mjs` and `script/test_ci_workflow_changed_file_detection_signals.mjs`.
- Compared branch against current `main` `01e0fa31668fca2a53b34dd87539f950cb445561`: `ahead_by:4`, `behind_by:0`.
- Changed files are docs only:
  - `docs/en/development.md`
  - `docs/ja/development.md`
- GitHub Actions CI #2887 / run `27556482587`: success
  - `changes`, `lint`, `pr_specs`, `gem_package`: success
  - `javascript`: `npm run test:docs-entrypoints` success
  - representative Rails lanes 7.0 / 7.2 / 8.0: docs-only skip / success
- Local checkout/test はこの環境から GitHub raw/HTTPS fetch が 403 で通らないため未実行です。PR CI を確認証跡にしています。