### PR TITLE
CI policy の mixed public API PR 判定を guard する

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -33,6 +33,18 @@ const cases = [
     }
   },
   {
+    name: "mixed public API docs and runtime changes request full package and docs entrypoint guards",
+    files: ["docs/en/public-api.md", "app/javascript/tree_view/index.js"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: true
+    }
+  },
+  {
     name: "public setup and release docs stay docs-only and request package and docs entrypoint guards",
     files: ["docs/en/public-setup-surface.md", "docs/ja/release.md"],
     expected: {


### PR DESCRIPTION
## 対応 Issue

Closes #2308

## Issue ごとの完了内容

- #2308: public API docs と runtime package entrypoint が同じ PR に混ざった場合に、docs-only shortcut へ落ちず、package / docs entrypoint guard の両方を要求する regression case を追加しました。

## 変更内容

- `script/test_ci_changed_files_policy.mjs` の `cases` に mixed public API docs/runtime case を 1 件追加しました。
- 代表パスは `docs/en/public-api.md` と `app/javascript/tree_view/index.js` です。
- 期待値は `docs_only:false`, `package_sensitive:true`, `docs_entrypoint_sensitive:true` とし、既存の public API docs-only case はそのまま残しています。

## 改善カテゴリ

- test
- CI guard hardening

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、docs本文、CI workflow topology は変更していません。
- 既存の changed-files policy の挙動を代表ケースで固定するだけです。

## 実施した確認

- Issue #2308 の labels を直接確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Default PR Check として open PR review follow-up を確認し、Quality Fixer が自動修正できる同 track の blocker は見つかりませんでした。
- branch freshness: current `main` `63a097d2f59f9236a74119d0a98be2c52394c865` から作成。
- compare `main...quality/2308-ci-policy-mixed-public-api`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local `node script/test_ci_changed_files_policy.mjs` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 policy test の代表 coverage 追加に閉じています。

## 補足事項

- `.github/workflows/ci.yml`、`script/ci_changed_files_policy.mjs`、package scripts、runtime code は変更していません。
- merge は行いません。