### PR TITLE
docs entrypoint suite の未登録script guardを追加する

### DIFF
--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict"
 import { spawnSync } from "node:child_process"
+import { readdirSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
 
 const checks = [
   {
@@ -144,6 +149,29 @@ const checks = [
   }
 ]
 
+const docsEntrypointScriptExclusions = new Map([
+  [
+    "test_development_docs_command_signals.mjs",
+    "registered through npm run test:development-docs-commands"
+  ],
+  ["test_docs_entrypoint_suite.mjs", "this suite's self-test entrypoint"],
+  ["test_docs_i18n_parity.mjs", "registered through npm run test:docs-i18n"]
+])
+
+const docsEntrypointScriptPatterns = [
+  /^test_.*docs.*\.mjs$/,
+  /^test_.*readme.*signals\.mjs$/,
+  /^test_.*mockup.*signals\.mjs$/,
+  /^test_breadcrumb_.*signals\.mjs$/,
+  /^test_configuration_.*signals\.mjs$/,
+  /^test_decision_guide_signals\.mjs$/,
+  /^test_grouped_option_.*signals\.mjs$/,
+  /^test_localized_and_hook_.*signals\.mjs$/,
+  /^test_quality_.*signals\.mjs$/,
+  /^test_release_.*signals\.mjs$/,
+  /^test_tree_view_rows_.*signals\.mjs$/
+]
+
 function commandLine({ command, args }) {
   return [command, ...args].join(" ")
 }
@@ -171,6 +199,47 @@ function printCheckList(selectedChecks = checks) {
 function usage() {
   console.error("[docs-entrypoints] usage: node script/test_docs_entrypoint_suite.mjs [--list] [--only <group-or-index>] [--self-test]")
   console.error("[docs-entrypoints] use --list to show available groups")
+}
+
+function registeredNodeScriptPaths() {
+  return new Set(
+    checks
+      .filter((check) => check.command === "node" && check.args[0]?.startsWith("script/"))
+      .map((check) => check.args[0])
+  )
+}
+
+function isDocsEntrypointCandidate(filename) {
+  if (!filename.endsWith(".mjs")) return false
+  if (docsEntrypointScriptExclusions.has(filename)) return false
+
+  return docsEntrypointScriptPatterns.some((pattern) => pattern.test(filename))
+}
+
+function docsEntrypointCandidateScriptPaths() {
+  return readdirSync(scriptDir)
+    .filter(isDocsEntrypointCandidate)
+    .map((filename) => `script/${filename}`)
+    .sort()
+}
+
+function unregisteredDocsEntrypointScriptPaths() {
+  const registeredPaths = registeredNodeScriptPaths()
+  return docsEntrypointCandidateScriptPaths().filter((scriptPath) => !registeredPaths.has(scriptPath))
+}
+
+function assertDocsEntrypointScriptsRegistered() {
+  const unregisteredScripts = unregisteredDocsEntrypointScriptPaths()
+
+  assert.deepEqual(
+    unregisteredScripts,
+    [],
+    [
+      "docs entrypoint suite is missing docs smoke/signal script registrations:",
+      ...unregisteredScripts.map((scriptPath) => `  - ${scriptPath}`),
+      "Add each script to the checks array or document an explicit exclusion."
+    ].join("\n")
+  )
 }
 
 function resolveOnlyGroupResult(groupName) {
@@ -284,6 +353,16 @@ function runSelfTest() {
     ],
     "ambiguous --only should report all matching groups"
   )
+
+  assert.ok(
+    docsEntrypointCandidateScriptPaths().includes("script/test_public_api_docs_signals.mjs"),
+    "docs script registration candidates should include public API docs signals"
+  )
+  assert.ok(
+    !docsEntrypointCandidateScriptPaths().includes("script/test_docs_i18n_parity.mjs"),
+    "npm-registered docs checks should stay out of direct node script registration candidates"
+  )
+  assertDocsEntrypointScriptsRegistered()
 
   console.log("[docs-entrypoints] self-test passed")
 }


### PR DESCRIPTION
## 対応 Issue

Closes #2253

## Issue ごとの完了内容

- #2253: `script/test_docs_entrypoint_suite.mjs --self-test` に、docs smoke / docs signal 系 script の未登録を検出する filesystem guard を追加しました。

## 変更内容

- `script/` 配下の conservative な docs entrypoint candidate pattern を定義しました。
- `checks` の direct `node script/...` 登録と実ファイル一覧を照合する self-test guard を追加しました。
- suite 自身、`test:docs-i18n`、`test:development-docs-commands` のように npm script 経由で登録されるものは明示的に除外しました。
- 未登録 script がある場合、対象 path と `checks` へ登録すべきことが failure message で分かるようにしました。

## 改善カテゴリ

- test
- docs smoke guard
- CI guard hardening

## 既存仕様への影響

既存の docs signal script、docs prose、runtime Ruby / JavaScript、CI workflow routing、public API manifest schema は変更していません。`--only` の group resolution と既存 group 名も維持しています。

## 実施した確認

- Issue #2253 の labels を個別確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- 既存 open PR に #2253 対応がないことを確認しました。
- compare `main...test/2253-docs-entrypoint-suite-registration`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local `node script/test_docs_entrypoint_suite.mjs --self-test` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。self-test の登録漏れ検出追加のみで、既存実行順・個別 docs smoke の中身・workflow topology は変更していません。

## 補足事項

- `npm run test:docs-entrypoints` は既存 suite の最後に self-test group を実行するため、この guard も同コマンド経由で走ります。
- merge は行いません。