### PR TITLE
public API declaration smoke の manifest loader error を明確化する

### DIFF
--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -2,21 +2,53 @@ import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 
 function loadJavascriptPackageManifest() {
-  const manifestJson = execFileSync(
-    "ruby",
-    [
-      "-e",
-      [
-        'require "json"',
-        'require "yaml"',
-        'data = YAML.load_file("config/public_api_manifest.yml")',
-        'print JSON.generate(data.fetch("javascript_package_root"))'
-      ].join("; ")
-    ],
-    { encoding: "utf8" }
-  )
+  const manifestJson = loadManifestJson()
 
-  return JSON.parse(manifestJson)
+  try {
+    return JSON.parse(manifestJson)
+  } catch (error) {
+    throw new Error(
+      [
+        "Could not parse config/public_api_manifest.yml javascript_package_root as JSON.",
+        "The declaration literal shape smoke uses Ruby to load YAML and prints that manifest section as JSON before Node assertions run.",
+        `Parser error: ${error.message}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
+}
+
+function loadManifestJson() {
+  try {
+    return execFileSync(
+      "ruby",
+      [
+        "-e",
+        [
+          'require "json"',
+          'require "yaml"',
+          'data = YAML.load_file("config/public_api_manifest.yml")',
+          'print JSON.generate(data.fetch("javascript_package_root"))'
+        ].join("; ")
+      ],
+      { encoding: "utf8" }
+    )
+  } catch (error) {
+    const rubyOutput = [error.stdout, error.stderr]
+      .filter((output) => output && output.length > 0)
+      .join("\n")
+      .trim()
+    const detail = rubyOutput || error.message
+
+    throw new Error(
+      [
+        "Could not load config/public_api_manifest.yml for the declaration literal shape smoke.",
+        "Run this command from the repository root with Ruby available, or inspect the manifest YAML around javascript_package_root.",
+        `Ruby loader output: ${detail}`
+      ].join("\n"),
+      { cause: error }
+    )
+  }
 }
 
 function camelizeKey(value) {


### PR DESCRIPTION
## 対応 Issue

Closes #2228

## Issue ごとの完了内容

- #2228: `script/test_declaration_literal_shapes.mjs` の manifest loader failure と JSON parse failure を、既存 entrypoint smoke と同じ粒度の context 付き error message に包むようにしました。

## 変更内容

- `loadJavascriptPackageManifest()` を、Ruby loader 実行と JSON parse の 2 段階に分けました。
- Ruby loader failure では、`config/public_api_manifest.yml`、Ruby availability、`javascript_package_root` 周辺の YAML 確認へ誘導する message を出します。
- JSON parse failure では、Ruby が出力した manifest section の JSON parse 問題として切り分けられる message を出します。
- literal shape assertion、public JS exports、TypeScript declaration shape、manifest schema は変更していません。

## 改善カテゴリ

- test diagnostics hardening
- public API smoke maintainability

## 既存仕様への影響

挙動変更はありません。失敗時の診断 message の改善のみで、runtime Ruby / JavaScript、manifest schema、`.d.ts`、public API surface、CI workflow は変更していません。

## 実施した確認

- Issue #2228 の labels と Planner handoff を個別確認しました。
- #2226 / #2227 は Planner handoff で単独扱い指定があったため、この PR には含めていません。
- current `main` は `d5eaf658e180a2d400d113c745127033310e4ccf`。
- compare `main...chore/2228-declaration-manifest-loader-message`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / `npm run test:entrypoints` / `node script/test_declaration_literal_shapes.mjs` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。test script の loader/parse error handling のみに閉じています。

## 補足事項

- Node YAML parser 追加、manifest schema redesign、CI workflow 変更、JavaScript export / declaration 変更は行っていません。
- merge は行いません。