### PR TITLE
CHANGELOG に release note candidates spec evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ Release preparation notes:
 - Added release docs signal coverage for release metadata guards and docs-entrypoint sensitive CI routing.
 - Added docs entrypoint suite self-test coverage for unregistered docs smoke / signal scripts.
 - Added CHANGELOG-only CI routing coverage to keep `CHANGELOG.md` changes on the docs-entrypoint and package verification paths.
+- Added release note candidate helper contract specs for formatter output, CLI option validation, and since-tag reference collection without network access.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応内容

- merged #2259 の release note candidates helper contract spec 追加を `CHANGELOG.md` の `Unreleased > Tests` に1行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 分類

- `code-ahead-of-docs`: `spec/release_note_candidates_spec.rb` が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `spec/release_note_candidates_spec.rb`
- `script/release_note_candidates.rb`
- release automation / GitHub Release 作成
- CHANGELOG 自動編集
- CI workflow / package verifier implementation

## 確認内容

- PR #2259 が main に merge済みであることを確認しました。
- current main `1eb673427b222396554c934dded453f4f7443cd5` から clean branch を作成しました。
- compare `main...docs/changelog-release-note-candidates-spec-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にします。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / spec implementation / release helper behavior は変更していません。