### PR TITLE
CHANGELOG に Docker guard 追加を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ Release preparation notes:
 - Added setup generator optional-argument manifest guard coverage and release-note candidate docs package verification.
 - Added CI changed-file detection workflow signal and configuration docs signal coverage for base-ref diff routing and `TreeView.configure` option docs.
 - Added controller entries contract smoke and `tree_view_rows` / Windowed Rendering docs signal coverage to the docs entrypoint suite.
+- Added Docker Ruby base image source guard coverage to the Ruby version source drift smoke.
+- Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2137 と #2138 が main に入り、次の maintenance guard が追加されました。

- Dockerfile の Ruby base image が minimum supported Ruby から drift していないことを確認する Ruby version source guard
- `docker_development_setup` workflow wiring を確認する CI changed-file policy guard

`CHANGELOG.md` の `Unreleased > Tests` には、この release-facing test evidence がまだ入っていなかったため、docs-only で2行だけ追従します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、Docker Ruby base image source guard と Docker development setup workflow wiring guard の2行を追加しました。

## 変更範囲

- `CHANGELOG.md` の2行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- CI workflow
- Dockerfile / docker-compose
- Ruby support policy
- package scripts

## 確認内容

- Default PR Check として #2145 / #2155 / #2030 を確認しました。
  - #2155 は `package.json` / `script/test_docs_entrypoint_suite.mjs` を含む quality/test PR のため、Docs Sync Agent の docs-only follow-up 対象外です。
  - #2030 は docs-only ですが、`TreeViewControllerEntries` public API stance の human review gate が継続しています。
- #2137 / #2138 が 2026-06-15 に merge済みであることを確認しました。
- `CHANGELOG.md` の current `Unreleased > Tests` に Docker guard evidence が未反映であることを確認しました。
- 重複 open PR / Issue は `CHANGELOG Docker Ruby base image docker_development_setup` で見当たりませんでした。
- current main `bc9cf5c807701b1b425f89e616827605ce9c61b7` に force なしの merge-style refresh commit `3932270fadbb23f601f7b279e1486e49b6859960` で追従しました。
- compare `main...docs/changelog-docker-guard-evidence`: `ahead_by:2` / `behind_by:0` / `status:ahead` / changed files `CHANGELOG.md` の1件のみ / additions 2 / deletions 0。
- GitHub Actions CI #2902 / run `27576656287`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript` (`npm run test:docs-entrypoints`), representative Rails lanes 7.0 / 7.2 / 8.0: success
  - broader `ruby_matrix`, `rails_matrix`, `docker_development_setup`: docs-only skip

merge は行いません。