### PR TITLE
Public API docs に TreeViewControllerEntries の位置づけを追記する clean replacement

### DIFF
--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -166,7 +166,7 @@ See [API reference](api.md), [Localized names](localized-names.md), and [Turbo F
 | `toggle_icons` | `by_state`, `by_depth`, `by_type` | Mirrors the documented declarative toggle icon map. `toggle_icon_builder` remains a callable escape hatch and is not manifest-backed. |
 | `selection` | `enabled`, `visibility`, `payload_builder`, `checkbox_name`, `disabled_builder`, `disabled_reason_builder`, `selected_keys`, `cascade`, `indeterminate`, `max_count` | Mirrors `TreeView::RenderState::SelectionConfig` and keeps grouped selection wiring aligned with the documented flat selection keywords. |
 | `lazy_loading` | `enabled`, `loaded_keys`, `scope` | Mirrors the documented lazy-loading row-state hooks and optional host-app scope passthrough. |
-| `row_status` | `row_disabled_builder`, `row_readonly_builder`, `row_disabled_reason_builder` | Mirrors the documented row disabled / readonly state hooks and disabled-reason surface. |
+| `row_status` | `row_disabled_builder`, `row_readonly_builder`, `row_disabled_reason_builder` | Mirrors the documented row disabled / readonly state hook and disabled-reason surface. |
 
 ### RenderState flat callback builder keys
 
@@ -209,6 +209,7 @@ Stable enough for host apps to use:
 - `TreeViewRemoteStateValues`
 - `TreeViewRemoteStateDataHooks`
 - `TreeViewControllerIdentifiers`
+- `TreeViewControllerEntries`
 - `TreeViewIntegrationHooks`
 - `TreeViewToolbarDataHooks`
 - `TreeViewSelectionDataHooks`
@@ -232,9 +233,10 @@ Stable enough for host apps to use:
 `TreeViewRemoteStateValues` exposes the documented remote-state value set for lazy-loading rows: `loading`, `loaded`, and `error`. Use it when host-app JavaScript or tests need to compare `data-tree-remote-state` values without hand-copying strings; `TreeViewEventNames.remoteState.*` still names controller-emitted events, and `TreeViewEventDetailKeys.remoteState.*` still lists their `event.detail` keys.
 `TreeViewRemoteStateDataHooks` exposes the documented lazy-loading and remote-state data attribute names as a machine-readable package-root export. Use it when custom lazy-loading markup, tests, or copied host-app partials need to reference `data-tree-lazy`, `data-tree-children-url`, `data-tree-loaded`, or `data-tree-remote-state` without hand-copying strings; request dispatch, response handling, retry UI, and authorization-safe copy stay with the host app and [Lazy Loading](lazy-loading.md).
 `TreeViewControllerIdentifiers` exposes the same documented identifiers as a machine-readable object. Host apps that selectively register controllers or choose a custom boot order should use this export instead of hand-copying identifier strings.
+`TreeViewControllerEntries` exposes the documented identifier/controller pairs in bundled registration order. Use it when host apps need custom registration, boot-order review, or tests that should not hand-copy identifier/controller tuples. `registerTreeViewControllers(application)` remains the standard registration path; the entries list is a manifest-backed convenience for selective wiring, not a new registration policy.
 `TreeViewIntegrationHooks` exposes documented integration hook attribute names as a machine-readable object for host-app JavaScript and tests that need to query or assert TreeView-owned wiring without hand-copying strings. Representative keys cover state row identity, remote-state children URLs, and transfer payload hooks; their detailed behavior still lives in the feature docs and [JavaScript event contract](js-events.md).
 `TreeViewToolbarDataHooks` exposes the documented toolbar container, action, and disabled data hook attribute names as a machine-readable package-root export. Use it when custom toolbar markup or tests need to reference TreeView-owned toolbar hooks without hand-copying strings; supported actions and metadata still come from the toolbar helpers, while action policy, labels, authorization copy, and final UI remain host-app responsibilities documented in [Toolbar](toolbar.md).
-`TreeViewSelectionDataHooks` exposes the documented `tree-view-selection` host-element value attribute names as a machine-readable object. Use it when JavaScript needs to author or query those host-owned attributes without hand-copying strings such as `TreeViewSelectionDataHooks.hiddenInputNameValue`.
+`TreeViewSelectionDataHooks` exposes the documented `tree-view-selection` host-element value attributes as a machine-readable object. Use it when JavaScript needs to author or query those host-owned attributes without hand-copying strings such as `TreeViewSelectionDataHooks.hiddenInputNameValue`.
 `TreeViewSelectionCheckboxHooks` exposes the rendered selection checkbox class and disabled-reason attribute emitted by TreeView's selection cell partial. Use it for browser-level tests or host-app JavaScript that needs to find TreeView-rendered checkbox elements, not for host-authored `tree-view-selection` controller values. See [Selection checkbox hooks](selection-checkbox-hooks.md).
 `TreeViewEmptyStateHooks` exposes the documented empty-state wrapper attribute and baseline row classes as a machine-readable object. Use it when host-app JavaScript, tests, or copied styling need to target the shipped empty-state reference pattern without hand-copying `data-tree-view-empty-state`, `.tree-view-empty-row__content`, or `.tree-view-empty-row__message`. The final empty-state copy, CTA, permission message, and filter-reset behavior stay host-app responsibilities.
 
@@ -266,6 +268,14 @@ Documented keys on `TreeViewRemoteStateDataHooks`:
 - `remoteStateAttribute`
 
 Documented keys on `TreeViewControllerIdentifiers`:
+
+- `state`
+- `client`
+- `selection`
+- `transfer`
+- `remoteState`
+
+Documented entry keys on `TreeViewControllerEntries`:
 
 - `state`
 - `client`
@@ -313,7 +323,7 @@ The `tree-view-selection` controller's documented host-element value attributes 
 
 Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
-The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, transfer drop-position values, transfer data MIME type values, remote-state values, remote-state data hook values, toolbar data hook values, integration hook values, selection data hook values, selection checkbox hook values, and empty-state hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, controller entry list, transfer drop-position values, transfer data MIME type values, remote-state values, remote-state data hook values, toolbar data hook values, integration hook values, selection data hook values, selection checkbox hook values, and empty-state hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 
 Internal by default:
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -209,6 +209,7 @@ host app が使ってよい入口:
 - `TreeViewRemoteStateValues`
 - `TreeViewRemoteStateDataHooks`
 - `TreeViewControllerIdentifiers`
+- `TreeViewControllerEntries`
 - `TreeViewIntegrationHooks`
 - `TreeViewToolbarDataHooks`
 - `TreeViewSelectionDataHooks`
@@ -232,9 +233,10 @@ host app が使ってよい入口:
 `TreeViewRemoteStateValues` は lazy-loading row の documented remote-state value set として、`loading`、`loaded`、`error` を公開します。host app の JavaScript や test が `data-tree-remote-state` の値を string の写経なしに照合したい場合に使えます。controller が emit する remote-state event 名は引き続き `TreeViewEventNames.remoteState.*`、その `event.detail` key は `TreeViewEventDetailKeys.remoteState.*` で扱います。
 `TreeViewRemoteStateDataHooks` は、documented された lazy-loading / remote-state data attribute names を machine-readable に参照するための package-root export です。custom lazy-loading markup、test、copied host-app partial が `data-tree-lazy`、`data-tree-children-url`、`data-tree-loaded`、`data-tree-remote-state` を写経せず参照したい場合に使えます。request dispatch、response handling、retry UI、authorization-safe copy は [Lazy Loading](lazy-loading.md) に沿って host app 側に残ります。
 `TreeViewControllerIdentifiers` は、同じ documented identifier を machine-readable な object として公開します。controller を部分登録したい host app や custom boot order を組みたい host app は、identifier string を写経せずこの export を使ってください。
+`TreeViewControllerEntries` は、documented identifier と controller export の対応を bundled registration order で公開します。custom registration、boot-order review、test で identifier / controller tuple を写経したくない場合に使ってください。標準の登録入口は引き続き `registerTreeViewControllers(application)` であり、この entries list は selective wiring 用の manifest-backed convenience であって、新しい registration policy ではありません。
 `TreeViewIntegrationHooks` は、documented integration hook attribute name を machine-readable object として公開します。host app の JavaScript や test が TreeView-owned wiring を query / assert するとき、raw string の写経を避けるために使えます。代表 key は state row identity、remote-state children URL、transfer payload hook を扱います。詳細な挙動は feature docs と [JavaScript event contract](js-events.md) を正本にしてください。
 `TreeViewToolbarDataHooks` は、documented された toolbar container、action、disabled data hook attribute names を machine-readable に参照するための package-root export です。custom toolbar markup や test が TreeView-owned toolbar hook を写経せず参照したい場合に使えます。supported action と metadata は toolbar helper から取得し、action policy、label、authorization copy、最終 UI は [Toolbar](toolbar.md) で説明している host app 側の責務です。
-`TreeViewSelectionDataHooks` は、documented された `tree-view-selection` host-element value attribute names を machine-readable object として公開します。JavaScript が host-owned attribute を author / query するとき、`TreeViewSelectionDataHooks.hiddenInputNameValue` のように使うことで string の写経を避けられます。
+`TreeViewSelectionDataHooks` は、documented された `tree-view-selection` host-element value attributes を machine-readable object として公開します。JavaScript が host-owned attribute を author / query するとき、`TreeViewSelectionDataHooks.hiddenInputNameValue` のように使うことで string の写経を避けられます。
 `TreeViewSelectionCheckboxHooks` は、TreeView の selection cell partial が出力する rendered selection checkbox class と disabled-reason attribute を公開します。TreeView-rendered checkbox element を探す browser-level test や host-app JavaScript 向けであり、host-authored な `tree-view-selection` controller value には使いません。詳細は [Selection checkbox hooks](selection-checkbox-hooks.md) を参照してください。
 `TreeViewEmptyStateHooks` は、documented された empty-state wrapper attribute と baseline row class を machine-readable object として公開します。host app の JavaScript、test、copied styling が shipped empty-state reference pattern を target するとき、`data-tree-view-empty-state`、`.tree-view-empty-row__content`、`.tree-view-empty-row__message` の写経を避けられます。最終的な empty-state copy、CTA、permission message、filter-reset behavior は host app 側の責務です。
 
@@ -266,6 +268,14 @@ host app が使ってよい入口:
 - `remoteStateAttribute`
 
 `TreeViewControllerIdentifiers` の documented key:
+
+- `state`
+- `client`
+- `selection`
+- `transfer`
+- `remoteState`
+
+`TreeViewControllerEntries` の documented entry key:
 
 - `state`
 - `client`
@@ -313,7 +323,7 @@ host app が使ってよい入口:
 
 これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する内部寄りの属性であり、host app が authoring する public hook ではありません。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
-package-root の JavaScript export、bundled controller identifier、transfer drop-position value、transfer data MIME type value、remote-state value、remote-state data hook value、toolbar data hook value、integration hook value、selection data hook value、selection checkbox hook value、empty-state hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+package-root の JavaScript export、bundled controller identifier、controller entry list、transfer drop-position value、transfer data MIME type value、remote-state value、remote-state data hook value、toolbar data hook value、integration hook value、selection data hook value、selection checkbox hook value、empty-state hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 
 内部扱い:
 
@@ -341,7 +351,7 @@ host app が依存してよい browser-facing surface は、documented された
 
 この inventory は代表例であり、網羅一覧ではありません。`config/public_api_manifest.yml` は helper method、JavaScript package-root export、controller identifier、integration hook、selection data hook、selection checkbox hook、empty-state hook、RenderState grouped option key の machine-readable source of truth です。docs-only の hook inventory は feature guide と mockup への導線を示すもので、出力されるすべての class や `data-*` attribute を compatibility contract にするものではありません。
 
-manifest に載っていない DOM helper 名は、生成される DOM ID や attribute が bundled markup に現れていても内部扱いです。特に button、selection checkbox、toggle path、lazy-loading path helper 名は、manifest に昇格されこのページで document されるまでは host app の公開依存先ではありません。
+manifest に載っていない DOM helper 名は、生成される DOM ID や attribute が bundled markup に現れても内部扱いです。特に button、selection checkbox、toggle path、lazy-loading path helper 名は、manifest に昇格されこのページで document されるまでは host app の公開依存先ではありません。
 
 undocumented な CSS helper class、data attribute、DOM 構造詳細、gem partial 内部 locals は内部実装です。
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2025
Supersedes #2030

## 置き換え理由

既存 PR #2030 は latest main 追従のための merge-style refresh を重ねた結果、net compare では docs 2件のみでも、GitHub の PR file list / diff 表示に main 側の `CHANGELOG.md` 追記が混ざる状態になりました。

この PR は current `main` `737b4593bfe18b52acbb8d90480863108f7b133a` から clean branch を作り直し、同じ英日 Public API docs の intended diff だけを載せ直す replacement PR です。旧 PR branch の force push は行っていません。

## 変更内容

- `docs/en/public-api.md` / `docs/ja/public-api.md` に `TreeViewControllerEntries` を追加します。
- `registerTreeViewControllers(application)` を標準登録入口として維持したまま、`TreeViewControllerEntries` は identifier / controller tuple を写経しないための manifest-backed convenience export と説明します。
- machine-readable source of truth の説明に controller entry list を追加します。

## 分類

- `docs-stale`: 既存 export / manifest-backed surface に対して Public API docs が追従していませんでした。
- `needs-human`: `TreeViewControllerEntries` を host app 向け public surface として説明してよいかは public API stance の人間レビュー対象です。

## 変更範囲

- `docs/en/public-api.md`
- `docs/ja/public-api.md`

## 非対象

- runtime JavaScript
- TypeScript declaration
- `config/public_api_manifest.yml`
- controller registration behavior / boot order implementation
- tests / scripts
- CHANGELOG

## 確認内容

- current main: `737b4593bfe18b52acbb8d90480863108f7b133a`
- head: `27872841d2a089473ee93347c6cf1812987858b1`
- compare `main...docs/2025-controller-entries-public-api-clean-v3`: `ahead_by:1` / `behind_by:0` / changed files 2。
- 変更ファイルは `docs/en/public-api.md` / `docs/ja/public-api.md` のみです。
- GitHub Actions CI #3113 / run `27675368810`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`: success
  - `javascript`: `npm run test:docs-entrypoints` success、core/browser checks は docs-only skip
  - representative Rails lanes: docs-only skip / success
- local checkout / local test は GitHub HTTPS 制約により未実行です。PR CI を確認証跡にしています。

## Review focus

`TreeViewControllerEntries` を package-facing, manifest-backed convenience export として Public API docs に含める方針でよいかを確認してください。docs は runtime Stimulus registration の入口を変更したとは書かず、標準入口を `registerTreeViewControllers(application)` のままにしています。