### PR TITLE
npm ci install path を CI と docs に反映する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           node-version: "22"
           cache: npm
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
-        run: npm install
+        run: npm ci
       - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true' && needs.changes.outputs.docs_entrypoint_sensitive == 'true'
         run: npm run test:docs-entrypoints
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
@@ -176,7 +176,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: docker compose build app
-      - run: docker compose run --rm app sh -lc 'node --version | grep -E "^v22\." && npm --version && npm install'
+      - run: docker compose run --rm app sh -lc 'node --version | grep -E "^v22\." && npm --version && npm ci'
 
   gem_package:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && needs.changes.outputs.package_sensitive == 'true'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ TreeView does not provide:
 - server-side pagination algorithms
 - a full virtual scrolling engine
 
-For very large trees, combine TreeView's render controls with host-app loading and paging strategies. Start with [Render Scale](docs/en/render-scale.md), then add [Lazy Loading](docs/en/lazy-loading.md), [Children Pagination](docs/en/children-pagination.md), or custom virtual scrolling owned by the host app when your UI needs it.
+For very large trees, combine TreeView's render controls with host-app loading and paging strategies. Start with [Render Scale](docs/en/render-scale.md) and [Rendering Boundaries](docs/en/rendering-boundaries.md), then add [Lazy Loading](docs/en/lazy-loading.md), [Children Pagination](docs/en/children-pagination.md), or custom virtual scrolling owned by the host app when your UI needs it.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Key documents:
 | Drag and drop | [Drag and Drop](docs/en/drag-and-drop.md) | [Drag and Drop](docs/ja/drag-and-drop.md) |
 | Children pagination | [Children Pagination](docs/en/children-pagination.md) | [Children Pagination](docs/ja/children-pagination.md) |
 | Tree identity and diagnostics | [Node keys](docs/en/node-keys.md) and [Tree diagnostics](docs/en/tree-diagnostics.md) | [Node key 設計](docs/ja/node-keys.md) and [Tree diagnostics](docs/ja/tree-diagnostics.md) |
