### PR TITLE
package-lock root engines drift を guard する

### DIFF
--- a/script/test_package_lock_dependency_drift.mjs
+++ b/script/test_package_lock_dependency_drift.mjs
@@ -44,11 +44,21 @@ function assertDependencySpecsMatch(packageMetadata, lockRootPackage, section) {
   );
 }
 
+function assertRootPackageEnginesMatch(packageMetadata, lockRootPackage) {
+  assert.deepEqual(
+    lockRootPackage.engines || {},
+    packageMetadata.engines || {},
+    `${packageLockPath} root package engines must match ${packagePath} engines; run npm install after changing Node engine metadata`
+  );
+}
+
 const packageMetadata = JSON.parse(readFileSync(packagePath, "utf8"));
 const packageLock = JSON.parse(readFileSync(packageLockPath, "utf8"));
 const lockRootPackage = packageLock.packages?.[""];
 
 assert.ok(lockRootPackage, `${packageLockPath} must include packages[""] root package metadata`);
+
+assertRootPackageEnginesMatch(packageMetadata, lockRootPackage);
 
 for (const section of ["dependencies", "devDependencies"]) {
   assertDependencyKeysMatch(packageMetadata, lockRootPackage, section);


### PR DESCRIPTION
## 対応 Issue

Closes #2230

## Issue ごとの完了内容

- #2230: `package.json` の `engines` と `package-lock.json` root package metadata (`packages[""]`) の `engines` が一致していることを、既存の package-lock dependency drift guard で確認するようにしました。

## 変更内容

- `script/test_package_lock_dependency_drift.mjs` に `assertRootPackageEnginesMatch()` を追加しました。
- root package metadata が存在する既存前提を維持したまま、dependency / devDependency drift check の前に Node engine metadata drift を検出します。
- mismatch 時の message で `package-lock.json` root package engines と `package.json` engines の drift であること、Node engine metadata 変更後は `npm install` で lockfile metadata を更新すべきことが分かるようにしました。

## 改善カテゴリ

- test / CI guard hardening
- lockfile metadata drift prevention

## 既存仕様への影響

挙動変更はありません。Node major version、`package-lock.json` の実データ、npm dependency、CI workflow、Dockerfile、`.nvmrc`、runtime Ruby / JavaScript、public API manifest は変更していません。

## 実施した確認

- Issue #2230 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff が単独 Issue 指定だったため、#2226 / #2227 は同じPRに含めていません。
- current `main`: `b8138ddf5d544021c021e316d0803c4b1d949763`。
- compare `main...chore/2230-lockfile-engine-drift`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / `node script/test_package_lock_dependency_drift.mjs` / `npm run test:ci-policy` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 smoke script の assertion 追加のみで、公開 API や runtime behavior には影響しません。

## 補足事項

- npm / packageManager pinning policy、Dependabot policy、npm audit、Node version policy の判断には広げていません。
- merge は行いません。