### PR TITLE
release docs に repository-only docs link boundary を追記する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -187,6 +187,8 @@ Before release:
   - `docs/ja/release.md`
   - `LICENSE*`
 
+Because `docs/**/*` is packaged, keep package-facing docs independent from repository-only maintainer docs. `Product Profile.md` and `AGENTS.md` stay repository-only; do not add fragile relative links such as `../Product%20Profile.md` or `../AGENTS.md` from packaged docs. The package contents guard reports `Forbidden repository-only root doc links in packaged <path>` when that boundary drifts.
+
 ## Repository
 
 - Confirm `main` is green before tagging.

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -187,7 +187,7 @@ Before release:
   - `docs/ja/release.md`
   - `LICENSE*`
 
-Because `docs/**/*` is packaged, keep package-facing docs independent from repository-only maintainer docs. `Product Profile.md` and `AGENTS.md` stay repository-only; do not add fragile relative links such as `../Product%20Profile.md` or `../AGENTS.md` from packaged docs. The package contents guard reports `Forbidden repository-only root doc links in packaged <path>` when that boundary drifts.
+Because `docs/**/*` is packaged, keep package-facing docs independent from repository-only maintainer docs. `Product Profile.md` and `AGENTS.md` stay repository-only; do not add encoded parent-directory links from packaged docs back to those root-only files. The package contents guard reports `Forbidden repository-only root doc links in packaged <path>` when that boundary drifts.
 
 ## Repository
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -187,7 +187,7 @@ release前に確認すること:
   - `docs/ja/release.md`
   - `LICENSE*`
 
-`docs/**/*` は packaged docs として gem に含まれるため、package-facing docs は repository-only maintainer docs から独立させます。`Product Profile.md` と `AGENTS.md` は repository-only のまま扱い、packaged docs から `../Product%20Profile.md` や `../AGENTS.md` のような壊れやすい relative link を追加しないでください。この境界が崩れると、package contents guard は `Forbidden repository-only root doc links in packaged <path>` として対象 path を報告します。
+`docs/**/*` は packaged docs として gem に含まれるため、package-facing docs は repository-only maintainer docs から独立させます。`Product Profile.md` と `AGENTS.md` は repository-only のまま扱い、packaged docs から repository root 専用文書へ戻る encoded parent-directory link を追加しないでください。この境界が崩れると、package contents guard は `Forbidden repository-only root doc links in packaged <path>` として対象 path を報告します。
 
 ## Repository
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -187,6 +187,8 @@ release前に確認すること:
   - `docs/ja/release.md`
   - `LICENSE*`
 
+`docs/**/*` は packaged docs として gem に含まれるため、package-facing docs は repository-only maintainer docs から独立させます。`Product Profile.md` と `AGENTS.md` は repository-only のまま扱い、packaged docs から `../Product%20Profile.md` や `../AGENTS.md` のような壊れやすい relative link を追加しないでください。この境界が崩れると、package contents guard は `Forbidden repository-only root doc links in packaged <path>` として対象 path を報告します。
+
 ## Repository
 
 - `main` がgreenであることを確認する


### PR DESCRIPTION
## 対応 Issue

Closes #2240

## 変更内容

- 英日 `docs/*/release.md` の Gem package 節に、packaged docs と repository-only maintainer docs の境界を追記しました。
- `docs/**/*` は gem に含まれる package-facing docs である一方、`Product Profile.md` / `AGENTS.md` は repository-only maintainer docs として扱うことを明記しました。
- packaged docs から repository root 専用文書へ戻る encoded parent-directory link を追加しないことと、package verifier の forbidden link failure message を短く説明しました。

## 分類

- `docs-sync`
- `docs-missing`: release docs から repository-only docs link boundary が読み取りにくい状態でした。

## 変更範囲

- `docs/en/release.md`
- `docs/ja/release.md`

## 非対象

- `script/check_gem_package_contents.rb` implementation
- `tree_view.gemspec` package file glob
- `Product Profile.md` / `AGENTS.md` の内容や公開範囲
- docs navigation 全体 redesign
- full-site link checker
- #2239 の release metadata guard

## 確認内容

- Issue #2240 と Planner handoff を確認しました。
- current code として `tree_view.gemspec` の `docs/**/*` packaging と `script/check_gem_package_contents.rb` の `PACKAGED_DOCS_FORBIDDEN_RELATIVE_ROOT_LINKS` / `Forbidden repository-only root doc links in packaged <path>` を確認しました。
- current `main` `bc9ace5c6e837880c6b2fd4cadaeeb4992f0b983` へ追従済みです。
- current head: `3103f8802283431e202c83e81d18a824322a2d63`。
- compare `main...docs/2240-repository-only-package-links`: `ahead_by:4` / `behind_by:0` / changed files 2 / deletions 0。
- diff は英日 release docs の1段落ずつの追記のみです。
- 初回 CI #3083 は、docs 本文に forbidden exact relative path strings を含めたため `gem_package` が失敗しました。本文を encoded parent-directory link という表現に直し、既存 package guard と矛盾しない形へ修正済みです。
- GitHub Actions CI #3085 / run `27663318649`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` は `npm run test:docs-entrypoints` を実行し、runtime JS / browser smoke は docs-only skip。
  - representative Rails compatibility lanes: docs-only skip / success。
- local checkout / local `node script/test_release_docs_signals.mjs` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。release docs の確認導線のみで、package verifier behavior、packaging policy、repository-only docs の扱いは変更していません。