### PR TITLE
gem package guard と release:check を同期する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -73,7 +73,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, verifies the gem can be built, confirms release-facing files are packaged, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The main-push `gem_package` CI job additionally runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem so representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, and public API manifest files remain packaged. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
+`bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, builds the gem, confirms release-facing files are packaged, runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The package contents guard checks representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, public API manifest, public runtime files, and gem metadata URI surfaces. The main-push `gem_package` CI job repeats the same package contents verification against its built gem. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
 
 Pull request CI checks:
 
@@ -90,7 +90,7 @@ Main-push CI checks:
 - Ruby version matrix
 - Rails version matrix
 - JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
-- Gem package verification, including representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, and public API manifest file contents
+- Gem package verification, including representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, public API manifest, public runtime files, and gem metadata URI contents
 
 PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes full compatibility matrices, JavaScript coverage, and unconditional package verification.
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -73,7 +73,7 @@ bundle exec rake
 npm run test:js
 ```
 
-`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。main-push の `gem_package` CI job では、built gem に Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest の代表ファイルが残っていることを `ruby script/check_gem_package_contents.rb tree_view-*.gem` でも確認します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
+`bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、built gem に対する `ruby script/check_gem_package_contents.rb tree_view-*.gem`、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。package contents guard は Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest / public runtime files / gem metadata URI の代表surfaceを確認します。main-push の `gem_package` CI job でも、同じ package contents verification を CI で build した gem に対して再実行します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
 
 Pull Request CI の確認項目:
 
@@ -90,7 +90,7 @@ package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_
 - Ruby version matrix
 - Rails version matrix
 - `package-lock.json` が `package.json` と同期するまでの間は、`npm install` と `npm run test:js` による JavaScript tests
-- Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest の代表ファイルを含む Gem package verification
+- Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest / public runtime files / gem metadata URI の代表ファイルとmetadataを含む Gem package verification
 
 merge前にPR CIを通します。release判定には、full compatibility matrices、JavaScript coverage、unconditional package verificationを含む、より広い `main` CIを使います。
 

--- a/lib/tree_view/release_check.rb
+++ b/lib/tree_view/release_check.rb
@@ -113,6 +113,7 @@ module TreeView
       def verify_package!
         gem_file_name = build_gem!
         verify_packaged_files!(gem_file_name)
+        verify_package_contents!(gem_file_name)
         verify_library_load!
       end
 
@@ -143,6 +144,18 @@ module TreeView
         return if missing.empty?
 
         raise Failure, "built gem is missing required release files: #{missing.join(", ")}"
+      end
+
+      def verify_package_contents!(gem_file_name)
+        stdout.puts("Running ruby script/check_gem_package_contents.rb #{gem_file_name}")
+
+        output, errors, status = Open3.capture3(RbConfig.ruby, "script/check_gem_package_contents.rb", gem_file_name, chdir: root)
+        stdout.print(output) unless output.empty?
+        stdout.print(errors) unless errors.empty?
+
+        return if status.success?
+
+        raise Failure, "script/check_gem_package_contents.rb failed for #{gem_file_name}"
       end
 
       def verify_library_load!

--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "rubygems/package"
+require "yaml"
 
 # Keep representative English and Japanese files in these groups so package
 # verification covers the bilingual locale, public API, docs entrypoints,
@@ -85,6 +86,40 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
 
 REQUIRED_PACKAGED_PATHS = REQUIRED_PACKAGED_PATH_GROUPS.values.flatten.freeze
 
