### PR TITLE
README の JavaScript surface 代表例を更新する

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Add the importmap pin when needed:
 pin "tree_view", to: "tree_view/index.js"
 ```
 
-Host apps that write tests or custom renderers against TreeView browser hooks can avoid raw event names, data attributes, and controller identifiers by using the package-root exports from `tree_view/index.js`, such as `TreeViewEventNames`, `TreeViewEventDetailKeys`, and the documented data hook objects. See the [Public API JavaScript surface](docs/en/public-api.md#javascript-surface) / [日本語](docs/ja/public-api.md#javascript-surface) and the [JavaScript event contract](docs/en/js-events.md) / [日本語](docs/ja/js-events.md).
+Host apps that write tests or custom renderers against TreeView browser hooks can avoid raw event names, data attributes, and controller identifiers by using the package-root exports from `tree_view/index.js`, such as `TreeViewEventNames`, `TreeViewEventDetailKeys`, `TreeViewControllerEntries`, `TreeViewIntegrationHooks`, and documented data hook objects like `TreeViewRemoteStateDataHooks`, `TreeViewToolbarDataHooks`, `TreeViewSelectionCheckboxHooks`, and `TreeViewEmptyStateHooks`. See the [Public API JavaScript surface](docs/en/public-api.md#javascript-surface) / [日本語](docs/ja/public-api.md#javascript-surface) and the [JavaScript event contract](docs/en/js-events.md) / [日本語](docs/ja/js-events.md).
 
 See [Installation](docs/en/installation.md) for details.
 


### PR DESCRIPTION
## 対応 Issue

Refs #2282

## 対応内容

- README の Installation section にある package-root JavaScript surface の代表例を current `tree_view/index.js` / Public API docs に合わせて更新しました。
- `TreeViewEventNames` / `TreeViewEventDetailKeys` に加えて、`TreeViewControllerEntries`、`TreeViewIntegrationHooks`、代表的な data hook objects を読めるようにしました。
- README は complete inventory ではなく入口として維持し、詳細は Public API JavaScript surface と JavaScript event contract への既存導線に委譲しています。

## 分類

- `docs-stale`: README の代表例が current package-root export 群に対して薄くなっていました。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `README.md`

## 非対象

- `app/javascript/tree_view/index.js`
- `app/javascript/tree_view/index.d.ts`
- `config/public_api_manifest.yml`
- docs smoke / signal script implementation
- Public API docs 全体の rewrite

## Review follow-up

- review comment の指摘どおり、この PR は #2282 の完了 PR ではなく、README 本文の stale だけを直す docs-sync PR として扱います。
- #2282 の lightweight docs signal / smoke 追加は `area:test` を含む script/test lane のため、この Docs Sync follow-up では実装しません。
- #2282 は `Refs` のまま残し、close keyword は使いません。

## 確認内容

- current main `0234ff4e7b29d128e7667f6a2c6f83fcd8cbada3` から clean branch を作成しました。
- review follow-up で current main `0ae288cad5aa419fbe2c745a5a43f5004cc04208` を取り直し、README 差分だけを再適用しました。
- `app/javascript/tree_view/index.js` に `TreeViewControllerEntries`、`TreeViewIntegrationHooks`、`TreeViewRemoteStateDataHooks`、`TreeViewToolbarDataHooks`、`TreeViewSelectionCheckboxHooks`、`TreeViewEmptyStateHooks` が存在することを確認しました。
- 英日 `docs/*/public-api.md` の JavaScript surface list に同じ代表 export が存在することを確認しました。
- compare `main...docs/2282-readme-js-surface-examples-v2`: `ahead_by:2` / `behind_by:0` / changed files 1 / additions 1 / deletions 1。
- 初回 GitHub Actions CI #3162 / run `27716935004`: success。
- refresh 後の GitHub Actions CI #3169 / run `27723344035`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
  - `docker_development_setup`: skipped as expected for this changed-file scope。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## 残る scope

- #2282 の docs smoke / signal guard は docs本文ではなく script/test lane のため、この PR では扱いません。

## リスク

low。README の代表例更新のみで、runtime / public export / manifest は変更していません。

## 補足

- merge は行いません。