### PR TITLE
Public API manifest の nested key parity guard を追加する

### DIFF
--- a/spec/public_api_manifest_top_level_key_parity_spec.rb
+++ b/spec/public_api_manifest_top_level_key_parity_spec.rb
@@ -2,7 +2,48 @@
 
 require "spec_helper"
 
-RSpec.describe "Public API manifest top-level key parity" do
+RSpec.describe "Public API manifest guard parity" do
+  NESTED_PUBLIC_API_MANIFEST_KEY_LISTS = {
+    "ui_config_builder_option_keys" => {
+      node_const: "requiredUiConfigBuilderOptionKeys",
+      expected_keys: %w[
+        build
+        build_turbo
+        build_static
+        build_client_side
+      ]
+    },
+    "helper_option_keys" => {
+      node_const: "requiredHelperOptionKeys",
+      expected_keys: %w[
+        tree_view_rows
+        tree_view_window
+        tree_view_breadcrumb
+        tree_view_toolbar
+      ]
+    },
+    "grouped_option_keys" => {
+      node_const: "requiredGroupedOptionKeys",
+      expected_keys: %w[
+        initial_expansion
+        render_scope
+        toggle_scope
+        toggle_icons
+        selection
+        lazy_loading
+        row_status
+      ]
+    },
+    "javascript_package_root.integration_hooks" => {
+      node_const: "requiredIntegrationHookKeys",
+      expected_keys: %w[
+        state
+        remote_state
+        transfer
+      ]
+    }
+  }.freeze
+
   let(:manifest_structure_spec_path) { File.expand_path("public_api_manifest_structure_spec.rb", __dir__) }
   let(:manifest_structure_smoke_path) { File.expand_path("../script/test_public_api_manifest_structure.mjs", __dir__) }
 
@@ -24,6 +65,15 @@ RSpec.describe "Public API manifest top-level key parity" do
     match[:keys].scan(/"([^"]+)"/).flatten
   end
 
+  def node_expected_nested_keys(const_name)
+    source = File.read(manifest_structure_smoke_path)
+    match = source.match(/const #{Regexp.escape(const_name)} = \[\n(?<keys>.*?)\n\]/m)
+
+    raise "Could not find #{const_name} literal in #{manifest_structure_smoke_path}" unless match
+
+    match[:keys].scan(/"([^"]+)"/).flatten
+  end
+
   it "keeps Ruby and Node manifest top-level section guards synchronized" do
     ruby_keys = ruby_expected_top_level_keys
     node_keys = node_expected_top_level_keys
@@ -34,5 +84,19 @@ RSpec.describe "Public API manifest top-level key parity" do
       missing from Node smoke: #{(ruby_keys - node_keys).inspect}
       extra in Node smoke: #{(node_keys - ruby_keys).inspect}
     MESSAGE
+  end
+
+  it "keeps representative nested manifest key guards synchronized" do
+    NESTED_PUBLIC_API_MANIFEST_KEY_LISTS.each do |manifest_path, config|
+      ruby_keys = config.fetch(:expected_keys)
+      node_keys = node_expected_nested_keys(config.fetch(:node_const))
+
+      expect(node_keys).to eq(ruby_keys), <<~MESSAGE
+        expected script/test_public_api_manifest_structure.mjs #{config.fetch(:node_const)}
+        to match the Ruby expected keys for config/public_api_manifest.yml##{manifest_path}.
+        missing from Node smoke: #{(ruby_keys - node_keys).inspect}
+        extra in Node smoke: #{(node_keys - ruby_keys).inspect}
+      MESSAGE
+    end
   end
 end

--- a/spec/public_api_manifest_top_level_key_parity_spec.rb
+++ b/spec/public_api_manifest_top_level_key_parity_spec.rb
@@ -2,48 +2,48 @@
 
 require "spec_helper"
 
