### PR TITLE
Public API manifest key list drift を guard する

### DIFF
--- a/spec/public_api_manifest_top_level_key_parity_spec.rb
+++ b/spec/public_api_manifest_top_level_key_parity_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Public API manifest top-level key parity" do
+  MANIFEST_STRUCTURE_SPEC_PATH = File.expand_path("public_api_manifest_structure_spec.rb", __dir__)
+  MANIFEST_STRUCTURE_SMOKE_PATH = File.expand_path("../script/test_public_api_manifest_structure.mjs", __dir__)
+
+  def ruby_expected_top_level_keys
+    source = File.read(MANIFEST_STRUCTURE_SPEC_PATH)
+    match = source.match(/PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w\[\n(?<keys>.*?)\n\]\.freeze/m)
+
+    raise "Could not find PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS literal in #{MANIFEST_STRUCTURE_SPEC_PATH}" unless match
+
+    match[:keys].lines.map(&:strip).reject(&:empty?)
+  end
+
+  def node_expected_top_level_keys
+    source = File.read(MANIFEST_STRUCTURE_SMOKE_PATH)
+    match = source.match(/const expectedKeys = \[\n(?<keys>.*?)\n  \]/m)
+
+    raise "Could not find assertTopLevelKeys expectedKeys literal in #{MANIFEST_STRUCTURE_SMOKE_PATH}" unless match
+
+    match[:keys].scan(/"([^"]+)"/).flatten
+  end
+
+  it "keeps Ruby and Node manifest top-level section guards synchronized" do
+    ruby_keys = ruby_expected_top_level_keys
+    node_keys = node_expected_top_level_keys
+
+    expect(node_keys).to eq(ruby_keys), <<~MESSAGE
+      expected script/test_public_api_manifest_structure.mjs assertTopLevelKeys expectedKeys
+      to match spec/public_api_manifest_structure_spec.rb PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS.
+      missing from Node smoke: #{(ruby_keys - node_keys).inspect}
+      extra in Node smoke: #{(node_keys - ruby_keys).inspect}
+    MESSAGE
+  end
+end

--- a/spec/public_api_manifest_top_level_key_parity_spec.rb
+++ b/spec/public_api_manifest_top_level_key_parity_spec.rb
@@ -3,23 +3,23 @@
 require "spec_helper"
 
 RSpec.describe "Public API manifest top-level key parity" do
-  MANIFEST_STRUCTURE_SPEC_PATH = File.expand_path("public_api_manifest_structure_spec.rb", __dir__)
-  MANIFEST_STRUCTURE_SMOKE_PATH = File.expand_path("../script/test_public_api_manifest_structure.mjs", __dir__)
+  let(:manifest_structure_spec_path) { File.expand_path("public_api_manifest_structure_spec.rb", __dir__) }
+  let(:manifest_structure_smoke_path) { File.expand_path("../script/test_public_api_manifest_structure.mjs", __dir__) }
 
   def ruby_expected_top_level_keys
-    source = File.read(MANIFEST_STRUCTURE_SPEC_PATH)
+    source = File.read(manifest_structure_spec_path)
     match = source.match(/PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS = %w\[\n(?<keys>.*?)\n\]\.freeze/m)
 
-    raise "Could not find PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS literal in #{MANIFEST_STRUCTURE_SPEC_PATH}" unless match
+    raise "Could not find PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS literal in #{manifest_structure_spec_path}" unless match
 
     match[:keys].lines.map(&:strip).reject(&:empty?)
   end
 
   def node_expected_top_level_keys
-    source = File.read(MANIFEST_STRUCTURE_SMOKE_PATH)
+    source = File.read(manifest_structure_smoke_path)
     match = source.match(/const expectedKeys = \[\n(?<keys>.*?)\n  \]/m)
 
-    raise "Could not find assertTopLevelKeys expectedKeys literal in #{MANIFEST_STRUCTURE_SMOKE_PATH}" unless match
+    raise "Could not find assertTopLevelKeys expectedKeys literal in #{manifest_structure_smoke_path}" unless match
 
     match[:keys].scan(/"([^"]+)"/).flatten
   end


### PR DESCRIPTION
## 対応 Issue

- Closes #2224

## Issue ごとの完了内容

- #2224: Ruby spec の `PUBLIC_API_MANIFEST_TOP_LEVEL_KEYS` と Node smoke の `assertTopLevelKeys` / `expectedKeys` がずれた場合に RSpec で検出できる parity spec を追加しました。

## 変更内容

- `spec/public_api_manifest_top_level_key_parity_spec.rb` を追加
- Ruby 側・Node 側それぞれの既存 literal key list を読み取り、順序を含めて一致することを確認
- 失敗時に Node smoke から欠けた key / 余分な key が分かる message を出す

## 改善カテゴリ

- test
- CI guard hardening
- docs/public API manifest maintenance signal

## 既存仕様への影響

- runtime code、manifest schema、public API section、docs 本文は変更していません。
- 既存の Ruby spec / Node smoke の期待値を変えず、drift 検出用の spec のみ追加しています。

## 実施した確認内容

- Issue #2224 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
- branch は最新 `main` (`db245639478660a5654c376758effa9a5c57ff23`) から作成
- PR 前 compare で差分が `spec/public_api_manifest_top_level_key_parity_spec.rb` の追加のみ、`behind_by: 0` であることを確認

## リスク評価

- low
- spec 追加のみで、公開挙動や manifest contract は変更しません。

## 補足事項

- 実行環境から GitHub checkout / raw download が 403 で制限されたため、ローカル RSpec は未実行です。PR CI で確認してください。