### PR TITLE
CHANGELOG に remote-state hook docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Release preparation notes:
 - Added malformed selection params troubleshooting guidance in English and Japanese, including `TreeView.parse_selection_params` error boundaries and host-app-owned request policy.
 - Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.
 - Clarified README package-root JavaScript surface examples for controller entries, integration hooks, and documented data hook objects.
+- Clarified Public API docs for the shared `data-tree-children-url` hook boundary between `TreeViewRemoteStateDataHooks` and `TreeViewIntegrationHooks`.
 
 ### Tests
 


### PR DESCRIPTION
## 対応内容

- merged #2294 の remote-state children URL hook boundary docs を `CHANGELOG.md` の `Unreleased > Documentation` に 1 行追加しました。
- 変更は release-facing evidence の CHANGELOG 追記のみです。

## 関連 PR / Issue

- Refs #2290
- Refs #2294

## 分類

- `docs-sync`: merge 済み docs-only 変更の release-facing evidence 追記です。
- `code-ahead-of-docs`: Public API docs 変更が main に入り、CHANGELOG の Documentation evidence が未追従でした。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `docs/en/public-api.md`
- `docs/ja/public-api.md`
- `app/javascript/tree_view/index.js`
- `app/javascript/tree_view/index.d.ts`
- `config/public_api_manifest.yml`
- docs smoke / signal script implementation

## 確認内容

- Default PR Check として #2294 は CI success / review comments なし / review threads なしを確認しました。その後 #2294 は maintainer merge 済みになりました。
- PR #2298 は確認中に #2286 分の CHANGELOG 追記として merge 済みになり、#2294 分は main に残っていないことを確認しました。
- current main `10156d80fadad0c2942caec7292d86560a3e7f3e` から clean branch を作成しました。
- compare `main...docs/changelog-remote-state-hook-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- changed files は `CHANGELOG.md` のみです。
- GitHub Actions CI #3180 / run `27728194116`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - `javascript` は `npm run test:docs-entrypoints` を実行し、js core / browser checks は docs-only scope として skipped。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
  - `docker_development_setup`: skipped as expected for this changed-file scope。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / public export / manifest / docs smoke scripts は変更していません。

## 補足

- merge は行いません。