### PR TITLE
Guard javascript job Ruby setup in CI policy smoke

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -148,7 +148,8 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: true
+      docker_setup_sensitive: true,
+      docs_entrypoint_sensitive: false
     }
   }
 ];

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -148,8 +148,7 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: true,
-      docs_entrypoint_sensitive: false
+      docker_setup_sensitive: true
     }
   }
 ];
@@ -291,6 +290,8 @@ assert.match(
   /run: npm run test:docs-entrypoints/,
   `${workflowPath} jobs.javascript must still run docs entrypoint checks for docs_entrypoint_sensitive changes`
 );
+assertJobMatches(javascriptJob, /uses: ruby\/setup-ruby@v1/, `${workflowPath} jobs.javascript must keep Ruby setup for manifest-loading Node smokes`);
+assertJobMatches(javascriptJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.javascript must keep Ruby 3.3 for manifest-loading Node smokes`);
 assertJobMatches(javascriptJob, /uses: actions\/setup-node@v6/, `${workflowPath} jobs.javascript must keep setup-node v6`);
 assertJobMatches(javascriptJob, /node-version: "22"/, `${workflowPath} jobs.javascript must keep the Node 22 CI lane`);
 assertJobMatches(javascriptJob, /cache: npm/, `${workflowPath} jobs.javascript must keep npm cache enabled`);


### PR DESCRIPTION
## 対応 Issue
- Closes #2270

## Issue ごとの完了内容
- #2270: `script/test_ci_changed_files_policy.mjs` の `jobs.javascript` block assertion に、job-local な `ruby/setup-ruby@v1` と `ruby-version: "3.3"` の確認を追加しました。

## 変更内容
- `.github/workflows/ci.yml` は変更せず、現在の `javascript` job が持つ Ruby setup dependency を既存 CI policy smoke で guard するようにしました。
- assertion は `workflowJavaScriptJob(workflowSource)` で切り出した `jobs.javascript` block に限定しています。

## 改善カテゴリ
- CI guard hardening
- test / smoke coverage

## 既存仕様への影響
- runtime Ruby / JavaScript behavior、workflow topology、docs-only shortcut、Node version、npm install policy、manifest schema は変更していません。
- 変更は test-only です。

## 実施した確認
- GitHub connector で `main...quality/2270-javascript-ruby-setup-policy` を比較し、変更ファイルが `script/test_ci_changed_files_policy.mjs` のみ、最終差分が 2 行追加のみであることを確認しました。
- connector-only 更新のため、対象テキストファイルの final newline を保持した full-file update として送信しました。

## 未実施の確認
- この実行環境では GitHub clone / raw API への直接アクセスが `CONNECT tunnel failed, response 403` で遮断されているため、`npm run test:ci-policy` はローカル実行できませんでした。PR CI で確認してください。

## リスク評価
- risk: low。既存 workflow を変更せず、既存 smoke の assertion を追加するだけです。

## 補足
- #2274 も同じ CI policy smoke 周辺ですが、Planner handoff で #2270 と混ぜないよう指定されていたため、この PR は #2270 の Ruby setup dependency guard のみに閉じています。