### PR TITLE
public JavaScript docs の package guard を拡張する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -72,6 +72,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
   "README-linked public JavaScript docs" => %w[
     docs/en/js-events.md
     docs/ja/js-events.md
+    docs/en/controller-registration.md
+    docs/ja/controller-registration.md
+    docs/en/selection-checkbox-hooks.md
+    docs/ja/selection-checkbox-hooks.md
   ],
   "Public setup surface docs" => %w[
     docs/en/public-setup-surface.md


### PR DESCRIPTION
## 対応 Issue

Closes #2284

## Issue ごとの完了内容

- #2284: gem package contents verifier の representative public JavaScript docs group に、controller registration docs と selection checkbox hooks docs の英日ペアを追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `README-linked public JavaScript docs` group に次の代表 path を追加しました。
  - `docs/en/controller-registration.md`
  - `docs/ja/controller-registration.md`
  - `docs/en/selection-checkbox-hooks.md`
  - `docs/ja/selection-checkbox-hooks.md`
- 既存の `docs/**/*` gemspec glob は変更せず、package verifier の release evidence signal だけを強くしています。

## 改善カテゴリ

- package guard hardening
- docs inventory drift prevention
- test / verifier 強化

## 既存仕様への影響

- `tree_view.gemspec`、package layout、release automation、runtime JavaScript、TypeScript declarations、public API manifest は変更していません。
- public export / manifest / docs prose の追加・rename は行っていません。

## 実施した確認

- Issue #2284 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` `593a83c0200589be674cc63f0aaad624518c8640` から branch を作成しました。
- compare `main...chore/2284-public-js-docs-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local gem build は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。package verifier の representative docs path 追加のみです。docs 全体を verifier に列挙する方向には広げていません。

## 補足事項

- #2282 の README guidance、#2283 の changed-files policy cases はこの PR に混ぜていません。
- merge は行いません。