### PR TITLE
README-linked render log docs を package contents guard に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -67,6 +67,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/public-api.md
     docs/ja/public-api.md
   ],
+  "README-linked render log level docs" => %w[
+    docs/en/render-log-level.md
+    docs/ja/render-log-level.md
+  ],
   "Bilingual development docs" => %w[
     docs/en/development.md
     docs/ja/development.md


### PR DESCRIPTION
## 対応 Issue

Closes #2315

## Issue ごとの完了内容

- #2315: README から直接辿る英日 Render log level docs を、gem package contents の representative guard に追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に `README-linked render log level docs` グループを追加しました。
- `docs/en/render-log-level.md` と `docs/ja/render-log-level.md` を packaged docs evidence として確認対象にしました。
- 既存の missing packaged files 出力はグループ名を出すため、欠落時に Render log level docs group と missing path が分かります。

## 改善カテゴリ

- test
- docs guard
- package contents verification

## 既存仕様への影響

- runtime Ruby / JavaScript、render logging behavior、accepted values、docs prose、gemspec glob、CI topology は変更していません。
- README の既存 Render log level docs link と矛盾しない、package contents guard のみの追加です。

## 実施した確認

- Issue #2315 の labels を個別確認し、`status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low` を満たすことを確認しました。
- current `main` の README が `docs/en/render-log-level.md` / `docs/ja/render-log-level.md` に直接リンクしていることを確認しました。
- current `main` の両 render-log-level docs が存在し、accepted values と host app global Rails logger level 境界を説明していることを確認しました。
- PR 前 compare: `main...quality/2315-render-log-docs-package-guard` は `ahead_by:1` / `behind_by:0`、changed files は `script/check_gem_package_contents.rb` の1件です。

## 未実行の確認

- local `bundle exec standardrb` / `bundle exec rspec` / gem build は未実行です。この環境では GitHub HTTPS checkout が `CONNECT tunnel failed, response 403` で使えないため、PR CI を確認対象にします。

## リスク評価

- risk: low
- representative package contents guard の1グループ追加のみで、公開挙動や API contract は変えません。

## 補足

- review follow-up 対象として #2311 なども確認しましたが、残件は desktop / narrow viewport の browser-capable visual evidence で、この環境では完了できないため新規実装とは分けています。