### PR TITLE
CHANGELOG に Dependabot refresh policy docs を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Release preparation notes:
 - Clarified Development docs for standalone gem package verification and docs i18n parity commands.
 - Clarified Development docs for public constants package guard mapping and Release docs for public setup generator package checklist / repository-only packaged-doc link boundaries.
 - Clarified `npm ci` install path guidance across README, installation, development, and release checklist docs so local setup, PR CI, Docker setup smoke, and main-push JavaScript checks share lockfile-backed evidence.
+- Clarified Development docs for edited Dependabot branch rebase / recreate handling and keeping broad baseline cleanups out of overlapping dependency PRs.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2343
Refs #2345

## 分類

- `docs-sync`: merge 済み docs-only PR #2345 の release-facing evidence を `CHANGELOG.md` に追従します。
- `code-ahead-of-docs`: Development docs の更新は main に入っていますが、CHANGELOG の Documentation entry が未追従でした。

## 変更内容

- `CHANGELOG.md` の Unreleased / Documentation に、edited Dependabot branch の rebase / recreate handling と overlapping dependency PR で broad baseline cleanup を重複投入しない方針を1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- Dependabot configuration
- dependency versions
- CI workflow
- lint rule / baseline cleanup
- `docs/en/development.md` / `docs/ja/development.md` 本文
- docs signal / smoke guard scripts

## 確認内容

- Default PR Check: #2311 は latest main から `behind_by:0` / CI success で、残件は browser-capable visual evidence の human review 待ちと確認しました。
- Default PR Check: #2347 は latest main から `behind_by:0` / CI success で、review / merge queue 待ちと確認しました。
- PR #2345 が merge 済みで、Development docs の Dependabot branch refresh policy が main に入っていることを確認しました。
- current main `8857997cc2d6c1ba59e2bb63e1c67c3f1b538dcb` から branch `docs/2343-changelog-dependabot-policy` を作成しました。
- compare `main...docs/2343-changelog-dependabot-policy`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local docs test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG 1行のみで、コード・設定・CI 挙動には触れていません。

merge は行いません。