### PR TITLE
CI changed-files policy に public docs 代表ケースを追加する

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -21,6 +21,30 @@ const cases = [
     }
   },
   {
+    name: "public API docs stay docs-only and request package and docs entrypoint guards",
+    files: ["docs/en/public-api.md", "docs/ja/public-api.md"],
+    expected: {
+      docs_only: true,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
+    }
+  },
+  {
+    name: "public setup and release docs stay docs-only and request package and docs entrypoint guards",
+    files: ["docs/en/public-setup-surface.md", "docs/ja/release.md"],
+    expected: {
+      docs_only: true,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
+    }
+  },
+  {
     name: "changelog-only docs request package and docs entrypoint guards",
     files: ["CHANGELOG.md"],
     expected: {


### PR DESCRIPTION
## 対応 Issue

Closes #2283

## Issue ごとの完了内容

- #2283: public API docs と public setup / release docs の representative path が、CI changed-files policy 上で `docs_only` / `package_sensitive` / `docs_entrypoint_sensitive` として守られることを focused smoke に追加しました。

## 変更内容

- `script/test_ci_changed_files_policy.mjs` の `cases` に次の代表ケースを追加しました。
  - `docs/en/public-api.md` / `docs/ja/public-api.md`
  - `docs/en/public-setup-surface.md` / `docs/ja/release.md`
- どちらも既存の broad docs classification を変えず、期待値は `docs_only: true`, `package_sensitive: true`, `docs_entrypoint_sensitive: true`、かつ mockup/browser/Docker ではないことを明示しています。

## 改善カテゴリ

- test / smoke 強化
- CI guard hardening
- docs routing drift prevention

## 既存仕様への影響

- `.github/workflows/ci.yml` と `script/ci_changed_files_policy.mjs` は変更していません。
- CI workflow topology、docs-only skip policy、Rails matrix、Docker setup job、runtime Ruby / JavaScript behavior は変更していません。

## 実施した確認

- Issue #2283 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` `593a83c0200589be674cc63f0aaad624518c8640` から branch を作成しました。
- compare `main...chore/2283-public-docs-ci-policy-cases`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local npm は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 policy behavior を変えない test-only guard 追加です。

## 補足事項

- #2282 の README guidance、#2284 の package contents verifier はこの PR に混ぜていません。
- merge は行いません。