### PR TITLE
CHANGELOG に release docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Release preparation notes:
 - Clarified development docs that `.nvmrc`, `package.json` `engines.node`, and workflow `node-version` stay aligned by a Node version source drift guard.
 - Clarified Development docs for the Ruby version source and CI changed-file policy guard commands, including Bundler dependency package-sensitive guidance.
 - Clarified Development docs for standalone gem package verification and docs i18n parity commands.
+- Clarified Development docs for public constants package guard mapping and Release docs for public setup generator package checklist / repository-only packaged-doc link boundaries.
 - Clarified `npm ci` install path guidance across README, installation, development, and release checklist docs so local setup, PR CI, Docker setup smoke, and main-push JavaScript checks share lockfile-backed evidence.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.


### PR DESCRIPTION
## 対応内容

- merged #2241 / #2244 / #2246 の development / release docs 追従を `CHANGELOG.md` の `Unreleased > Documentation` に1行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 分類

- `code-ahead-of-docs`: Development / Release docs の package guard mapping、repository-only packaged-doc link boundary、public setup generator package checklist guidance が main に入っており、CHANGELOG の Documentation evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `docs/en/release.md` / `docs/ja/release.md` 本文
- `docs/en/development.md` / `docs/ja/development.md` 本文
- package verifier implementation
- release docs signal scripts
- CI workflow
- release automation / tag / publish 作業

## 確認内容

- PR #2241 / #2244 / #2246 が main に merge済みであることを確認しました。
- current main `812a29e56afea188ac4b71ea1fbda99d23d9b7fb` から clean branch を作成しました。
- compare `main...docs/changelog-release-docs-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。docs-only CHANGELOG 追記のため PR CI を確認対象にします。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / docs本文 / test implementation / CI behavior は変更していません。