### PR TITLE
CHANGELOG に render log docs package guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ Release preparation notes:
 - Added CI changed-file policy coverage for public API, public setup surface, and release docs package/docs-entrypoint routing cases.
 - Expanded package contents verification coverage for README-linked public JavaScript docs, including controller registration and selection checkbox hook docs.
 - Added gem package verification coverage for manifest-listed package-root JavaScript named exports in packaged `index.js` and `index.d.ts`.
+- Added gem package verification coverage for README-linked render log level docs so the packaged gem keeps the docs reached from README's render logging guidance.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2315
Refs #2318

## 変更内容

- merged #2318 の README-linked render log level docs package contents guard について、`CHANGELOG.md` の `Unreleased > Tests` に release-facing evidence を 1 行追加しました。
- 変更は CHANGELOG の追記のみです。

## 分類

- `code-ahead-of-docs`: package verification guard が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: 既存の CHANGELOG category に沿った追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/check_gem_package_contents.rb`
- render log level docs prose
- runtime Ruby / JavaScript
- CI workflow / package verification logic

## 確認内容

- Default PR Check として #2311 を確認し、latest main 追従 / fresh CI は回復済み、残件は human browser-capable visual evidence と判定しました。
- #2318 が merged 済みで、`script/check_gem_package_contents.rb` に README-linked render log level docs guard を追加していることを確認しました。
- current main `07cb4881333284d1cc0fb54f0fada54b8ee25b4e` から branch `docs/changelog-render-log-package-guard` を作成しました。
- compare `main...docs/changelog-render-log-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- GitHub Actions CI #3211 / run `27758636290`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - `javascript` は `npm run test:docs-entrypoints` を実行し、JS core / browser smoke は docs-only routingで skipped。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / docs prose / package verification logic は変更していません。

merge は行いません。