### PR TITLE
CHANGELOG に Development docs guard 導線の追従を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Release preparation notes:
 - Clarified the CI policy split between pull request Ruby checks and broader `main` / release checks.
 - Clarified development docs for the Ruby-backed `npm run test:entrypoints` manifest loader path and setup expectations.
 - Clarified development docs that `.nvmrc`, `package.json` `engines.node`, and workflow `node-version` stay aligned by a Node version source drift guard.
+- Clarified Development docs for the Ruby version source and CI changed-file policy guard commands, including Bundler dependency package-sensitive guidance.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.


### PR DESCRIPTION
## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

最近 main に入った Development docs 更新で、Ruby version source guard、CI changed-file policy guard、Bundler dependency の package-sensitive 方針が英日 `docs/en/development.md` / `docs/ja/development.md` に揃いました。

`CHANGELOG.md` の `Unreleased > Documentation` には、この reader-facing docs 整備がまだ release evidence として要約されていなかったため、docs-only で1行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、Development docs の Ruby version source / CI changed-file policy guard command と Bundler dependency package-sensitive guidance の追従を1行追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- CI workflow
- `docs/en/development.md` / `docs/ja/development.md` 本文
- Ruby support policy
- changed-file policy behavior
- Bundler dependency update 自体

## 確認内容

- Default PR Check として #2030 / #2074 を確認しました。
  - #2030: docs-only / `behind_by:0` / CI success。残る gate は `TreeViewControllerEntries` public API stance の human review です。
  - #2074: docs mockup-only / `behind_by:0` / CI success。残る gate は Mode E section の desktop / narrow viewport browser-capable visual evidence です。
- `README.md`, `docs/README.md`, `AGENTS.md`, `Product Profile.md`, `CHANGELOG.md`, 英日 Development docs を確認しました。
- 重複 open PR / Issue は `CHANGELOG` + Ruby version / CI policy / Bundler package-sensitive で見当たりませんでした。
- compare `main...docs/changelog-development-guard-docs`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` の1件のみ / additions 1 / deletions 0。

merge は行いません。