### PR TITLE
public API declaration boundary guard を追加する

### DIFF
--- a/script/test_public_api_entrypoint_guard_signals.mjs
+++ b/script/test_public_api_entrypoint_guard_signals.mjs
@@ -51,6 +51,35 @@ assert(
   "README package-root export guidance no longer states the raw hook-copying boundary"
 )
 
+const publicApiDeclarationBoundarySignals = [
+  ["runtime entrypoint", "tree_view/index.js"],
+  ["TypeScript declaration", "app/javascript/tree_view/index.d.ts"],
+  ["manifest source of truth", "config/public_api_manifest.yml"],
+  ["compile-time declaration role", "compile-time aid"],
+  ["importmap-only host-app boundary", "importmap-only"]
+]
+
+publicApiDeclarationBoundarySignals.forEach(([label, signal]) => {
+  publicApiDocs.forEach(([relativePath, document]) => {
+    assertIncludes(document, signal, `${relativePath} JavaScript declaration boundary ${label}`)
+  })
+})
+
+publicApiDocs.forEach(([relativePath, document]) => {
+  assert(
+    /entrypoint smoke checks?/.test(document),
+    `${relativePath}: JavaScript declaration boundary no longer points to entrypoint smoke checks as source of truth`
+  )
+
+  assert(
+    /runtime behavior.*public surface/.test(document),
+    `${relativePath}: JavaScript declaration boundary no longer separates declaration files from runtime behavior and public surface`
+  )
+})
+
+assertIncludes(manifest, "javascript_package_root:", "public API manifest JavaScript package-root boundary")
+assertIncludes(manifest, "named_exports:", "public API manifest JavaScript package-root boundary")
+
 const resourceTableManifestSignals = [
   "resource_table_render_state_call:",
   "required_keywords:",


### PR DESCRIPTION
## 対応 Issue

- Closes #2207

## Issue ごとの完了内容

- #2207: `app/javascript/tree_view/index.d.ts` が runtime surface ではなく compile-time aid であることを、public API docs と manifest source-of-truth の signal guard で固定しました。

## 変更内容

- `script/test_public_api_entrypoint_guard_signals.mjs` に JavaScript declaration boundary の検査を追加しました。
- 英日 `docs/*/public-api.md` が以下を維持することを確認します。
  - runtime entrypoint は `tree_view/index.js`
  - declaration file は `app/javascript/tree_view/index.d.ts`
  - source of truth は `config/public_api_manifest.yml` と entrypoint smoke checks
  - declaration は `compile-time aid`
  - importmap-only host app に追加 runtime setup を求めない
- `config/public_api_manifest.yml` の `javascript_package_root:` / `named_exports:` も entrypoint guard 側で確認します。

## 改善カテゴリ

- test
- docs drift guard
- public API boundary guard

## 既存仕様への影響

- 実装コード、公開 API、UI、DB、認可、外部サービス契約は変更していません。
- 既存 docs にある境界説明を regression guard として固定するだけで、runtime behavior は変わりません。

## 実施した確認

- GitHub connector で Issue labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` から branch を作成し、branch freshness を確認しました。
- `main...quality/public-api-declaration-boundary-2207` の差分が `script/test_public_api_entrypoint_guard_signals.mjs` 1 ファイル、29 additions のみに限定されていることを確認しました。
- commit patch を確認し、意図した guard 追加だけであることを確認しました。

## 実行できなかった確認

- この実行環境では GitHub の clone/archive download が 403 で失敗するため、ローカルで `npm run test:docs-entrypoints -- --only "Public API entrypoint guard signals"` は実行できていません。PR CI で確認してください。

## リスク評価

- risk: low
- 既存文書の signal check 追加のみで、挙動変更はありません。

## 補足

- #2150 は eligible でしたが、59 ファイルの Standard autocorrect が必要で、connector-only の全文置換では安全確認が不足するため今回の PR には混ぜていません。Issue には既に同じ停止理由と next action が記録済みです。