### PR TITLE
release_note_candidates helper の contract spec を追加する

### DIFF
--- a/spec/release_note_candidates_spec.rb
+++ b/spec/release_note_candidates_spec.rb
@@ -5,11 +5,13 @@ require_relative "../script/release_note_candidates"
 
 RSpec.describe ReleaseNoteCandidates::MarkdownFormatter do
   def entry(type:, number:, title:, closed_at: nil, merged_at: nil)
+    path_segment = (type == :pull_request) ? "pull" : "issues"
+
     ReleaseNoteCandidates::Entry.new(
       type: type,
       number: number,
       title: title,
-      url: "https://github.com/matsuo-haruhito/tree_view-rails/#{type == :pull_request ? "pull" : "issues"}/#{number}",
+      url: "https://github.com/matsuo-haruhito/tree_view-rails/#{path_segment}/#{number}",
       closed_at: closed_at,
       merged_at: merged_at
     )

--- a/spec/release_note_candidates_spec.rb
+++ b/spec/release_note_candidates_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../script/release_note_candidates"
+
+RSpec.describe ReleaseNoteCandidates::MarkdownFormatter do
+  def entry(type:, number:, title:, closed_at: nil, merged_at: nil)
+    ReleaseNoteCandidates::Entry.new(
+      type: type,
+      number: number,
+      title: title,
+      url: "https://github.com/matsuo-haruhito/tree_view-rails/#{type == :pull_request ? "pull" : "issues"}/#{number}",
+      closed_at: closed_at,
+      merged_at: merged_at
+    )
+  end
+
+  it "formats merged pull request and closed issue sections with timestamps" do
+    output = described_class.new.call(
+      repo: "matsuo-haruhito/tree_view-rails",
+      source: "closed or merged since 2026-06-01",
+      merged_prs: [entry(type: :pull_request, number: 12, title: "Add package guard", merged_at: "2026-06-12T01:23:45Z")],
+      closed_issues: [entry(type: :issue, number: 9, title: "Document release boundary", closed_at: "2026-06-10T00:00:00Z")]
+    )
+
+    expect(output).to include("# Release note candidates for matsuo-haruhito/tree_view-rails")
+    expect(output).to include("Source: closed or merged since 2026-06-01")
+    expect(output).to include("This is a maintainer review aid. It does not rewrite CHANGELOG.md and does not decide the final release notes.")
+    expect(output).to include("## Merged pull requests")
+    expect(output).to include("- #12 Add package guard (2026-06-12T01:23:45Z)")
+    expect(output).to include("  https://github.com/matsuo-haruhito/tree_view-rails/pull/12")
+    expect(output).to include("## Closed issues")
+    expect(output).to include("- #9 Document release boundary (2026-06-10T00:00:00Z)")
+    expect(output).to end_with("\n")
+  end
+
+  it "keeps empty candidate sections explicit" do
+    output = described_class.new.call(
+      repo: "matsuo-haruhito/tree_view-rails",
+      source: "commit references since tag v0.1.0",
+      merged_prs: [],
+      closed_issues: []
+    )
+
+    expect(output.scan("- No candidates found.").length).to eq(2)
+    expect(output).to include("## Merged pull requests\n\n- No candidates found.")
+    expect(output).to include("## Closed issues\n\n- No candidates found.")
+  end
+end
+
+RSpec.describe ReleaseNoteCandidates::CLI do
+  def expect_parse_abort(argv, message)
+    expect do
+      expect { described_class.parse_options(argv) }.to raise_error(SystemExit)
+    end.to output(/#{Regexp.escape(message)}/).to_stderr
+  end
+
+  it "requires a repo option" do
+    expect_parse_abort(["--since", "2026-06-01"], "--repo is required")
+  end
+
+  it "requires exactly one collection source" do
+    expect_parse_abort(["--repo", "matsuo-haruhito/tree_view-rails"], "Use exactly one of --since or --since-tag")
+    expect_parse_abort(
+      ["--repo", "matsuo-haruhito/tree_view-rails", "--since", "2026-06-01", "--since-tag", "v0.1.0"],
+      "Use exactly one of --since or --since-tag"
+    )
+  end
+
+  it "parses valid since-date options without network access" do
+    options = described_class.parse_options(["--repo", "matsuo-haruhito/tree_view-rails", "--since", "2026-06-01"])
+
+    expect(options).to eq(repo: "matsuo-haruhito/tree_view-rails", since: "2026-06-01")
+  end
+
+  it "parses valid since-tag options without network access" do
+    options = described_class.parse_options(["--repo", "matsuo-haruhito/tree_view-rails", "--since-tag", "v0.1.0"])
+
+    expect(options).to eq(repo: "matsuo-haruhito/tree_view-rails", since_tag: "v0.1.0")
+  end
+end
+
+RSpec.describe ReleaseNoteCandidates::Collector do
+  def fake_client(compare_messages:, issues:)
+    Class.new do
+      def initialize(compare_messages:, issues:)
+        @compare_messages = compare_messages
+        @issues = issues
+      end
+
+      def compare(_repo, _base_ref)
+        {
+          "commits" => @compare_messages.map do |message|
+            {"commit" => {"message" => message}}
+          end
+        }
+      end
+
+      def issue(_repo, number)
+        @issues.fetch(number.to_s)
+      end
+    end.new(compare_messages: compare_messages, issues: issues)
+  end
+
+  it "maps unique commit references since a tag to pull request and issue entries" do
+    client = fake_client(
+      compare_messages: [
+        "Merge pull request #12 from feature/release-notes\n\nRefs #7",
+        "Follow-up for #12 and closes #8"
+      ],
+      issues: {
+        "7" => {
+          "number" => 7,
+          "title" => "Document the release helper",
+          "html_url" => "https://github.com/matsuo-haruhito/tree_view-rails/issues/7",
+          "closed_at" => "2026-06-07T00:00:00Z"
+        },
+        "8" => {
+          "number" => 8,
+          "title" => "Tighten release docs",
+          "html_url" => "https://github.com/matsuo-haruhito/tree_view-rails/issues/8",
+          "closed_at" => "2026-06-08T00:00:00Z"
+        },
+        "12" => {
+          "number" => 12,
+          "title" => "Add release note candidates helper",
+          "html_url" => "https://github.com/matsuo-haruhito/tree_view-rails/pull/12",
+          "closed_at" => "2026-06-12T00:00:00Z",
+          "pull_request" => {"merged_at" => "2026-06-12T01:23:45Z"}
+        }
+      }
+    )
+
+    merged_prs, closed_issues = described_class.new(client: client).by_since_tag(
+      repo: "matsuo-haruhito/tree_view-rails",
+      since_tag: "v0.1.0"
+    )
+
+    expect(merged_prs.map(&:number)).to eq([12])
+    expect(merged_prs.first).to have_attributes(
+      type: :pull_request,
+      title: "Add release note candidates helper",
+      merged_at: "2026-06-12T01:23:45Z"
+    )
+    expect(closed_issues.map(&:number)).to eq([7, 8])
+    expect(closed_issues.map(&:type)).to eq([:issue, :issue])
+  end
+end


### PR DESCRIPTION
## 対応 Issue

Closes #2257

## Issue ごとの完了内容

- #2257
  - `ReleaseNoteCandidates::MarkdownFormatter` の merged PR / closed issue section、empty candidates、timestamp suffix、maintainer review boundary sentence を focused spec で確認しました。
  - `ReleaseNoteCandidates::CLI.parse_options` の `--repo` 必須、`--since` / `--since-tag` exactly-one constraint、valid option parsing を network なしで確認しました。
  - `ReleaseNoteCandidates::Collector#by_since_tag` が compare commit message の `#123` references を重複排除し、fake client 経由で PR / issue entries に解決することを確認しました。

## 変更内容

- `spec/release_note_candidates_spec.rb` を追加しました。
- GitHub API 実通信、token、現在日時、実 repo 状態に依存しない fake client / pure formatter / parse_options spec に閉じています。

## 改善カテゴリ

- test
- devops / release helper guard
- small maintenance hardening

## 既存仕様への影響

- 既存 runtime / release helper behavior は変更していません。
- release automation、GitHub Release 作成、CHANGELOG 自動編集、CLI redesign、GitHub API pagination/rate-limit policy には触れていません。

## 実施した確認

- Issue #2257 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- branch は current main `5d20f0a83315cfe5634c33510308965821488a39` から作成しました。
- PR 作成前 compare: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local RSpec は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。spec-only の guard 追加で、外部 API や release behavior は変更していません。

## 補足事項

- #1709 の docs smoke とは分け、`script/release_note_candidates.rb` 自体の formatter / option validation / input mapping contract だけを守ります。
- merge は行いません。