### PR TITLE
AGENTS の CI routing 要約を更新する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,8 @@ For implementation changes, run or preserve compatibility with:
 bundle exec standardrb
 bundle exec rspec
 bundle exec rake build
-npm test
-npm run test:entrypoints
+npm run test:js
+npm run test:docs-entrypoints
 npm run test:browser
 ```
 
@@ -126,7 +126,7 @@ GitHub Actions runs the following on pull requests:
 - `bundle exec standardrb`
 - `bundle exec rspec`
 - representative Rails compatibility checks via `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
-- `npm run test:js`
+- JavaScript checks selected by the changed-files policy: `npm run test:docs-entrypoints` for package-facing docs entrypoints, `npm run test:browser` for mockup or browser-smoke paths, and `npm run test:js:core` for non-docs pull requests
 
 Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile.md`, `CHANGELOG.md`, and `AGENTS.md` keep the `lint` and `pr_specs` jobs, but short-circuit the representative Rails lanes while preserving the same check names for branch protection. Package-facing docs paths (`README.md`, `CHANGELOG.md`, and `docs/**`) are package-sensitive and run the `gem_package` job so the built gem keeps release-facing docs present. Repository-only maintainer docs (`Product Profile.md` and `AGENTS.md`) skip JavaScript and package checks unless they are paired with package-facing docs. The JavaScript job uses the changed-file policy outputs to choose the lightest useful docs check: README, `docs/**`, and `CHANGELOG.md` run `npm run test:docs-entrypoints`; `Product Profile.md` and `AGENTS.md` skip JavaScript when no package-facing docs changed; `docs/mockups/**` and `test/browser/**` changes install Playwright and run `npm run test:browser`. Pull requests that touch `test/browser/**` are not docs-only, and pull requests that touch `.github/workflows/**` do not use the docs-only shortcut.
 
@@ -134,6 +134,7 @@ Pushes to `main` also run the broader compatibility and release checks:
 
 - Ruby version matrix
 - full Rails version matrix
+- JavaScript checks outside the pull request docs-only shortcut
 - gem package verification
 
 ## Issue / Work Item Guidance


### PR DESCRIPTION
## 概要

- Refs #2312
- classification: `docs-stale` / `docs-sync`

#2313 で Installation docs が current changed-files policy に追従したため、repository-only maintainer guidance の `AGENTS.md` も Testing 要約だけを同じ境界に合わせます。

## 変更範囲

- `AGENTS.md`

## 変更内容

- ローカル確認コマンド例を `npm run test:js` / `npm run test:docs-entrypoints` / `npm run test:browser` の current scripts に揃えました。
- PR CI の JavaScript checks を一律 `npm run test:js` ではなく、changed-files policy による `test:docs-entrypoints` / `test:browser` / `test:js:core` の分岐として要約しました。
- `main` push 側の broader checks に JavaScript checks も含まれることを明記しました。

## 対象外

- runtime Ruby / JavaScript の変更
- workflow / CI 設定の変更
- docs signal script / test の変更
- Installation docs の追加変更

## 確認

- `package.json` の scripts と current `AGENTS.md` を確認しました。
- compare `main...docs/agents-ci-routing-summary`: `ahead_by:1` / `behind_by:0`
- changed files: `AGENTS.md` のみ (+4 / -3)
- local checkout / local test は GitHub HTTPS / npm registry 制限のため未実行です。PR CI を確認対象にします。