### PR TITLE
CHANGELOG に Development docs / package guard 追従を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Release preparation notes:
 - Clarified development docs for the Ruby-backed `npm run test:entrypoints` manifest loader path and setup expectations.
 - Clarified development docs that `.nvmrc`, `package.json` `engines.node`, and workflow `node-version` stay aligned by a Node version source drift guard.
 - Clarified Development docs for the Ruby version source and CI changed-file policy guard commands, including Bundler dependency package-sensitive guidance.
+- Clarified Development docs for standalone gem package verification and docs i18n parity commands.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
@@ -144,6 +145,8 @@ Release preparation notes:
 - Added controller entries contract smoke and `tree_view_rows` / Windowed Rendering docs signal coverage to the docs entrypoint suite.
 - Added Docker Ruby base image source guard coverage to the Ruby version source drift smoke.
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
+- Added a standalone Public API manifest structure command and docs entrypoint suite wiring for manifest structure smoke.
+- Added Development docs package verification coverage to the gem package contents guard.
 
 ## 0.1.0 - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Release preparation notes:
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
 - Added a standalone Public API manifest structure command and docs entrypoint suite wiring for manifest structure smoke.
 - Added Development docs package verification coverage to the gem package contents guard.
+- Added release:check package contents verification plus gem metadata URI and public runtime packaging guard coverage.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 PR / 背景

Refs #2155
Refs #2162
Refs #2163
Refs #2169

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

最近 main に入った Development docs / docs command / package guard / release check 系の変更について、`CHANGELOG.md` の Unreleased に release-facing evidence がまだ残っていませんでした。

確認した current main の根拠:

- #2155: `test:public-api-manifest-structure` の npm script と docs entrypoint suite wiring が main に入っています。
- #2162: 英日 Development docs に standalone gem package verification と `npm run test:docs-i18n` の導線が入っています。
- #2163: gem package contents guard に Development docs の代表 group が入っています。
- #2169: `release:check` から package contents guard を実行し、gem metadata URI / public runtime file packaging を guard する変更が main に入っています。

## 変更内容

- `CHANGELOG.md > Unreleased > Documentation` に Development docs の package verification / docs i18n command guidance を1行追加しました。
- `CHANGELOG.md > Unreleased > Tests` に public API manifest structure smoke の単体 command / docs entrypoint suite wiring を1行追加しました。
- `CHANGELOG.md > Unreleased > Tests` に Development docs package verification guard を1行追加しました。
- `CHANGELOG.md > Unreleased > Tests` に `release:check` package contents verification と gem metadata / public runtime packaging guard を1行追加しました。

## 変更範囲

- `CHANGELOG.md` の4行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- package scripts
- CI workflow
- Development docs / Release docs 本文
- release automation

## 確認内容

- Default PR Check として #2158 / #1993 / #2161 を確認しました。
  - #2158 は test script / package script 側の review follow-up で Docs Sync Agent の docs-only 変更範囲外です。
  - #1993 は browser-capable visual evidence が残るため、この環境では解消できません。
  - #2161 は public API stance の human review gate が継続しています。
- current main: `c8b7115c9607b42cd4019c5dee485ea871417411`
- compare `main...docs/changelog-development-guard-evidence`: changed files `CHANGELOG.md` の1件のみ / additions 4 / deletions 0
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

merge は行いません。