### PR TITLE
Release checklist の Tests category guidance を current main で再提案する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -152,8 +152,9 @@ Use these categories:
 - Deprecated
 - Removed
 - Documentation
+- Tests
 
-Record public API manifest changes by their user-visible effect. Use Added or Changed for backward-compatible public surface updates, Deprecated or Removed for compatibility changes that require migration notes, and Documentation only when the manifest or docs guidance changed without a runtime contract change.
+Record test, CI, docs smoke, and package verification changes under Tests. Record public API manifest changes by their user-visible effect. Use Added or Changed for backward-compatible public surface updates, Deprecated or Removed for compatibility changes that require migration notes, and Documentation only when the manifest or docs guidance changed without a runtime contract change.
 
 Include migration notes for breaking changes or deprecations.
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -152,8 +152,9 @@ releaseごとに `CHANGELOG.md` へ日付付きentryを追加します。
 - Deprecated
 - Removed
 - Documentation
+- Tests
 
-public API manifest の変更は、user-visible な影響に合わせて記録します。後方互換な public surface 追加や変更は Added / Changed、migration note が必要な互換性変更は Deprecated / Removed、runtime contract を変えない manifest や docs guidance の変更は Documentation に入れてください。
+test、CI、docs smoke、package verification の変更は Tests に記録します。public API manifest の変更は、user-visible な影響に合わせて記録します。後方互換な public surface 追加や変更は Added / Changed、migration note が必要な互換性変更は Deprecated / Removed、runtime contract を変えない manifest や docs guidance の変更は Documentation に入れてください。
 
 breaking changeやdeprecationにはmigration noteを書きます。
 


### PR DESCRIPTION
## 対応 Issue / PR

Closes #2176
Supersedes #2180

## 分類

- `docs-stale`
- `docs-sync`

## 置き換え理由

PR #2180 は docs-only の方向性は合っていましたが、review:changes-requested で latest `main` 追従と fresh CI が求められていました。その後 main がさらに進み、#2180 は `behind_by:5` / `status:diverged` になっていました。

この PR は current `main` `edb64cb4501b12b4513822a288f45ddc04f2cbf2` を起点に、Release checklist の `Tests` category guidance だけを再作成した replacement PR です。latest main 側の release tag alignment guidance も保持しています。

## 変更内容

- `docs/en/release.md`
  - CHANGELOG category list に `Tests` を追加しました。
  - test / CI / docs smoke / package verification changes を `Tests` に記録する方針を追記しました。
- `docs/ja/release.md`
  - 同じ方針を日本語側へ同期しました。

## 変更範囲

- docs-only
- 英日 Release checklist の CHANGELOG category guidance のみ

## 非対象

- `CHANGELOG.md` 全体再編集
- release automation
- version bump / tag / GitHub Release
- CI workflow
- `script/test_release_docs_signals.mjs`
- public API manifest schema
- `release:check` の category allowlist変更

## 確認内容

- Default PR Check として自作 open docs PR を確認し、#2180 が review follow-up 対象であることを確認しました。
- #2180 の latest main 追従要求を確認し、既存 branch の安全な tree refresh が難しいため latest main から replacement branch を作成しました。
- compare `main...docs/2176-release-tests-category-current-main`: `ahead_by:2` / `behind_by:0` / `status:ahead`
- changed files: `docs/en/release.md`, `docs/ja/release.md` の2件のみ
- local checkout / local docs smoke は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

merge は行いません。