-| Large tree rendering strategy | [Render Scale](docs/en/render-scale.md), [Lazy Loading](docs/en/lazy-loading.md), [Children Pagination](docs/en/children-pagination.md), [Windowed Rendering](docs/en/windowed-rendering.md), [Rendering Boundaries](docs/en/rendering-boundaries.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [Lazy Loading](docs/ja/lazy-loading.md), [Children Pagination](docs/ja/children-pagination.md), [Windowed Rendering](docs/ja/windowed-rendering.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
+| Large tree rendering strategy | [Render Scale](docs/en/render-scale.md), [Lazy Loading](docs/en/lazy-loading.md), [Children Pagination](docs/en/children-pagination.md), [Windowed Rendering](docs/en/windowed-rendering.md), and [Render log level](docs/en/render-log-level.md) | [描画スケール](docs/ja/render-scale.md), [Lazy Loading](docs/ja/lazy-loading.md), [Children Pagination](docs/ja/children-pagination.md), [Windowed Rendering](docs/ja/windowed-rendering.md), [描画責務の境界](docs/ja/rendering-boundaries.md), and [render log レベル](docs/ja/render-log-level.md) |
 | Styling and direction-aware boundary | [Direction-aware styling boundary](docs/en/direction-aware-styling.md) | [Direction-aware styling boundary](docs/ja/direction-aware-styling.md) |
 | Packaged stylesheet state cues | [Styling state cues](docs/en/styling-state-cues.md) | [State cue のスタイリング](docs/ja/styling-state-cues.md) |
 | API overview | [API overview](docs/en/api-overview.md) | [API概要](docs/ja/api-overview.md) |
@@ -264,7 +264,7 @@ bundle install
 bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
-npm install
+npm ci
 npm run test:js
 ```
 
@@ -272,4 +272,4 @@ Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the 
 
 `npm run test:js` runs the documented JavaScript pull-request checks together: entrypoint smoke (`npm run test:entrypoints`), Vitest (`npm test`), and Playwright browser smoke (`npm run test:browser`). See the [English development guide](docs/en/development.md) and [日本語の開発・保守方針](docs/ja/development.md) for details.
 
-A committed `package-lock.json` is present, but it is not yet in sync with `package.json`, so CI and local setup keep using `npm install` until that lockfile is refreshed in a registry-enabled environment.
+Use `npm ci` for local JavaScript setup. The committed `package-lock.json` is the source of truth for repeatable installs, and CI/Docker setup use the same lockfile-backed install path.

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -6,7 +6,7 @@ This page summarizes common development and maintenance tasks for the TreeView g
 
 ```bash
 bundle install
-npm install
+npm ci
 ```
 
 With Docker:
@@ -15,14 +15,14 @@ With Docker:
 cp .env.example .env
 docker compose build
 docker compose run --rm app bundle install
-docker compose run --rm app npm install
+docker compose run --rm app npm ci
 ```
 
 The development Docker image installs Node 22 and npm so the Docker setup can run the same JavaScript install path as local development. Keep the Dockerfile Node major aligned with `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value when any of them changes.
 
-Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version. Keep `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value aligned when any of them changes. The automated drift guard is `script/test_node_version_sources.mjs`, exposed as `npm run test:node-version-sources` and included in `npm run test:entrypoints`; it verifies those Node version sources stay on Node 22 without changing the current install policy.
+Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version. Keep `.nvmrc`, `package.json` `engines.node`, and the workflow `node-version` value aligned when any of them changes. The automated drift guard is `script/test_node_version_sources.mjs`, exposed as `npm run test:node-version-sources` and included in `npm run test:entrypoints`; it verifies those Node version sources stay on Node 22 without changing the lockfile-backed install policy.
 
-Keep using `npm install` for now. The repository has a committed `package-lock.json`, but it is not yet refreshed in sync with `package.json`, so local setup and pull-request CI stay on `npm install` until that lockfile refresh is completed in a registry-enabled environment. See [Installation](installation.md) for the current CI and install-path summary.
+Use `npm ci` for local JavaScript setup. The committed `package-lock.json` is now the source of truth for repeatable installs, and pull-request CI and Docker setup use the same lockfile-backed install path. See [Installation](installation.md) for the current CI and install-path summary.
 
 ## Common commands
 
@@ -67,7 +67,7 @@ BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake
 
 Public API compatibility specs protect documented Ruby entry points, helper methods, helper option keys, grouped options, and JavaScript package-root exports from accidental removals or renames. The JavaScript entrypoint smoke also checks manifest-backed controller registrations, public event names, and documented `event.detail` key groups. Keep these specs focused on API existence and representative behavior rather than full implementation details.
 
-Docs entrypoint smoke and public API docs signal smoke have separate responsibilities within `npm run test:docs-entrypoints`: `script/test_docs_entrypoints.mjs` protects broad documentation entry points, links, and feature-guide signals, while `script/test_repository_only_maintainer_entrypoints.mjs` protects repository-only maintainer entry points such as `Product Profile.md`, `AGENTS.md`, `CHANGELOG.md`, and `docs/i18n-audit.md` from disappearing out of the root docs map or language README files. `script/test_public_api_docs_signals.mjs` protects representative Public API and feature-doc signals. When a public API manifest entry, package-root export, public helper surface, or docs signal is added or renamed, review and update the public API docs signal smoke alongside the affected English and Japanese docs.
+Docs entrypoint smoke and public API docs signal smoke have separate responsibilities within `npm run test:docs-entrypoints`: `script/test_docs_entrypoints.mjs` protects broad documentation entry points, links, and feature-guide signals, while `script/test_repository_only_maintainer_entrypoints.mjs` protects repository-only maintainer entry points such as `Product Profile.md`, `AGENTS.md`, `CHANGELOG.md`, and `docs/i18n-audit.md` from disappearing out of the root docs map or language README files without treating them as gem-packaged host-app API guides. `script/test_public_api_docs_signals.mjs` protects representative Public API and feature-doc signals. When a public API manifest entry, package-root export, public helper surface, or docs signal is added or renamed, review and update the public API docs signal smoke alongside the affected English and Japanese docs.
 
 When an intentional breaking change is accepted, update the public API docs and the compatibility specs together so the documented contract and test coverage stay aligned.
 

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -16,16 +16,16 @@ GitHub Actions runs the following checks on pull requests:
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
 - Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
-- JavaScript tests through `npm install`, Playwright browser setup, and `npm run test:js`
+- JavaScript tests through `npm ci`, Playwright browser setup, and `npm run test:js`
 
 Pushes to `main` keep the heavier compatibility and release checks:
 
 - Ruby version matrix
 - Full Rails version matrix
-- JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
+- JavaScript tests through `npm ci` and `npm run test:js`
 - gem package verification
 
-The repository keeps a committed `package-lock.json`, but CI stays on `npm install` until that lockfile is refreshed in sync with `package.json`.
+The repository keeps a committed `package-lock.json`. CI and local setup use `npm ci` so JavaScript checks install from the lockfile rather than updating dependency resolution during verification.
 
 Release tags should be placed only on `main` commits whose full CI has passed.
 
@@ -181,11 +181,11 @@ bundle install
 bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
-npm install
+npm ci
 npm run test:js
 ```
 
-Use `npm install` here for the same reason as CI: the committed `package-lock.json` still needs a refresh before `npm ci` can be trusted. `npm run test:js` runs the entrypoint smoke, Vitest suite, and Playwright browser smoke checks documented in the CI lane.
+Use `npm ci` here for the same reason as CI: the committed `package-lock.json` is the repeatable install source. `npm run test:js` runs the entrypoint smoke, Vitest suite, and Playwright browser smoke checks documented in the CI lane.
 
 Rails compatibility Gemfiles live under `gemfiles/`.
 
@@ -213,6 +213,6 @@ GitHub Actions runs the following on pull requests:
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
-- JavaScript checks through `npm install`, Playwright browser setup, and `npm run test:js`
+- JavaScript checks through `npm ci`, Playwright browser setup, and `npm run test:js`
 
 On pushes to `main`, GitHub Actions runs the Ruby version matrix, full Rails version matrix, JavaScript tests, and gem package verification.

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -50,19 +50,18 @@ Minimum release conditions:
 
 ## Code and tests
 
-The committed `package-lock.json` is not yet in sync with `package.json`, so both local setup and CI still use `npm install` for the JavaScript lane. Switch these release checks back to `npm ci` after the lockfile refresh work lands.
+The committed `package-lock.json` is the source of truth for JavaScript dependency installs. Local setup, pull-request CI, Docker setup smoke, and main-push JavaScript checks use `npm ci` so release evidence does not update dependency resolution during verification.
 
-### Lockfile refresh handoff
+### JavaScript install path
 
-When a registry-enabled lockfile refresh lands, review these release-facing points before switching the JavaScript lane back to `npm ci`:
+When JavaScript dependencies change, keep these release-facing points aligned:
 
-- Confirm `package-lock.json` was refreshed against the current `package.json` without bundling unrelated dependency upgrades.
-- Update the setup wording in `docs/en/development.md` and `docs/ja/development.md` if `npm ci` becomes the current local and Docker install path.
-- Update this release checklist and any CI wording that still describes the `npm install` exception.
-- Keep the Node 22 source guard separate: `.nvmrc`, `package.json` `engines.node`, workflow `node-version`, and `script/test_node_version_sources.mjs` confirm the Node major, while the lockfile refresh decides whether `npm ci` is safe again.
-- Observe fresh PR or main-push CI after the switch so the JavaScript lane proves the refreshed lockfile works in CI.
+- Update `package.json` and `package-lock.json` together without bundling unrelated dependency upgrades.
+- Keep setup wording in `README.md`, `docs/en/installation.md`, `docs/ja/installation.md`, `docs/en/development.md`, and `docs/ja/development.md` aligned with `npm ci`.
+- Keep the Node 22 source guard separate: `.nvmrc`, `package.json` `engines.node`, workflow `node-version`, and `script/test_node_version_sources.mjs` confirm the Node major, while the lockfile-backed install path confirms dependency resolution.
+- Observe fresh PR or main-push CI after dependency changes so the JavaScript lane proves the updated lockfile works in CI.
 
-Do not change `package-lock.json`, workflow setup, dependency versions, or the Node major from this checklist alone; those belong in the lockfile refresh or CI change PR that owns the actual switch.
+Do not change dependency versions, the Node major, or package manager policy from this checklist alone; those belong in the dependency or CI change PR that owns the actual switch.
 
 Local checks:
 
@@ -80,7 +79,7 @@ Pull request CI checks:
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
 - Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
-- JavaScript tests through `npm install`, Playwright browser setup, and `npm run test:js`
+- JavaScript tests through `npm ci`, Playwright browser setup, and `npm run test:js`
 - Gem package verification when the PR touches package-sensitive paths
 
 Package-sensitive PR paths include `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb`, `config/public_api_manifest.yml`, and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Prose-only docs PRs keep the lighter docs-only behavior unless they also touch one of those package-sensitive paths.
@@ -89,7 +88,7 @@ Main-push CI checks:
 
 - Ruby version matrix
 - Rails version matrix
-- JavaScript tests through `npm install` and `npm run test:js` until the lockfile is refreshed in sync with `package.json`
+- JavaScript tests through `npm ci` and `npm run test:js`
 - Gem package verification, including representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, public API manifest, public runtime files, and gem metadata URI contents
 
 PR CI must pass before merge. Use the broader `main` CI for release decisions because it includes full compatibility matrices, JavaScript coverage, and unconditional package verification.

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -6,7 +6,7 @@
 
 ```bash
 bundle install
-npm install
+npm ci
 ```
 
 Dockerを使う場合:
@@ -15,14 +15,14 @@ Dockerを使う場合:
 cp .env.example .env
 docker compose build
 docker compose run --rm app bundle install
-docker compose run --rm app npm install
+docker compose run --rm app npm ci
 ```
 
 開発用 Docker image は Node 22 と npm を含めるため、Docker setup でもローカル開発と同じ JavaScript install path を実行できます。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` を変更する場合は、Dockerfile の Node major も同じ方針にそろえてください。
 
-ローカルの JavaScript 作業では Node 22 を使ってください。repository root の `.nvmrc` が CI の JavaScript lane とそろった、推奨 Node major version の source of truth です。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` は、どれかを変更するときに同じ Node major を指すように同期してください。自動 drift guard は `script/test_node_version_sources.mjs` です。`npm run test:node-version-sources` として実行でき、`npm run test:entrypoints` にも含まれており、これらの Node version source が Node 22 を指し続けることを現在の install policy を変えずに確認します。
+ローカルの JavaScript 作業では Node 22 を使ってください。repository root の `.nvmrc` が CI の JavaScript lane とそろった、推奨 Node major version の source of truth です。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version` は、どれかを変更するときに同じ Node major を指すように同期してください。自動 drift guard は `script/test_node_version_sources.mjs` です。`npm run test:node-version-sources` として実行でき、`npm run test:entrypoints` にも含まれており、これらの Node version source が Node 22 を指し続けることを lockfile-backed install policy を変えずに確認します。
 
-現状は `npm install` を使い続けてください。repo には `package-lock.json` を commit していますが、まだ `package.json` と同期していないため、ローカルセットアップと Pull Request CI は、registry-enabled な環境で lockfile refresh が完了するまで `npm install` を前提にしています。現在の CI と install path の整理は [導入手順](installation.md) を参照してください。
+ローカルの JavaScript setup には `npm ci` を使ってください。commit 済みの `package-lock.json` が repeatable install の source of truth になり、Pull Request CI と Docker setup も同じ lockfile-backed install path を使います。現在の CI と install path の整理は [導入手順](installation.md) を参照してください。
 
 ## よく使うコマンド
 

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -16,16 +16,16 @@ GitHub Actions では、Pull Requestで以下を実行します。
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
-- JavaScript tests: `npm install`、Playwright browser setup、`npm run test:js`
+- JavaScript tests: `npm ci`、Playwright browser setup、`npm run test:js`
 
 `main` へのpushでは、重めの互換性確認とrelease向けchecksを実行します。
 
 - Ruby version matrix
 - full Rails version matrix
-- `package-lock.json` が `package.json` と同期するまでは、`npm install` と `npm run test:js` による JavaScript tests
+- `npm ci` と `npm run test:js` による JavaScript tests
 - gem package verification
 
-repo には `package-lock.json` を commit していますが、まだ `package.json` と同期が取れていないため、CI は lockfile refresh が済むまで `npm install` を使います。
+repo には `package-lock.json` を commit しています。CI とローカルセットアップは `npm ci` を使い、検証中に dependency resolution を更新せず、lockfile から JavaScript dependencies を install します。
 
 release tag は、`main` のfull CIが成功したcommitに付けます。
 
@@ -179,11 +179,11 @@ bundle install
 bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
-npm install
+npm ci
 npm run test:js
 ```
 
-ローカル手順も CI と同じく `npm install` を使います。理由は、commit 済みの `package-lock.json` を `npm ci` で安全に使うには、まだ lockfile refresh が必要だからです。`npm run test:js` は CI lane と同じく entrypoint smoke、Vitest suite、Playwright browser smoke をまとめて実行します。
+ローカル手順も CI と同じく `npm ci` を使います。commit 済みの `package-lock.json` を repeatable install の source として使うためです。`npm run test:js` は CI lane と同じく entrypoint smoke、Vitest suite、Playwright browser smoke をまとめて実行します。
 
 Rails互換性確認用のGemfileは `gemfiles/` 配下にあります。
 
@@ -211,6 +211,6 @@ GitHub Actions では、Pull Requestで以下を実行します。
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
-- JavaScript checks: `npm install`、Playwright browser setup、`npm run test:js`
+- JavaScript checks: `npm ci`、Playwright browser setup、`npm run test:js`
 
 `main` へのpushでは、Ruby version matrix、full Rails version matrix、JavaScript tests、gem package verificationを実行します。

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -50,19 +50,18 @@ GitHub Release notes を書く前に、[Release note candidate collector](releas
 
 ## コードとテスト
 
-committed `package-lock.json` はまだ `package.json` と同期していないため、JavaScript lane は local setup / CI ともに現時点では `npm install` 前提です。lockfile refresh 作業が入ったら、release checks も `npm ci` 前提へ戻します。
+commit 済みの `package-lock.json` は JavaScript dependency install の source of truth です。ローカルセットアップ、Pull Request CI、Docker setup smoke、main-push JavaScript checks は `npm ci` を使い、release evidence の検証中に dependency resolution を更新しません。
 
-### Lockfile refresh handoff
+### JavaScript install path
 
-registry-enabled な環境で lockfile refresh が入ったら、JavaScript lane を `npm ci` に戻す前に、release-facing な確認点を見直してください。
+JavaScript dependencies を変更するときは、release-facing な確認点をそろえてください。
 
-- `package-lock.json` が current `package.json` に対して refresh され、関係ない dependency upgrade を同じ PR に混ぜていないことを確認する。
-- `npm ci` が現在の local / Docker install path になる場合は、`docs/en/development.md` と `docs/ja/development.md` の setup 説明も同期する。
-- この release checklist と、`npm install` 例外を説明している CI wording を更新する。
-- Node 22 source guard とは責務を分ける。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version`、`script/test_node_version_sources.mjs` は Node major の整合を確認し、lockfile refresh は `npm ci` に戻して安全かどうかを判断する。
-- 切り替え後は fresh な PR CI または main-push CI を観測し、refreshed lockfile が CI の JavaScript lane で動くことを確認する。
+- `package.json` と `package-lock.json` を一緒に更新し、関係ない dependency upgrade を同じ PR に混ぜない。
+- `README.md`、`docs/en/installation.md`、`docs/ja/installation.md`、`docs/en/development.md`、`docs/ja/development.md` の setup 説明を `npm ci` とそろえる。
+- Node 22 source guard とは責務を分ける。`.nvmrc`、`package.json` の `engines.node`、workflow の `node-version`、`script/test_node_version_sources.mjs` は Node major の整合を確認し、lockfile-backed install path は dependency resolution の整合を確認する。
+- dependency 変更後は fresh な PR CI または main-push CI を観測し、更新した lockfile が CI の JavaScript lane で動くことを確認する。
 
-この checklist だけを根拠に `package-lock.json`、workflow setup、dependency version、Node major を変更しないでください。実際の切り替えは、lockfile refresh または CI 変更を担当する PR に閉じます。
+この checklist だけを根拠に dependency version、Node major、package manager policy を変更しないでください。実際の切り替えは、その dependency または CI 変更を担当する PR に閉じます。
 
 ローカル確認:
 
@@ -80,7 +79,7 @@ Pull Request CI の確認項目:
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
-- JavaScript tests: `npm install`、Playwright browser setup、`npm run test:js`
+- JavaScript tests: `npm ci`、Playwright browser setup、`npm run test:js`
 - package-sensitive path を触るPRでの Gem package verification
 
 package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb`、`config/public_api_manifest.yml`、`config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。prose-only docs PR は、その package-sensitive path も触らない限り、従来どおり軽い docs-only 挙動を維持します。
@@ -89,7 +88,7 @@ package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_
 
 - Ruby version matrix
 - Rails version matrix
-- `package-lock.json` が `package.json` と同期するまでの間は、`npm install` と `npm run test:js` による JavaScript tests
+- `npm ci` と `npm run test:js` による JavaScript tests
 - Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest / public runtime files / gem metadata URI の代表ファイルとmetadataを含む Gem package verification
 
 merge前にPR CIを通します。release判定には、full compatibility matrices、JavaScript coverage、unconditional package verificationを含む、より広い `main` CIを使います。

--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -86,7 +86,8 @@ function isDockerSetupSensitivePath(file) {
     file === "docker-compose.yml" ||
     file === "package.json" ||
     file === "package-lock.json" ||
-    file === ".nvmrc"
+    file === ".nvmrc" ||
+    file === ".github/workflows/ci.yml"
   );
 }
 

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -249,7 +249,7 @@ assertJobMatches(
   `${workflowPath} jobs.docker_development_setup must keep the Docker app setup smoke`
 );
 assert.ok(
-  dockerDevelopmentSetupJob.includes('node --version | grep -E "^v22\\." && npm --version && npm install'),
+  dockerDevelopmentSetupJob.includes('node --version | grep -E "^v22\\." && npm --version && npm ci'),
   `${workflowPath} jobs.docker_development_setup must keep the representative Node/npm setup smoke`
 );
 

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -55,14 +55,14 @@ const cases = [
     }
   },
   {
-    name: "workflow changes are package-sensitive full CI changes",
+    name: "workflow changes are package- and Docker-sensitive full CI changes",
     files: [".github/workflows/ci.yml"],
     expected: {
       docs_only: false,
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: true,
-      docker_setup_sensitive: false,
+      docker_setup_sensitive: true,
       docs_entrypoint_sensitive: false
     }
   },

--- a/script/test_development_docs_node_version_signals.mjs
+++ b/script/test_development_docs_node_version_signals.mjs
@@ -36,7 +36,7 @@ const nodeVersionSourceSignals = [
       "script/test_node_version_sources.mjs",
       "npm run test:node-version-sources",
       "npm run test:entrypoints",
-      "without changing the current install policy"
+      "without changing the lockfile-backed install policy"
     ]
   },
   {
@@ -51,13 +51,13 @@ const nodeVersionSourceSignals = [
       "script/test_node_version_sources.mjs",
       "npm run test:node-version-sources",
       "npm run test:entrypoints",
-      "現在の install policy を変えずに確認します"
+      "lockfile-backed install policy を変えずに確認します"
     ]
   }
 ]
 
 nodeVersionSourceSignals.forEach(({ feature, sourcePath, signals }) => {
-  assertSignals(sourcePath, feature, signals)
+  assertSignals(sourcePath, feature, sourcePath, signals)
 })
 
 const nodeVersionSourceFiles = [

--- a/script/test_development_docs_node_version_signals.mjs
+++ b/script/test_development_docs_node_version_signals.mjs
@@ -57,7 +57,7 @@ const nodeVersionSourceSignals = [
 ]
 
 nodeVersionSourceSignals.forEach(({ feature, sourcePath, signals }) => {
-  assertSignals(sourcePath, feature, sourcePath, signals)
+  assertSignals(sourcePath, feature, signals)
 })
 
 const nodeVersionSourceFiles = [


### PR DESCRIPTION
## 対応 Issue

- Closes #2171
- Closes #413

## Issue ごとの完了内容

- #2171: `package-lock.json` が main にある前提で、JavaScript CI setup、Docker development setup smoke、README、英日 Installation / Development / Release docs を `npm ci` 前提へ同期しました。
- #413: lockfile refresh 済み後に残っていた `npm install` 前提の CI / Docker / docs drift を同じ根本原因として整理しました。

## 変更内容

- `.github/workflows/ci.yml`
  - JavaScript job の install step を `npm ci` に変更しました。
  - Docker development setup smoke の Node/npm setup を `npm ci` に変更しました。
- `script/ci_changed_files_policy.mjs`
  - workflow 変更で Docker setup smoke も走るよう、`.github/workflows/ci.yml` を `docker_setup_sensitive` に含めました。
- `script/test_ci_changed_files_policy.mjs`
  - workflow 変更の Docker-sensitive 判定と Docker setup smoke の代表文字列を更新しました。
- `script/test_development_docs_node_version_signals.mjs`
  - Development docs の Node version guard signal を lockfile-backed install wording に同期しました。
- `README.md`
  - Development 手順を `npm ci` に変更し、lockfile-backed install path として説明しました。
  - docs smoke に合わせて Render Scale 導線に Rendering Boundaries link を補いました。
- `docs/en/installation.md` / `docs/ja/installation.md`
  - PR / main CI と local setup の説明を `npm ci` 前提へ同期しました。
- `docs/en/development.md` / `docs/ja/development.md`
  - local / Docker setup と Node version guard の説明を `npm ci` 前提へ更新しました。
- `docs/en/release.md` / `docs/ja/release.md`
  - 古い lockfile refresh handoff を削除し、release-facing な JavaScript install path checklist に置き換えました。

## 改善カテゴリ

- CI 改善
- Docker setup smoke 改善
- docs 改善
- 小さな test / smoke expectation 更新

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、UI、DB schema、認可、外部サービス契約は変更していません。
- dependency version、Node major、package manager policy、`package-lock.json` は変更していません。
- 変更は install/setup の再現性、CI smoke、docs drift 解消に限定しています。

## 実施した確認内容

- Issue eligibility を個別確認しました。
  - #2171: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`
  - #413: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:medium`
- 既存 open PR の review follow-up を確認し、今回の範囲で人間判断なしに処理できる blocker はありませんでした。
- PR 作成前に同じ `Closes #2171` / `Closes #413` を持つ open PR がないことを確認しました。
- 最終 compare: `main...chore/2171-npm-ci-install-path` は `ahead_by:14` / `behind_by:0`、変更ファイルは意図した11件です。
- GitHub Actions CI run #2940 / head `2bfdea3f760beecc408152ca113f5d0ad1e59420`: success。
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: success
  - `javascript`: success（`npm ci` と `npm run test:js:core`）
  - `docker_development_setup`: success（`docker compose build app` と Docker 内 `npm ci` smoke）
  - `gem_package`: success
- local checkout / local npm は、この実行環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク評価

low。install command と docs / smoke expectation の同期であり、公開挙動や依存バージョンは変更しません。

## 補足事項

- workflow 定義を変更しているため、fresh head SHA で CI を確認済みです。
- merge は行いません。