### PR TITLE
CHANGELOG に Development docs / package guard 追従を記録する v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Release preparation notes:
 - Clarified development docs for the Ruby-backed `npm run test:entrypoints` manifest loader path and setup expectations.
 - Clarified development docs that `.nvmrc`, `package.json` `engines.node`, and workflow `node-version` stay aligned by a Node version source drift guard.
 - Clarified Development docs for the Ruby version source and CI changed-file policy guard commands, including Bundler dependency package-sensitive guidance.
+- Clarified Development docs for standalone gem package verification and docs i18n parity commands.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
@@ -144,6 +145,10 @@ Release preparation notes:
 - Added controller entries contract smoke and `tree_view_rows` / Windowed Rendering docs signal coverage to the docs entrypoint suite.
 - Added Docker Ruby base image source guard coverage to the Ruby version source drift smoke.
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
+- Added a standalone Public API manifest structure command and docs entrypoint suite wiring for manifest structure smoke.
+- Added Development docs command signal smoke coverage for maintainer npm command guidance.
+- Added Development docs package verification coverage to the gem package contents guard.
+- Added release:check package contents verification plus gem metadata URI and public runtime packaging guard coverage.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 PR / 背景

Superseded by #2181
Supersedes #2172
Refs #2155
Refs #2158
Refs #2162
Refs #2163
Refs #2169

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2172 は CHANGELOG-only の docs-sync PR でしたが、#2158 merge 後に `main` が進み、branch freshness / mergeability と #2158 の Development docs command signal smoke を CHANGELOG 対象に含めるべきかが review follow-up として残りました。

この PR は current `main` から作り直し、#2172 と同じ Development docs / package guard 系の release-facing evidence に #2158 の smoke 追加を含めた後継 PR でした。

#2177 merge 後にさらに `npm ci` install path / CI・Docker setup smoke / docs sync の CHANGELOG 追従が必要になったため、current main から #2181 を作成し、この PR は supersede しました。

## 変更内容

- `CHANGELOG.md > Unreleased > Documentation` に Development docs の package verification / docs i18n command guidance を1行追加しました。
- `CHANGELOG.md > Unreleased > Tests` に以下を追加しました。
  - public API manifest structure smoke の単体 command / docs entrypoint suite wiring
  - Development docs command signal smoke
  - Development docs package verification guard
  - `release:check` package contents verification と gem metadata / public runtime packaging guard

## 変更範囲

- `CHANGELOG.md` の5行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- package scripts
- CI workflow
- Development docs / Release docs 本文
- release automation

## 確認内容

- 後継 PR #2181 を作成済みです。
- #2181 current main: `0ad423924b7c0ddb288fb6c94dddba8a4a4eaf76`
- #2181 compare: `ahead_by:1` / `behind_by:0`
- #2181 changed files: `CHANGELOG.md` の1件のみ

merge は行いません。