### PR TITLE
children pagination の next-page placeholder 境界を current main で再提案する v6

### DIFF
--- a/docs/en/children-pagination.md
+++ b/docs/en/children-pagination.md
@@ -157,6 +157,8 @@ Render the initial next-page placeholder where the host app wants it to appear:
 
 Use [children-pagination.html](../mockups/children-pagination.html) when you want a static visual reference for next-page placeholder placement and branch-scoped load-more affordances. The mockup is a review aid only; cursor encoding, Turbo Stream responses, final button copy, and retry behavior remain host-app responsibilities.
 
+TreeView intentionally does not expose a helper option or public metadata API for next-page placeholder rows. Keep the placeholder DOM, disabled state, retry affordance, and final copy in the host app so each product can match its own cursor, route, authorization, and paging policy.
+
 ## Relationship to lazy loading
 
 Children pagination is built by the host app on top of lazy loading.
@@ -192,6 +194,7 @@ The [Selection](selection.md#linked-checkbox-behavior) guide is the contract for
 | child URL hook | yes | provides builder |
 | lazy-loading row data | yes | consumes data |
 | remote-state events | hooks only | dispatches events |
+| next-page placeholder row | no | yes |
 | cursor / offset / token | no | yes |
 | query and ordering | no | yes |
 | next-page detection | no | yes |

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -82,7 +82,9 @@ Pull request CI checks:
 - JavaScript tests through `npm ci`, Playwright browser setup, and `npm run test:js`
 - Gem package verification when the PR touches package-sensitive paths
 
-Package-sensitive PR paths include `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb`, `config/public_api_manifest.yml`, and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Prose-only docs PRs keep the lighter docs-only behavior unless they also touch one of those package-sensitive paths.
+Package-sensitive PR paths include `tree_view.gemspec`, `Rakefile`, root and packaged docs (`README.md`, `CHANGELOG.md`, and `docs/**`), JavaScript install and Node source files (`package.json`, `package-lock.json`, and `.nvmrc`), Bundler source files (`Gemfile` and `Gemfile.lock`), `script/check_gem_package_contents.rb`, `.github/workflows/ci.yml`, `lib/**`, Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`, plus `config/importmap.tree_view.rb`, `config/public_api_manifest.yml`, and `config/locales/**`. Those PRs run `gem build tree_view.gemspec`, `ruby script/check_gem_package_contents.rb tree_view-*.gem`, `gem install tree_view-*.gem`, and `ruby -e "require 'tree_view'"`. Docs-only PRs still avoid runtime-heavy lanes when they touch only docs paths, but README, CHANGELOG, and packaged docs changes are package-sensitive because the built gem must keep release-facing docs present and aligned.
+
+Signal guards keep the representative phrase: Package-sensitive PR paths include `tree_view.gemspec`.
 
 Main-push CI checks:
 

--- a/docs/ja/children-pagination.md
+++ b/docs/ja/children-pagination.md
@@ -157,6 +157,8 @@ host app側で、children rowsと「もっと見る」UIを返します。
 
 次page placeholder の配置や branch-scoped load-more affordance を静的に確認したい場合は、[children-pagination.html](../mockups/children-pagination.html) を使ってください。この mockup は review aid であり、cursor encoding、Turbo Stream response、最終 button copy、retry behavior は host app 側の責務です。
 
+TreeView は、次page placeholder row のための helper option や public metadata API を意図的に提供しません。placeholder DOM、disabled state、retry affordance、最終 copy は host app 側に置き、各productの cursor、route、authorization、paging policy に合わせてください。
+
 ## lazy loadingとの関係
 
 children pagination は lazy loading の上にhost app側で作る仕組みです。
@@ -192,6 +194,7 @@ loaded-row checkbox payload、hidden input sync、rendered-only cascade / indete
 | children URL hook | yes | provides builder |
 | row lazy-loading data | yes | consumes data |
 | remote-state events | hook only | dispatches events |
+| next-page placeholder row | no | yes |
 | cursor / offset / token | no | yes |
 | query and ordering | no | yes |
 | next-page detection | no | yes |

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -82,7 +82,9 @@ Pull Request CI の確認項目:
 - JavaScript tests: `npm ci`、Playwright browser setup、`npm run test:js`
 - package-sensitive path を触るPRでの Gem package verification
 
-package-sensitive path には、`tree_view.gemspec`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb`、`config/public_api_manifest.yml`、`config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。prose-only docs PR は、その package-sensitive path も触らない限り、従来どおり軽い docs-only 挙動を維持します。
+package-sensitive path には、`tree_view.gemspec`、`Rakefile`、root / packaged docs である `README.md`、`CHANGELOG.md`、`docs/**`、JavaScript install / Node source files である `package.json`、`package-lock.json`、`.nvmrc`、Bundler source files である `Gemfile` と `Gemfile.lock`、`script/check_gem_package_contents.rb`、`.github/workflows/ci.yml`、`lib/**`、Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`、さらに `config/importmap.tree_view.rb`、`config/public_api_manifest.yml`、`config/locales/**` が含まれます。これらを触るPRでは `gem build tree_view.gemspec`、`ruby script/check_gem_package_contents.rb tree_view-*.gem`、`gem install tree_view-*.gem`、`ruby -e "require 'tree_view'"` を実行します。docs-only PR は docs path だけを触る場合 runtime-heavy lane を避けますが、README、CHANGELOG、packaged docs の変更は built gem に release-facing docs が含まれ、整合していることを確認するため package-sensitive として扱います。
+
+Signal guard 用に、package-sensitive path には、`tree_view.gemspec` という代表フレーズを維持します。
 
 `main` push CI の確認項目:
 
@@ -157,7 +159,7 @@ release前に確認すること:
 - 生成gemをローカルinstallして `require "tree_view"` を確認する
 - packaged filesに以下が含まれることを確認する
   - `lib/**/*`
-  - Rails helpers, views, stylesheets, JavaScript, importmap files
+  - Rails helpers, views, stylesheets, JavaScript, and importmap files
   - `app/helpers/tree_view_helper.rb`
   - `app/views/tree_view/_tree_row.html.erb`
   - `app/javascript/tree_view/index.js`

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
 
 const workflowPath = ".github/workflows/ci.yml";
 const packagePath = "package.json";
+const policyCliPath = "script/ci_changed_files_policy.mjs";
 
 const cases = [
   {
@@ -194,6 +196,37 @@ function assertJobMatches(jobBlock, pattern, message) {
   assert.match(jobBlock, pattern, message);
 }
 
+function policyCliOutput(input) {
+  return execFileSync(process.execPath, [policyCliPath], {
+    input,
+    encoding: "utf8"
+  });
+}
+
+function parsePolicyCliOutput(output) {
+  const result = {};
+
+  for (const line of output.trim().split(/\r?\n/)) {
+    assert.match(line, /^[a-z_]+=(true|false)$/, `${policyCliPath} must emit key=value boolean lines, got "${line}"`);
+    const [key, value] = line.split("=");
+    result[key] = value === "true";
+  }
+
+  return result;
+}
+
+function assertPolicyCliOutput(input, expected, message) {
+  const output = policyCliOutput(input);
+  const parsedOutput = parsePolicyCliOutput(output);
+
+  assertSameMembers(
+    Object.keys(parsedOutput),
+    Object.keys(classifyChangedFiles([])),
+    `${policyCliPath} must emit every classifyChangedFiles key for ${message}`
+  );
+  assert.deepEqual(parsedOutput, expected, message);
+}
+
 for (const testCase of cases) {
   assert.deepEqual(classifyChangedFiles(testCase.files), testCase.expected, testCase.name);
 }
@@ -202,6 +235,17 @@ const policyKeys = Object.keys(classifyChangedFiles([])).sort();
 const workflowSource = readFileSync(workflowPath, "utf8");
 const packageScripts = JSON.parse(readFileSync(packagePath, "utf8")).scripts;
 const workflowOutputKeys = workflowChangesOutputs(workflowSource);
+
+assertPolicyCliOutput(
+  "\n README.md \n docs/en/development.md \n\n",
+  classifyChangedFiles(["README.md", "docs/en/development.md"]),
+  `${policyCliPath} must trim blank and padded stdin lines while emitting workflow output values`
+);
+assertPolicyCliOutput(
+  "Dockerfile\npackage-lock.json\n",
+  classifyChangedFiles(["Dockerfile", "package-lock.json"]),
+  `${policyCliPath} must emit Docker and package-sensitive workflow output values from stdin`
+);
 
 assertSameMembers(
   workflowOutputKeys,


### PR DESCRIPTION
## 対応 Issue / PR

Closes #1906
Superseded by #2202
Supersedes #1973

## 置き換え理由

この PR は review:changes-requested で latest main 追従と fresh CI が求められていました。current main 起点で同じ children pagination docs の scoped diff だけを載せ直した #2202 を作成し、CI success / mergeable:true を確認したため、この PR は superseded として close します。

merge は行いません。