### PR TITLE
CHANGELOG に release CI docs signal guard を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ Release preparation notes:
 - Added dependency spec, non-PR workflow output, public API manifest unknown-key, and duplicate YAML-key guard coverage for package-lock, CI changed-file policy, and manifest structure smoke.
 - Added public setup generator file package contents guard coverage for install generator and state templates.
 - Added public API manifest top-level key parity coverage to keep Ruby and Node manifest structure guards synchronized.
+- Added release docs signal coverage for release metadata guards and docs-entrypoint sensitive CI routing.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応内容

- merged #2245 の release metadata guard / docs-entrypoint sensitive CI routing 追従を `CHANGELOG.md` の `Unreleased > Tests` に1行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 分類

- `code-ahead-of-docs`: release docs signal guard の改善が main に入っており、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/test_release_docs_signals.mjs`
- CI changed-file policy
- package verifier implementation
- release docs 本文
- release automation / tag / publish 作業

## 確認内容

- PR #2245 が main に merge済みであることを確認しました。
- current main `63bd91a9a4c4f69affeb140625e4a3bcea7a1061` から branch を作成しました。
- compare `main...docs/changelog-release-ci-signal-guard`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。docs-only CHANGELOG 追記のため PR CI を確認対象にします。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / test implementation / CI behavior は変更していません。