### PR TITLE
CI policy smoke で Ruby / JavaScript gates を guard する

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -148,7 +148,8 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: true
+      docker_setup_sensitive: true,
+      docs_entrypoint_sensitive: false
     }
   }
 ];

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -148,8 +148,7 @@ const cases = [
       mockups_changed: false,
       browser_smoke_changed: false,
       package_sensitive: false,
-      docker_setup_sensitive: true,
-      docs_entrypoint_sensitive: false
+      docker_setup_sensitive: true
     }
   }
 ];
@@ -279,8 +278,24 @@ assertJobMatches(
 const lintJob = workflowJobBlock(workflowSource, "lint");
 assertJobMatches(lintJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.lint must keep Ruby 3.3`);
 assertJobMatches(lintJob, /bundler-cache: true/, `${workflowPath} jobs.lint must keep bundler-cache enabled`);
+assertJobMatches(lintJob, /run: bundle exec standardrb/, `${workflowPath} jobs.lint must run StandardRB`);
+
+const prSpecsJob = workflowJobBlock(workflowSource, "pr_specs");
+assertJobMatches(
+  prSpecsJob,
+  /if: github\.event_name == 'pull_request'/,
+  `${workflowPath} jobs.pr_specs must stay pull-request gated`
+);
+assertJobMatches(prSpecsJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.pr_specs must keep Ruby 3.3`);
+assertJobMatches(prSpecsJob, /bundler-cache: true/, `${workflowPath} jobs.pr_specs must keep bundler-cache enabled`);
+assertJobMatches(prSpecsJob, /run: bundle exec rspec/, `${workflowPath} jobs.pr_specs must run the RSpec suite`);
 
 const javascriptJob = workflowJavaScriptJob(workflowSource);
+assertJobMatches(
+  javascriptJob,
+  /needs: changes/,
+  `${workflowPath} jobs.javascript must depend on changed-file detection`
+);
 assert.match(
   javascriptJob,
   /needs\.changes\.outputs\.docs_entrypoint_sensitive == 'true'/,


### PR DESCRIPTION
## 対応 Issue 一覧

- Closes #2274
- Closes #2278

## Issue ごとの完了内容

- #2274: `script/test_ci_changed_files_policy.mjs` が `jobs.javascript` の `needs: changes` を直接確認するようにしました。
- #2278: 同じ CI policy smoke で `jobs.lint` の `bundle exec standardrb`、`jobs.pr_specs` の pull request gate / Ruby 3.3 / bundler-cache / `bundle exec rspec` を確認するようにしました。

## 変更内容

- `.github/workflows/ci.yml` は変更していません。
- 既存の workflow block assertion に、Ruby PR gate と JavaScript changed-file dependency の代表 signal を追加しました。
- #2274 と #2278 は同じ `script/test_ci_changed_files_policy.mjs` の CI guard hardening なので、1つの品質改善単位として束ねています。

## 改善カテゴリ

- CI guard hardening
- test / smoke coverage

## 既存仕様への影響

- workflow topology、Ruby version policy、RSpec scope、Standard/RuboCop config、Node/npm policy、runtime Ruby / JavaScript behavior は変更していません。
- 変更は test-only です。

## 実施した確認内容

- Issue #2274 / #2278 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- connector compare で `main...quality/2274-2278-ci-policy-guards` が `behind_by: 0` であることを確認しました。
- changed files は `script/test_ci_changed_files_policy.mjs` のみです。
- GitHub Actions CI #3153 / run `27707027325`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`: success。
  - representative Rails lanes 7.0 / 7.2 / 8.0: success。
  - `gem_package`, `docker_development_setup`: skipped as expected for this changed-file scope。
- ローカル checkout / `npm run test:ci-policy` は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で遮断されているため未実行です。PR CI を確認対象にしました。

## リスク評価

- risk: low。既存 workflow を変更せず、既存 smoke の assertion を追加するだけです。

## 補足事項

- Planner handoff では #2270 と #2274 を混ぜない指示がありましたが、#2270 は既に別PRで扱われています。このPRは未処理の #2274 と #2278 の同系統 CI policy guard のみを束ねています。