### PR TITLE
CHANGELOG に manifest nested key parity guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ Release preparation notes:
 - Added dependency spec, non-PR workflow output, public API manifest unknown-key, and duplicate YAML-key guard coverage for package-lock, CI changed-file policy, and manifest structure smoke.
 - Added public setup generator file package contents guard coverage for install generator and state templates.
 - Added public API manifest top-level key parity coverage to keep Ruby and Node manifest structure guards synchronized.
+- Added nested Public API manifest key parity coverage so Ruby and Node manifest structure guards stay synchronized for option key and integration hook lists.
 - Added release docs signal coverage for release metadata guards and docs-entrypoint sensitive CI routing.
 - Added docs entrypoint suite self-test coverage for unregistered docs smoke / signal scripts.
 - Added CHANGELOG-only CI routing coverage to keep `CHANGELOG.md` changes on the docs-entrypoint and package verification paths.


### PR DESCRIPTION
## 概要

- Refs #2260
- Refs #2305
- classification: `code-ahead-of-docs` / `docs-sync`

#2305 で merged 済みの Public API manifest nested key parity guard について、`CHANGELOG.md` の `Unreleased > Tests` に release evidence を 1 行追記します。

## 変更範囲

- `CHANGELOG.md`

## 対象外

- spec / script / manifest / runtime code の変更
- CI 設定や依存関係の変更

## 確認

- base: `main` (`63a097d2f59f9236a74119d0a98be2c52394c865`)
- compare: `ahead_by=1`, `behind_by=0`
- changed files: `CHANGELOG.md` のみ (+1 / -0)
- CI #3191: success
  - `changes`, `pr_specs`, `lint`, `javascript`, `gem_package`: success
  - docs-only routingで representative Rails lanes は skip/success
