### PR TITLE
children pagination placeholder 境界を current main で再提案する v8

### DIFF
--- a/docs/en/children-pagination.md
+++ b/docs/en/children-pagination.md
@@ -157,6 +157,8 @@ Render the initial next-page placeholder where the host app wants it to appear:
 
 Use [children-pagination.html](../mockups/children-pagination.html) when you want a static visual reference for next-page placeholder placement and branch-scoped load-more affordances. The mockup is a review aid only; cursor encoding, Turbo Stream responses, final button copy, and retry behavior remain host-app responsibilities.
 
+TreeView intentionally does not expose a helper option or public metadata API for next-page placeholder rows. Keep the placeholder DOM, disabled state, retry affordance, and final copy in the host app so each product can match its own cursor, route, authorization, and paging policy.
+
 ## Relationship to lazy loading
 
 Children pagination is built by the host app on top of lazy loading.
@@ -192,6 +194,7 @@ The [Selection](selection.md#linked-checkbox-behavior) guide is the contract for
 | child URL hook | yes | provides builder |
 | lazy-loading row data | yes | consumes data |
 | remote-state events | hooks only | dispatches events |
+| next-page placeholder row | no | yes |
 | cursor / offset / token | no | yes |
 | query and ordering | no | yes |
 | next-page detection | no | yes |

--- a/docs/ja/children-pagination.md
+++ b/docs/ja/children-pagination.md
@@ -157,6 +157,8 @@ host app側で、children rowsと「もっと見る」UIを返します。
 
 次page placeholder の配置や branch-scoped load-more affordance を静的に確認したい場合は、[children-pagination.html](../mockups/children-pagination.html) を使ってください。この mockup は review aid であり、cursor encoding、Turbo Stream response、最終 button copy、retry behavior は host app 側の責務です。
 
+TreeView は、次page placeholder row のための helper option や public metadata API を意図的に提供しません。placeholder DOM、disabled state、retry affordance、最終 copy は host app 側に置き、各productの cursor、route、authorization、paging policy に合わせてください。
+
 ## lazy loadingとの関係
 
 children pagination は lazy loading の上にhost app側で作る仕組みです。
@@ -192,6 +194,7 @@ loaded-row checkbox payload、hidden input sync、rendered-only cascade / indete
 | children URL hook | yes | provides builder |
 | row lazy-loading data | yes | consumes data |
 | remote-state events | hook only | dispatches events |
+| next-page placeholder row | no | yes |
 | cursor / offset / token | no | yes |
 | query and ordering | no | yes |
 | next-page detection | no | yes |


### PR DESCRIPTION
children pagination の next-page placeholder responsibility boundary を current main 起点で載せ直します。

## 対応 Issue / PR

Closes #1906
Supersedes #2200
Supersedes #2189
Supersedes #1973

## 置き換え理由

PR #2189 は docs-only boundary clarification として方向性は一致していましたが、review:changes-requested で latest `main` 追従と fresh CI が求められていました。

いったん #2200 を作成しましたが、その直後に main が進み、#2200 の有効差分に unrelated package policy 変更が混ざって見える状態になりました。この PR は current `main` `515c7a583e0aaead9a9d85ce76a41ce8765c3271` を親にして、children pagination docs の scoped diff だけを再作成しています。既存 PR branch の force push や履歴書き換えは行っていません。

## 変更内容

- EN/JA docs に、next-page placeholder row 用の helper option / public metadata API を意図的に提供しないことを明記します。
- placeholder DOM、disabled state、retry affordance、final copy を host app responsibility として整理します。
- responsibility table に `next-page placeholder row` の境界を追加します。

## 受け入れ条件との対応

- public helper option / public metadata API は追加していません。
- next-page placeholder row の DOM と UX 方針を host app owned boundary として明記しました。
- runtime Ruby / JavaScript、public API、helper behavior、DB、認可、外部 API は変更していません。

## 変更範囲

- `docs/en/children-pagination.md`
- `docs/ja/children-pagination.md`

## 実施した確認

- PR #2189 の review:changes-requested を確認し、latest main 追従 / fresh CI が必要な follow-up と分類しました。
- current main との差分確認: `main...refresh/2189-children-pagination-current-main-v8` は `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local docs test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。docs-only responsibility boundary の追記に閉じています。

## 未対応・補足

- runtime behavior、public helper option、public metadata API は扱っていません。
- merge は行いません。