### PR TITLE
CHANGELOG-only CI routing を changed-files policy test で守る

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -21,6 +21,18 @@ const cases = [
     }
   },
   {
+    name: "changelog-only docs request package and docs entrypoint guards",
+    files: ["CHANGELOG.md"],
+    expected: {
+      docs_only: true,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
+    }
+  },
+  {
     name: "repository-only docs stay docs-only without package or docs entrypoint guard",
     files: ["Product Profile.md", "AGENTS.md"],
     expected: {


### PR DESCRIPTION
## 対応 Issue

- Closes #2250

## Issue ごとの完了内容

- #2250: `CHANGELOG.md` 単独変更の changed-files policy case を追加し、docs-only でありながら package guard と docs entrypoint guard が有効になることを明示的に守りました。

## 変更内容

- `script/test_ci_changed_files_policy.mjs` の代表ケースに `CHANGELOG.md` only case を追加
- 期待値として以下を明示
  - `docs_only: true`
  - `package_sensitive: true`
  - `docs_entrypoint_sensitive: true`
  - `mockups_changed: false`
  - `browser_smoke_changed: false`
  - `docker_setup_sensitive: false`

## 改善カテゴリ

- test 改善
- CI routing guard hardening
- docs/release evidence guard

## 既存仕様への影響

- policy implementation と workflow behavior は変更していません。
- CI workflow の再設計、CHANGELOG 本文、release automation、package verifier には触れていません。
- 既存の `CHANGELOG.md` 分類を代表テストで固定するだけの変更です。

## 実施した確認

- Issue #2250 のラベルを個別確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`
- `script/ci_changed_files_policy.mjs` と `.github/workflows/ci.yml` の現行分岐を確認
- GitHub compare で `main...quality/2250-changelog-only-policy-test` を確認
  - `behind_by: 0`
  - 変更ファイルは `script/test_ci_changed_files_policy.mjs` の 1 件のみ

## リスク評価

- risk: low
- 既存 behavior を変えないテスト追加のみです。

## 補足事項

- connector-only での小変更として、最新 main `812a29e56afea188ac4b71ea1fbda99d23d9b7fb` から branch を作成しました。
- ローカル checkout は GitHub HTTPS 制約により使わず、PR CI を確認します。