### PR TITLE
CHANGELOG に Public API manifest runtime guard を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Release preparation notes:
 - Added controller entries contract smoke and `tree_view_rows` / Windowed Rendering docs signal coverage to the docs entrypoint suite.
 - Added Docker Ruby base image source guard coverage to the Ruby version source drift smoke.
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
+- Added Public API manifest runtime surface guard coverage for documented module methods, constants, and helper methods.
 - Added CI changed-file policy CLI output guard coverage for workflow `key=value` handoff formatting and stdin trimming.
 
 ## 0.1.0 - 2026-05-07


### PR DESCRIPTION
## 対応 PR

Refs #2192

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 背景

#2192 で `spec/public_api_manifest_structure_spec.rb` に、Public API manifest の `module_methods` / `public_constants` / `helper_methods` が runtime と英日 Public API docs の documented surface と同期していることを確認する guard が追加されました。

`CHANGELOG.md > Unreleased > Tests` には、この release-facing test evidence がまだ記録されていなかったため、docs-only で追従します。

## 変更内容

- `CHANGELOG.md > Unreleased > Tests` に Public API manifest runtime surface guard coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` の1行追加のみ

## 非対象

- runtime Ruby / JavaScript
- specs / test scripts
- Public API docs 本文
- public API manifest schema
- helper behavior / public API surface
- CI workflow

## 確認内容

- Default PR Check として #2193 の review:changes-requested follow-up を優先し、latest main refresh / fresh CI success / PR comment まで対応しました。その後 #2193 は merge 済みになっています。
- #2192 が current main に merge 済みであることを確認しました。
- #2192 の差分が `spec/public_api_manifest_structure_spec.rb` の guard 追加のみで、runtime / docs wording / manifest schema を変更していないことを確認しました。
- README / `docs/README.md` / `AGENTS.md` / `Product Profile.md` を確認し、今回の guard追加に対して追加の入口docs更新は不要と判断しました。
- 重複 open PR / Issue は `Public API manifest runtime surface guard` / `CHANGELOG` で見当たりませんでした。
- current main: `4288bcc510d746329ed950040f8dabaa3d26a26e`
- compare `main...docs/2192-changelog-public-api-manifest-runtime-guard`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files: `CHANGELOG.md` の1件のみ / additions 1 / deletions 0
- PR metadata: `mergeable:true`
- GitHub Actions CI #2984 / run `27610729533`: success
  - `changes`, `lint`, `pr_specs`, `javascript` (`npm ci` + `npm run test:docs-entrypoints`), `gem_package`: success
  - representative Rails lanes and Docker setup are docs-only skip paths as expected
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

merge は行いません。