-RSpec.describe "Public API manifest guard parity" do
-  NESTED_PUBLIC_API_MANIFEST_KEY_LISTS = {
-    "ui_config_builder_option_keys" => {
-      node_const: "requiredUiConfigBuilderOptionKeys",
-      expected_keys: %w[
-        build
-        build_turbo
-        build_static
-        build_client_side
-      ]
-    },
-    "helper_option_keys" => {
-      node_const: "requiredHelperOptionKeys",
-      expected_keys: %w[
-        tree_view_rows
-        tree_view_window
-        tree_view_breadcrumb
-        tree_view_toolbar
-      ]
-    },
-    "grouped_option_keys" => {
-      node_const: "requiredGroupedOptionKeys",
-      expected_keys: %w[
-        initial_expansion
-        render_scope
-        toggle_scope
-        toggle_icons
-        selection
-        lazy_loading
-        row_status
-      ]
-    },
-    "javascript_package_root.integration_hooks" => {
-      node_const: "requiredIntegrationHookKeys",
-      expected_keys: %w[
-        state
-        remote_state
-        transfer
-      ]
-    }
-  }.freeze
+NESTED_PUBLIC_API_MANIFEST_KEY_LISTS = {
+  "ui_config_builder_option_keys" => {
+    node_const: "requiredUiConfigBuilderOptionKeys",
+    expected_keys: %w[
+      build
+      build_turbo
+      build_static
+      build_client_side
+    ]
+  },
+  "helper_option_keys" => {
+    node_const: "requiredHelperOptionKeys",
+    expected_keys: %w[
+      tree_view_rows
+      tree_view_window
+      tree_view_breadcrumb
+      tree_view_toolbar
+    ]
+  },
+  "grouped_option_keys" => {
+    node_const: "requiredGroupedOptionKeys",
+    expected_keys: %w[
+      initial_expansion
+      render_scope
+      toggle_scope
+      toggle_icons
+      selection
+      lazy_loading
+      row_status
+    ]
+  },
+  "javascript_package_root.integration_hooks" => {
+    node_const: "requiredIntegrationHookKeys",
+    expected_keys: %w[
+      state
+      remote_state
+      transfer
+    ]
+  }
+}.freeze
 
+RSpec.describe "Public API manifest guard parity" do
   let(:manifest_structure_spec_path) { File.expand_path("public_api_manifest_structure_spec.rb", __dir__) }
   let(:manifest_structure_smoke_path) { File.expand_path("../script/test_public_api_manifest_structure.mjs", __dir__) }
 
@@ -67,7 +67,7 @@ RSpec.describe "Public API manifest guard parity" do
 
   def node_expected_nested_keys(const_name)
     source = File.read(manifest_structure_smoke_path)
-    match = source.match(/const #{Regexp.escape(const_name)} = \[\n(?<keys>.*?)\n\]/m)
+    match = source.match(/const #{Regexp.escape(const_name)} = \[(?<keys>.*?)\]/m)
 
     raise "Could not find #{const_name} literal in #{manifest_structure_smoke_path}" unless match
 


### PR DESCRIPTION
## 対応 Issue

Closes #2260

## Issue ごとの完了内容

- #2260: Public API manifest の代表 nested required key list について、Ruby spec 側の期待値と Node smoke 側の literal が同期していることを検出できるようにしました。

## 変更内容

- `spec/public_api_manifest_top_level_key_parity_spec.rb` を manifest guard parity 全体の spec として読みやすい describe 名にしました。
- 既存 top-level section parity は維持しました。
- 以下の nested section list parity を追加しました。
  - `ui_config_builder_option_keys`
  - `helper_option_keys`
  - `grouped_option_keys`
  - `javascript_package_root.integration_hooks`
- Node 側 literal がずれた場合、対象 manifest path と missing / extra key が分かる failure message にしています。

## 改善カテゴリ

- test guard hardening
- public API manifest / docs smoke drift prevention

## 既存仕様への影響

- runtime Ruby / JavaScript behavior は変更していません。
- `config/public_api_manifest.yml`、public API surface、manifest schema、docs prose、CI workflow は変更していません。
- 既存 top-level parity guard はそのまま残しています。

## 実施した確認

- Issue #2260 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff を確認し、他の public API manifest surface / docs smoke issue とは混ぜていません。
- branch `quality/2260-manifest-nested-parity` は current `main` `0511a76436760143c78403d4567aca9a6a61b1f1` から作成しました。
- compare `main...quality/2260-manifest-nested-parity`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local RSpec は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。spec-only の guard 追加で、公開挙動や manifest 内容は変えていません。

## 補足事項

- merge は行いません。