### PR TITLE
quality: release / CI evidence signals を強化する

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -62,7 +62,14 @@ function assertPackageScript(scriptName) {
 }
 
 const changesJob = workflowJobBlock(workflowSource, "changes")
+const lintJob = workflowJobBlock(workflowSource, "lint")
+const prSpecsJob = workflowJobBlock(workflowSource, "pr_specs")
+const prRailsMatrixJob = workflowJobBlock(workflowSource, "pr_rails_matrix")
+const rubyMatrixJob = workflowJobBlock(workflowSource, "ruby_matrix")
+const railsMatrixJob = workflowJobBlock(workflowSource, "rails_matrix")
 const javascriptJob = workflowJobBlock(workflowSource, "javascript")
+const dockerDevelopmentSetupJob = workflowJobBlock(workflowSource, "docker_development_setup")
+const gemPackageJob = workflowJobBlock(workflowSource, "gem_package")
 
 const nonPullRequestDefaultOutputs = {
   docs_only: false,
@@ -125,6 +132,62 @@ assertOrdered(
   `${workflowPath} jobs.changes must pass the collected file list into the policy script`
 )
 
+const workflowActionMajorSignals = [
+  ["changes", changesJob, "actions/checkout@v6"],
+  ["lint", lintJob, "actions/checkout@v6"],
+  ["pr_specs", prSpecsJob, "actions/checkout@v6"],
+  ["pr_rails_matrix", prRailsMatrixJob, "actions/checkout@v6"],
+  ["ruby_matrix", rubyMatrixJob, "actions/checkout@v6"],
+  ["rails_matrix", railsMatrixJob, "actions/checkout@v6"],
+  ["javascript", javascriptJob, "actions/checkout@v6"],
+  ["docker_development_setup", dockerDevelopmentSetupJob, "actions/checkout@v6"],
+  ["gem_package", gemPackageJob, "actions/checkout@v6"],
+  ["lint", lintJob, "ruby/setup-ruby@v1"],
+  ["pr_specs", prSpecsJob, "ruby/setup-ruby@v1"],
+  ["pr_rails_matrix", prRailsMatrixJob, "ruby/setup-ruby@v1"],
+  ["ruby_matrix", rubyMatrixJob, "ruby/setup-ruby@v1"],
+  ["rails_matrix", railsMatrixJob, "ruby/setup-ruby@v1"],
+  ["javascript", javascriptJob, "ruby/setup-ruby@v1"],
+  ["gem_package", gemPackageJob, "ruby/setup-ruby@v1"],
+  ["javascript", javascriptJob, "actions/setup-node@v6"]
+]
+
+workflowActionMajorSignals.forEach(([jobName, jobSource, action]) => {
+  assertIncludes(
+    jobSource,
+    `uses: ${action}`,
+    `${workflowPath} jobs.${jobName} workflow action major version signal`
+  )
+})
+
+assertIncludes(
+  javascriptJob,
+  'node-version: "22"',
+  `${workflowPath} jobs.javascript setup-node representative Node version`
+)
+assert(
+  packageJson.engines?.node === "22.x",
+  `${packagePath} engines.node must remain aligned with the CI JavaScript job Node major`
+)
+
+const rubyMatrixVersionSignals = [
+  ["ruby_matrix", rubyMatrixJob, 'ruby-version:'],
+  ["ruby_matrix", rubyMatrixJob, '- "3.2"'],
+  ["ruby_matrix", rubyMatrixJob, '- "3.3"'],
+  ["rails_matrix", railsMatrixJob, 'ruby-version: "3.2"'],
+  ["rails_matrix", railsMatrixJob, 'ruby-version: "3.3"'],
+  ["pr_rails_matrix", prRailsMatrixJob, 'ruby-version: "3.2"'],
+  ["pr_rails_matrix", prRailsMatrixJob, 'ruby-version: "3.3"']
+]
+
+rubyMatrixVersionSignals.forEach(([jobName, jobSource, signal]) => {
+  assertIncludes(
+    jobSource,
+    signal,
+    `${workflowPath} jobs.${jobName} representative Ruby version signal`
+  )
+})
+
 const javascriptJobNpmScripts = [
   "test:docs-entrypoints",
   "test:js:core",
@@ -142,4 +205,6 @@ javascriptJobNpmScripts.forEach((scriptName) => {
 
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
+console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)
+console.log(`Checked ${rubyMatrixVersionSignals.length} representative Ruby workflow version signals.`)
 console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)

--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -75,6 +75,72 @@ releaseDocs.forEach(([sourcePath, signals]) => {
   assertSignals(sourcePath, "Release checklist changelog policy", signals)
 })
 
+const releaseDocsRubyEvidenceSignals = [
+  [
+    "docs/en/release.md",
+    [
+      "main-push full CI is green",
+      "Ruby version matrix",
+      "Rails version matrix",
+      "full compatibility matrices",
+      "required Ruby version",
+      "Ruby support",
+      "release evidence"
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "main-push full CI が green",
+      "Ruby version matrix",
+      "Rails version matrix",
+      "full compatibility matrices",
+      "required Ruby version",
+      "Ruby support",
+      "release evidence"
+    ]
+  ]
+]
+
+releaseDocsRubyEvidenceSignals.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Release docs Ruby and Rails evidence signal", signals)
+})
+
+const gemPackageWorkflowSignals = [
+  [
+    ".github/workflows/ci.yml",
+    [
+      "gem_package:",
+      "gem build tree_view.gemspec",
+      "ruby script/check_gem_package_contents.rb tree_view-*.gem",
+      "gem install tree_view-*.gem",
+      "ruby -e \"require 'tree_view'\""
+    ]
+  ],
+  [
+    "docs/en/release.md",
+    [
+      "gem build tree_view.gemspec",
+      "ruby script/check_gem_package_contents.rb tree_view-*.gem",
+      "gem install tree_view-*.gem",
+      "ruby -e \"require 'tree_view'\""
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "gem build tree_view.gemspec",
+      "ruby script/check_gem_package_contents.rb tree_view-*.gem",
+      "gem install tree_view-*.gem",
+      "ruby -e \"require 'tree_view'\""
+    ]
+  ]
+]
+
+gemPackageWorkflowSignals.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Gem package install and require workflow signal", signals)
+})
+
 const packageContentsVerificationSignals = [
   [
     "script/check_gem_package_contents.rb",


### PR DESCRIPTION
## 対応 Issue

Closes #2331
Closes #2332
Closes #2333

## Issue ごとの完了内容

- #2331: Release docs が Ruby / Rails matrix と release evidence を代表 signal として持ち続けることを `script/test_release_docs_signals.mjs` で確認します。
- #2332: `gem_package` job の `gem build`、package contents check、`gem install`、`require "tree_view"` smoke が workflow と英日 Release docs の双方に残ることを確認します。
- #2333: CI workflow の `actions/checkout@v6`、`actions/setup-node@v6`、`ruby/setup-ruby@v1` と代表 Ruby / Node version signal を `script/test_ci_workflow_changed_file_detection_signals.mjs` で確認します。

## 変更内容

- 既存の release docs signal smoke に Ruby / Rails release evidence と gem install / require smoke の代表 signal を追加しました。
- 既存の CI workflow signal smoke に GitHub Actions major version、JavaScript job の Node 22、Ruby 3.2 / 3.3 representative lane の確認を追加しました。

## 改善カテゴリ

- test
- CI guard
- docs drift guard

## 既存仕様への影響

workflow behavior、runtime Ruby / JavaScript、Ruby / Rails / Node support policy、dependency versions、branch protection、package contents policy は変更していません。既存ファイルの軽量 signal test のみを強化しています。

## 実施した確認

- Issue #2331 / #2332 / #2333 の labels を個別確認し、いずれも `status:ready-for-agent` / `track:quality` / `agent:planned` / `risk:low` であることを確認しました。
- PR 前 compare `main...quality/2331-release-ci-signals`: `ahead_by:2` / `behind_by:0`。
- changed files は次の2件のみです。
  - `script/test_ci_workflow_changed_file_detection_signals.mjs`
  - `script/test_release_docs_signals.mjs`
- ローカル checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存の lightweight smoke test に代表 signal を足すだけで、実行される workflow や docs本文の意味は変えていません。

## 補足事項

- tree_view-rails の既存 review follow-up PR #2311 は static mockup の browser-capable visual evidence 待ちで、この環境では解消できないため重複コメントや無関係な更新は行っていません。
- merge は行いません。