### PR TITLE
CHANGELOG に Rails 7.1 main matrix guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked public JavaScript docs, including controller registration and selection checkbox hook docs.
 - Added gem package verification coverage for manifest-listed package-root JavaScript named exports in packaged `index.js` and `index.d.ts`.
 - Added gem package verification coverage for README-linked render log level docs so the packaged gem keeps the docs reached from README's render logging guidance.
+- Added Ruby version source guard coverage for the Rails 7.1 main-push matrix signal so workflow, Gemfile, Ruby version, and Development docs wording stay aligned.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2320
Refs #2324

## 変更内容

- merged #2324 の Rails 7.1 main-push matrix signal guard について、`CHANGELOG.md` の `Unreleased > Tests` に release-facing evidence を 1 行追加しました。
- 変更は CHANGELOG の追記のみです。

## 分類

- `code-ahead-of-docs`: Ruby version source guard が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: 既存の CHANGELOG category に沿った追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `script/test_ruby_version_sources.mjs`
- `.github/workflows/ci.yml`
- Ruby / Rails support policy
- Development docs prose
- runtime Ruby / JavaScript

## 確認内容

- Default PR Check として #2311 を確認し、latest main 追従 / fresh CI は回復済み、残件は human browser-capable visual evidence と判定しました。
- #2324 が merged 済みで、`script/test_ruby_version_sources.mjs` に Rails 7.1 main-matrix signal guard を追加していることを確認しました。
- current main `73572e7d818f6d6b7f3a44762884370d3d363356` から branch `docs/changelog-rails71-main-matrix-guard` を作成しました。
- compare `main...docs/changelog-rails71-main-matrix-guard`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- GitHub Actions CI #3217 / run `27765949223`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - `javascript` は `npm run test:docs-entrypoints` を実行し、JS core / browser smoke は docs-only routingで skipped。
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0: docs-only skip / success。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認証跡にしています。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / docs prose / CI guard logic は変更していません。

merge は行いません。