### PR TITLE
gem package contents guard に Development docs を追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -61,6 +61,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/public-api.md
     docs/ja/public-api.md
   ],
+  "Bilingual development docs" => %w[
+    docs/en/development.md
+    docs/ja/development.md
+  ],
   "README-linked public JavaScript docs" => %w[
     docs/en/js-events.md
     docs/ja/js-events.md


### PR DESCRIPTION
## 対応 Issue

Closes #2159

## Issue ごとの完了内容

- #2159: `script/check_gem_package_contents.rb` の representative packaged path groups に `Bilingual development docs` を追加しました。
- #2159: `docs/en/development.md` / `docs/ja/development.md` が built gem から欠けた場合に、missing group 名として Development docs が分かるようにしました。

## 変更内容

- `REQUIRED_PACKAGED_PATH_GROUPS` に専用 group `Bilingual development docs` を追加しました。
- `tree_view.gemspec` の package glob、CI workflow、Development docs 本文は変更していません。

## 改善カテゴリ

- test
- package verification
- docs drift guard

## 既存仕様への影響

runtime Ruby / JavaScript、public API、package対象、CI topology、Development docs 本文には影響ありません。既存 `docs/**/*` package対象の代表 guard を1 group 増やすだけです。

## 実施した確認

- Issue #2159 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff で #2156 / #2157 を吸収しない指定を確認し、#2159 単独の変更にしました。
- compare `main...quality/2159-development-docs-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- changed files は `script/check_gem_package_contents.rb` のみです。
- local checkout / local `gem build` / checker 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

Low. 既存 package contents checker の代表 path group 追加のみです。

## 補足事項

merge は行いません。