### PR TITLE
Docker setup docs command signal を guard する

### DIFF
--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -15,6 +15,16 @@ const requiredMaintenanceScripts = [
   "test:docs-i18n"
 ]
 
+const requiredDockerSetupSignals = [
+  "cp .env.example .env",
+  "docker compose build",
+  "docker compose run --rm app bundle install",
+  "docker compose run --rm app npm ci",
+  "Node 22",
+  "npm",
+  "lockfile-backed install path"
+]
+
 const missingSignals = []
 
 for (const scriptName of requiredMaintenanceScripts) {
@@ -32,6 +42,14 @@ for (const scriptName of requiredMaintenanceScripts) {
   }
 }
 
+for (const signal of requiredDockerSetupSignals) {
+  for (const [docPath, doc] of docs) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: Docker setup signal ${signal}`)
+    }
+  }
+}
+
 if (missingSignals.length > 0) {
   console.error("[development-docs-command-signals] missing maintenance command signals:")
   for (const signal of missingSignals) {
@@ -41,5 +59,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands are present in package.json and both Development docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands and ${requiredDockerSetupSignals.length} Docker setup signals are present in package.json and both Development docs`
 )


### PR DESCRIPTION
## 対応 Issue

Closes #2280

## Issue ごとの完了内容

- #2280: 英日 Development docs にある Docker setup command guidance と Node/npm/lockfile-backed install path の代表 signal を、既存の docs command smoke で確認するようにしました。

## 変更内容

- `script/test_development_docs_command_signals.mjs` に Docker setup docs の代表 signal を追加しました。
- 代表 signal は `cp .env.example .env`、`docker compose build`、`docker compose run --rm app bundle install`、`docker compose run --rm app npm ci`、`Node 22`、`npm`、`lockfile-backed install path` です。
- failure message には対象 docs path と missing signal が出るよう、既存 `missingSignals` の流れに乗せています。

## 改善カテゴリ

- docs guard hardening
- test / smoke 強化
- CI / devops documentation drift prevention

## 既存仕様への影響

- Dockerfile、`docker-compose.yml`、GitHub Actions workflow、runtime Ruby / JavaScript behavior は変更していません。
- Development docs の既存文面も変更していません。既存 docs が持つ代表 command / install-path signal を守るだけです。

## 実施した確認

- Issue #2280 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- #2280 を close する既存 open PR がないことを確認しました。
- local GitHub checkout / raw fetch は `CONNECT tunnel failed, response 403` のため利用不可でした。
- connector compare `main...chore/2284-maintenance-doc-guards`: `ahead_by:1` / `behind_by:0` / changed files 1。
- PR CI を確認対象にします。

## リスク評価

low。既存 docs と package script を読む Node smoke の検証対象を増やすだけで、公開挙動や CI workflow topology は変えていません。

## 補足事項

- #2283 / #2284 も同じ maintenance guard family ですが、今回の connector-only 実行では大きめの検証スクリプト全文更新リスクを避け、#2280 の小さな既存 script 追記に限定しました。
- merge は行いません。