### PR TITLE
children pagination placeholder 境界を current main で再提案する v7

### DIFF
--- a/docs/en/children-pagination.md
+++ b/docs/en/children-pagination.md
@@ -157,6 +157,8 @@ Render the initial next-page placeholder where the host app wants it to appear:
 
 Use [children-pagination.html](../mockups/children-pagination.html) when you want a static visual reference for next-page placeholder placement and branch-scoped load-more affordances. The mockup is a review aid only; cursor encoding, Turbo Stream responses, final button copy, and retry behavior remain host-app responsibilities.
 
+TreeView intentionally does not expose a helper option or public metadata API for next-page placeholder rows. Keep the placeholder DOM, disabled state, retry affordance, and final copy in the host app so each product can match its own cursor, route, authorization, and paging policy.
+
 ## Relationship to lazy loading
 
 Children pagination is built by the host app on top of lazy loading.
@@ -192,6 +194,7 @@ The [Selection](selection.md#linked-checkbox-behavior) guide is the contract for
 | child URL hook | yes | provides builder |
 | lazy-loading row data | yes | consumes data |
 | remote-state events | hooks only | dispatches events |
+| next-page placeholder row | no | yes |
 | cursor / offset / token | no | yes |
 | query and ordering | no | yes |
 | next-page detection | no | yes |

--- a/docs/ja/children-pagination.md
+++ b/docs/ja/children-pagination.md
@@ -157,6 +157,8 @@ host app側で、children rowsと「もっと見る」UIを返します。
 
 次page placeholder の配置や branch-scoped load-more affordance を静的に確認したい場合は、[children-pagination.html](../mockups/children-pagination.html) を使ってください。この mockup は review aid であり、cursor encoding、Turbo Stream response、最終 button copy、retry behavior は host app 側の責務です。
 
+TreeView は、次page placeholder row のための helper option や public metadata API を意図的に提供しません。placeholder DOM、disabled state、retry affordance、最終 copy は host app 側に置き、各productの cursor、route、authorization、paging policy に合わせてください。
+
 ## lazy loadingとの関係
 
 children pagination は lazy loading の上にhost app側で作る仕組みです。
@@ -192,6 +194,7 @@ loaded-row checkbox payload、hidden input sync、rendered-only cascade / indete
 | children URL hook | yes | provides builder |
 | row lazy-loading data | yes | consumes data |
 | remote-state events | hook only | dispatches events |
+| next-page placeholder row | no | yes |
 | cursor / offset / token | no | yes |
 | query and ordering | no | yes |
 | next-page detection | no | yes |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs",
+    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_package_lock_dependency_drift.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/script/test_package_lock_dependency_drift.mjs
+++ b/script/test_package_lock_dependency_drift.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const packagePath = "package.json";
+const packageLockPath = "package-lock.json";
+
+function dependencyKeys(metadata, section) {
+  return Object.keys(metadata?.[section] || {}).sort();
+}
+
+function assertDependencyKeysMatch(packageMetadata, lockRootPackage, section) {
+  const packageKeys = dependencyKeys(packageMetadata, section);
+  const lockKeys = dependencyKeys(lockRootPackage, section);
+  const missingFromLock = packageKeys.filter((key) => !lockKeys.includes(key));
+  const extraInLock = lockKeys.filter((key) => !packageKeys.includes(key));
+
+  assert.deepEqual(
+    { missingFromLock, extraInLock },
+    { missingFromLock: [], extraInLock: [] },
+    `${packageLockPath} root package ${section} keys must match ${packagePath} ${section} keys`
+  );
+}
+
+const packageMetadata = JSON.parse(readFileSync(packagePath, "utf8"));
+const packageLock = JSON.parse(readFileSync(packageLockPath, "utf8"));
+const lockRootPackage = packageLock.packages?.[""];
+
+assert.ok(lockRootPackage, `${packageLockPath} must include packages[""] root package metadata`);
+
+for (const section of ["dependencies", "devDependencies"]) {
+  assertDependencyKeysMatch(packageMetadata, lockRootPackage, section);
+}


### PR DESCRIPTION
children pagination の next-page placeholder responsibility boundary を current main 起点で載せ直します。

## 対応 Issue / PR

Superseded by #2202
Supersedes #2189
Supersedes #1973

## 置き換え理由

この PR は作成直後に main が進み、effective diff に unrelated package policy 変更が混ざって見える状態になりました。Issue #1906 の scoped docs diff だけを current main へ載せ直した #2202 を作成したため、この PR は superseded として close します。

merge は行いません。