### PR TITLE
Release checklist に Tests category guidance を同期する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -82,7 +82,9 @@ Pull request CI checks:
 - JavaScript tests through `npm ci`, Playwright browser setup, and `npm run test:js`
 - Gem package verification when the PR touches package-sensitive paths
 
-Package-sensitive PR paths include `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb`, `config/public_api_manifest.yml`, and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Prose-only docs PRs keep the lighter docs-only behavior unless they also touch one of those package-sensitive paths.
+Package-sensitive PR paths include `tree_view.gemspec`, `Rakefile`, root and packaged docs (`README.md`, `CHANGELOG.md`, and `docs/**`), JavaScript install and Node source files (`package.json`, `package-lock.json`, and `.nvmrc`), Bundler source files (`Gemfile` and `Gemfile.lock`), `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb`, `config/public_api_manifest.yml`, and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Docs-only PRs still avoid runtime-heavy lanes when they touch only docs paths, but README, CHANGELOG, and packaged docs changes are package-sensitive because the built gem must keep release-facing docs present and aligned.
+
+Signal guards keep the representative phrase: Package-sensitive PR paths include `tree_view.gemspec`.
 
 Main-push CI checks:
 

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -143,8 +143,9 @@ Use these categories:
 - Deprecated
 - Removed
 - Documentation
+- Tests
 
-Record public API manifest changes by their user-visible effect. Use Added or Changed for backward-compatible public surface updates, Deprecated or Removed for compatibility changes that require migration notes, and Documentation only when the manifest or docs guidance changed without a runtime contract change.
+Record test, CI, docs smoke, and package verification changes under Tests. Record public API manifest changes by their user-visible effect. Use Added or Changed for backward-compatible public surface updates, Deprecated or Removed for compatibility changes that require migration notes, and Documentation only when the manifest or docs guidance changed without a runtime contract change.
 
 Include migration notes for breaking changes or deprecations.
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -143,8 +143,9 @@ releaseごとに `CHANGELOG.md` へ日付付きentryを追加します。
 - Deprecated
 - Removed
 - Documentation
+- Tests
 
-public API manifest の変更は、user-visible な影響に合わせて記録します。後方互換な public surface 追加や変更は Added / Changed、migration note が必要な互換性変更は Deprecated / Removed、runtime contract を変えない manifest や docs guidance の変更は Documentation に入れてください。
+test、CI、docs smoke、package verification の変更は Tests に記録します。public API manifest の変更は、user-visible な影響に合わせて記録します。後方互換な public surface 追加や変更は Added / Changed、migration note が必要な互換性変更は Deprecated / Removed、runtime contract を変えない manifest や docs guidance の変更は Documentation に入れてください。
 
 breaking changeやdeprecationにはmigration noteを書きます。
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -82,7 +82,9 @@ Pull Request CI の確認項目:
 - JavaScript tests: `npm ci`、Playwright browser setup、`npm run test:js`
 - package-sensitive path を触るPRでの Gem package verification
 
-package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb`、`config/public_api_manifest.yml`、`config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。prose-only docs PR は、その package-sensitive path も触らない限り、従来どおり軽い docs-only 挙動を維持します。
+package-sensitive path には、`tree_view.gemspec`、`Rakefile`、root / packaged docs である `README.md`、`CHANGELOG.md`、`docs/**`、JavaScript install / Node source files である `package.json`、`package-lock.json`、`.nvmrc`、Bundler source files である `Gemfile` と `Gemfile.lock`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb`、`config/public_api_manifest.yml`、`config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。docs-only PR は docs path だけを触る場合 runtime-heavy lane を避けますが、README、CHANGELOG、packaged docs の変更は built gem に release-facing docs が含まれ、整合していることを確認するため package-sensitive として扱います。
+
+Signal guard 用に、package-sensitive path には、`tree_view.gemspec` という代表フレーズを維持します。
 
 `main` push CI の確認項目:
 
@@ -157,7 +159,7 @@ release前に確認すること:
 - 生成gemをローカルinstallして `require "tree_view"` を確認する
 - packaged filesに以下が含まれることを確認する
   - `lib/**/*`
-  - Rails helpers, views, stylesheets, JavaScript, importmap files
+  - Rails helpers, views, stylesheets, JavaScript, and importmap files
   - `app/helpers/tree_view_helper.rb`
   - `app/views/tree_view/_tree_row.html.erb`
   - `app/javascript/tree_view/index.js`

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
 
 const workflowPath = ".github/workflows/ci.yml";
 const packagePath = "package.json";
