### PR TITLE
CHANGELOG に CI policy CLI 出力ガードを記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Release preparation notes:
 - Added controller entries contract smoke and `tree_view_rows` / Windowed Rendering docs signal coverage to the docs entrypoint suite.
 - Added Docker Ruby base image source guard coverage to the Ruby version source drift smoke.
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
+- Added CI changed-file policy CLI output guard coverage for workflow `key=value` handoff formatting and stdin trimming.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 PR

Refs #2191

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2191 で `script/test_ci_changed_files_policy.mjs` に、`script/ci_changed_files_policy.mjs` の CLI 出力が GitHub Actions `$GITHUB_OUTPUT` 向けの `key=value` boolean formatを維持することを確認する guard が追加されました。

`CHANGELOG.md` の `Unreleased > Tests` には、この release-facing test evidence がまだ記録されていなかったため、docs-only で追従します。

## 変更内容

- `CHANGELOG.md > Unreleased > Tests` に CI changed-file policy CLI output guard coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- test scripts
- CI workflow
- changed-file classification policy
- package-sensitive path list

## 確認内容

- Default PR Check として open docs PR #2187 / #2180 / #2181 / #2188 / #2189 を確認し、前回 follow-up 後の追加修正要求は #2193 の latest main 追従要求のみと判断しました。
- #2191 が main に merge 済みであることを確認しました。
- #2192 merge 後の review:changes-requested に対応し、latest main `55027133316746a7d6c1cd9c198f9cbc9b094b33` を取り込む docs-only refresh commit `2c907ee98d5ae3efbc1598ee1ad1a6fc5edea23a` を追加しました。
- compare `main...docs/2191-changelog-ci-policy-cli-output`: `ahead_by:2` / `behind_by:0` / `status:ahead`
- changed files: `CHANGELOG.md` の1件のみ / additions 1 / deletions 0
- PR metadata: `mergeable:true`
- GitHub Actions CI #2976 / run `27610136978`: success
  - `changes`, `lint`, `pr_specs`, `javascript` (`npm ci` + `npm run test:docs-entrypoints`), `gem_package`: success
  - representative Rails lanes and Docker setup are docs-only skip paths as expected
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

merge は行いません。