### PR TITLE
CI / manifest guard hardening を追加する

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -14,65 +14,278 @@ function assertIncludes(source, needle, label) {
 function workflowJobBlock(workflowSource, jobName) {
   const marker = `  ${jobName}:\n`
   const start = workflowSource.indexOf(marker)
-  assert(start !== -1, `${workflowPath} must define jobs.${jobName}`)
+  assert(start !== -1, `${workflowPath}: missing jobs.${jobName}`)
 
-  const bodyStart = start + marker.length
-  const remainingWorkflow = workflowSource.slice(bodyStart)
-  const nextJobOffset = remainingWorkflow.search(/\n  [a-z_]+:\n/)
-
-  return nextJobOffset === -1 ? remainingWorkflow : remainingWorkflow.slice(0, nextJobOffset + 1)
+  const nextJob = workflowSource.indexOf("\n  ", start + marker.length)
+  return nextJob === -1 ? workflowSource.slice(start) : workflowSource.slice(start, nextJob)
 }
 
 function assertOrdered(source, earlier, later, label) {
   const earlierIndex = source.indexOf(earlier)
   const laterIndex = source.indexOf(later)
 
-  assert(earlierIndex !== -1, `${label}: missing ${earlier}`)
-  assert(laterIndex !== -1, `${label}: missing ${later}`)
+  assert(earlierIndex !== -1, `${label}: missing earlier marker ${earlier}`)
+  assert(laterIndex !== -1, `${label}: missing later marker ${later}`)
   assert(earlierIndex < laterIndex, `${label}: expected ${earlier} before ${later}`)
 }
 
+function workflowNonPullRequestDefaultOutputBlock(changesJob) {
+  const match = changesJob.match(
+    /if \[ "\$\{\{ github\.event_name \}\}" != "pull_request" \]; then\n(?<body>(?:            echo "[a-z_]+=(?:true|false)" >> "\$GITHUB_OUTPUT"\n)+)            exit 0\n          fi/
+  )
+
+  assert(
+    match,
+    `${workflowPath} jobs.changes must define non-pull-request default outputs before pull request file detection`
+  )
+  return match.groups.body
+}
+
+function assertDefaultWorkflowOutput(block, key, value) {
+  assertIncludes(
+    block,
+    `echo "${key}=${value}" >> "$GITHUB_OUTPUT"`,
+    `${workflowPath} jobs.changes non-pull-request default output ${key}`
+  )
+}
+
 const changesJob = workflowJobBlock(workflowSource, "changes")
+const rspecJob = workflowJobBlock(workflowSource, "rspec")
+const browserSmokeJob = workflowJobBlock(workflowSource, "browser-smoke")
+const packageGuardJob = workflowJobBlock(workflowSource, "package-guard")
+const dockerBuildJob = workflowJobBlock(workflowSource, "docker-build")
+const docsBuildJob = workflowJobBlock(workflowSource, "docs-build")
+const docsQualityJob = workflowJobBlock(workflowSource, "docs-quality")
+const docsLinkCheckJob = workflowJobBlock(workflowSource, "docs-link-check")
+const docsEntryPointJob = workflowJobBlock(workflowSource, "docs-entrypoint-check")
 
-const changedFileDetectionSignals = [
-  ["base ref fetch", 'git fetch origin "${{ github.base_ref }}" --depth=1'],
-  ["merge-base branch", 'git merge-base "origin/${{ github.base_ref }}" HEAD'],
-  ["three-dot diff", 'git diff --name-only "origin/${{ github.base_ref }}"...HEAD'],
-  ["fallback diff", 'git diff --name-only "origin/${{ github.base_ref }}" HEAD'],
-  ["policy invocation", 'node script/ci_changed_files_policy.mjs <<EOF >> "$GITHUB_OUTPUT"'],
-  ["changed files heredoc", "$changed_files"]
-]
-
-changedFileDetectionSignals.forEach(([label, signal]) => {
-  assertIncludes(changesJob, signal, `${workflowPath} jobs.changes changed-file detection ${label}`)
+const nonPullRequestDefaultOutputs = {
+  docs_only: false,
+  mockups_changed: false,
+  browser_smoke_changed: false,
+  package_sensitive: true,
+  docker_setup_sensitive: true,
+  docs_entrypoint_sensitive: true
+}
+const nonPullRequestDefaultOutputBlock = workflowNonPullRequestDefaultOutputBlock(changesJob)
+Object.entries(nonPullRequestDefaultOutputs).forEach(([key, value]) => {
+  assertDefaultWorkflowOutput(nonPullRequestDefaultOutputBlock, key, value)
 })
 
+assertIncludes(
+  changesJob,
+  "git diff --name-only --diff-filter=ACMRT origin/${{ github.base_ref }}...HEAD > /tmp/changed_files.txt",
+  `${workflowPath} jobs.changes changed-file diff`
+)
+assertIncludes(
+  changesJob,
+  "only_docs=true",
+  `${workflowPath} jobs.changes docs-only default`
+)
+assertIncludes(
+  changesJob,
+  "docs_only=false",
+  `${workflowPath} jobs.changes non-docs fallback`
+)
+assertIncludes(
+  changesJob,
+  "changed_mockups=false",
+  `${workflowPath} jobs.changes mockups default`
+)
+assertIncludes(
+  changesJob,
+  "browser_smoke_changed=false",
+  `${workflowPath} jobs.changes browser smoke output default`
+)
+assertIncludes(
+  changesJob,
+  "package_sensitive=false",
+  `${workflowPath} jobs.changes package-sensitive default`
+)
+assertIncludes(
+  changesJob,
+  "docker_setup_sensitive=false",
+  `${workflowPath} jobs.changes docker-setup-sensitive default`
+)
+assertIncludes(
+  changesJob,
+  "docs_entrypoint_sensitive=false",
+  `${workflowPath} jobs.changes docs-entrypoint-sensitive default`
+)
+assertIncludes(
+  changesJob,
+  "while IFS= read -r file; do",
+  `${workflowPath} jobs.changes changed-file loop`
+)
+assertIncludes(
+  changesJob,
+  "docs/mockups/*)",
+  `${workflowPath} jobs.changes mockups detection`
+)
+assertIncludes(
+  changesJob,
+  "test/dummy/)",
+  `${workflowPath} jobs.changes browser smoke directory detection`
+)
+assertIncludes(
+  changesJob,
+  "package.json|package-lock.json|app/assets/javascripts/)",
+  `${workflowPath} jobs.changes package-sensitive detection`
+)
+assertIncludes(
+  changesJob,
+  "Dockerfile|docker-compose*.yml|entrypoint.sh|bin/docker-entrypoint)",
+  `${workflowPath} jobs.changes docker setup detection`
+)
+assertIncludes(
+  changesJob,
+  "docs/index.md|docs/)",
+  `${workflowPath} jobs.changes docs entrypoint detection`
+)
+assertIncludes(
+  changesJob,
+  "mockups_changed=$changed_mockups",
+  `${workflowPath} jobs.changes mockups output`
+)
+assertIncludes(
+  changesJob,
+  "browser_smoke_changed=$browser_smoke_changed",
+  `${workflowPath} jobs.changes browser smoke output`
+)
+assertIncludes(
+  changesJob,
+  "package_sensitive=$package_sensitive",
+  `${workflowPath} jobs.changes package-sensitive output`
+)
+assertIncludes(
+  changesJob,
+  "docker_setup_sensitive=$docker_setup_sensitive",
+  `${workflowPath} jobs.changes docker-setup-sensitive output`
+)
+assertIncludes(
+  changesJob,
+  "docs_entrypoint_sensitive=$docs_entrypoint_sensitive",
+  `${workflowPath} jobs.changes docs-entrypoint-sensitive output`
+)
 assertOrdered(
   changesJob,
+  "only_docs=true",
+  "while IFS= read -r file; do",
+  `${workflowPath} jobs.changes must initialize docs-only before iterating files`
+)
+assertOrdered(
+  changesJob,
+  "changed_mockups=false",
+  "while IFS= read -r file; do",
+  `${workflowPath} jobs.changes must initialize mockups before iterating files`
+)
+assertOrdered(
+  changesJob,
+  "browser_smoke_changed=false",
+  "while IFS= read -r file; do",
+  `${workflowPath} jobs.changes must initialize browser smoke before iterating files`
+)
+assertOrdered(
+  changesJob,
+  "package_sensitive=false",
+  "while IFS= read -r file; do",
+  `${workflowPath} jobs.changes must initialize package-sensitive before iterating files`
+)
+assertOrdered(
+  changesJob,
+  "docker_setup_sensitive=false",
+  "while IFS= read -r file; do",
+  `${workflowPath} jobs.changes must initialize docker setup before iterating files`
+)
+assertOrdered(
+  changesJob,
+  "docs_entrypoint_sensitive=false",
+  "while IFS= read -r file; do",
+  `${workflowPath} jobs.changes must initialize docs entrypoint before iterating files`
+)
+assertOrdered(
+  changesJob,
+  "while IFS= read -r file; do",
+  "echo \"docs_only=$only_docs\" >> \"$GITHUB_OUTPUT\"",
+  `${workflowPath} jobs.changes must emit docs-only after iterating files`
+)
+assertOrdered(
+  changesJob,
+  "while IFS= read -r file; do",
+  "echo \"mockups_changed=$changed_mockups\" >> \"$GITHUB_OUTPUT\"",
+  `${workflowPath} jobs.changes must emit mockups after iterating files`
+)
+assertOrdered(
+  changesJob,
+  "while IFS= read -r file; do",
+  "echo \"browser_smoke_changed=$browser_smoke_changed\" >> \"$GITHUB_OUTPUT\"",
+  `${workflowPath} jobs.changes must emit browser smoke after iterating files`
+)
+assertOrdered(
+  changesJob,
+  "while IFS= read -r file; do",
+  "echo \"package_sensitive=$package_sensitive\" >> \"$GITHUB_OUTPUT\"",
+  `${workflowPath} jobs.changes must emit package-sensitive after iterating files`
+)
+assertOrdered(
+  changesJob,
+  "while IFS= read -r file; do",
+  "echo \"docker_setup_sensitive=$docker_setup_sensitive\" >> \"$GITHUB_OUTPUT\"",
+  `${workflowPath} jobs.changes must emit docker setup after iterating files`
+)
+assertOrdered(
+  changesJob,
+  "while IFS= read -r file; do",
+  "echo \"docs_entrypoint_sensitive=$docs_entrypoint_sensitive\" >> \"$GITHUB_OUTPUT\"",
+  `${workflowPath} jobs.changes must emit docs entrypoint after iterating files`
+)
+assertOrdered(
+  changesJob,
+  'if [ "${{ github.event_name }}" != "pull_request" ]; then',
   'git fetch origin "${{ github.base_ref }}" --depth=1',
-  'git merge-base "origin/${{ github.base_ref }}" HEAD',
-  `${workflowPath} jobs.changes must fetch the base ref before merge-base detection`
+  `${workflowPath} jobs.changes must emit non-pull-request defaults before pull request fetch`
 )
 
-assertOrdered(
-  changesJob,
-  'git merge-base "origin/${{ github.base_ref }}" HEAD',
-  'git diff --name-only "origin/${{ github.base_ref }}"...HEAD',
-  `${workflowPath} jobs.changes must try merge-base before the three-dot diff`
+assertIncludes(
+  rspecJob,
+  "if: needs.changes.outputs.docs_only != 'true'",
+  `${workflowPath} jobs.rspec docs-only skip condition`
 )
-
-assertOrdered(
-  changesJob,
-  'git diff --name-only "origin/${{ github.base_ref }}"...HEAD',
-  'git diff --name-only "origin/${{ github.base_ref }}" HEAD',
-  `${workflowPath} jobs.changes must keep a fallback diff after the three-dot diff path`
+assertIncludes(
+  browserSmokeJob,
+  "if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.browser_smoke_changed == 'true'",
+  `${workflowPath} jobs.browser-smoke docs-only/browser-smoke condition`
 )
-
-assertOrdered(
-  changesJob,
-  'git diff --name-only "origin/${{ github.base_ref }}" HEAD',
-  'node script/ci_changed_files_policy.mjs <<EOF >> "$GITHUB_OUTPUT"',
-  `${workflowPath} jobs.changes must pass the collected file list into the policy script`
+assertIncludes(
+  packageGuardJob,
+  "if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.package_sensitive == 'true'",
+  `${workflowPath} jobs.package-guard package-sensitive condition`
+)
+assertIncludes(
+  dockerBuildJob,
+  "if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.docker_setup_sensitive == 'true'",
+  `${workflowPath} jobs.docker-build docker-setup-sensitive condition`
+)
+assertIncludes(
+  docsBuildJob,
+  "if: needs.changes.outputs.docs_only == 'true'",
+  `${workflowPath} jobs.docs-build docs-only condition`
+)
+assertIncludes(
+  docsQualityJob,
+  "if: needs.changes.outputs.docs_only == 'true'",
+  `${workflowPath} jobs.docs-quality docs-only condition`
+)
+assertIncludes(
+  docsLinkCheckJob,
+  "if: needs.changes.outputs.docs_only == 'true'",
+  `${workflowPath} jobs.docs-link-check docs-only condition`
+)
+assertIncludes(
+  docsEntryPointJob,
+  "if: needs.changes.outputs.docs_entrypoint_sensitive == 'true'",
+  `${workflowPath} jobs.docs-entrypoint-check docs entrypoint condition`
 )
 
 console.log("Checked CI changed-file detection workflow signals.")
+console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -14,18 +14,21 @@ function assertIncludes(source, needle, label) {
 function workflowJobBlock(workflowSource, jobName) {
   const marker = `  ${jobName}:\n`
   const start = workflowSource.indexOf(marker)
-  assert(start !== -1, `${workflowPath}: missing jobs.${jobName}`)
+  assert(start !== -1, `${workflowPath} must define jobs.${jobName}`)
 
-  const nextJob = workflowSource.indexOf("\n  ", start + marker.length)
-  return nextJob === -1 ? workflowSource.slice(start) : workflowSource.slice(start, nextJob)
+  const bodyStart = start + marker.length
+  const remainingWorkflow = workflowSource.slice(bodyStart)
+  const nextJobOffset = remainingWorkflow.search(/\n  [a-z_]+:\n/)
+
+  return nextJobOffset === -1 ? remainingWorkflow : remainingWorkflow.slice(0, nextJobOffset + 1)
 }
 
 function assertOrdered(source, earlier, later, label) {
   const earlierIndex = source.indexOf(earlier)
   const laterIndex = source.indexOf(later)
 
-  assert(earlierIndex !== -1, `${label}: missing earlier marker ${earlier}`)
-  assert(laterIndex !== -1, `${label}: missing later marker ${later}`)
+  assert(earlierIndex !== -1, `${label}: missing ${earlier}`)
+  assert(laterIndex !== -1, `${label}: missing ${later}`)
   assert(earlierIndex < laterIndex, `${label}: expected ${earlier} before ${later}`)
 }
 
@@ -50,14 +53,6 @@ function assertDefaultWorkflowOutput(block, key, value) {
 }
 
 const changesJob = workflowJobBlock(workflowSource, "changes")
-const rspecJob = workflowJobBlock(workflowSource, "rspec")
-const browserSmokeJob = workflowJobBlock(workflowSource, "browser-smoke")
-const packageGuardJob = workflowJobBlock(workflowSource, "package-guard")
-const dockerBuildJob = workflowJobBlock(workflowSource, "docker-build")
-const docsBuildJob = workflowJobBlock(workflowSource, "docs-build")
-const docsQualityJob = workflowJobBlock(workflowSource, "docs-quality")
-const docsLinkCheckJob = workflowJobBlock(workflowSource, "docs-link-check")
-const docsEntryPointJob = workflowJobBlock(workflowSource, "docs-entrypoint-check")
 
 const nonPullRequestDefaultOutputs = {
   docs_only: false,
@@ -72,173 +67,6 @@ Object.entries(nonPullRequestDefaultOutputs).forEach(([key, value]) => {
   assertDefaultWorkflowOutput(nonPullRequestDefaultOutputBlock, key, value)
 })
 
-assertIncludes(
-  changesJob,
-  "git diff --name-only --diff-filter=ACMRT origin/${{ github.base_ref }}...HEAD > /tmp/changed_files.txt",
-  `${workflowPath} jobs.changes changed-file diff`
-)
-assertIncludes(
-  changesJob,
-  "only_docs=true",
-  `${workflowPath} jobs.changes docs-only default`
-)
-assertIncludes(
-  changesJob,
-  "docs_only=false",
-  `${workflowPath} jobs.changes non-docs fallback`
-)
-assertIncludes(
-  changesJob,
-  "changed_mockups=false",
-  `${workflowPath} jobs.changes mockups default`
-)
-assertIncludes(
-  changesJob,
-  "browser_smoke_changed=false",
-  `${workflowPath} jobs.changes browser smoke output default`
-)
-assertIncludes(
-  changesJob,
-  "package_sensitive=false",
-  `${workflowPath} jobs.changes package-sensitive default`
-)
-assertIncludes(
-  changesJob,
-  "docker_setup_sensitive=false",
-  `${workflowPath} jobs.changes docker-setup-sensitive default`
-)
-assertIncludes(
-  changesJob,
-  "docs_entrypoint_sensitive=false",
-  `${workflowPath} jobs.changes docs-entrypoint-sensitive default`
-)
-assertIncludes(
-  changesJob,
-  "while IFS= read -r file; do",
-  `${workflowPath} jobs.changes changed-file loop`
-)
-assertIncludes(
-  changesJob,
-  "docs/mockups/*)",
-  `${workflowPath} jobs.changes mockups detection`
-)
-assertIncludes(
-  changesJob,
-  "test/dummy/)",
-  `${workflowPath} jobs.changes browser smoke directory detection`
-)
-assertIncludes(
-  changesJob,
-  "package.json|package-lock.json|app/assets/javascripts/)",
-  `${workflowPath} jobs.changes package-sensitive detection`
-)
-assertIncludes(
-  changesJob,
-  "Dockerfile|docker-compose*.yml|entrypoint.sh|bin/docker-entrypoint)",
-  `${workflowPath} jobs.changes docker setup detection`
-)
-assertIncludes(
-  changesJob,
-  "docs/index.md|docs/)",
-  `${workflowPath} jobs.changes docs entrypoint detection`
-)
-assertIncludes(
-  changesJob,
-  "mockups_changed=$changed_mockups",
-  `${workflowPath} jobs.changes mockups output`
-)
-assertIncludes(
-  changesJob,
-  "browser_smoke_changed=$browser_smoke_changed",
-  `${workflowPath} jobs.changes browser smoke output`
-)
-assertIncludes(
-  changesJob,
-  "package_sensitive=$package_sensitive",
-  `${workflowPath} jobs.changes package-sensitive output`
-)
-assertIncludes(
-  changesJob,
-  "docker_setup_sensitive=$docker_setup_sensitive",
-  `${workflowPath} jobs.changes docker-setup-sensitive output`
-)
-assertIncludes(
-  changesJob,
-  "docs_entrypoint_sensitive=$docs_entrypoint_sensitive",
-  `${workflowPath} jobs.changes docs-entrypoint-sensitive output`
-)
-assertOrdered(
-  changesJob,
-  "only_docs=true",
-  "while IFS= read -r file; do",
-  `${workflowPath} jobs.changes must initialize docs-only before iterating files`
-)
-assertOrdered(
-  changesJob,
-  "changed_mockups=false",
-  "while IFS= read -r file; do",
-  `${workflowPath} jobs.changes must initialize mockups before iterating files`
-)
-assertOrdered(
-  changesJob,
-  "browser_smoke_changed=false",
-  "while IFS= read -r file; do",
-  `${workflowPath} jobs.changes must initialize browser smoke before iterating files`
-)
-assertOrdered(
-  changesJob,
-  "package_sensitive=false",
-  "while IFS= read -r file; do",
-  `${workflowPath} jobs.changes must initialize package-sensitive before iterating files`
-)
-assertOrdered(
-  changesJob,
-  "docker_setup_sensitive=false",
-  "while IFS= read -r file; do",
-  `${workflowPath} jobs.changes must initialize docker setup before iterating files`
-)
-assertOrdered(
-  changesJob,
-  "docs_entrypoint_sensitive=false",
-  "while IFS= read -r file; do",
-  `${workflowPath} jobs.changes must initialize docs entrypoint before iterating files`
-)
-assertOrdered(
-  changesJob,
-  "while IFS= read -r file; do",
-  "echo \"docs_only=$only_docs\" >> \"$GITHUB_OUTPUT\"",
-  `${workflowPath} jobs.changes must emit docs-only after iterating files`
-)
-assertOrdered(
-  changesJob,
-  "while IFS= read -r file; do",
-  "echo \"mockups_changed=$changed_mockups\" >> \"$GITHUB_OUTPUT\"",
-  `${workflowPath} jobs.changes must emit mockups after iterating files`
-)
-assertOrdered(
-  changesJob,
-  "while IFS= read -r file; do",
-  "echo \"browser_smoke_changed=$browser_smoke_changed\" >> \"$GITHUB_OUTPUT\"",
-  `${workflowPath} jobs.changes must emit browser smoke after iterating files`
-)
-assertOrdered(
-  changesJob,
-  "while IFS= read -r file; do",
-  "echo \"package_sensitive=$package_sensitive\" >> \"$GITHUB_OUTPUT\"",
-  `${workflowPath} jobs.changes must emit package-sensitive after iterating files`
-)
-assertOrdered(
-  changesJob,
-  "while IFS= read -r file; do",
-  "echo \"docker_setup_sensitive=$docker_setup_sensitive\" >> \"$GITHUB_OUTPUT\"",
-  `${workflowPath} jobs.changes must emit docker setup after iterating files`
-)
-assertOrdered(
-  changesJob,
-  "while IFS= read -r file; do",
-  "echo \"docs_entrypoint_sensitive=$docs_entrypoint_sensitive\" >> \"$GITHUB_OUTPUT\"",
-  `${workflowPath} jobs.changes must emit docs entrypoint after iterating files`
-)
 assertOrdered(
   changesJob,
   'if [ "${{ github.event_name }}" != "pull_request" ]; then',
@@ -246,45 +74,45 @@ assertOrdered(
   `${workflowPath} jobs.changes must emit non-pull-request defaults before pull request fetch`
 )
 
-assertIncludes(
-  rspecJob,
-  "if: needs.changes.outputs.docs_only != 'true'",
-  `${workflowPath} jobs.rspec docs-only skip condition`
+const changedFileDetectionSignals = [
+  ["base ref fetch", 'git fetch origin "${{ github.base_ref }}" --depth=1'],
+  ["merge-base branch", 'git merge-base "origin/${{ github.base_ref }}" HEAD'],
+  ["three-dot diff", 'git diff --name-only "origin/${{ github.base_ref }}"...HEAD'],
+  ["fallback diff", 'git diff --name-only "origin/${{ github.base_ref }}" HEAD'],
+  ["policy invocation", 'node script/ci_changed_files_policy.mjs <<EOF >> "$GITHUB_OUTPUT"'],
+  ["changed files heredoc", "$changed_files"]
+]
+
+changedFileDetectionSignals.forEach(([label, signal]) => {
+  assertIncludes(changesJob, signal, `${workflowPath} jobs.changes changed-file detection ${label}`)
+})
+
+assertOrdered(
+  changesJob,
+  'git fetch origin "${{ github.base_ref }}" --depth=1',
+  'git merge-base "origin/${{ github.base_ref }}" HEAD',
+  `${workflowPath} jobs.changes must fetch the base ref before merge-base detection`
 )
-assertIncludes(
-  browserSmokeJob,
-  "if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.browser_smoke_changed == 'true'",
-  `${workflowPath} jobs.browser-smoke docs-only/browser-smoke condition`
+
+assertOrdered(
+  changesJob,
+  'git merge-base "origin/${{ github.base_ref }}" HEAD',
+  'git diff --name-only "origin/${{ github.base_ref }}"...HEAD',
+  `${workflowPath} jobs.changes must try merge-base before the three-dot diff`
 )
-assertIncludes(
-  packageGuardJob,
-  "if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.package_sensitive == 'true'",
-  `${workflowPath} jobs.package-guard package-sensitive condition`
+
+assertOrdered(
+  changesJob,
+  'git diff --name-only "origin/${{ github.base_ref }}"...HEAD',
+  'git diff --name-only "origin/${{ github.base_ref }}" HEAD',
+  `${workflowPath} jobs.changes must keep a fallback diff after the three-dot diff path`
 )
-assertIncludes(
-  dockerBuildJob,
-  "if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.docker_setup_sensitive == 'true'",
-  `${workflowPath} jobs.docker-build docker-setup-sensitive condition`
-)
-assertIncludes(
-  docsBuildJob,
-  "if: needs.changes.outputs.docs_only == 'true'",
-  `${workflowPath} jobs.docs-build docs-only condition`
-)
-assertIncludes(
-  docsQualityJob,
-  "if: needs.changes.outputs.docs_only == 'true'",
-  `${workflowPath} jobs.docs-quality docs-only condition`
-)
-assertIncludes(
-  docsLinkCheckJob,
-  "if: needs.changes.outputs.docs_only == 'true'",
-  `${workflowPath} jobs.docs-link-check docs-only condition`
-)
-assertIncludes(
-  docsEntryPointJob,
-  "if: needs.changes.outputs.docs_entrypoint_sensitive == 'true'",
-  `${workflowPath} jobs.docs-entrypoint-check docs entrypoint condition`
+
+assertOrdered(
+  changesJob,
+  'git diff --name-only "origin/${{ github.base_ref }}" HEAD',
+  'node script/ci_changed_files_policy.mjs <<EOF >> "$GITHUB_OUTPUT"',
+  `${workflowPath} jobs.changes must pass the collected file list into the policy script`
 )
 
 console.log("Checked CI changed-file detection workflow signals.")

--- a/script/test_package_lock_dependency_drift.mjs
+++ b/script/test_package_lock_dependency_drift.mjs
@@ -8,6 +8,10 @@ function dependencyKeys(metadata, section) {
   return Object.keys(metadata?.[section] || {}).sort();
 }
 
+function dependencySpecs(metadata, section) {
+  return metadata?.[section] || {};
+}
+
 function assertDependencyKeysMatch(packageMetadata, lockRootPackage, section) {
   const packageKeys = dependencyKeys(packageMetadata, section);
   const lockKeys = dependencyKeys(lockRootPackage, section);
@@ -21,6 +25,25 @@ function assertDependencyKeysMatch(packageMetadata, lockRootPackage, section) {
   );
 }
 
+function assertDependencySpecsMatch(packageMetadata, lockRootPackage, section) {
+  const packageSpecs = dependencySpecs(packageMetadata, section);
+  const lockSpecs = dependencySpecs(lockRootPackage, section);
+  const mismatches = dependencyKeys(packageMetadata, section)
+    .filter((key) => packageSpecs[key] !== lockSpecs[key])
+    .map((key) => ({
+      section,
+      name: key,
+      packageJson: packageSpecs[key],
+      packageLock: lockSpecs[key]
+    }));
+
+  assert.deepEqual(
+    mismatches,
+    [],
+    `${packageLockPath} root package ${section} specs must match ${packagePath} ${section} specs`
+  );
+}
+
 const packageMetadata = JSON.parse(readFileSync(packagePath, "utf8"));
 const packageLock = JSON.parse(readFileSync(packageLockPath, "utf8"));
 const lockRootPackage = packageLock.packages?.[""];
@@ -29,4 +52,5 @@ assert.ok(lockRootPackage, `${packageLockPath} must include packages[""] root pa
 
 for (const section of ["dependencies", "devDependencies"]) {
   assertDependencyKeysMatch(packageMetadata, lockRootPackage, section);
+  assertDependencySpecsMatch(packageMetadata, lockRootPackage, section);
 }

--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -1,114 +1,29 @@
-import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import YAML from "yaml"
 
-function loadManifest() {
-  try {
-    return JSON.parse(
-      execFileSync(
-        "ruby",
-        [
-          "-e",
-          [
-            'require "json"',
-            'require "yaml"',
-            'data = YAML.load_file("config/public_api_manifest.yml")',
-            "print JSON.generate(data)"
-          ].join("; ")
-        ],
-        { encoding: "utf8" }
-      )
-    )
-  } catch (error) {
-    const detail = [error.stdout, error.stderr]
-      .filter((output) => output && output.length > 0)
-      .join("\n")
-      .trim() || error.message
-
-    throw new Error(
-      [
-        "Could not load config/public_api_manifest.yml for the manifest structure smoke.",
-        "Run this command from the repository root with Ruby available, or inspect the manifest YAML syntax.",
-        `Loader output: ${detail}`
-      ].join("\n"),
-      { cause: error }
-    )
-  }
-}
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, "..")
 
 function assert(condition, message) {
   if (!condition) throw new Error(message)
 }
 
-function valueType(value) {
-  if (Array.isArray(value)) return "array"
-  if (value === null) return "null"
-
-  return typeof value
+function loadManifest() {
+  const manifestPath = path.join(repoRoot, "config", "public_api_manifest.yml")
+  return YAML.parse(readFileSync(manifestPath, "utf8"))
 }
 
-function assertObject(value, path) {
-  assert(
-    value && typeof value === "object" && !Array.isArray(value),
-    `${path} must be an object, got ${valueType(value)}`
-  )
+function flattenYamlValues(value) {
+  if (Array.isArray(value)) return value.flatMap(flattenYamlValues)
+  if (value && typeof value === "object") return Object.values(value).flatMap(flattenYamlValues)
+  return [value]
 }
 
-function assertString(value, path) {
-  assert(typeof value === "string" && value.length > 0, `${path} must be a non-empty string`)
-}
-
-function assertUniqueStringList(value, path) {
-  assert(Array.isArray(value), `${path} must be an array, got ${valueType(value)}`)
-  assert(value.length > 0, `${path} must not be empty`)
-
-  const seenValues = new Set()
-
-  value.forEach((item, index) => {
-    assertString(item, `${path}[${index}]`)
-    assert(!seenValues.has(item), `${path} contains duplicate value: ${item}`)
-    seenValues.add(item)
-  })
-}
-
-function assertStringMap(value, path) {
-  assertObject(value, path)
-  Object.entries(value).forEach(([key, item]) => {
-    assertString(item, `${path}.${key}`)
-  })
-}
-
-function assertObjectWithLists(value, path, keys) {
-  assertObject(value, path)
-  keys.forEach((key) => assertUniqueStringList(value[key], `${path}.${key}`))
-}
-
-function assertRequiredObjectKeys(value, path, keys) {
-  assertObject(value, path)
-  keys.forEach((key) => assertObject(value[key], `${path}.${key}`))
-}
-
-function assertRequiredKeys(value, path, keys) {
-  assertObject(value, path)
-  keys.forEach((key) => assert(key in value, `${path} missing required key: ${key}`))
-}
-
-function assertPathTreeBuilderNodeShapes(value, path, keys) {
-  assertRequiredObjectKeys(value, path, keys)
-  keys.forEach((key) => {
-    const shape = value[key]
-    assertString(shape.constant, `${path}.${key}.constant`)
-    assertUniqueStringList(shape.fields, `${path}.${key}.fields`)
-    assertUniqueStringList(shape.predicates, `${path}.${key}.predicates`)
-  })
-}
-
-function assertEntries(value, path, requiredKeys) {
-  assert(Array.isArray(value), `${path} must be an array, got ${valueType(value)}`)
-  assert(value.length > 0, `${path} must not be empty`)
-
-  value.forEach((entry, index) => {
-    assertObject(entry, `${path}[${index}]`)
-    requiredKeys.forEach((key) => assertString(entry[key], `${path}[${index}].${key}`))
-  })
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
 }
 
 function assertTopLevelKeys(manifest) {
@@ -139,182 +54,78 @@ function assertTopLevelKeys(manifest) {
   expectedKeys.forEach((key) => {
     assert(key in manifest, `config/public_api_manifest.yml missing top-level key: ${key}`)
   })
+
+  const unexpectedKeys = Object.keys(manifest).filter((key) => !expectedKeys.includes(key)).sort()
+  assert(
+    unexpectedKeys.length === 0,
+    `config/public_api_manifest.yml contains unexpected top-level key(s): ${unexpectedKeys.join(", ")}. Update script/test_public_api_manifest_structure.mjs before adding manifest sections.`
+  )
 }
 
-function assertEventClassification(javascriptPackageRoot) {
-  const requiredEventNameGroups = ["state", "selection", "remote_state", "host_lifecycle", "transfer"]
-  const requiredEventDetailGroups = ["state", "selection", "remote_state", "transfer"]
-  const requiredNoDetailGroups = ["host_lifecycle"]
+function assertArraySection(manifest, key) {
+  assert(Array.isArray(manifest[key]), `config/public_api_manifest.yml ${key} must be an array`)
+}
 
-  assertRequiredObjectKeys(
-    javascriptPackageRoot.event_names,
-    "javascript_package_root.event_names",
-    requiredEventNameGroups
-  )
-  assertRequiredObjectKeys(
-    javascriptPackageRoot.event_detail_keys,
-    "javascript_package_root.event_detail_keys",
-    requiredEventDetailGroups
-  )
-  assertRequiredKeys(
-    javascriptPackageRoot.event_names_without_detail,
-    "javascript_package_root.event_names_without_detail",
-    requiredNoDetailGroups
-  )
-
-  requiredNoDetailGroups.forEach((group) => {
-    const groupEvents = javascriptPackageRoot.event_names[group]
-    const noDetailEventNames = javascriptPackageRoot.event_names_without_detail[group]
-
-    assertStringMap(groupEvents, `javascript_package_root.event_names.${group}`)
-    assertUniqueStringList(noDetailEventNames, `javascript_package_root.event_names_without_detail.${group}`)
-
-    const validEventNames = new Set(Object.keys(groupEvents))
-    noDetailEventNames.forEach((eventName) => {
-      assert(
-        validEventNames.has(eventName),
-        `javascript_package_root.event_names_without_detail.${group} includes unknown event: ${eventName}`
-      )
-      assert(
-        !(javascriptPackageRoot.event_detail_keys[group] && javascriptPackageRoot.event_detail_keys[group][eventName]),
-        `javascript_package_root.event_names_without_detail.${group} overlaps detail-bearing event: ${eventName}`
-      )
-    })
+function assertStringValues(section, key) {
+  flattenYamlValues(section).forEach((value) => {
+    assert(typeof value === "string", `config/public_api_manifest.yml ${key} values must be strings`)
+    assert(value.trim().length > 0, `config/public_api_manifest.yml ${key} values must be non-empty`)
   })
 }
 
-const requiredUiConfigBuilderOptionKeys = [
-  "build",
-  "build_turbo",
-  "build_static",
-  "build_client_side"
-]
-
-const requiredPathTreeBuilderNodeShapeKeys = ["folder_node", "record_node"]
-
-const requiredHelperOptionKeys = [
-  "tree_view_rows",
-  "tree_view_window",
-  "tree_view_breadcrumb",
-  "tree_view_toolbar"
-]
-
-const requiredGroupedOptionKeys = [
-  "initial_expansion",
-  "render_scope",
-  "toggle_scope",
-  "toggle_icons",
-  "selection",
-  "lazy_loading",
-  "row_status"
-]
-
-const requiredLocalizedNameI18nKeyGroups = [
-  "model_names",
-  "attribute_names",
-  "node_type_names"
-]
-
-const requiredIntegrationHookKeys = ["state", "remote_state", "transfer"]
+function assertFileIncludes(relativePath, expectedText, label) {
+  const source = readRepoFile(relativePath)
+  assert(
+    source.includes(expectedText),
+    `${label}: ${relativePath} is missing ${expectedText}`
+  )
+}
 
 const manifest = loadManifest()
-
 assertTopLevelKeys(manifest)
-assertUniqueStringList(manifest.module_methods, "module_methods")
-assertObjectWithLists(manifest.configuration_options, "configuration_options", ["tree_view_configure"])
-assertUniqueStringList(manifest.public_constants, "public_constants")
-assertUniqueStringList(manifest.filtered_tree_modes, "filtered_tree_modes")
-assertObjectWithLists(manifest.visible_rows_row_metadata, "visible_rows_row_metadata", ["fields", "predicates"])
-assertUniqueStringList(manifest.node_presenter_builder_names, "node_presenter_builder_names")
-assertObjectWithLists(manifest.graph_adapter_initializer, "graph_adapter_initializer", ["required_keywords", "optional_keywords"])
-assertObjectWithLists(manifest.ui_config_builder_option_keys, "ui_config_builder_option_keys", requiredUiConfigBuilderOptionKeys)
-assertPathTreeBuilderNodeShapes(manifest.path_tree_builder_node_shapes, "path_tree_builder_node_shapes", requiredPathTreeBuilderNodeShapeKeys)
-assertObjectWithLists(manifest.helper_option_keys, "helper_option_keys", requiredHelperOptionKeys)
-assertUniqueStringList(manifest.render_window_metadata, "render_window_metadata")
-assertStringMap(manifest.toolbar_actions, "toolbar_actions")
-assertObjectWithLists(manifest.toolbar_action_metadata, "toolbar_action_metadata", ["keys", "data_keys"])
-assertObjectWithLists(manifest.grouped_option_keys, "grouped_option_keys", requiredGroupedOptionKeys)
-assertObjectWithLists(manifest.resource_table_render_state_call, "resource_table_render_state_call", ["required_keywords", "optional_keywords"])
-assertString(manifest.resource_table_render_state_call.render_options_contract, "resource_table_render_state_call.render_options_contract")
-assertUniqueStringList(manifest.render_state_callback_builder_keys, "render_state_callback_builder_keys")
 
-assertRequiredObjectKeys(
-  manifest.localized_name_i18n_keys,
+for (const key of [
+  "module_methods",
+  "configuration_options",
+  "public_constants",
   "localized_name_i18n_keys",
-  requiredLocalizedNameI18nKeyGroups
-)
-for (const [name, config] of Object.entries(manifest.localized_name_i18n_keys)) {
-  assertObject(config, `localized_name_i18n_keys.${name}`)
-  assertString(config.helper, `localized_name_i18n_keys.${name}.helper`)
-  assertString(config.fallback, `localized_name_i18n_keys.${name}.fallback`)
+  "filtered_tree_modes",
+  "visible_rows_row_metadata",
+  "node_presenter_builder_names",
+  "graph_adapter_initializer",
+  "ui_config_builder_option_keys",
+  "path_tree_builder_node_shapes",
+  "helper_methods",
+  "helper_option_keys",
+  "render_window_metadata",
+  "toolbar_actions",
+  "toolbar_action_metadata",
+  "setup_generators",
+  "grouped_option_keys",
+  "diagnostics",
+  "render_state_callback_builder_keys"
+]) {
+  assertArraySection(manifest, key)
+  assertStringValues(manifest[key], key)
 }
-assertUniqueStringList(
-  manifest.localized_name_i18n_keys.model_names.delegated_lookup_prefixes,
-  "localized_name_i18n_keys.model_names.delegated_lookup_prefixes"
-)
-assertUniqueStringList(
-  manifest.localized_name_i18n_keys.attribute_names.delegated_lookup_prefixes,
-  "localized_name_i18n_keys.attribute_names.delegated_lookup_prefixes"
-)
-assertString(
-  manifest.localized_name_i18n_keys.node_type_names.lookup_prefix,
-  "localized_name_i18n_keys.node_type_names.lookup_prefix"
-)
 
-assertObject(manifest.setup_generators, "setup_generators")
-assertObject(manifest.setup_generators.persisted_state_install, "setup_generators.persisted_state_install")
-assertString(manifest.setup_generators.persisted_state_install.name, "setup_generators.persisted_state_install.name")
-assertString(manifest.setup_generators.persisted_state_install.class_name, "setup_generators.persisted_state_install.class_name")
-assertEntries(
-  manifest.setup_generators.persisted_state_install.optional_arguments,
-  "setup_generators.persisted_state_install.optional_arguments",
-  ["name", "banner"]
-)
-assertUniqueStringList(
-  manifest.setup_generators.persisted_state_install.generated_paths,
-  "setup_generators.persisted_state_install.generated_paths"
-)
+assert(typeof manifest.resource_table_render_state_call === "string", "resource_table_render_state_call must be a string")
+assert(typeof manifest.javascript_package_root === "string", "javascript_package_root must be a string")
 
-assertObject(manifest.diagnostics, "diagnostics")
-assertUniqueStringList(manifest.diagnostics.accepted_checks, "diagnostics.accepted_checks")
-assertUniqueStringList(manifest.diagnostics.run_options, "diagnostics.run_options")
-assertObjectWithLists(manifest.diagnostics.result_surface, "diagnostics.result_surface", ["attributes", "methods"])
-
-const javascriptPackageRoot = manifest.javascript_package_root
-assertObject(javascriptPackageRoot, "javascript_package_root")
-assertUniqueStringList(javascriptPackageRoot.named_exports, "javascript_package_root.named_exports")
-assertEntries(javascriptPackageRoot.controller_registrations, "javascript_package_root.controller_registrations", ["key", "identifier", "export"])
-assertStringMap(javascriptPackageRoot.transfer_drop_positions, "javascript_package_root.transfer_drop_positions")
-assertStringMap(javascriptPackageRoot.transfer_data_mime_types, "javascript_package_root.transfer_data_mime_types")
-assertStringMap(javascriptPackageRoot.remote_state_values, "javascript_package_root.remote_state_values")
-assertStringMap(javascriptPackageRoot.remote_state_data_hooks, "javascript_package_root.remote_state_data_hooks")
-assertStringMap(javascriptPackageRoot.toolbar_data_hooks, "javascript_package_root.toolbar_data_hooks")
-assertObject(javascriptPackageRoot.integration_hooks, "javascript_package_root.integration_hooks")
-requiredIntegrationHookKeys.forEach((key) => {
-  assertStringMap(javascriptPackageRoot.integration_hooks[key], `javascript_package_root.integration_hooks.${key}`)
-})
-assertStringMap(javascriptPackageRoot.selection_data_hooks, "javascript_package_root.selection_data_hooks")
-assertStringMap(javascriptPackageRoot.selection_checkbox_hooks, "javascript_package_root.selection_checkbox_hooks")
-assertStringMap(javascriptPackageRoot.empty_state_hooks, "javascript_package_root.empty_state_hooks")
-
-assertObject(javascriptPackageRoot.event_names, "javascript_package_root.event_names")
-assertObject(javascriptPackageRoot.event_detail_keys, "javascript_package_root.event_detail_keys")
-assertObject(javascriptPackageRoot.event_names_without_detail, "javascript_package_root.event_names_without_detail")
-assertEventClassification(javascriptPackageRoot)
-
-Object.entries(javascriptPackageRoot.event_names).forEach(([group, events]) => {
-  assertStringMap(events, `javascript_package_root.event_names.${group}`)
+manifest.helper_methods.forEach((methodName) => {
+  assertFileIncludes("app/helpers/tree_view_helper.rb", `def ${methodName}`, `helper method ${methodName}`)
 })
 
-Object.entries(javascriptPackageRoot.event_detail_keys).forEach(([group, events]) => {
-  assertObject(events, `javascript_package_root.event_detail_keys.${group}`)
-  Object.entries(events).forEach(([eventName, keys]) => {
-    assertUniqueStringList(keys, `javascript_package_root.event_detail_keys.${group}.${eventName}`)
-  })
+manifest.configuration_options.forEach((optionName) => {
+  assertFileIncludes("lib/tree_view/configuration.rb", optionName, `configuration option ${optionName}`)
 })
 
-Object.entries(javascriptPackageRoot.event_names_without_detail).forEach(([group, eventNames]) => {
-  assertUniqueStringList(eventNames, `javascript_package_root.event_names_without_detail.${group}`)
+manifest.localized_name_i18n_keys.forEach((key) => {
+  assertFileIncludes("config/locales/en.yml", key, `localized name i18n key ${key}`)
 })
 
-console.log("Public API manifest structure smoke passed.")
+manifest.toolbar_actions.forEach((actionName) => {
+  assertFileIncludes("app/helpers/tree_view_helper.rb", actionName, `toolbar action ${actionName}`)
+})
+
+console.log("Checked public API manifest structure.")

--- a/script/test_public_api_manifest_structure.mjs
+++ b/script/test_public_api_manifest_structure.mjs
@@ -1,29 +1,114 @@
-import { readFileSync } from "node:fs"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
-import YAML from "yaml"
+import { execFileSync } from "node:child_process"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-const repoRoot = path.resolve(__dirname, "..")
+function loadManifest() {
+  try {
+    return JSON.parse(
+      execFileSync(
+        "ruby",
+        [
+          "-e",
+          [
+            'require "json"',
+            'require "yaml"',
+            'data = YAML.load_file("config/public_api_manifest.yml")',
+            "print JSON.generate(data)"
+          ].join("; ")
+        ],
+        { encoding: "utf8" }
+      )
+    )
+  } catch (error) {
+    const detail = [error.stdout, error.stderr]
+      .filter((output) => output && output.length > 0)
+      .join("\n")
+      .trim() || error.message
+
+    throw new Error(
+      [
+        "Could not load config/public_api_manifest.yml for the manifest structure smoke.",
+        "Run this command from the repository root with Ruby available, or inspect the manifest YAML syntax.",
+        `Loader output: ${detail}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
+}
 
 function assert(condition, message) {
   if (!condition) throw new Error(message)
 }
 
-function loadManifest() {
-  const manifestPath = path.join(repoRoot, "config", "public_api_manifest.yml")
-  return YAML.parse(readFileSync(manifestPath, "utf8"))
+function valueType(value) {
+  if (Array.isArray(value)) return "array"
+  if (value === null) return "null"
+
+  return typeof value
 }
 
-function flattenYamlValues(value) {
-  if (Array.isArray(value)) return value.flatMap(flattenYamlValues)
-  if (value && typeof value === "object") return Object.values(value).flatMap(flattenYamlValues)
-  return [value]
+function assertObject(value, path) {
+  assert(
+    value && typeof value === "object" && !Array.isArray(value),
+    `${path} must be an object, got ${valueType(value)}`
+  )
 }
 
-function readRepoFile(relativePath) {
-  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+function assertString(value, path) {
+  assert(typeof value === "string" && value.length > 0, `${path} must be a non-empty string`)
+}
+
+function assertUniqueStringList(value, path) {
+  assert(Array.isArray(value), `${path} must be an array, got ${valueType(value)}`)
+  assert(value.length > 0, `${path} must not be empty`)
+
+  const seenValues = new Set()
+
+  value.forEach((item, index) => {
+    assertString(item, `${path}[${index}]`)
+    assert(!seenValues.has(item), `${path} contains duplicate value: ${item}`)
+    seenValues.add(item)
+  })
+}
+
+function assertStringMap(value, path) {
+  assertObject(value, path)
+  Object.entries(value).forEach(([key, item]) => {
+    assertString(item, `${path}.${key}`)
+  })
+}
+
+function assertObjectWithLists(value, path, keys) {
+  assertObject(value, path)
+  keys.forEach((key) => assertUniqueStringList(value[key], `${path}.${key}`))
+}
+
+function assertRequiredObjectKeys(value, path, keys) {
+  assertObject(value, path)
+  keys.forEach((key) => assertObject(value[key], `${path}.${key}`))
+}
+
+function assertRequiredKeys(value, path, keys) {
+  assertObject(value, path)
+  keys.forEach((key) => assert(key in value, `${path} missing required key: ${key}`))
+}
+
+function assertPathTreeBuilderNodeShapes(value, path, keys) {
+  assertRequiredObjectKeys(value, path, keys)
+  keys.forEach((key) => {
+    const shape = value[key]
+    assertString(shape.constant, `${path}.${key}.constant`)
+    assertUniqueStringList(shape.fields, `${path}.${key}.fields`)
+    assertUniqueStringList(shape.predicates, `${path}.${key}.predicates`)
+  })
+}
+
+function assertEntries(value, path, requiredKeys) {
+  assert(Array.isArray(value), `${path} must be an array, got ${valueType(value)}`)
+  assert(value.length > 0, `${path} must not be empty`)
+
+  value.forEach((entry, index) => {
+    assertObject(entry, `${path}[${index}]`)
+    requiredKeys.forEach((key) => assertString(entry[key], `${path}[${index}].${key}`))
+  })
 }
 
 function assertTopLevelKeys(manifest) {
@@ -62,70 +147,180 @@ function assertTopLevelKeys(manifest) {
   )
 }
 
-function assertArraySection(manifest, key) {
-  assert(Array.isArray(manifest[key]), `config/public_api_manifest.yml ${key} must be an array`)
-}
+function assertEventClassification(javascriptPackageRoot) {
+  const requiredEventNameGroups = ["state", "selection", "remote_state", "host_lifecycle", "transfer"]
+  const requiredEventDetailGroups = ["state", "selection", "remote_state", "transfer"]
+  const requiredNoDetailGroups = ["host_lifecycle"]
 
-function assertStringValues(section, key) {
-  flattenYamlValues(section).forEach((value) => {
-    assert(typeof value === "string", `config/public_api_manifest.yml ${key} values must be strings`)
-    assert(value.trim().length > 0, `config/public_api_manifest.yml ${key} values must be non-empty`)
+  assertRequiredObjectKeys(
+    javascriptPackageRoot.event_names,
+    "javascript_package_root.event_names",
+    requiredEventNameGroups
+  )
+  assertRequiredObjectKeys(
+    javascriptPackageRoot.event_detail_keys,
+    "javascript_package_root.event_detail_keys",
+    requiredEventDetailGroups
+  )
+  assertRequiredKeys(
+    javascriptPackageRoot.event_names_without_detail,
+    "javascript_package_root.event_names_without_detail",
+    requiredNoDetailGroups
+  )
+
+  requiredNoDetailGroups.forEach((group) => {
+    const groupEvents = javascriptPackageRoot.event_names[group]
+    const noDetailEventNames = javascriptPackageRoot.event_names_without_detail[group]
+
+    assertStringMap(groupEvents, `javascript_package_root.event_names.${group}`)
+    assertUniqueStringList(noDetailEventNames, `javascript_package_root.event_names_without_detail.${group}`)
+
+    const validEventNames = new Set(Object.keys(groupEvents))
+    noDetailEventNames.forEach((eventName) => {
+      assert(
+        validEventNames.has(eventName),
+        `javascript_package_root.event_names_without_detail.${group} includes unknown event: ${eventName}`
+      )
+      assert(
+        !(javascriptPackageRoot.event_detail_keys[group] && javascriptPackageRoot.event_detail_keys[group][eventName]),
+        `javascript_package_root.event_names_without_detail.${group} overlaps detail-bearing event: ${eventName}`
+      )
+    })
   })
 }
 
-function assertFileIncludes(relativePath, expectedText, label) {
-  const source = readRepoFile(relativePath)
-  assert(
-    source.includes(expectedText),
-    `${label}: ${relativePath} is missing ${expectedText}`
-  )
-}
+const requiredUiConfigBuilderOptionKeys = [
+  "build",
+  "build_turbo",
+  "build_static",
+  "build_client_side"
+]
+
+const requiredPathTreeBuilderNodeShapeKeys = ["folder_node", "record_node"]
+
+const requiredHelperOptionKeys = [
+  "tree_view_rows",
+  "tree_view_window",
+  "tree_view_breadcrumb",
+  "tree_view_toolbar"
+]
+
+const requiredGroupedOptionKeys = [
+  "initial_expansion",
+  "render_scope",
+  "toggle_scope",
+  "toggle_icons",
+  "selection",
+  "lazy_loading",
+  "row_status"
+]
+
+const requiredLocalizedNameI18nKeyGroups = [
+  "model_names",
+  "attribute_names",
+  "node_type_names"
+]
+
+const requiredIntegrationHookKeys = ["state", "remote_state", "transfer"]
 
 const manifest = loadManifest()
+
 assertTopLevelKeys(manifest)
+assertUniqueStringList(manifest.module_methods, "module_methods")
+assertObjectWithLists(manifest.configuration_options, "configuration_options", ["tree_view_configure"])
+assertUniqueStringList(manifest.public_constants, "public_constants")
+assertUniqueStringList(manifest.filtered_tree_modes, "filtered_tree_modes")
+assertObjectWithLists(manifest.visible_rows_row_metadata, "visible_rows_row_metadata", ["fields", "predicates"])
+assertUniqueStringList(manifest.node_presenter_builder_names, "node_presenter_builder_names")
+assertObjectWithLists(manifest.graph_adapter_initializer, "graph_adapter_initializer", ["required_keywords", "optional_keywords"])
+assertObjectWithLists(manifest.ui_config_builder_option_keys, "ui_config_builder_option_keys", requiredUiConfigBuilderOptionKeys)
+assertPathTreeBuilderNodeShapes(manifest.path_tree_builder_node_shapes, "path_tree_builder_node_shapes", requiredPathTreeBuilderNodeShapeKeys)
+assertObjectWithLists(manifest.helper_option_keys, "helper_option_keys", requiredHelperOptionKeys)
+assertUniqueStringList(manifest.render_window_metadata, "render_window_metadata")
+assertStringMap(manifest.toolbar_actions, "toolbar_actions")
+assertObjectWithLists(manifest.toolbar_action_metadata, "toolbar_action_metadata", ["keys", "data_keys"])
+assertObjectWithLists(manifest.grouped_option_keys, "grouped_option_keys", requiredGroupedOptionKeys)
+assertObjectWithLists(manifest.resource_table_render_state_call, "resource_table_render_state_call", ["required_keywords", "optional_keywords"])
+assertString(manifest.resource_table_render_state_call.render_options_contract, "resource_table_render_state_call.render_options_contract")
+assertUniqueStringList(manifest.render_state_callback_builder_keys, "render_state_callback_builder_keys")
 
-for (const key of [
-  "module_methods",
-  "configuration_options",
-  "public_constants",
+assertRequiredObjectKeys(
+  manifest.localized_name_i18n_keys,
   "localized_name_i18n_keys",
-  "filtered_tree_modes",
-  "visible_rows_row_metadata",
-  "node_presenter_builder_names",
-  "graph_adapter_initializer",
-  "ui_config_builder_option_keys",
-  "path_tree_builder_node_shapes",
-  "helper_methods",
-  "helper_option_keys",
-  "render_window_metadata",
-  "toolbar_actions",
-  "toolbar_action_metadata",
-  "setup_generators",
-  "grouped_option_keys",
-  "diagnostics",
-  "render_state_callback_builder_keys"
-]) {
-  assertArraySection(manifest, key)
-  assertStringValues(manifest[key], key)
+  requiredLocalizedNameI18nKeyGroups
+)
+for (const [name, config] of Object.entries(manifest.localized_name_i18n_keys)) {
+  assertObject(config, `localized_name_i18n_keys.${name}`)
+  assertString(config.helper, `localized_name_i18n_keys.${name}.helper`)
+  assertString(config.fallback, `localized_name_i18n_keys.${name}.fallback`)
 }
+assertUniqueStringList(
+  manifest.localized_name_i18n_keys.model_names.delegated_lookup_prefixes,
+  "localized_name_i18n_keys.model_names.delegated_lookup_prefixes"
+)
+assertUniqueStringList(
+  manifest.localized_name_i18n_keys.attribute_names.delegated_lookup_prefixes,
+  "localized_name_i18n_keys.attribute_names.delegated_lookup_prefixes"
+)
+assertString(
+  manifest.localized_name_i18n_keys.node_type_names.lookup_prefix,
+  "localized_name_i18n_keys.node_type_names.lookup_prefix"
+)
 
-assert(typeof manifest.resource_table_render_state_call === "string", "resource_table_render_state_call must be a string")
-assert(typeof manifest.javascript_package_root === "string", "javascript_package_root must be a string")
+assertObject(manifest.setup_generators, "setup_generators")
+assertObject(manifest.setup_generators.persisted_state_install, "setup_generators.persisted_state_install")
+assertString(manifest.setup_generators.persisted_state_install.name, "setup_generators.persisted_state_install.name")
+assertString(manifest.setup_generators.persisted_state_install.class_name, "setup_generators.persisted_state_install.class_name")
+assertEntries(
+  manifest.setup_generators.persisted_state_install.optional_arguments,
+  "setup_generators.persisted_state_install.optional_arguments",
+  ["name", "banner"]
+)
+assertUniqueStringList(
+  manifest.setup_generators.persisted_state_install.generated_paths,
+  "setup_generators.persisted_state_install.generated_paths"
+)
 
-manifest.helper_methods.forEach((methodName) => {
-  assertFileIncludes("app/helpers/tree_view_helper.rb", `def ${methodName}`, `helper method ${methodName}`)
+assertObject(manifest.diagnostics, "diagnostics")
+assertUniqueStringList(manifest.diagnostics.accepted_checks, "diagnostics.accepted_checks")
+assertUniqueStringList(manifest.diagnostics.run_options, "diagnostics.run_options")
+assertObjectWithLists(manifest.diagnostics.result_surface, "diagnostics.result_surface", ["attributes", "methods"])
+
+const javascriptPackageRoot = manifest.javascript_package_root
+assertObject(javascriptPackageRoot, "javascript_package_root")
+assertUniqueStringList(javascriptPackageRoot.named_exports, "javascript_package_root.named_exports")
+assertEntries(javascriptPackageRoot.controller_registrations, "javascript_package_root.controller_registrations", ["key", "identifier", "export"])
+assertStringMap(javascriptPackageRoot.transfer_drop_positions, "javascript_package_root.transfer_drop_positions")
+assertStringMap(javascriptPackageRoot.transfer_data_mime_types, "javascript_package_root.transfer_data_mime_types")
+assertStringMap(javascriptPackageRoot.remote_state_values, "javascript_package_root.remote_state_values")
+assertStringMap(javascriptPackageRoot.remote_state_data_hooks, "javascript_package_root.remote_state_data_hooks")
+assertStringMap(javascriptPackageRoot.toolbar_data_hooks, "javascript_package_root.toolbar_data_hooks")
+assertObject(javascriptPackageRoot.integration_hooks, "javascript_package_root.integration_hooks")
+requiredIntegrationHookKeys.forEach((key) => {
+  assertStringMap(javascriptPackageRoot.integration_hooks[key], `javascript_package_root.integration_hooks.${key}`)
+})
+assertStringMap(javascriptPackageRoot.selection_data_hooks, "javascript_package_root.selection_data_hooks")
+assertStringMap(javascriptPackageRoot.selection_checkbox_hooks, "javascript_package_root.selection_checkbox_hooks")
+assertStringMap(javascriptPackageRoot.empty_state_hooks, "javascript_package_root.empty_state_hooks")
+
+assertObject(javascriptPackageRoot.event_names, "javascript_package_root.event_names")
+assertObject(javascriptPackageRoot.event_detail_keys, "javascript_package_root.event_detail_keys")
+assertObject(javascriptPackageRoot.event_names_without_detail, "javascript_package_root.event_names_without_detail")
+assertEventClassification(javascriptPackageRoot)
+
+Object.entries(javascriptPackageRoot.event_names).forEach(([group, events]) => {
+  assertStringMap(events, `javascript_package_root.event_names.${group}`)
 })
 
-manifest.configuration_options.forEach((optionName) => {
-  assertFileIncludes("lib/tree_view/configuration.rb", optionName, `configuration option ${optionName}`)
+Object.entries(javascriptPackageRoot.event_detail_keys).forEach(([group, events]) => {
+  assertObject(events, `javascript_package_root.event_detail_keys.${group}`)
+  Object.entries(events).forEach(([eventName, keys]) => {
+    assertUniqueStringList(keys, `javascript_package_root.event_detail_keys.${group}.${eventName}`)
+  })
 })
 
-manifest.localized_name_i18n_keys.forEach((key) => {
-  assertFileIncludes("config/locales/en.yml", key, `localized name i18n key ${key}`)
+Object.entries(javascriptPackageRoot.event_names_without_detail).forEach(([group, eventNames]) => {
+  assertUniqueStringList(eventNames, `javascript_package_root.event_names_without_detail.${group}`)
 })
 
-manifest.toolbar_actions.forEach((actionName) => {
-  assertFileIncludes("app/helpers/tree_view_helper.rb", actionName, `toolbar action ${actionName}`)
-})
-
-console.log("Checked public API manifest structure.")
+console.log("Public API manifest structure smoke passed.")


### PR DESCRIPTION
## 対応 Issue

Closes #2217
Closes #2218
Closes #2219

## Issue ごとの完了内容

- #2217: `package-lock.json` root package の dependency / devDependency について、キー一致だけでなく spec 値の一致も検査するようにしました。差分がある場合は section、依存名、`package.json` 側、`package-lock.json` 側の値が分かる形で失敗します。
- #2218: CI `changes` job の pull_request 以外の default output を guard し、push / schedule 系でも後続 job の条件に必要な output が維持されることを検査します。
- #2219: `config/public_api_manifest.yml` の top-level key について、必須 key の存在確認に加えて未知 key を失敗させる guard を追加しました。

## 変更内容

- `script/test_package_lock_dependency_drift.mjs` に dependency spec 値の drift 検査を追加
- `script/test_ci_workflow_changed_file_detection_signals.mjs` に non-PR default output の存在・順序検査を追加
- `script/test_public_api_manifest_structure.mjs` に未知 top-level key 検査を追加

## 改善カテゴリ

- test / CI guard hardening
- public API manifest guard
- build metadata consistency guard

## 既存仕様への影響

既存の runtime 挙動、UI、API 契約、DB、認可、状態遷移には触れていません。既存の検査スクリプトを強化する quality 改善のみです。

## 実施した確認

- Issue #2217 / #2218 / #2219 の `status:ready-for-agent`、`agent:planned`、`track:quality`、`risk:low` を個別確認
- branch freshness 確認: `main` から `behind_by: 0`
- PR 前差分確認: 変更対象は以下3ファイルのみ
  - `script/test_package_lock_dependency_drift.mjs`
  - `script/test_ci_workflow_changed_file_detection_signals.mjs`
  - `script/test_public_api_manifest_structure.mjs`

ローカル checkout は GitHub への direct network が制限されているため作成できず、最終的な実行確認は PR CI で確認します。

## リスク評価

低リスクです。検査対象は既存スクリプトのみで、失敗時の診断情報を増やす変更です。workflow や manifest 本体の挙動は変更していません。

## 補足

3件はいずれも既存品質 guard の抜けを補う同系統の改善なので、1つの PR にまとめています。