### PR TITLE
CHANGELOG に CHANGELOG-only CI routing guard を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Release preparation notes:
 - Clarified that `docs/mockups/README.md` is the source of truth for mockup technical asset inventory.
 - Added root docs index entry points for the English and Japanese Rendering Boundaries guides.
 - Added malformed selection params troubleshooting guidance in English and Japanese, including `TreeView.parse_selection_params` error boundaries and host-app-owned request policy.
+- Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ Release preparation notes:
 - Added public setup generator file package contents guard coverage for install generator and state templates.
 - Added public API manifest top-level key parity coverage to keep Ruby and Node manifest structure guards synchronized.
 - Added release docs signal coverage for release metadata guards and docs-entrypoint sensitive CI routing.
+- Added CHANGELOG-only CI routing coverage to keep `CHANGELOG.md` changes on the docs-entrypoint and package verification paths.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応内容

- merged #2252 の `CHANGELOG.md` 単独変更 changed-files policy guard を `CHANGELOG.md` の `Unreleased > Tests` に1行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 分類

- `code-ahead-of-docs`: `script/test_ci_changed_files_policy.mjs` に CHANGELOG-only case が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/test_ci_changed_files_policy.mjs`
- `.github/workflows/ci.yml`
- package verifier implementation
- release docs 本文
- release automation / tag / publish 作業

## 確認内容

- PR #2252 が main に merge済みであることを確認しました。
- 作業中に main が進んだため、current main `afb7d531b2794af9af7e12507cd2a31c224c64e6` を取り込む refresh commit を追加しました。
- current head: `ec846d3f7c700623e9e98c11d690bc739d0148f4`。
- compare `main...docs/changelog-changed-files-policy-evidence`: `ahead_by:2` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- GitHub Actions CI #3122 / run `27678505067`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`: success
  - `javascript`: `npm run test:docs-entrypoints` success、core/browser checks は docs-only skip
  - representative Rails lanes: docs-only skip / success
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / test implementation / CI behavior は変更していません。