### PR TITLE
JavaScript package-root named exports を gem package guard で確認する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -2,7 +2,9 @@
 # frozen_string_literal: true
 
 require "rubygems/package"
+require "stringio"
 require "yaml"
+require "zlib"
 
 # Keep representative English and Japanese files in these groups so package
 # verification covers the bilingual locale, public API, docs entrypoints,
@@ -141,6 +143,9 @@ PUBLIC_CONSTANT_RUNTIME_FILES = {
   "Diagnostics" => "lib/tree_view/diagnostics.rb"
 }.freeze
 
+JAVASCRIPT_PACKAGE_ROOT_PATH = "app/javascript/tree_view/index.js"
+TYPESCRIPT_PACKAGE_ROOT_PATH = "app/javascript/tree_view/index.d.ts"
+
 INSTALLATION_DOC_PATHS = %w[
   docs/en/installation.md
   docs/ja/installation.md
@@ -188,6 +193,41 @@ PACKAGED_DOCS_FORBIDDEN_RELATIVE_ROOT_LINKS = [
   "../AGENTS.md"
 ].freeze
 
+def packaged_file_content(gem_path, target_path)
+  data_tar_gz = nil
+
+  File.open(gem_path, "rb") do |gem_io|
+    Gem::Package::TarReader.new(gem_io) do |gem_tar|
+      gem_tar.each do |entry|
+        data_tar_gz = entry.read if entry.full_name == "data.tar.gz"
+      end
+    end
+  end
+
+  return nil unless data_tar_gz
+
+  Zlib::GzipReader.wrap(StringIO.new(data_tar_gz)) do |gzip|
+    Gem::Package::TarReader.new(gzip) do |data_tar|
+      data_tar.each do |entry|
+        return entry.read if entry.full_name == target_path
+      end
+    end
+  end
+
+  nil
+end
+
+def javascript_named_export?(source, export_name)
+  escaped_name = Regexp.escape(export_name)
+  source.match?(/export\s+(?:const|function|class)\s+#{escaped_name}\b/) ||
+    source.match?(/export\s*\{[^}]*\b#{escaped_name}\b[^}]*\}/m)
+end
+
+def typescript_named_export?(source, export_name)
+  escaped_name = Regexp.escape(export_name)
+  source.match?(/export\s+declare\s+(?:const|function|class)\s+#{escaped_name}\b/)
+end
+
 root = File.expand_path("..", __dir__)
 gem_path = ARGV.first || Dir[File.join(root, "tree_view-*.gem")].max_by { |path| File.mtime(path) }
 
@@ -233,6 +273,28 @@ missing_manifest_constant_paths = manifest.fetch("public_constants").each_with_o
   missing_paths[constant] = expected_path unless expected_path && files.include?(expected_path)
 end
 unknown_manifest_constants = manifest.fetch("public_constants") - PUBLIC_CONSTANT_RUNTIME_FILES.keys
+
+named_exports = manifest.fetch("javascript_package_root").fetch("named_exports")
+packaged_javascript_entrypoint = packaged_file_content(gem_path, JAVASCRIPT_PACKAGE_ROOT_PATH)
+packaged_typescript_entrypoint = packaged_file_content(gem_path, TYPESCRIPT_PACKAGE_ROOT_PATH)
+missing_package_root_named_exports = {}
+if packaged_javascript_entrypoint
+  missing_javascript_exports = named_exports.reject do |export_name|
+    javascript_named_export?(packaged_javascript_entrypoint, export_name)
+  end
+  missing_package_root_named_exports[JAVASCRIPT_PACKAGE_ROOT_PATH] = missing_javascript_exports unless missing_javascript_exports.empty?
+else
+  missing_package_root_named_exports[JAVASCRIPT_PACKAGE_ROOT_PATH] = named_exports
+end
+if packaged_typescript_entrypoint
+  missing_typescript_exports = named_exports.reject do |export_name|
+    typescript_named_export?(packaged_typescript_entrypoint, export_name)
+  end
+  missing_package_root_named_exports[TYPESCRIPT_PACKAGE_ROOT_PATH] = missing_typescript_exports unless missing_typescript_exports.empty?
+else
+  missing_package_root_named_exports[TYPESCRIPT_PACKAGE_ROOT_PATH] = named_exports
+end
+
 missing_installation_signals = INSTALLATION_DOC_PATHS.to_h do |path|
   content = File.read(File.join(root, path))
   [path, INSTALLATION_REQUIRED_SIGNALS.reject { |signal| content.include?(signal) }]
@@ -263,7 +325,7 @@ importmap_path = File.join(root, "config/importmap.tree_view.rb")
 importmap_content = File.read(importmap_path)
 importmap_pin_missing = !importmap_content.include?("pin \"tree_view\", to: \"tree_view/index.js\"")
 
-if missing.empty? && missing_gem_metadata.empty? && unexpected_release_metadata.empty? && missing_manifest_constant_paths.empty? && unknown_manifest_constants.empty? && missing_installation_signals.empty? && unexpected_public_setup_generator.empty? && missing_public_setup_generator_source_signals.empty? && missing_public_setup_generator_package_paths.empty? && forbidden_packaged_doc_links.empty? && !importmap_pin_missing
+if missing.empty? && missing_gem_metadata.empty? && unexpected_release_metadata.empty? && missing_manifest_constant_paths.empty? && unknown_manifest_constants.empty? && missing_package_root_named_exports.empty? && missing_installation_signals.empty? && unexpected_public_setup_generator.empty? && missing_public_setup_generator_source_signals.empty? && missing_public_setup_generator_package_paths.empty? && forbidden_packaged_doc_links.empty? && !importmap_pin_missing
   puts "Gem package contents verified: #{File.basename(gem_path)}"
 else
   warn "Gem package contents verification failed: #{File.basename(gem_path)}"
@@ -298,6 +360,11 @@ else
   unless unknown_manifest_constants.empty?
     warn "Public constants missing package guard mappings:"
     unknown_manifest_constants.each { |constant| warn "  - #{constant}" }
+  end
+
+  missing_package_root_named_exports.each do |path, export_names|
+    warn "Missing manifest-listed JavaScript package-root named exports in packaged #{path}:"
+    export_names.each { |export_name| warn "  - #{export_name}" }
   end
 
   missing_installation_signals.each do |path, signals|


### PR DESCRIPTION
## 対応 Issue

Closes #2295

## Issue ごとの完了内容

- #2295: `config/public_api_manifest.yml` の `javascript_package_root.named_exports` を source of truth として、built gem 内の `app/javascript/tree_view/index.js` と `app/javascript/tree_view/index.d.ts` に代表 export 名が残っていることを package contents checker で確認するようにしました。

## 変更内容

- `script/check_gem_package_contents.rb` に packaged gem 内ファイルを読む小さな helper を追加しました。
- manifest の `javascript_package_root.named_exports` を読み、packaged `index.js` の `export const` / `export function` / `export class` / re-export と照合します。
- packaged `index.d.ts` の `export declare const` / `function` / `class` と同じ export list を照合します。
- 失敗時は対象 packaged file と missing export name が分かる error message を出します。

## 改善カテゴリ

- test / package guard hardening
- CI / release package verification

## 既存仕様への影響

- runtime JavaScript、TypeScript declaration、manifest schema、gemspec files glob、workflow topology は変更していません。
- package contents checker の検証追加のみで、公開 API 名の追加・削除・rename はしていません。

## 実施した確認

- Issue #2295 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Default PR Check として直近の own open PR を確認し、#2298 はコメントなし、#2271 は draft / needs-human、#2161/#2057/#2048/#2047 は public contract / freshness gate で Quality Fixer が勝手に処理しない対象と分類しました。
- #2296 は current main の既存 `script/test_ci_changed_files_policy.mjs` guard で達成済みだったため、証拠コメントを残して close しました。
- branch は current `main` `10156d80fadad0c2942caec7292d86560a3e7f3e` から作成しました。
- compare `main...quality/2295-package-root-named-exports-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。built gem verification の追加に限定しており、runtime behavior や public surface は変更していません。

## 補足

- merge は行いません。