### PR TITLE
CHANGELOG に controller registration docs signal evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ Release preparation notes:
 - Added gem package verification coverage for manifest-listed package-root JavaScript named exports in packaged `index.js` and `index.d.ts`.
 - Added gem package verification coverage for README-linked render log level docs so the packaged gem keeps the docs reached from README's render logging guidance.
 - Added Ruby version source guard coverage for the Rails 7.1 main-push matrix signal so workflow, Gemfile, Ruby version, and Development docs wording stay aligned.
+- Added release docs signal coverage for controller registration troubleshooting and public setup generator packaging guidance.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #1652
Refs #2247
Refs #2330
Refs #2338

## 変更内容

- merged #2330 の controller registration / public setup generator docs signal guard について、`CHANGELOG.md` の `Unreleased > Tests` に release-facing evidence を 1 行追加しました。
- merged #2338 の release / CI evidence signal guard について、同じ `Unreleased > Tests` に release-facing evidence を 1 行追加しました。
- 変更は CHANGELOG の追記のみです。

## 分類

- `code-ahead-of-docs`: docs / CI signal guard が main に入り、CHANGELOG の Tests evidence が未追従でした。
- `docs-sync`: 既存の CHANGELOG category に沿った追従修正です。

## 変更範囲

- `CHANGELOG.md`

## 非対象

- `docs/en/troubleshooting.md`
- `docs/ja/troubleshooting.md`
- `script/test_release_docs_signals.mjs`
- `script/test_ci_workflow_changed_file_detection_signals.mjs`
- runtime Ruby / JavaScript
- public setup generator / controller registration behavior
- CI workflow behavior / action versions

## 確認内容

- Default PR Check として #2311 は open / `behind_by:0` / CI success ですが、残件は browser-capable visual evidence の human review 待ちと確認しました。
- #2337 は docs-only / `behind_by:0` / CI success / review threads なしと確認しました。
- #2330 が merged 済みで、controller registration troubleshooting と public setup generator packaging guidance の docs signal guard を追加していることを確認しました。
- PR 作成後に #2338 が main に mergeされたため、latest main `765d40b110367d11a7b21e985897cef1d51b6dd9` を取り込み、release / CI evidence signal guard の CHANGELOG evidence も同じ PR に吸収しました。
- branch `docs/changelog-controller-registration-setup-signals` の current head は `ad330c021389c9b481b64de9e807c8ca4e8689d1` です。
- compare `main...docs/changelog-controller-registration-setup-signals`: `ahead_by:2` / `behind_by:0` / changed files 1 / additions 2 / deletions 0。
- 初回 head `8dd88d38873603a60694598f3a6e22131c8b3d85` の GitHub Actions CI #3228 / run `27783185941` は success でした。refresh 後の CI を確認対象にします。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。CHANGELOG の release evidence 追記のみで、runtime / docs prose / signal script / CI workflow は変更していません。

merge は行いません。