### PR TITLE
CHANGELOG に maintenance guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,9 @@ Release preparation notes:
 - Added mockup demo application boundary docs signal coverage for static mockup / future real Rails demo app responsibility boundaries.
 - Added CI policy smoke coverage for gem package and JavaScript package install job signals, including package-sensitive routing and lockfile-backed `npm ci` expectations.
 - Added CI policy smoke coverage for JavaScript `needs: changes`, lint Standard Ruby command, and pull request specs Ruby / RSpec gate signals.
+- Added Development docs command smoke coverage for Docker setup command guidance and lockfile-backed Node/npm install signals.
+- Added CI changed-file policy coverage for public API, public setup surface, and release docs package/docs-entrypoint routing cases.
+- Expanded package contents verification coverage for README-linked public JavaScript docs, including controller registration and selection checkbox hook docs.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応内容

- merged #2287 の Docker setup docs command signal guard を `CHANGELOG.md` の `Unreleased > Tests` に 1 行追加しました。
- merged #2288 の public docs changed-file policy representative cases を `CHANGELOG.md` の `Unreleased > Tests` に 1 行追加しました。
- merged #2289 の README-linked public JavaScript docs package guard を `CHANGELOG.md` の `Unreleased > Tests` に 1 行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 関連 PR

- Refs #2280
- Refs #2283
- Refs #2284
- Refs #2287
- Refs #2288
- Refs #2289

## 分類

- `code-ahead-of-docs`: maintenance guard の変更が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: docs-only の追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/test_development_docs_command_signals.mjs`
- `script/test_ci_changed_files_policy.mjs`
- `script/check_gem_package_contents.rb`
- CI routing / workflow topology
- package checker implementation
- runtime Ruby / JavaScript behavior

## 確認内容

- PR #2287 / #2288 / #2289 が main に merge 済みであることを確認しました。
- current main `0ae288cad5aa419fbe2c745a5a43f5004cc04208` から branch を作成しました。
- compare `main...docs/changelog-maintenance-guard-evidence-2287-2289`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 3 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- GitHub Actions CI #3170 / run `27723600934`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
  - `docker_development_setup`: skipped as expected for this changed-file scope。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、test implementation / CI behavior は変更していません。

## 補足

- merge は行いません。