### PR TITLE
Release checklist に tag alignment 必須確認を追記する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -74,6 +74,14 @@ npm run test:js
 
 `bundle exec rake release:check` validates the current `TreeView::VERSION`, checks for a dated `CHANGELOG.md` section for that version, builds the gem, confirms release-facing files are packaged, runs `ruby script/check_gem_package_contents.rb tree_view-*.gem` against the built gem, and runs a `bundle exec ruby -Ilib -e 'require "tree_view"'` load check. The package contents guard checks representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, public API manifest, public runtime files, and gem metadata URI surfaces. The main-push `gem_package` CI job repeats the same package contents verification against its built gem. Tag alignment is skipped until `vX.Y.Z` exists, then verifies that the release tag points at the current `HEAD`.
 
+After creating the release tag, rerun the release check with tag alignment required:
+
+```bash
+TREE_VIEW_REQUIRE_RELEASE_TAG=1 bundle exec rake release:check
+```
+
+Use the default command during release preparation PRs because the tag usually does not exist yet. Use the flagged command after tagging so the check fails if `vX.Y.Z` is missing or points at a different commit from the current `HEAD`.
+
 Pull request CI checks:
 
 - Ruby lint through `bundle exec standardrb`

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -74,6 +74,14 @@ npm run test:js
 
 `bundle exec rake release:check` は current `TreeView::VERSION` と日付付き `CHANGELOG.md` section の整合を確認し、gem build、release-facing files の packaging、built gem に対する `ruby script/check_gem_package_contents.rb tree_view-*.gem`、`bundle exec ruby -Ilib -e 'require "tree_view"'` による load check までまとめて実行します。package contents guard は Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest / public runtime files / gem metadata URI の代表surfaceを確認します。main-push の `gem_package` CI job でも、同じ package contents verification を CI で build した gem に対して再実行します。`vX.Y.Z` tag がまだ無い段階では tag alignment は skip し、tag 作成後はその release tag が current `HEAD` を指していることを確認します。
 
+tag 作成後は、tag alignment を必須にして release check を再実行します。
+
+```bash
+TREE_VIEW_REQUIRE_RELEASE_TAG=1 bundle exec rake release:check
+```
+
+release preparation PR の段階では tag がまだ無いことが多いため、通常の command を使います。tag 後はこの flag 付き command を使い、`vX.Y.Z` が存在しない場合や current `HEAD` とは別の commit を指している場合に失敗させます。
+
 Pull Request CI の確認項目:
 
 - Ruby lint: `bundle exec standardrb`


### PR DESCRIPTION
## 対応 Issue

Closes #2196

## 分類

- `docs-stale`
- `docs-sync`

## 背景

`TreeView::ReleaseCheck` は通常の `bundle exec rake release:check` では release preparation PR 段階を考慮して、`vX.Y.Z` tag が未作成なら tag alignment check を skip します。一方、`TREE_VIEW_REQUIRE_RELEASE_TAG=1` を付けると、release tag の存在と current `HEAD` への alignment を必須確認できます。

英日 Release checklist は通常時の skip には触れていましたが、tag 作成後に maintainer が明示的に必須確認する command が読み取りにくかったため、docs-only で追従します。

## 変更内容

- `docs/en/release.md`
  - tag 作成後に `TREE_VIEW_REQUIRE_RELEASE_TAG=1 bundle exec rake release:check` を実行する手順を追加しました。
  - release preparation PR では通常 command を使い、tag 後は flag 付き command で missing tag / wrong commit を失敗させる境界を明記しました。
- `docs/ja/release.md`
  - 同じ guidance を日本語側へ同期しました。

## 変更範囲

- docs-only
- 英日 Release checklist の local release check 説明のみ

## 非対象

- release tag の作成
- `TREE_VIEW_REQUIRE_RELEASE_TAG` の挙動変更
- `TreeView::ReleaseCheck` / `Rakefile` の変更
- GitHub Release / gem publish automation
- CHANGELOG category policy
- docs smoke / spec / CI workflow

## 確認内容

- Default PR Check として #2198 を確認し、コメントは作業記録のみ、review / review thread なし、`CHANGELOG.md` 1行の docs-only PRで追加修正不要と判断しました。
- Issue #2196 の labels を確認: `status:ready-for-agent`, `track:docs`, `type:docs`, `risk:low`, `scope:maintenance`。
- `lib/tree_view/release_check.rb` が `TREE_VIEW_REQUIRE_RELEASE_TAG=1` で tag alignment を必須化できることを確認しました。
- `Rakefile` が `bundle exec rake release:check` から `TreeView::ReleaseCheck.run!` を呼ぶことを確認しました。
- `README.md`, `docs/README.md`, `AGENTS.md`, `Product Profile.md` を確認し、今回の tag alignment guidance に対する入口docs更新は不要と判断しました。
- current main: `515c7a583e0aaead9a9d85ce76a41ce8765c3271`
- compare `main...docs/2196-release-tag-alignment-check`: `ahead_by:4` / `behind_by:0` / `status:ahead`
- changed files: `docs/en/release.md`, `docs/ja/release.md` の2件のみ
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

merge は行いません。