### PR TITLE
CHANGELOG に Development docs / npm ci 追従を記録する v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Release preparation notes:
 - Clarified development docs for the Ruby-backed `npm run test:entrypoints` manifest loader path and setup expectations.
 - Clarified development docs that `.nvmrc`, `package.json` `engines.node`, and workflow `node-version` stay aligned by a Node version source drift guard.
 - Clarified Development docs for the Ruby version source and CI changed-file policy guard commands, including Bundler dependency package-sensitive guidance.
+- Clarified Development docs for standalone gem package verification and docs i18n parity commands.
+- Clarified `npm ci` install path guidance across README, installation, development, and release checklist docs so local setup, PR CI, Docker setup smoke, and main-push JavaScript checks share lockfile-backed evidence.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
@@ -144,6 +146,11 @@ Release preparation notes:
 - Added controller entries contract smoke and `tree_view_rows` / Windowed Rendering docs signal coverage to the docs entrypoint suite.
 - Added Docker Ruby base image source guard coverage to the Ruby version source drift smoke.
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
+- Added `npm ci` CI and Docker setup smoke coverage so workflow routing, JavaScript setup, and docs install guidance stay aligned.
+- Added a standalone Public API manifest structure command and docs entrypoint suite wiring for manifest structure smoke.
+- Added Development docs command signal smoke coverage for maintainer npm command guidance.
+- Added Development docs package verification coverage to the gem package contents guard.
+- Added release:check package contents verification plus gem metadata URI and public runtime packaging guard coverage.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 PR / 背景

Supersedes #2175
Supersedes #2172
Refs #2155
Refs #2158
Refs #2162
Refs #2163
Refs #2169
Refs #2177
Refs #2182

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2175 は CHANGELOG-only の docs-sync PR でしたが、#2177 merge 後に `main` が進み、`npm ci` install path / CI・Docker setup smoke / docs sync の release-facing evidence を CHANGELOG に含める review follow-up が残りました。

その後 #2182 が merge されたため、review:changes-requested の指摘どおり latest `main` を取り込み直し、fresh CI を確認しています。

## 変更内容

- `CHANGELOG.md > Unreleased > Documentation` に Development docs / package verification / docs i18n parity / `npm ci` install path guidance を追加しました。
- `CHANGELOG.md > Unreleased > Tests` に以下を追加しました。
  - `npm ci` CI / Docker setup smoke coverage
  - public API manifest structure smoke の単体 command / docs entrypoint suite wiring
  - Development docs command signal smoke
  - Development docs package verification guard
  - `release:check` package contents verification と gem metadata / public runtime packaging guard

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- package scripts
- CI workflow
- Development docs / Release docs 本文
- release automation

## 確認内容

- review:changes-requested の内容を確認し、latest main 追従 / fresh CI が必要な follow-up と分類しました。
- current main: `d3f6116b63eae0e3d9133f36da82d74d8ef29544`
- head: `e97ef6973357761c3c5440c0b4e3c834a475c909`
- compare `main...docs/changelog-development-guard-evidence-v3`: `ahead_by:2` / `behind_by:0` / changed files 1
- PR metadata: `mergeable:true`
- GitHub Actions CI #2948 / run `27598202854`: success
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

merge は行いません。