### PR TITLE
CHANGELOG に README JavaScript surface docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Release preparation notes:
 - Added root docs index entry points for the English and Japanese Rendering Boundaries guides.
 - Added malformed selection params troubleshooting guidance in English and Japanese, including `TreeView.parse_selection_params` error boundaries and host-app-owned request policy.
 - Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.
+- Clarified README package-root JavaScript surface examples for controller entries, integration hooks, and documented data hook objects.
 
 ### Tests
 


### PR DESCRIPTION
## 対応内容

- merged #2286 の README JavaScript surface 代表例更新を `CHANGELOG.md` の `Unreleased > Documentation` に 1 行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 関連 PR / Issue

- Refs #2282
- Refs #2286

## 分類

- `docs-sync`: merge 済み docs-only 変更の release-facing evidence 追記です。
- `code-ahead-of-docs`: README docs 変更が main に入り、CHANGELOG の Documentation evidence が未追従でした。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `README.md`
- `app/javascript/tree_view/index.js`
- `app/javascript/tree_view/index.d.ts`
- `config/public_api_manifest.yml`
- docs smoke / signal script implementation
- package-root export の追加 / rename / 削除

## 確認内容

- Default PR Check として、直近の own docs PR #2294 は CI success / review comments なし / review threads なし、#2293 は code/test 系で自己コメントのみ・review threads なしと確認しました。
- PR #2286 が main に merge 済みであることを確認しました。
- current main `dffb07c948ced0cd9c9586a90ae26412e53a225f` から branch を作成しました。
- compare `main...docs/changelog-readme-js-surface-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / public export / manifest / docs smoke scripts は変更していません。

## 補足

- merge は行いません。