### PR TITLE
package-lock dependency drift guard を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs",
+    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_package_lock_dependency_drift.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/script/test_package_lock_dependency_drift.mjs
+++ b/script/test_package_lock_dependency_drift.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const packagePath = "package.json";
+const packageLockPath = "package-lock.json";
+
+function dependencyKeys(metadata, section) {
+  return Object.keys(metadata?.[section] || {}).sort();
+}
+
+function assertDependencyKeysMatch(packageMetadata, lockRootPackage, section) {
+  const packageKeys = dependencyKeys(packageMetadata, section);
+  const lockKeys = dependencyKeys(lockRootPackage, section);
+  const missingFromLock = packageKeys.filter((key) => !lockKeys.includes(key));
+  const extraInLock = lockKeys.filter((key) => !packageKeys.includes(key));
+
+  assert.deepEqual(
+    { missingFromLock, extraInLock },
+    { missingFromLock: [], extraInLock: [] },
+    `${packageLockPath} root package ${section} keys must match ${packagePath} ${section} keys`
+  );
+}
+
+const packageMetadata = JSON.parse(readFileSync(packagePath, "utf8"));
+const packageLock = JSON.parse(readFileSync(packageLockPath, "utf8"));
+const lockRootPackage = packageLock.packages?.[""];
+
+assert.ok(lockRootPackage, `${packageLockPath} must include packages[""] root package metadata`);
+
+for (const section of ["dependencies", "devDependencies"]) {
+  assertDependencyKeysMatch(packageMetadata, lockRootPackage, section);
+}


### PR DESCRIPTION
## 対応 Issue 一覧

- Closes #2141

## Issue ごとの完了内容

- #2141: `package.json` と `package-lock.json` root package の direct `dependencies` / `devDependencies` key set が再びずれた時に、npm registry へアクセスせず検出できる lightweight Node check を追加しました。

## 変更内容

- `script/test_package_lock_dependency_drift.mjs` を追加しました。
  - checkout 済みの `package.json` / `package-lock.json` だけを読みます。
  - `packages[""]` の direct dependency key set だけを比較します。
  - missing / extra dependency が section ごとに分かる failure message になります。
- `npm run test:ci-policy` にこの check を接続しました。

## 改善カテゴリ

- test / CI guard
- lockfile drift prevention
- maintenance quality hardening

## 既存仕様への影響

なし。package version 解決、lockfile refresh、dependency update、npm audit、CI workflow topology、required check name、runtime Ruby / JavaScript behavior は変更していません。

## 実施した確認内容

- Issue #2141 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` の `package.json` と `package-lock.json` root package dependency key set が同期済みであることを確認しました。
- branch: `quality/2141-package-lock-drift-guard`
- base: current `main` `4288bcc510d746329ed950040f8dabaa3d26a26e`
- compare `main...quality/2141-package-lock-drift-guard`: `ahead_by:2` / `behind_by:0` / changed files 2。
- ローカル checkout / local npm check は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。root package の direct dependency key set のみを比較し、transitive packages や version 完全一致には広げていません。

## 補足事項

- #413 の lockfile refresh 本体は扱っていません。
- merge は行いません。