### PR TITLE
ci_changed_files_policy の CLI 出力ガードを追加する

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
 
 const workflowPath = ".github/workflows/ci.yml";
 const packagePath = "package.json";
+const policyCliPath = "script/ci_changed_files_policy.mjs";
 
 const cases = [
   {
@@ -134,8 +136,7 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: true,
-      docs_entrypoint_sensitive: false
+      docker_setup_sensitive: true
     }
   }
 ];
@@ -194,6 +195,37 @@ function assertJobMatches(jobBlock, pattern, message) {
   assert.match(jobBlock, pattern, message);
 }
 
+function policyCliOutput(input) {
+  return execFileSync(process.execPath, [policyCliPath], {
+    input,
+    encoding: "utf8"
+  });
+}
+
+function parsePolicyCliOutput(output) {
+  const result = {};
+
+  for (const line of output.trim().split(/\r?\n/)) {
+    assert.match(line, /^[a-z_]+=(true|false)$/, `${policyCliPath} must emit key=value boolean lines, got "${line}"`);
+    const [key, value] = line.split("=");
+    result[key] = value === "true";
+  }
+
+  return result;
+}
+
+function assertPolicyCliOutput(input, expected, message) {
+  const output = policyCliOutput(input);
+  const parsedOutput = parsePolicyCliOutput(output);
+
+  assertSameMembers(
+    Object.keys(parsedOutput),
+    Object.keys(classifyChangedFiles([])),
+    `${policyCliPath} must emit every classifyChangedFiles key for ${message}`
+  );
+  assert.deepEqual(parsedOutput, expected, message);
+}
+
 for (const testCase of cases) {
   assert.deepEqual(classifyChangedFiles(testCase.files), testCase.expected, testCase.name);
 }
@@ -202,6 +234,17 @@ const policyKeys = Object.keys(classifyChangedFiles([])).sort();
 const workflowSource = readFileSync(workflowPath, "utf8");
 const packageScripts = JSON.parse(readFileSync(packagePath, "utf8")).scripts;
 const workflowOutputKeys = workflowChangesOutputs(workflowSource);
+
+assertPolicyCliOutput(
+  "\n README.md \n docs/en/development.md \n\n",
+  classifyChangedFiles(["README.md", "docs/en/development.md"]),
+  `${policyCliPath} must trim blank and padded stdin lines while emitting workflow output values`
+);
+assertPolicyCliOutput(
+  "Dockerfile\npackage-lock.json\n",
+  classifyChangedFiles(["Dockerfile", "package-lock.json"]),
+  `${policyCliPath} must emit Docker and package-sensitive workflow output values from stdin`
+);
 
 assertSameMembers(
   workflowOutputKeys,

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -136,7 +136,8 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: true
+      docker_setup_sensitive: true,
+      docs_entrypoint_sensitive: false
     }
   }
 ];


### PR DESCRIPTION
## 対応 Issue

Closes #2190

## Issue ごとの完了内容

- #2190: `script/ci_changed_files_policy.mjs` を実際に Node CLI として実行し、GitHub Actions `$GITHUB_OUTPUT` に渡す `key=value` 形式の出力が維持されることを `script/test_ci_changed_files_policy.mjs` で確認するようにしました。

## 変更内容

- 既存の CI changed-file policy test に `execFileSync` ベースの CLI 実行ガードを追加しました。
- stdin の blank line / surrounding whitespace が既存の trim behavior と同じ扱いになることを代表ケースで確認します。
- Docker setup / package-sensitive の代表ケースで、CLI 出力の boolean key set と値が `classifyChangedFiles(...)` と一致することを確認します。
- 出力行は `key=true|false` の形式に限定して検査し、workflow handoff 用の stdout format drift を検出しやすくしました。

## 改善カテゴリ

- test
- CI guard hardening
- devops

## 既存仕様への影響

- runtime Ruby / JavaScript behavior、CI workflow topology、changed-file classification policy、package-sensitive path list は変更していません。
- 既存の分類関数テストに CLI wrapper / stdout format の代表ガードを追加しただけです。

## 実施した確認

- Issue #2190 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch は current `main` `a5d65f22c3bcde7091737d7bc45e7159cf00aa7b` から作成しました。
- compare `main...quality/2190-ci-policy-cli-output`: `ahead_by:2` / `behind_by:0` / changed files 1。
- changed files は `script/test_ci_changed_files_policy.mjs` のみです。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。テスト追加のみで、CI の分類ロジックや workflow 条件は変更していません。

## 補足事項

- `#2150` は eligibility を確認しましたが、59ファイル規模の Standard autocorrect であり、ローカル checkout / full target coverage / final newline / verification が必要なため、この connector-only run では着手しませんでした。
- `#2183` / `#2184` は同じ public API manifest guard family ですが、今回の PR とはテーマが異なるため束ねていません。
- merge は行いません。