### PR TITLE
CI policy smoke の Ruby / JavaScript gate guard を latest main で再提案する

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -279,6 +279,17 @@ assertJobMatches(
 const lintJob = workflowJobBlock(workflowSource, "lint");
 assertJobMatches(lintJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.lint must keep Ruby 3.3`);
 assertJobMatches(lintJob, /bundler-cache: true/, `${workflowPath} jobs.lint must keep bundler-cache enabled`);
+assertJobMatches(lintJob, /run: bundle exec standardrb/, `${workflowPath} jobs.lint must run StandardRB`);
+
+const prSpecsJob = workflowJobBlock(workflowSource, "pr_specs");
+assertJobMatches(
+  prSpecsJob,
+  /if: github\.event_name == 'pull_request'/,
+  `${workflowPath} jobs.pr_specs must stay pull-request gated`
+);
+assertJobMatches(prSpecsJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.pr_specs must keep Ruby 3.3`);
+assertJobMatches(prSpecsJob, /bundler-cache: true/, `${workflowPath} jobs.pr_specs must keep bundler-cache enabled`);
+assertJobMatches(prSpecsJob, /run: bundle exec rspec/, `${workflowPath} jobs.pr_specs must run the RSpec suite`);
 
 const prRailsMatrixJob = workflowJobBlock(workflowSource, "pr_rails_matrix");
 assertJobMatches(
@@ -314,6 +325,11 @@ assertJobMatches(
 });
 
 const javascriptJob = workflowJavaScriptJob(workflowSource);
+assertJobMatches(
+  javascriptJob,
+  /needs: changes/,
+  `${workflowPath} jobs.javascript must depend on changed-file detection`
+);
 assert.match(
   javascriptJob,
   /needs\.changes\.outputs\.docs_entrypoint_sensitive == 'true'/,


### PR DESCRIPTION
## 対応 Issue / PR

Closes #2274
Closes #2278
Supersedes #2279

## Issue ごとの完了内容

- #2274: `script/test_ci_changed_files_policy.mjs` が `jobs.javascript` の `needs: changes` を直接確認するようにしました。
- #2278: 同じ CI policy smoke で `jobs.lint` の `bundle exec standardrb`、`jobs.pr_specs` の pull request gate / Ruby 3.3 / bundler-cache / `bundle exec rspec` を確認するようにしました。

## 変更内容

- `.github/workflows/ci.yml` は変更していません。
- 既存の workflow block assertion に、Ruby PR gate と JavaScript changed-file dependency の代表 signal を追加しました。
- #2279 の review follow-up で求められた latest main 追従のため、current `main` から replacement branch を作成しました。
- main 側で追加済みの `jobs.javascript` Ruby setup guard は保持しています。

## 改善カテゴリ

- CI guard hardening
- test / smoke coverage

## 既存仕様への影響

- workflow topology、Ruby version policy、RSpec scope、Standard/RuboCop config、Node/npm policy、runtime Ruby / JavaScript behavior は変更していません。
- 変更は test-only です。

## 実施した確認内容

- #2279 の review comment を確認し、latest main 追従と fresh CI が必要な follow-up と分類しました。
- compare `main...quality/2274-2278-ci-policy-guards-v2`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files は `script/test_ci_changed_files_policy.mjs` の1件のみです。
- PR metadata: `mergeable:true`。
- GitHub Actions CI #3158 / run `27710314957`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`: success。
  - representative Rails lanes 7.0 / 7.2 / 8.0: success。
  - `gem_package`, `docker_development_setup`: skipped as expected for this changed-file scope。
- local checkout / `npm run test:ci-policy` は、この環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` で遮断されているため未実行です。PR CI を確認対象にしました。

## リスク評価

- risk: low。既存 workflow を変更せず、既存 smoke の assertion を追加するだけです。

## 補足事項

- 旧 #2279 は古い main から diverged していたため、force push せず replacement PR としました。
- merge は行いません。