### PR TITLE
CHANGELOG に package-root named exports guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Release preparation notes:
 - Added Development docs command smoke coverage for Docker setup command guidance and lockfile-backed Node/npm install signals.
 - Added CI changed-file policy coverage for public API, public setup surface, and release docs package/docs-entrypoint routing cases.
 - Expanded package contents verification coverage for README-linked public JavaScript docs, including controller registration and selection checkbox hook docs.
+- Added gem package verification coverage for manifest-listed package-root JavaScript named exports in packaged `index.js` and `index.d.ts`.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2295
Refs #2300

## 変更内容

- merged #2300 の gem package verification hardening について、`CHANGELOG.md` の `Unreleased > Tests` に release-facing evidence を 1 行追加しました。
- 変更は CHANGELOG の追記のみです。

## 分類

- `code-ahead-of-docs`: package verification guard が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: 既存の CHANGELOG category に沿った追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/check_gem_package_contents.rb`
- JavaScript package-root export / TypeScript declaration / manifest schema
- CI workflow / package verification logic

## 確認内容

- Default PR Check として前回の docs-only PR #2299 と quality PR #2300 が merge 済みであることを確認しました。
- open PR #2304 は fresh / CI success / review thread なしで、追加修正依頼はありませんでした。
- current main `0511a76436760143c78403d4567aca9a6a61b1f1` から branch `docs/changelog-package-root-named-exports-guard` を作成しました。
- compare `main...docs/changelog-package-root-named-exports-guard`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- GitHub Actions CI #3188 / run `27734155815`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - `javascript` は `npm run test:docs-entrypoints` を実行し、js core / browser checks は docs-only scope として skipped。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
  - `docker_development_setup`: skipped as expected for this changed-file scope。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / manifest / package verification logic は変更していません。

## 補足

- merge は行いません。