### PR TITLE
Development docs の PR JavaScript CI lane 説明を更新する

### DIFF
--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -131,12 +131,12 @@ When browser-level accessibility smoke is added, do not silently suppress tree o
 
 ## CI policy
 
-Pull requests run the fast Ruby checks and JavaScript tests that protect day-to-day changes:
+Pull requests run the fast Ruby checks and JavaScript checks that protect day-to-day changes:
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
 - Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
-- JavaScript entrypoint, unit, and browser smoke tests through `npm run test:js`
+- JavaScript checks through the changed-files policy: docs-entrypoint-sensitive docs-only PRs run `npm run test:docs-entrypoints`, non-docs PRs run `npm run test:js:core`, and mockup or browser-smoke-sensitive PRs install Playwright Chromium and run `npm run test:browser`. Docs-only PRs that are not docs-entrypoint-sensitive and do not touch mockups or browser-smoke paths can skip JavaScript checks.
 
 The pull-request Rails lanes intentionally skip Rails 7.1 to keep PR feedback focused on representative lower, current, and next-major coverage; the `main` push full Rails matrix is the final compatibility gate that includes Rails 7.1.
 

--- a/docs/ja/development.md
+++ b/docs/ja/development.md
@@ -131,12 +131,12 @@ browser-level の accessibility smoke を追加するときは、tree や treegr
 
 ## CI方針
 
-Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScript testsを実行します。
+Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScript checksを実行します。
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
 - representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
-- JavaScript entrypoint、unit、browser smoke tests: `npm run test:js`
+- JavaScript checks: changed-files policy に従い、docs-entrypoint-sensitive な docs-only PR では `npm run test:docs-entrypoints`、docs-only ではない PR では `npm run test:js:core`、mockup / browser-smoke sensitive な PR では Playwright Chromium setup と `npm run test:browser` を実行します。docs-entrypoint-sensitive ではなく、mockup / browser-smoke path も触らない docs-only PR は JavaScript checks を skip できます。
 
 Pull Request の Rails lanes では、lower / current / next-major の代表範囲に絞るため Rails 7.1 は意図的に含めていません。Rails 7.1 は `main` push の full Rails matrix で確認する最終互換ゲートです。
 


### PR DESCRIPTION
## 対応 Issue

Closes #2344

## 変更内容

- 英日 `docs/*/development.md` の `CI policy` サマリで、Pull Request の JavaScript checks を一律 `npm run test:js` と読ませないように更新しました。
- current `.github/workflows/ci.yml` に合わせて、docs-entrypoint-sensitive docs-only PR、non-docs PR、mockup / browser-smoke sensitive PR、JavaScript checks を skip できる docs-only PR の境界を明記しました。
- `Common commands`、Release checklist、CI workflow、package scripts、docs signal scripts は変更していません。

## 分類

- `docs-stale`: Development docs の PR JavaScript checks サマリが current changed-files policy より古く読める状態でした。
- `docs-sync`: current CI workflow の conditional lanes に合わせた本文更新です。

## 変更範囲

- `docs/en/development.md`
- `docs/ja/development.md`

## 非対象

- `.github/workflows/ci.yml`
- `package.json`
- `script/test_development_docs_command_signals.mjs`
- `script/test_ci_workflow_changed_file_detection_signals.mjs`
- #2336 の Release checklist / release docs signal 残件
- runtime Ruby / JavaScript behavior

## 確認内容

- Default PR Check: #2311 は open / `behind_by:0` / changed files 1 / CI success で、残件は browser-capable visual evidence の human review 待ちと確認しました。
- #2322 は merge 済みと確認しました。
- current main `8857997cc2d6c1ba59e2bb63e1c67c3f1b538dcb` から branch `docs/2344-development-js-ci-lanes` を作成しました。
- compare `main...docs/2344-development-js-ci-lanes`: `ahead_by:2` / `behind_by:0` / changed files 2。
- local checkout / local docs test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。英日 Development docs の説明更新のみで、CI workflow / scripts / runtime は変更していません。

merge は行いません。