### PR TITLE
Docs entrypoint suite の lightweight guard を追加する

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict"
 import { spawnSync } from "node:child_process"
 
 const checks = [
@@ -92,6 +93,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "Host lifecycle no-detail docs signals",
+    command: "node",
+    args: ["script/test_host_lifecycle_no_detail_docs_signals.mjs"]
+  },
+  {
     group: "tree_view_rows helper docs signals",
     command: "node",
     args: ["script/test_tree_view_rows_docs_signals.mjs"]
@@ -125,6 +131,11 @@ const checks = [
     group: "Docs i18n parity",
     command: "npm",
     args: ["run", "test:docs-i18n"]
+  },
+  {
+    group: "Docs entrypoint suite option contract",
+    command: "node",
+    args: ["script/test_docs_entrypoint_suite.mjs", "--self-test"]
   }
 ]
 
@@ -153,60 +164,137 @@ function printCheckList(selectedChecks = checks) {
 }
 
 function usage() {
-  console.error("[docs-entrypoints] usage: node script/test_docs_entrypoint_suite.mjs [--list] [--only <group-or-index>]")
+  console.error("[docs-entrypoints] usage: node script/test_docs_entrypoint_suite.mjs [--list] [--only <group-or-index>] [--self-test]")
   console.error("[docs-entrypoints] use --list to show available groups")
 }
 