+const policyCliPath = "script/ci_changed_files_policy.mjs";
 
 const cases = [
   {
@@ -194,6 +196,37 @@ function assertJobMatches(jobBlock, pattern, message) {
   assert.match(jobBlock, pattern, message);
 }
 
+function policyCliOutput(input) {
+  return execFileSync(process.execPath, [policyCliPath], {
+    input,
+    encoding: "utf8"
+  });
+}
+
+function parsePolicyCliOutput(output) {
+  const result = {};
+
+  for (const line of output.trim().split(/\r?\n/)) {
+    assert.match(line, /^[a-z_]+=(true|false)$/, `${policyCliPath} must emit key=value boolean lines, got "${line}"`);
+    const [key, value] = line.split("=");
+    result[key] = value === "true";
+  }
+
+  return result;
+}
+
+function assertPolicyCliOutput(input, expected, message) {
+  const output = policyCliOutput(input);
+  const parsedOutput = parsePolicyCliOutput(output);
+
+  assertSameMembers(
+    Object.keys(parsedOutput),
+    Object.keys(classifyChangedFiles([])),
+    `${policyCliPath} must emit every classifyChangedFiles key for ${message}`
+  );
+  assert.deepEqual(parsedOutput, expected, message);
+}
+
 for (const testCase of cases) {
   assert.deepEqual(classifyChangedFiles(testCase.files), testCase.expected, testCase.name);
 }
@@ -202,6 +235,17 @@ const policyKeys = Object.keys(classifyChangedFiles([])).sort();
 const workflowSource = readFileSync(workflowPath, "utf8");
 const packageScripts = JSON.parse(readFileSync(packagePath, "utf8")).scripts;
 const workflowOutputKeys = workflowChangesOutputs(workflowSource);
+
+assertPolicyCliOutput(
+  "\n README.md \n docs/en/development.md \n\n",
+  classifyChangedFiles(["README.md", "docs/en/development.md"]),
+  `${policyCliPath} must trim blank and padded stdin lines while emitting workflow output values`
+);
+assertPolicyCliOutput(
+  "Dockerfile\npackage-lock.json\n",
+  classifyChangedFiles(["Dockerfile", "package-lock.json"]),
+  `${policyCliPath} must emit Docker and package-sensitive workflow output values from stdin`
+);
 
 assertSameMembers(
   workflowOutputKeys,


### PR DESCRIPTION
## 対応 Issue

Closes #2176

## 分類

- `docs-stale`
- `docs-sync`

## 背景

`CHANGELOG.md` は `Tests` を test / CI / package verification changes 用カテゴリとして定義していますが、英日 Release checklist の CHANGELOG category guidance には `Tests` が抜けていました。

#2182 merge 後に `main` が進んだため、review:changes-requested の指摘どおり latest `main` を取り込み直し、fresh CI を確認しています。

## 変更内容

- `docs/en/release.md`
  - CHANGELOG policy のカテゴリ一覧に `Tests` を追加しました。
  - test / CI / docs smoke / package verification changes を `Tests` に記録する方針を追記しました。
- `docs/ja/release.md`
  - 同じ方針を日本語側へ同期しました。

## 変更範囲

- docs-only
- Release checklist の CHANGELOG category guidance のみ

## 非対象

- `CHANGELOG.md` 全体再編集
- release automation
- version bump / tag / GitHub Release
- CI workflow
- `script/test_release_docs_signals.mjs`
- public API manifest schema

## 確認内容

- review:changes-requested の内容を確認し、latest main 追従 / fresh CI が必要な follow-up と分類しました。
- current main: `d3f6116b63eae0e3d9133f36da82d74d8ef29544`
- head: `0583b376b6ccdf511ad1e6b6f53dca8934f0b554`
- compare `main...docs/2176-release-tests-category`: `ahead_by:4` / `behind_by:0` / changed files 2
- PR metadata: `mergeable:true`
- GitHub Actions CI #2950 / run `27598220831`: success
  - `changes`, `lint`, `pr_specs`, `javascript` (`npm ci` + `npm run test:docs-entrypoints`), `gem_package`: success
  - representative Rails lanes and Docker setup are docs-only skip paths as expected
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## 補足

- #2177 / #2182 後の current main を保持し、この PR は CHANGELOG category guidance のみに閉じています。
- Issue の smoke 追加は「必要なら」の範囲であり、今回は docs-only prose update に留めています。