### PR TITLE
Installation docs の CI routing 説明を更新する

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -15,14 +15,18 @@ GitHub Actions runs the following checks on pull requests:
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
-- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
-- JavaScript tests through `npm ci`, Playwright browser setup, and `npm run test:js`
+- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`; docs-only pull requests keep the check names but skip the heavy Rails lanes
+- JavaScript checks through the changed-files policy:
+  - README, `docs/**`, and `CHANGELOG.md` changes run `npm ci` and `npm run test:docs-entrypoints`
+  - `docs/mockups/**` and `test/browser/**` changes install Playwright and run `npm run test:browser`
+  - non-docs pull requests run `npm run test:js:core`
+- Package-sensitive paths, including README, `CHANGELOG.md`, `docs/**`, runtime files, manifest files, and package metadata, run the `gem_package` job
 
 Pushes to `main` keep the heavier compatibility and release checks:
 
 - Ruby version matrix
 - Full Rails version matrix
-- JavaScript tests through `npm ci` and `npm run test:js`
+- JavaScript tests through `npm ci`, `npm run test:js:core`, and browser smoke when the workflow runs outside the pull request docs-only shortcut
 - gem package verification
 
 The repository keeps a committed `package-lock.json`. CI and local setup use `npm ci` so JavaScript checks install from the lockfile rather than updating dependency resolution during verification.
@@ -185,7 +189,7 @@ npm ci
 npm run test:js
 ```
 
-Use `npm ci` here for the same reason as CI: the committed `package-lock.json` is the repeatable install source. `npm run test:js` runs the entrypoint smoke, Vitest suite, and Playwright browser smoke checks documented in the CI lane.
+Use `npm ci` here for the same reason as CI: the committed `package-lock.json` is the repeatable install source. `npm run test:js` runs the full local JavaScript suite. Pull request CI may choose a lighter docs-entrypoint, browser-smoke, or JS core path from the changed-files policy described in the CI section.
 
 Rails compatibility Gemfiles live under `gemfiles/`.
 
@@ -212,7 +216,11 @@ GitHub Actions runs the following on pull requests:
 
 - `bundle exec standardrb`
 - `bundle exec rspec`
-- representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
-- JavaScript checks through `npm ci`, Playwright browser setup, and `npm run test:js`
+- representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`, with docs-only pull requests keeping the check names while skipping the heavy Rails commands
+- JavaScript checks selected by changed files:
+  - README, `docs/**`, and `CHANGELOG.md` run `npm run test:docs-entrypoints`
+  - `docs/mockups/**` and `test/browser/**` install Playwright and run `npm run test:browser`
+  - non-docs pull requests run `npm run test:js:core`
+- package-sensitive paths run gem package verification
 
 On pushes to `main`, GitHub Actions runs the Ruby version matrix, full Rails version matrix, JavaScript tests, and gem package verification.

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -15,14 +15,18 @@ GitHub Actions では、Pull Requestで以下を実行します。
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
-- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
-- JavaScript tests: `npm ci`、Playwright browser setup、`npm run test:js`
+- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`。docs-only PR では check name を維持したまま重い Rails lane を skip します
+- changed-files policy による JavaScript checks:
+  - README、`docs/**`、`CHANGELOG.md` の変更では `npm ci` と `npm run test:docs-entrypoints` を実行します
+  - `docs/mockups/**` と `test/browser/**` の変更では Playwright を install し、`npm run test:browser` を実行します
+  - docs 以外を含む PR では `npm run test:js:core` を実行します
+- README、`CHANGELOG.md`、`docs/**`、runtime files、manifest files、package metadata など package-sensitive path の変更では `gem_package` job を実行します
 
 `main` へのpushでは、重めの互換性確認とrelease向けchecksを実行します。
 
 - Ruby version matrix
 - full Rails version matrix
-- `npm ci` と `npm run test:js` による JavaScript tests
+- PR の docs-only shortcut 外で実行される JavaScript tests: `npm ci`、`npm run test:js:core`、必要な browser smoke
 - gem package verification
 
 repo には `package-lock.json` を commit しています。CI とローカルセットアップは `npm ci` を使い、検証中に dependency resolution を更新せず、lockfile から JavaScript dependencies を install します。
@@ -183,7 +187,7 @@ npm ci
 npm run test:js
 ```
 
-ローカル手順も CI と同じく `npm ci` を使います。commit 済みの `package-lock.json` を repeatable install の source として使うためです。`npm run test:js` は CI lane と同じく entrypoint smoke、Vitest suite、Playwright browser smoke をまとめて実行します。
+ローカル手順も CI と同じく `npm ci` を使います。commit 済みの `package-lock.json` を repeatable install の source として使うためです。`npm run test:js` は local の full JavaScript suite をまとめて実行します。Pull Request CI では、CI section に書いた changed-files policy により、docs-entrypoint、browser-smoke、JS core のいずれか軽い経路を選ぶことがあります。
 
 Rails互換性確認用のGemfileは `gemfiles/` 配下にあります。
 
@@ -210,7 +214,11 @@ GitHub Actions では、Pull Requestで以下を実行します。
 
 - `bundle exec standardrb`
 - `bundle exec rspec`
-- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
-- JavaScript checks: `npm ci`、Playwright browser setup、`npm run test:js`
+- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`。docs-only PR では check name を維持しつつ重い Rails command を skip します
+- changed-files policy で選ばれる JavaScript checks:
+  - README、`docs/**`、`CHANGELOG.md` は `npm run test:docs-entrypoints` を実行します
+  - `docs/mockups/**` と `test/browser/**` は Playwright を install し、`npm run test:browser` を実行します
+  - docs 以外を含む PR は `npm run test:js:core` を実行します
+- package-sensitive path の変更では gem package verification を実行します
 
 `main` へのpushでは、Ruby version matrix、full Rails version matrix、JavaScript tests、gem package verificationを実行します。


### PR DESCRIPTION
## 対応 Issue

Refs #2312

## 変更内容

- 英日 `docs/*/installation.md` の CI coverage / CI section を current `.github/workflows/ci.yml` と `script/ci_changed_files_policy.mjs` に合わせました。
- PR JavaScript checks を一律 `npm run test:js` と読ませず、docs-entrypoint / browser smoke / JS core の changed-files policy 分岐として整理しました。
- docs-only PR の代表 Rails lane skip、package-sensitive path の `gem_package` 実行も Installation docs から読めるようにしました。
- ローカルの `npm run test:js` は full local suite、PR CI は changed-files policy で軽い経路を選ぶ場合がある、という境界を追記しました。

## 分類

- `docs-stale`: Installation docs の CI 説明が current workflow 分岐より古く、`npm run test:js` / Playwright を一律実行するように読める状態でした。
- `docs-sync`: current workflow と changed-files policy への追従修正です。

## 変更範囲

- `docs/en/installation.md`
- `docs/ja/installation.md`

## 非対象

- `.github/workflows/ci.yml`
- `script/ci_changed_files_policy.mjs`
- docs smoke / signal script implementation
- runtime Ruby / JavaScript behavior
- Installation docs 全体の rewrite

## 残る scope

- #2312 の lightweight docs signal / smoke guard は `area:test` を含むため、この Docs Sync PR では実装しません。
- この PR は docs 本文の stale だけを直すため、#2312 は close せず `Refs` に留めます。

## 確認内容

- current main `faff8963d75badac38b8d4d6a1269f1aeb4f9040` から branch `docs/2312-installation-ci-policy` を作成しました。
- `.github/workflows/ci.yml` の `javascript` job と `script/ci_changed_files_policy.mjs` の docs-only / docs-entrypoint / mockup / browser-smoke / package-sensitive 分岐を確認しました。
- compare `main...docs/2312-installation-ci-policy`: `ahead_by:2` / `behind_by:0` / changed files 2。
- PR metadata: `mergeable:true`。
- GitHub Actions CI #3197 / run `27740576304`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job は `npm ci` と `npm run test:docs-entrypoints` を実行し、JS core / browser smoke は docs-only routingで skipped。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
- local checkout / local tests は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。docs-only の説明更新で、CI workflow や test script の挙動は変更していません。

merge は行いません。