### PR TITLE
CHANGELOG に quality guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@ Release preparation notes:
 - Added docs entrypoint suite self-test coverage for unregistered docs smoke / signal scripts.
 - Added CHANGELOG-only CI routing coverage to keep `CHANGELOG.md` changes on the docs-entrypoint and package verification paths.
 - Added release note candidate helper contract specs for formatter output, CLI option validation, and since-tag reference collection without network access.
+- Added mockup demo application boundary docs signal coverage for static mockup / future real Rails demo app responsibility boundaries.
+- Added CI policy smoke coverage for gem package and JavaScript package install job signals, including package-sensitive routing and lockfile-backed `npm ci` expectations.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応内容

- merged #2263 の mockup demo boundary docs signal guard を `CHANGELOG.md` の `Unreleased > Tests` に1行追加しました。
- merged #2267 の package install job signal CI policy smoke を `CHANGELOG.md` の `Unreleased > Tests` に1行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 関連 Issue / PR

- Refs #2248
- Refs #2262
- Refs #2266
- Refs #2263
- Refs #2267

## 分類

- `code-ahead-of-docs`: quality/test guard の変更が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/test_mockup_docs_asset_signals.mjs`
- `script/test_ci_changed_files_policy.mjs`
- `.github/workflows/ci.yml`
- `package.json` / `package-lock.json`
- mockup README / docs prose 本文

## 確認内容

- PR #2263 と #2267 が main に merge 済みであることを確認しました。
- current main `0f5affa8b073e3ba3722928d459b16ba362a9a0a` から branch を作成しました。
- compare `main...docs/changelog-quality-guard-evidence-2263-2267`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 2 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。docs-only CHANGELOG 追記のため PR CI を確認対象にします。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / test implementation / CI behavior は変更していません。