+EXPECTED_GEM_METADATA = {
+  "homepage_uri" => "https://github.com/matsuo-haruhito/tree_view-rails",
+  "source_code_uri" => "https://github.com/matsuo-haruhito/tree_view-rails",
+  "changelog_uri" => "https://github.com/matsuo-haruhito/tree_view-rails/blob/main/CHANGELOG.md",
+  "bug_tracker_uri" => "https://github.com/matsuo-haruhito/tree_view-rails/issues"
+}.freeze
+
+PUBLIC_CONSTANT_RUNTIME_FILES = {
+  "Error" => "lib/tree_view/errors.rb",
+  "ConfigurationError" => "lib/tree_view/errors.rb",
+  "InvalidTreeError" => "lib/tree_view/errors.rb",
+  "DuplicateNodeKeyError" => "lib/tree_view/errors.rb",
+  "CycleDetectedError" => "lib/tree_view/errors.rb",
+  "InvalidRenderWindowError" => "lib/tree_view/errors.rb",
+  "Configuration" => "lib/tree_view/configuration.rb",
+  "LocalizedNames" => "lib/tree_view/localized_names.rb",
+  "Tree" => "lib/tree_view/tree.rb",
+  "RenderState" => "lib/tree_view/render_state.rb",
+  "ResourceTableRenderState" => "lib/tree_view/resource_table_render_state.rb",
+  "VisibleRows" => "lib/tree_view/visible_rows.rb",
+  "RenderWindow" => "lib/tree_view/render_window.rb",
+  "FilteredTree" => "lib/tree_view/filtered_tree.rb",
+  "UiConfig" => "lib/tree_view/ui_config.rb",
+  "UiConfigBuilder" => "lib/tree_view/ui_config_builder.rb",
+  "GraphAdapter" => "lib/tree_view/graph_adapter.rb",
+  "NodePresenter" => "lib/tree_view/node_presenter.rb",
+  "PathTree" => "lib/tree_view/path_tree.rb",
+  "PathTreeBuilder" => "lib/tree_view/path_tree_builder.rb",
+  "ReverseTree" => "lib/tree_view/reverse_tree.rb",
+  "PersistedState" => "lib/tree_view/persisted_state.rb",
+  "StateStore" => "lib/tree_view/state_store.rb",
+  "Diagnostics" => "lib/tree_view/diagnostics.rb"
+}.freeze
+
 INSTALLATION_DOC_PATHS = %w[
   docs/en/installation.md
   docs/ja/installation.md
@@ -117,11 +152,21 @@ gem_path = ARGV.first || Dir[File.join(root, "tree_view-*.gem")].max_by { |path|
 
 abort "No built gem found. Run `gem build tree_view.gemspec` first." unless gem_path
 
-files = Gem::Package.new(gem_path).spec.files
+package_spec = Gem::Package.new(gem_path).spec
+files = package_spec.files
+manifest = YAML.load_file(File.join(root, "config/public_api_manifest.yml"))
 missing_by_group = REQUIRED_PACKAGED_PATH_GROUPS.transform_values do |paths|
   paths.reject { |path| files.include?(path) }
 end.reject { |_group, paths| paths.empty? }
 missing = missing_by_group.values.flatten
+missing_gem_metadata = EXPECTED_GEM_METADATA.reject do |key, expected_value|
+  package_spec.metadata[key] == expected_value
+end
+missing_manifest_constant_paths = manifest.fetch("public_constants").to_h do |constant|
+  expected_path = PUBLIC_CONSTANT_RUNTIME_FILES[constant]
+  [constant, expected_path] unless expected_path && files.include?(expected_path)
+end.compact
+unknown_manifest_constants = manifest.fetch("public_constants") - PUBLIC_CONSTANT_RUNTIME_FILES.keys
 missing_installation_signals = INSTALLATION_DOC_PATHS.to_h do |path|
   content = File.read(File.join(root, path))
   [path, INSTALLATION_REQUIRED_SIGNALS.reject { |signal| content.include?(signal) }]
@@ -135,7 +180,7 @@ importmap_path = File.join(root, "config/importmap.tree_view.rb")
 importmap_content = File.read(importmap_path)
 importmap_pin_missing = !importmap_content.include?("pin \"tree_view\", to: \"tree_view/index.js\"")
 
-if missing.empty? && missing_installation_signals.empty? && forbidden_packaged_doc_links.empty? && !importmap_pin_missing
+if missing.empty? && missing_gem_metadata.empty? && missing_manifest_constant_paths.empty? && unknown_manifest_constants.empty? && missing_installation_signals.empty? && forbidden_packaged_doc_links.empty? && !importmap_pin_missing
   puts "Gem package contents verified: #{File.basename(gem_path)}"
 else
   warn "Gem package contents verification failed: #{File.basename(gem_path)}"
@@ -143,6 +188,26 @@ else
   missing_by_group.each do |group, paths|
     warn "Missing packaged files for #{group}:"
     paths.each { |path| warn "  - #{path}" }
+  end
+
+  unless missing_gem_metadata.empty?
+    warn "Missing or unexpected gem metadata URI values:"
+    missing_gem_metadata.each do |key, expected_value|
+      actual_value = package_spec.metadata[key]
+      warn "  - #{key}: expected #{expected_value.inspect}, got #{actual_value.inspect}"
+    end
+  end
+
+  unless missing_manifest_constant_paths.empty?
+    warn "Missing manifest-listed public Ruby runtime files:"
+    missing_manifest_constant_paths.each do |constant, expected_path|
+      warn "  - #{constant}: expected packaged file #{expected_path || "<no mapping>"}"
+    end
+  end
+
+  unless unknown_manifest_constants.empty?
+    warn "Public constants missing package guard mappings:"
+    unknown_manifest_constants.each { |constant| warn "  - #{constant}" }
   end
 
   missing_installation_signals.each do |path, signals|

--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -162,10 +162,10 @@ missing = missing_by_group.values.flatten
 missing_gem_metadata = EXPECTED_GEM_METADATA.reject do |key, expected_value|
   package_spec.metadata[key] == expected_value
 end
-missing_manifest_constant_paths = manifest.fetch("public_constants").to_h do |constant|
+missing_manifest_constant_paths = manifest.fetch("public_constants").each_with_object({}) do |constant, missing_paths|
   expected_path = PUBLIC_CONSTANT_RUNTIME_FILES[constant]
-  [constant, expected_path] unless expected_path && files.include?(expected_path)
-end.compact
+  missing_paths[constant] = expected_path unless expected_path && files.include?(expected_path)
+end
 unknown_manifest_constants = manifest.fetch("public_constants") - PUBLIC_CONSTANT_RUNTIME_FILES.keys
 missing_installation_signals = INSTALLATION_DOC_PATHS.to_h do |path|
   content = File.read(File.join(root, path))

--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -99,7 +99,7 @@ const packageContentsVerificationSignals = [
     "docs/en/release.md",
     [
       "ruby script/check_gem_package_contents.rb tree_view-*.gem",
-      "representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, and public API manifest",
+      "representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, public API manifest, public runtime files, and gem metadata URI surfaces",
       "Package-sensitive PR paths include `tree_view.gemspec`",
       "Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`",
       "config/importmap.tree_view.rb",
@@ -113,7 +113,7 @@ const packageContentsVerificationSignals = [
     "docs/ja/release.md",
     [
       "ruby script/check_gem_package_contents.rb tree_view-*.gem",
-      "Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest",
+      "Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest / public runtime files / gem metadata URI",
       "package-sensitive path には、`tree_view.gemspec`",
       "Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`",
       "config/importmap.tree_view.rb",

--- a/spec/release_check_spec.rb
+++ b/spec/release_check_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe TreeView::ReleaseCheck::Runner do
       hide_const("TreeView::VERSION")
       allow(runner).to receive(:build_gem!).and_return("tree_view-0.1.0.gem")
       allow(runner).to receive(:verify_packaged_files!).with("tree_view-0.1.0.gem")
+      expect(runner).to receive(:verify_package_contents!).with("tree_view-0.1.0.gem")
 
       expect { runner.send(:verify_package!) }.not_to raise_error
     end


### PR DESCRIPTION
## 対応 Issue

Closes #2165
Closes #2166
Closes #2157

## Issue ごとの完了内容

- #2165: built gem の metadata から `homepage_uri` / `source_code_uri` / `changelog_uri` / `bug_tracker_uri` の代表値を検証する guard を追加しました。
- #2166: `config/public_api_manifest.yml` の `public_constants` と、代表 `lib/tree_view/**/*.rb` package path の対応を package contents guard で確認するようにしました。
- #2157: `bundle exec rake release:check` が gem build 後に `script/check_gem_package_contents.rb` を実行するようにし、英日 release docs と docs signal spec の説明を同期しました。

## 変更内容

- `script/check_gem_package_contents.rb`
  - built gem spec metadata URI の期待値を検証します。
  - manifest-listed public Ruby constants に対応する runtime file が built gem に含まれることを検証します。
  - missing / unexpected metadata と manifest entry ごとの expected packaged file を failure message に出します。
- `lib/tree_view/release_check.rb`
  - gem build / basic packaged release file check の後に package contents checker を実行します。
  - checker output を release:check の出力へ流し、失敗時に release:check failure として扱います。
- `docs/en/release.md` / `docs/ja/release.md`
  - local `release:check` と CI `gem_package` job が同じ package contents guard を見ることを説明しました。
- `script/test_release_docs_signals.mjs` / `spec/release_check_spec.rb`
  - release docs の代表シグナルと release check fixture spec を、追加した package guard boundary に合わせて同期しました。

## 改善カテゴリ

- test
- CI / release guard hardening
- docs

## 既存仕様への影響

runtime Ruby behavior、public API manifest schema、gemspec file glob、CI workflow topology、gem publish / tag / GitHub Release automation は変更していません。built gem の検証を強め、release:check から既存 checker を再利用するだけです。

## 実施した確認

- Issue #2165 / #2166 / #2157 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 3件とも package guard / release check hardening の同系統改善として束ねました。
- 既存 open PR 検索で #2165 / #2166 / #2157 を担当する重複PRがないことを確認しました。
- compare `main...quality/2165-2166-package-guard`: `ahead_by:7` / `behind_by:0` / changed files 6。
- PR CI #2926: success。
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success
  - `gem_package`: success, including `ruby script/check_gem_package_contents.rb tree_view-*.gem`
  - representative Rails matrix: success
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク評価

Low. package verification と release preflight の guard を強化する変更で、公開挙動や package 対象 glob は変えていません。

## 補足事項

- manifest constant to file mapping は現在の `lib/tree_view.rb` require surface に合わせた明示 map にしています。新しい public constant を manifest に追加した場合は、package guard mapping も更新する必要があります。
- merge は行いません。