### PR TITLE
Ruby version source guard に Rails 7.1 main matrix signal を追加する

### DIFF
--- a/script/test_ruby_version_sources.mjs
+++ b/script/test_ruby_version_sources.mjs
@@ -35,6 +35,17 @@ assertIncludes(workflow, '- "3.2"', ".github/workflows/ci.yml");
 assertIncludes(workflow, '- "3.3"', ".github/workflows/ci.yml");
 assertIncludes(workflow, "ruby_matrix:", ".github/workflows/ci.yml");
 assertIncludes(workflow, "rails_matrix:", ".github/workflows/ci.yml");
+[
+  '- rails: "7.1"',
+  "gemfile: gemfiles/rails_7_1.gemfile",
+  'ruby-version: "3.2"'
+].forEach((signal) => {
+  assertIncludes(
+    workflow,
+    signal,
+    ".github/workflows/ci.yml Rails 7.1 main-matrix signal"
+  );
+});
 
 const dockerRubyBaseImage = dockerfile.match(/^FROM ruby:(?<version>\d+\.\d+(?:\.\d+)?)-slim$/m);
 assert.ok(
@@ -63,11 +74,13 @@ assert.ok(
   [japaneseDevelopment, "docs/ja/development.md"]
 ].forEach(([content, path]) => {
   assertIncludes(content, "gemfiles/rails_7_0.gemfile", path);
+  assertIncludes(content, "gemfiles/rails_7_1.gemfile", path);
   assertIncludes(content, "gemfiles/rails_7_2.gemfile", path);
   assertIncludes(content, "gemfiles/rails_8_0.gemfile", path);
   assertIncludes(content, "Ruby version matrix", path);
+  assertIncludes(content, "Rails 7.1", `${path} Rails 7.1 main-matrix wording`);
 });
 
 console.log(
-  `Ruby version sources stay aligned with Ruby ${minimumRubyVersion}+ and representative Ruby ${minimumRubyVersion}/${currentRubyVersion} CI lanes, plus Docker Ruby ${dockerRubyBaseImage.groups.version}.`
+  `Ruby version sources stay aligned with Ruby ${minimumRubyVersion}+ and representative Ruby ${minimumRubyVersion}/${currentRubyVersion} CI lanes, Rails 7.1 main-matrix coverage, plus Docker Ruby ${dockerRubyBaseImage.groups.version}.`
 );


### PR DESCRIPTION
## 対応 Issue

Closes #2320

## Issue ごとの完了内容

- #2320: `script/test_ruby_version_sources.mjs` が Rails 7.1 の main-push full matrix signal と Development docs 側の Rails 7.1 wording を確認するようにしました。

## 変更内容

- `.github/workflows/ci.yml` 内の Rails 7.1 main-matrix representative signals を Ruby version source guard で確認します。
- 英日 Development docs が `gemfiles/rails_7_1.gemfile` と Rails 7.1 main-matrix wording を持つことを確認します。
- 成功メッセージにも Rails 7.1 main-matrix coverage を含めました。

## 改善カテゴリ

- test / CI guard hardening
- docs drift guard

## 既存仕様への影響

- CI workflow behavior、Ruby / Rails support policy、runtime Ruby / JavaScript は変更していません。
- docs本文も変更せず、既存の方針が落ちた時に検出する smoke guard だけを強化しています。

## 実施した確認

- compare `main...test/2320-rails71-main-matrix-signal`: `ahead_by:1` / `behind_by:0` / changed files 1
- changed files: `script/test_ruby_version_sources.mjs`
- local checkout / local `npm run test:ruby-version-sources` は GitHub HTTPS が利用できないため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 smoke script の assertion 追加のみです。

## 補足事項

- #2150 は同じ quality ready issue ですが、repo notes どおり checkout-capable `standardrb --fix` が必要な baseline lint drift のため、今回の connector-only PRには含めていません。
- #2311 の review follow-up は desktop / narrow viewport browser evidence が残っており、この実行環境では解消できません。