### PR TITLE
CHANGELOG に docs entrypoint suite guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ Release preparation notes:
 - Added public setup generator file package contents guard coverage for install generator and state templates.
 - Added public API manifest top-level key parity coverage to keep Ruby and Node manifest structure guards synchronized.
 - Added release docs signal coverage for release metadata guards and docs-entrypoint sensitive CI routing.
+- Added docs entrypoint suite self-test coverage for unregistered docs smoke / signal scripts.
 - Added CHANGELOG-only CI routing coverage to keep `CHANGELOG.md` changes on the docs-entrypoint and package verification paths.
 
 ## 0.1.0 - 2026-05-07


### PR DESCRIPTION
## 対応内容

- merged #2256 の docs entrypoint suite 未登録 script guard を `CHANGELOG.md` の `Unreleased > Tests` に1行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 分類

- `code-ahead-of-docs`: `script/test_docs_entrypoint_suite.mjs --self-test` に未登録 docs smoke / signal script guard が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/test_docs_entrypoint_suite.mjs`
- `package.json` scripts
- CI workflow
- docs smoke / signal script implementation
- release automation / tag / publish 作業

## 確認内容

- PR #2256 が main に merge済みであることを確認しました。
- current main `5d20f0a83315cfe5634c33510308965821488a39` から clean branch を作成しました。
- current head: `78dda7ef07bb47618ca49e233d82838c5ef33922`。
- compare `main...docs/changelog-docs-entrypoint-suite-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- GitHub Actions CI #3131 / run `27681856685`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`: success
  - `javascript`: `npm run test:docs-entrypoints` success、core/browser checks は docs-only skip
  - representative Rails lanes: docs-only skip / success
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / test implementation / CI behavior は変更していません。