### PR TITLE
CI JavaScript job の npm script guard を追加する

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -1,7 +1,9 @@
 import { readFileSync } from "node:fs"
 
 const workflowPath = ".github/workflows/ci.yml"
+const packagePath = "package.json"
 const workflowSource = readFileSync(workflowPath, "utf8")
+const packageJson = JSON.parse(readFileSync(packagePath, "utf8"))
 
 function assert(condition, message) {
   if (!condition) throw new Error(message)
@@ -52,7 +54,15 @@ function assertDefaultWorkflowOutput(block, key, value) {
   )
 }
 
+function assertPackageScript(scriptName) {
+  assert(
+    Object.hasOwn(packageJson.scripts ?? {}, scriptName),
+    `${packagePath} scripts must define ${scriptName} for the CI JavaScript job`
+  )
+}
+
 const changesJob = workflowJobBlock(workflowSource, "changes")
+const javascriptJob = workflowJobBlock(workflowSource, "javascript")
 
 const nonPullRequestDefaultOutputs = {
   docs_only: false,
@@ -115,5 +125,21 @@ assertOrdered(
   `${workflowPath} jobs.changes must pass the collected file list into the policy script`
 )
 
+const javascriptJobNpmScripts = [
+  "test:docs-entrypoints",
+  "test:js:core",
+  "test:browser"
+]
+
+javascriptJobNpmScripts.forEach((scriptName) => {
+  assertIncludes(
+    javascriptJob,
+    `npm run ${scriptName}`,
+    `${workflowPath} jobs.javascript npm script command`
+  )
+  assertPackageScript(scriptName)
+})
+
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
+console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)


### PR DESCRIPTION
## 対応 Issue

Closes #2316

## Issue ごとの完了内容

- #2316: `.github/workflows/ci.yml` の `javascript` job が直接呼ぶ npm scripts と、`package.json` の script 定義が drift しないよう、既存 CI workflow signal script に代表 guard を追加しました。

## 変更内容

- `script/test_ci_workflow_changed_file_detection_signals.mjs` が `package.json` を読み込むようにしました。
- `jobs.javascript` 内に次の command が残ることを確認します。
  - `npm run test:docs-entrypoints`
  - `npm run test:js:core`
  - `npm run test:browser`
- 同じ script names が `package.json` の `scripts` に存在することを確認します。
- failure message で workflow command missing か package script missing か分かるようにしています。

## 改善カテゴリ

- test
- CI guard
- devops maintenance

## 既存仕様への影響

なし。CI workflow topology、changed-files policy、npm script の意味、runtime Ruby / JavaScript、package exports、docs prose は変更していません。

## 実施した確認

- Issue labels を個別確認済み: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` の `.github/workflows/ci.yml`、`package.json`、既存 signal script を確認しました。
- `main...quality/2316-ci-javascript-script-guard`: `ahead_by:1`, `behind_by:0`, changed files 1。
- local checkout / local Node 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

risk: low。既存 checker に representative assertion を追加するだけで、実行される CI job や package scripts は変更していません。

## 補足事項

#2315 と #2150 も対象条件を満たしますが、#2315 は package contents checker の別 guard、#2150 は repo-wide autocorrect で checkout-capable 実行が安全なため、この PR には混ぜていません。