### PR TITLE
CHANGELOG に CI policy Ruby / JavaScript gate evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ Release preparation notes:
 - Added release note candidate helper contract specs for formatter output, CLI option validation, and since-tag reference collection without network access.
 - Added mockup demo application boundary docs signal coverage for static mockup / future real Rails demo app responsibility boundaries.
 - Added CI policy smoke coverage for gem package and JavaScript package install job signals, including package-sensitive routing and lockfile-backed `npm ci` expectations.
+- Added CI policy smoke coverage for JavaScript `needs: changes`, lint Standard Ruby command, and pull request specs Ruby / RSpec gate signals.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応内容

- merged #2281 の CI policy smoke guard 追加を `CHANGELOG.md` の `Unreleased > Tests` に 1 行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 関連 PR

- Refs #2281
- Refs #2274
- Refs #2278

## 分類

- `code-ahead-of-docs`: CI policy smoke の Ruby / JavaScript gate guard が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/test_ci_changed_files_policy.mjs`
- `.github/workflows/ci.yml`
- CI routing / workflow topology
- runtime Ruby / JavaScript behavior
- docs smoke / signal script implementation

## 確認内容

- PR #2281 が `2026-06-17T18:20:20Z` に main へ merge 済みであることを確認しました。
- current main `e3452cad34a07145ae256f96eb5a9caceaa9d671` から branch を作成しました。
- compare `main...docs/changelog-ci-policy-ruby-js-gates`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- GitHub Actions CI #3160 / run `27713286073`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
  - `docker_development_setup`: skipped as expected for this changed-file scope。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、test implementation / CI behavior は変更していません。

## 補足

- merge は行いません。