### PR TITLE
Dependabot config の CI changed-file policy 分類を明示する

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -61,6 +61,7 @@ function isPackageSensitivePath(file) {
     file === ".nvmrc" ||
     file === "script/check_gem_package_contents.rb" ||
     file === ".github/workflows/ci.yml" ||
+    file === ".github/dependabot.yml" ||
     file === "config/importmap.tree_view.rb" ||
     file === "config/public_api_manifest.yml" ||
     file.startsWith("lib/") ||

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -117,6 +117,18 @@ const cases = [
     }
   },
   {
+    name: "Dependabot config changes are package-sensitive full CI changes without Docker setup",
+    files: [".github/dependabot.yml"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false
+    }
+  },
+  {
     name: "public manifest changes request full JS and docs entrypoint guards",
     files: ["config/public_api_manifest.yml"],
     expected: {
@@ -211,8 +223,7 @@ function workflowJobBlock(workflowSource, jobName) {
 
 function workflowJavaScriptJob(workflowSource) {
   return workflowJobBlock(workflowSource, "javascript");
-}
-
+}\n
 function npmRunScripts(workflowSource) {
   return [...workflowJavaScriptJob(workflowSource).matchAll(/run: npm run (?<script>[\w:-]+)/g)]
     .map((match) => match.groups.script)

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -223,7 +223,8 @@ function workflowJobBlock(workflowSource, jobName) {
 
 function workflowJavaScriptJob(workflowSource) {
   return workflowJobBlock(workflowSource, "javascript");
-}\n
+}
+
 function npmRunScripts(workflowSource) {
   return [...workflowJavaScriptJob(workflowSource).matchAll(/run: npm run (?<script>[\w:-]+)/g)]
     .map((match) => match.groups.script)


### PR DESCRIPTION
## 対応 Issue

Closes #2346

## Issue ごとの完了内容

- #2346: `.github/dependabot.yml` 変更時の CI changed-file policy を明示しました。
- `script/ci_changed_files_policy.mjs` では Dependabot config を `package_sensitive` に分類し、Docker setup / docs entrypoint sensitive には含めていません。
- `script/test_ci_changed_files_policy.mjs` に representative case を追加し、分類意図を test name と期待値から読めるようにしました。

## 変更内容

- `.github/dependabot.yml` を package-sensitive な設定変更として扱う分類を追加。
- Dependabot config 単独変更の期待値を追加。
  - `docs_only: false`
  - `package_sensitive: true`
  - `docker_setup_sensitive: false`
  - `docs_entrypoint_sensitive: false`

## 改善カテゴリ

- test
- CI changed-file policy guard
- 小さな devops maintenance

## 既存仕様への影響

- Dependabot schedule、dependency versions、package lock、CI workflow job 構成は変更していません。
- runtime Ruby / JavaScript、public API、docs prose、DB、認可、外部サービス契約には触れていません。

## 実施した確認

- Issue #2346 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Default PR Check で直近 open PR を確認し、Quality Fixer が対応すべき review follow-up はありませんでした。
- current main `8857997cc2d6c1ba59e2bb63e1c67c3f1b538dcb` から branch を作成しました。
- compare `main...chore/2346-dependabot-ci-policy`: `ahead_by:3` / `behind_by:0` / changed files 2。
- local checkout / local `npm run test:ci-policy` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。分類ロジックと代表テストのみの変更で、実際の Dependabot 設定や workflow topology は変更していません。

## 補足事項

- #2168 の npm Dependabot schedule 採用判断はこの PR では扱いません。
- merge は行いません。