### PR TITLE
main matrix CI lanes を policy smoke で守る

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -348,6 +348,48 @@ assertJobMatches(
   );
 });
 
+const rubyMatrixJob = workflowJobBlock(workflowSource, "ruby_matrix");
+assertJobMatches(
+  rubyMatrixJob,
+  /if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'/,
+  `${workflowPath} jobs.ruby_matrix must stay limited to pushes on main`
+);
+assertJobMatches(rubyMatrixJob, /uses: actions\/checkout@v6/, `${workflowPath} jobs.ruby_matrix must keep checkout v6`);
+assertJobMatches(rubyMatrixJob, /uses: ruby\/setup-ruby@v1/, `${workflowPath} jobs.ruby_matrix must keep ruby/setup-ruby v1`);
+assertJobMatches(rubyMatrixJob, /bundler-cache: true/, `${workflowPath} jobs.ruby_matrix must keep bundler-cache enabled`);
+assertJobMatches(rubyMatrixJob, /run: bundle exec rake/, `${workflowPath} jobs.ruby_matrix must run the full rake task on main`);
+["3.2", "3.3"].forEach((rubyVersion) => {
+  assertJobMatches(
+    rubyMatrixJob,
+    new RegExp(`- "${escapeRegExp(rubyVersion)}"`),
+    `${workflowPath} jobs.ruby_matrix must keep the Ruby ${rubyVersion} main-branch lane`
+  );
+});
+
+const railsMatrixJob = workflowJobBlock(workflowSource, "rails_matrix");
+assertJobMatches(
+  railsMatrixJob,
+  /if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'/,
+  `${workflowPath} jobs.rails_matrix must stay limited to pushes on main`
+);
+assertJobMatches(railsMatrixJob, /uses: actions\/checkout@v6/, `${workflowPath} jobs.rails_matrix must keep checkout v6`);
+assertJobMatches(railsMatrixJob, /uses: ruby\/setup-ruby@v1/, `${workflowPath} jobs.rails_matrix must keep ruby/setup-ruby v1`);
+assertJobMatches(railsMatrixJob, /bundler-cache: true/, `${workflowPath} jobs.rails_matrix must keep bundler-cache enabled`);
+assertJobMatches(railsMatrixJob, /BUNDLE_GEMFILE: \$\{\{ matrix\.gemfile \}\}/, `${workflowPath} jobs.rails_matrix must keep per-lane Gemfile wiring`);
+assertJobMatches(railsMatrixJob, /run: bundle exec rake/, `${workflowPath} jobs.rails_matrix must run the full rake task on main`);
+[
+  ["7.0", "gemfiles/rails_7_0.gemfile", "3.2"],
+  ["7.1", "gemfiles/rails_7_1.gemfile", "3.2"],
+  ["7.2", "gemfiles/rails_7_2.gemfile", "3.2"],
+  ["8.0", "gemfiles/rails_8_0.gemfile", "3.3"]
+].forEach(([railsVersion, gemfile, rubyVersion]) => {
+  assertJobMatches(
+    railsMatrixJob,
+    new RegExp(`rails: "${railsVersion}"[\\s\\S]*gemfile: ${escapeRegExp(gemfile)}[\\s\\S]*ruby-version: "${rubyVersion}"`),
+    `${workflowPath} jobs.rails_matrix must keep the Rails ${railsVersion} main-branch lane`
+  );
+});
+
 const javascriptJob = workflowJavaScriptJob(workflowSource);
 assertJobMatches(
   javascriptJob,


### PR DESCRIPTION
## 対応 Issue

Closes #2292

## Issue ごとの完了内容

- #2292: main push 専用の `ruby_matrix` / `rails_matrix` が workflow refactor で静かに薄くならないよう、既存 CI policy smoke に代表 guard を追加しました。

## 変更内容

- `script/test_ci_changed_files_policy.mjs` に `ruby_matrix` job の guard を追加しました。
  - `push` to `main` gate
  - Ruby 3.2 / 3.3 lanes
  - `actions/checkout@v6` / `ruby/setup-ruby@v1`
  - `bundler-cache: true`
  - `bundle exec rake`
- 同じ smoke に `rails_matrix` job の guard を追加しました。
  - `push` to `main` gate
  - Rails 7.0 / 7.1 / 7.2 / 8.0 lanes
  - lane ごとの Gemfile / Ruby version
  - `BUNDLE_GEMFILE` wiring
  - `bundle exec rake`

## 改善カテゴリ

- test
- CI guard hardening
- maintenance

## 既存仕様への影響

CI workflow topology、Ruby / Rails support policy、Gemfile contents、runtime Ruby / JavaScript behavior は変更していません。既存 workflow を検査する smoke のみを強化しています。

## 実施した確認

- Issue #2292 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- review follow-up 候補を確認し、残件は human review / browser evidence / design sequencing で Quality Fixer が自動修正すべきものではないと分類しました。
- connector compare `main...chore/2292-main-matrix-ci-policy`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local Node test は GitHub HTTPS / raw fetch が `CONNECT tunnel failed, response 403` / 403 のため未実行です。PR CI を確認対象にします。

## リスク評価

risk: low。検査追加のみで、実行される CI job や repository behavior は変えていません。

## 補足事項

- #2260 も eligible でしたが、Ruby/Node nested manifest guard の同期は spec構造整理が絡みやすいため、この PR には混ぜていません。
- merge は行いません。