-function resolveOnlyGroup(groupName) {
+function resolveOnlyGroupResult(groupName) {
   if (/^\d+$/.test(groupName)) {
     const groupIndex = Number(groupName) - 1
     const indexedMatch = checks[groupIndex]
-    if (indexedMatch) return indexedMatch
+    if (indexedMatch) return { check: indexedMatch }
 
-    console.error(`[docs-entrypoints] --only index out of range: ${groupName}`)
-    console.error("[docs-entrypoints] available groups:")
-    console.error(formatAvailableGroups())
-    console.error("[docs-entrypoints] run with --list to inspect commands")
-    process.exit(1)
+    return {
+      error: "out_of_range",
+      message: `[docs-entrypoints] --only index out of range: ${groupName}`
+    }
   }
 
   const exactMatches = checks.filter((check) => check.group === groupName)
-  if (exactMatches.length === 1) return exactMatches[0]
+  if (exactMatches.length === 1) return { check: exactMatches[0] }
 
   const normalizedGroupName = groupName.toLowerCase()
   const caseInsensitiveExactMatches = checks.filter(
     (check) => check.group.toLowerCase() === normalizedGroupName
   )
-  if (caseInsensitiveExactMatches.length === 1) return caseInsensitiveExactMatches[0]
+  if (caseInsensitiveExactMatches.length === 1) return { check: caseInsensitiveExactMatches[0] }
 
   const partialMatches = checks.filter((check) =>
     check.group.toLowerCase().includes(normalizedGroupName)
   )
 
-  if (partialMatches.length === 1) return partialMatches[0]
+  if (partialMatches.length === 1) return { check: partialMatches[0] }
 
   if (partialMatches.length > 1) {
-    console.error(`[docs-entrypoints] ambiguous --only group: ${groupName}`)
+    return {
+      error: "ambiguous",
+      message: `[docs-entrypoints] ambiguous --only group: ${groupName}`,
+      matches: partialMatches
+    }
+  }
+
+  return {
+    error: "unknown",
+    message: `[docs-entrypoints] unknown --only group: ${groupName}`
+  }
+}
+
+function printOnlyGroupError(result) {
+  console.error(result.message)
+
+  if (result.error === "ambiguous") {
     console.error("[docs-entrypoints] matching groups:")
-    console.error(partialMatches.map((check) => `  - ${check.group}`).join("\n"))
-  } else {
-    console.error(`[docs-entrypoints] unknown --only group: ${groupName}`)
+    console.error(result.matches.map((check) => `  - ${check.group}`).join("\n"))
   }
 
   console.error("[docs-entrypoints] available groups:")
   console.error(formatAvailableGroups())
   console.error("[docs-entrypoints] run with --list to inspect commands")
+}
+
+function resolveOnlyGroup(groupName) {
+  const result = resolveOnlyGroupResult(groupName)
+  if (result.check) return result.check
+
+  printOnlyGroupError(result)
   process.exit(1)
 }
 
+function runSelfTest() {
+  const availableGroups = formatAvailableGroups()
+
+  assert.match(
+    availableGroups,
+    /1\. Foundational docs entrypoints/,
+    "available group list should include a stable first index"
+  )
+  assert.ok(
+    availableGroups.includes(`${checks.length}. Docs entrypoint suite option contract`),
+    "available group list should include the self-test group"
+  )
+
+  assert.equal(
+    resolveOnlyGroupResult("1").check.group,
+    "Foundational docs entrypoints",
+    "numeric --only should resolve a one-based index"
+  )
+  assert.equal(
+    resolveOnlyGroupResult("public api docs signals").check.group,
+    "Public API docs signals",
+    "case-insensitive exact --only should resolve a group"
+  )
+  assert.equal(
+    resolveOnlyGroupResult("Localized and hook").check.group,
+    "Localized and hook docs signals",
+    "unique partial --only should resolve a group"
+  )
+
+  const outOfRange = resolveOnlyGroupResult("999")
+  assert.equal(outOfRange.error, "out_of_range")
+  assert.match(outOfRange.message, /--only index out of range: 999/)
+
+  const unknown = resolveOnlyGroupResult("does-not-exist")
+  assert.equal(unknown.error, "unknown")
+  assert.match(unknown.message, /unknown --only group: does-not-exist/)
+
+  const ambiguous = resolveOnlyGroupResult("Public API")
+  assert.equal(ambiguous.error, "ambiguous")
+  assert.deepEqual(
+    ambiguous.matches.map((check) => check.group),
+    [
+      "Public API docs signals",
+      "Public API manifest structure",
+      "Public API entrypoint guard signals"
+    ],
+    "ambiguous --only should report all matching groups"
+  )
+
+  console.log("[docs-entrypoints] self-test passed")
+}
+
 function parseArgs(argv) {
-  const options = { list: false, only: null }
+  const options = { list: false, only: null, selfTest: false }
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
 
     if (arg === "--list") {
       options.list = true
+      continue
+    }
+
+    if (arg === "--self-test") {
+      options.selfTest = true
       continue
     }
 
@@ -235,6 +323,11 @@ function parseArgs(argv) {
 }
 
 const options = parseArgs(process.argv.slice(2))
+
+if (options.selfTest) {
+  runSelfTest()
+  process.exit(0)
+}
 
 if (options.list) {
   printCheckList()

--- a/script/test_host_lifecycle_no_detail_docs_signals.mjs
+++ b/script/test_host_lifecycle_no_detail_docs_signals.mjs
@@ -63,7 +63,7 @@ assertMatches(
 )
 assertMatches(
   publicApiJa,
-  /TreeViewEventNames\.hostLifecycle\.\*[\s\S]*host app 側の request-state dispatch 専用[\s\S]*TreeViewEventNames\.remoteState\.\*/,
+  /TreeViewEventNames\.hostLifecycle\.\*[\s\S]*host app 側の request-state dispatch(?: surface)? 専用[\s\S]*TreeViewEventNames\.remoteState\.\*/,
   "Japanese public API docs hostLifecycle boundary"
 )
 
@@ -74,7 +74,7 @@ assertMatches(
 )
 assertMatches(
   lazyLoadingJa,
-  /TreeViewEventNames\.hostLifecycle\.loading[\s\S]*\.loaded[\s\S]*\.error[\s\S]*\.retry[\s\S]*host app 側の request-state dispatch 専用[\s\S]*TreeViewEventNames\.remoteState\.\*/,
+  /TreeViewEventNames\.hostLifecycle\.loading[\s\S]*\.loaded[\s\S]*\.error[\s\S]*\.retry[\s\S]*host app 側の request-state dispatch(?: surface)? 専用[\s\S]*TreeViewEventNames\.remoteState\.\*/,
   "Japanese lazy-loading docs hostLifecycle lifecycle boundary"
 )
 

--- a/script/test_host_lifecycle_no_detail_docs_signals.mjs
+++ b/script/test_host_lifecycle_no_detail_docs_signals.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+
+function readText(path) {
+  return readFileSync(path, "utf8")
+}
+
+function assertIncludes(source, expected, context) {
+  assert.ok(
+    source.includes(expected),
+    `${context} should include ${expected}`
+  )
+}
+
+function assertMatches(source, pattern, context) {
+  assert.match(source, pattern, `${context} should match ${pattern}`)
+}
+
+function sectionBetween(source, startMarker, endMarker, context) {
+  const start = source.indexOf(startMarker)
+  assert.notEqual(start, -1, `${context} should include ${startMarker.trim()}`)
+
+  const end = source.indexOf(endMarker, start + startMarker.length)
+  assert.notEqual(end, -1, `${context} should include ${endMarker.trim()} after ${startMarker.trim()}`)
+
+  return source.slice(start + startMarker.length, end)
+}
+
+const manifest = readText("config/public_api_manifest.yml")
+const publicApiEn = readText("docs/en/public-api.md")
+const publicApiJa = readText("docs/ja/public-api.md")
+const lazyLoadingEn = readText("docs/en/lazy-loading.md")
+const lazyLoadingJa = readText("docs/ja/lazy-loading.md")
+
+const lifecycleNames = ["loading", "loaded", "error", "retry"]
+const noDetailSection = sectionBetween(
+  manifest,
+  "  event_names_without_detail:\n",
+  "  event_detail_keys:\n",
+  "public API manifest"
+)
+const detailKeysSection = sectionBetween(
+  manifest,
+  "  event_detail_keys:\n",
+  "  integration_hooks:\n",
+  "public API manifest"
+)
+
+assertIncludes(noDetailSection, "    host_lifecycle:", "event_names_without_detail section")
+for (const name of lifecycleNames) {
+  assertIncludes(noDetailSection, `      - ${name}`, "host_lifecycle no-detail event names")
+}
+assert.doesNotMatch(
+  detailKeysSection,
+  /^    host_lifecycle:/m,
+  "host_lifecycle events should stay out of event_detail_keys because they do not define public event.detail payload keys"
+)
+
+assertMatches(
+  publicApiEn,
+  /TreeViewEventNames\.hostLifecycle\.\*[\s\S]*host-app dispatch surface[\s\S]*TreeViewEventNames\.remoteState\.\*/,
+  "English public API docs hostLifecycle boundary"
+)
+assertMatches(
+  publicApiJa,
+  /TreeViewEventNames\.hostLifecycle\.\*[\s\S]*host app 側の request-state dispatch 専用[\s\S]*TreeViewEventNames\.remoteState\.\*/,
+  "Japanese public API docs hostLifecycle boundary"
+)
+
+assertMatches(
+  lazyLoadingEn,
+  /TreeViewEventNames\.hostLifecycle\.loading[\s\S]*\.loaded[\s\S]*\.error[\s\S]*\.retry[\s\S]*host-app request-state dispatch[\s\S]*TreeViewEventNames\.remoteState\.\*/,
+  "English lazy-loading docs hostLifecycle lifecycle boundary"
+)
+assertMatches(
+  lazyLoadingJa,
+  /TreeViewEventNames\.hostLifecycle\.loading[\s\S]*\.loaded[\s\S]*\.error[\s\S]*\.retry[\s\S]*host app 側の request-state dispatch 専用[\s\S]*TreeViewEventNames\.remoteState\.\*/,
+  "Japanese lazy-loading docs hostLifecycle lifecycle boundary"
+)
+
+assertMatches(
+  lazyLoadingEn,
+  /TreeViewRemoteStateValues\.loading[\s\S]*not event names[\s\S]*not a validation list/,
+  "English lazy-loading docs remote-state values boundary"
+)
+assertMatches(
+  lazyLoadingJa,
+  /TreeViewRemoteStateValues\.loading[\s\S]*event 名ではありません[\s\S]*validation list でもありません/,
+  "Japanese lazy-loading docs remote-state values boundary"
+)
+
+console.log("[host-lifecycle-docs] no-detail host lifecycle docs signals passed")


### PR DESCRIPTION
## 対応 Issue 一覧

- Closes #2146
- Closes #2148

## Issue ごとの完了内容

- #2146: `hostLifecycle` event が `event.detail` payload key を持たない host-app request-state dispatch surface であることを、manifest と英日 public API / lazy-loading docs の代表文言で確認する docs smoke guard を追加しました。
- #2148: docs-entrypoint suite の `--list` / `--only` 解決ロジックを軽量 self-test として検証し、通常 suite 内でも全 group を二重実行せずに option contract だけを確認できるようにしました。

## 変更内容

- `script/test_host_lifecycle_no_detail_docs_signals.mjs` を追加し、`event_names_without_detail.host_lifecycle`、`event_detail_keys` 非掲載、英日 docs の hostLifecycle / remoteState boundary を確認します。
- `script/test_docs_entrypoint_suite.mjs` に以下を追加しました。
  - `Host lifecycle no-detail docs signals` group
  - `Docs entrypoint suite option contract` self-test group
  - `resolveOnlyGroupResult` による `--only` 解決の pure result 化
  - index / case-insensitive exact / unique partial / out-of-range / unknown / ambiguous の代表 self-test

## 改善カテゴリ

- test / docs smoke guard
- CLI option contract guard
- maintenance quality hardening

## 既存仕様への影響

なし。runtime code、public API、manifest schema、docs 文言、UI/API/DB/認可/外部契約は変更していません。既存 docs-entrypoint suite の検査対象を追加し、`--self-test` は軽量検証用の内部オプションとして追加しています。

## 実施した確認内容

- Issue #2146 / #2148 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- review follow-up: 対象 3 repo の自作 open PR を確認し、Quality Fixer 範囲で直ちに対応すべき external review follow-up はありませんでした。`tree_view-rails` の既存 quality PR #2192 は merge 済みでした。
- branch freshness: `main` `55027133316746a7d6c1cd9c198f9cbc9b094b33` 起点、compare `ahead_by:3` / `behind_by:0`。
- 差分対象: `script/test_docs_entrypoint_suite.mjs`, `script/test_host_lifecycle_no_detail_docs_signals.mjs` の 2 ファイルのみ。
- 更新ファイルは final newline 付きで作成・更新しています。
- ローカル checkout / local npm test は、この実行環境で GitHub clone/archive が `CONNECT tunnel failed, response 403` で利用できないため未実行です。
- PR CI run #2975: success。

## リスク評価

low。docs / manifest の既存 contract を読む smoke test 追加であり、公開挙動は変えません。主なリスクは docs 文言に対する guard がやや具体的になることですが、英日 docs で既に明示されている hostLifecycle / remoteState 境界に限定しています。

## 補足事項

- #2150 も eligible issue として確認しましたが、59 ファイルの `Style/RedundantStructKeywordInit` autocorrect であり、checkout 可能な環境で `standardrb --fix` を使って確認すべき変更です。今回の docs-entrypoint smoke guard とは共通性が薄いため、この PR には含めていません。
- merge は行いません。