### PR TITLE
public setup generator files を package guard に明示する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -77,6 +77,12 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/public-setup-surface.md
     docs/ja/public-setup-surface.md
   ],
+  "Public setup generator files" => %w[
+    lib/generators/tree_view/state/install_generator.rb
+    lib/generators/tree_view/state/templates/create_tree_view_states.rb
+    lib/generators/tree_view/state/templates/tree_view_state.rb
+    lib/generators/tree_view/state/templates/tree_view_state_owner.rb
+  ],
   "Bilingual release docs" => %w[
     docs/en/release.md
     docs/ja/release.md


### PR DESCRIPTION
## 対応 Issue
- Closes #2221

## Issue ごとの完了内容
- #2221: `script/check_gem_package_contents.rb` の必須 packaged path group に `Public setup generator files` を追加し、public setup generator 本体と state template 3件が gem package contents guard の対象になるようにしました。

## 変更内容
- `REQUIRED_PACKAGED_PATH_GROUPS` に以下を追加しました。
  - `lib/generators/tree_view/state/install_generator.rb`
  - `lib/generators/tree_view/state/templates/create_tree_view_states.rb`
  - `lib/generators/tree_view/state/templates/tree_view_state.rb`
  - `lib/generators/tree_view/state/templates/tree_view_state_owner.rb`

## 改善カテゴリ
- test / release guard / package contents guard

## 既存仕様への影響
- generator の挙動、template 内容、manifest、gemspec、release workflow は変更していません。
- packaged file の検証対象を明示しただけなので、既存の public behavior への影響はありません。

## 実施した確認
- GitHub connector で `main...quality/2221-public-setup-generator-package-guard` を確認し、`behind_by: 0`、差分が `script/check_gem_package_contents.rb` のみであることを確認しました。
- ローカル checkout / test 実行は、実行環境から GitHub への HTTPS 接続が `CONNECT tunnel failed, response 403` でブロックされたため未実施です。PR CI で確認します。

## リスク評価
- Low。既存の package guard 設定への代表ファイル追加のみです。

## 補足
- #2150 も eligible として再確認しましたが、59ファイルの mechanical autocorrect であり、checkout がブロックされた connector-only 環境では安全な一括置換と検証ができません。既存の停止コメントと同じ状況だったため、重複コメントは追加していません。