### PR TITLE
Public API docs の controller class export を signal で守る

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -93,6 +93,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "Public API exported controller class docs signals",
+    command: "node",
+    args: ["script/test_public_api_exported_controller_class_docs_signals.mjs"]
+  },
+  {
     group: "Host lifecycle no-detail docs signals",
     command: "node",
     args: ["script/test_host_lifecycle_no_detail_docs_signals.mjs"]
@@ -273,6 +278,7 @@ function runSelfTest() {
     ambiguous.matches.map((check) => check.group),
     [
       "Public API docs signals",
+      "Public API exported controller class docs signals",
       "Public API manifest structure",
       "Public API entrypoint guard signals"
     ],

--- a/script/test_public_api_exported_controller_class_docs_signals.mjs
+++ b/script/test_public_api_exported_controller_class_docs_signals.mjs
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const publicApiDocs = [
+  ["docs/en/public-api.md", read("docs/en/public-api.md")],
+  ["docs/ja/public-api.md", read("docs/ja/public-api.md")]
+]
+
+const exportedControllerClassSignals = [
+  "TreeViewStateController",
+  "TreeViewClientController",
+  "TreeViewSelectionController",
+  "TreeViewTransferController",
+  "TreeViewRemoteStateController"
+]
+
+publicApiDocs.forEach(([relativePath, document]) => {
+  assertIncludes(
+    document,
+    "exported controller classes",
+    `${relativePath} exported controller class surface label`
+  )
+
+  assertIncludes(
+    document,
+    "registerTreeViewControllers(application)",
+    `${relativePath} standard controller registration entrypoint`
+  )
+
+  exportedControllerClassSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} exported controller class docs`)
+  })
+})
+
+console.log(
+  `[public-api-exported-controller-class-docs] checked ${exportedControllerClassSignals.length} controller classes across ${publicApiDocs.length} public API docs`
+)


### PR DESCRIPTION
## 対応 Issue

Closes #2199

## Issue ごとの完了内容

- #2199
  - 英日 Public API docs に載る exported controller class list を lightweight docs signal で guard しました。
  - `TreeViewStateController`, `TreeViewClientController`, `TreeViewSelectionController`, `TreeViewTransferController`, `TreeViewRemoteStateController` の5件を対象にしています。
  - `registerTreeViewControllers(application)` が標準入口であることと、`exported controller classes` の surface label が docs に残ることも確認対象にしました。

## 変更内容

- `script/test_public_api_exported_controller_class_docs_signals.mjs` を追加。
  - `docs/en/public-api.md` / `docs/ja/public-api.md` を読み、missing docs path と class name が分かる failure message を出します。
- `script/test_docs_entrypoint_suite.mjs` に新しい docs signal group を追加。
  - `--self-test` の ambiguous `Public API` group 期待値も更新しました。

## 改善カテゴリ

- test
- docs drift guard

## 既存仕様への影響

- runtime JavaScript、controller registration order、TypeScript declaration、public API manifest schema、docs prose は変更していません。
- #2025 の `TreeViewControllerEntries` 整理や controller class の追加・rename・削除には広げていません。

## 実施した確認

- Issue #2199 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff を確認し、script guard 追加のみの low-risk quality lane と判断しました。
- compare `main...chore/2199-public-api-controller-docs`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local `node script/test_public_api_exported_controller_class_docs_signals.mjs` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs signal の追加だけで、公開 API surface や実行時挙動は変更していません。

## 補足事項

- #2150 も eligible でしたが、59ファイルの `standardrb --fix` 相当であり、既に同じ connector-only 停止理由が Issue コメントに記録済みだったため、この実行では重複コメント・重複PRを作っていません。
- merge は行いません。