### PR TITLE
CI policy smoke で package install job signals を守る

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -294,6 +294,7 @@ assert.match(
 assertJobMatches(javascriptJob, /uses: actions\/setup-node@v6/, `${workflowPath} jobs.javascript must keep setup-node v6`);
 assertJobMatches(javascriptJob, /node-version: "22"/, `${workflowPath} jobs.javascript must keep the Node 22 CI lane`);
 assertJobMatches(javascriptJob, /cache: npm/, `${workflowPath} jobs.javascript must keep npm cache enabled`);
+assertJobMatches(javascriptJob, /run: npm ci/, `${workflowPath} jobs.javascript must use npm ci for lockfile-backed installs`);
 
 const dockerDevelopmentSetupJob = workflowJobBlock(workflowSource, "docker_development_setup");
 assertJobMatches(
@@ -322,8 +323,31 @@ assert.ok(
 );
 
 const gemPackageJob = workflowJobBlock(workflowSource, "gem_package");
+assertJobMatches(
+  gemPackageJob,
+  /github\.event_name == 'pull_request' && needs\.changes\.outputs\.package_sensitive == 'true'/,
+  `${workflowPath} jobs.gem_package must stay gated by package_sensitive pull request changes`
+);
+assertJobMatches(
+  gemPackageJob,
+  /needs: changes/,
+  `${workflowPath} jobs.gem_package must depend on changed-file detection`
+);
 assertJobMatches(gemPackageJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.gem_package must keep Ruby 3.3`);
 assertJobMatches(gemPackageJob, /bundler-cache: true/, `${workflowPath} jobs.gem_package must keep bundler-cache enabled`);
+assertJobMatches(gemPackageJob, /run: gem build tree_view\.gemspec/, `${workflowPath} jobs.gem_package must build the gem`);
+assertJobMatches(
+  gemPackageJob,
+  /run: ruby script\/check_gem_package_contents\.rb tree_view-\*\.gem/,
+  `${workflowPath} jobs.gem_package must run package contents verification`
+);
+assertJobMatches(gemPackageJob, /run: gem install tree_view-\*\.gem/, `${workflowPath} jobs.gem_package must install the built gem`);
+assertJobMatches(gemPackageJob, /run: ruby -e "require 'tree_view'"/, `${workflowPath} jobs.gem_package must keep the installed gem require smoke`);
+
+assert.ok(
+  packageScripts["test:ci-policy"].includes("script/test_package_lock_dependency_drift.mjs"),
+  `${packagePath} scripts.test:ci-policy must keep the package lock dependency drift guard`
+);
 
 for (const scriptName of npmRunScripts(workflowSource)) {
   assert.ok(


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2262
Closes #2266

補足: #2264 は current main の既存 assertion で満たされているため、この PR では重複実装せず Issue 側に evidence を残します。

## Issue ごとの完了内容

- #2262: `gem_package` job が package-sensitive PR で走る条件、`needs: changes`、gem build / package contents check / gem install / require smoke の代表 command を CI policy smoke で確認します。
- #2266: `javascript` job の `npm ci` と、`package.json` の `test:ci-policy` が package-lock drift guard を含むことを CI policy smoke で確認します。Docker job 内の `npm ci` guard は既存 assertion を維持しています。

## 変更内容

- `script/test_ci_changed_files_policy.mjs` に workflow / package script signal assertion を追加しました。
- `.github/workflows/ci.yml`、`package.json`、`package-lock.json`、Dockerfile / compose、runtime Ruby / JavaScript は変更していません。

## 改善カテゴリ

- CI guard hardening
- test hardening
- maintenance quality

## 既存仕様への影響

なし。既存 workflow と package scripts の代表 signal を読む smoke 追加だけで、CI topology、changed-file classification、package contents checker、install policy、runtime behavior は変更していません。

## 実施した確認内容

- Issue #2262 / #2266 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- sibling #2264 は current main の既存 `dockerDevelopmentSetupJob` assertion block で条件・needs・代表 command が確認済みであることを確認。
- PR 前 compare: `main...quality/2262-2266-ci-policy-job-guards` は `ahead_by:1` / `behind_by:0`。
- changed files は `script/test_ci_changed_files_policy.mjs` の1件のみ。
- local checkout / local `npm run test:ci-policy` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。正規表現 assertion が workflow の代表 signal を読むだけで、実行挙動は変わりません。failure message は job / missing signal を読めるように分けています。

## 補足事項

- dependency update、`package-lock.json` regeneration、package manager 変更、CI workflow redesign は扱っていません。
- merge は行いません。