### PR TITLE
Host App Extension Points docs を package guard に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -83,6 +83,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/selection-checkbox-hooks.md
     docs/ja/selection-checkbox-hooks.md
   ],
+  "README-linked host app extension docs" => %w[
+    docs/en/host-app-extension-points.md
+    docs/ja/host-app-extension-points.md
+  ],
   "Public setup surface docs" => %w[
     docs/en/public-setup-surface.md
     docs/ja/public-setup-surface.md


### PR DESCRIPTION
## 対応 Issue

Closes #2350

## Issue ごとの完了内容

- #2350: `script/check_gem_package_contents.rb` の representative packaged docs group に、英日 Host App Extension Points docs を追加しました。

## 変更内容

- `REQUIRED_PACKAGED_PATH_GROUPS` に `README-linked host app extension docs` group を追加しました。
- 対象 path は次の2件です。
  - `docs/en/host-app-extension-points.md`
  - `docs/ja/host-app-extension-points.md`

## 改善カテゴリ

- quality / test
- package contents guard
- docs discoverability guard

## 既存仕様への影響

runtime Ruby / JavaScript、public API manifest schema、gemspec glob、docs 本文、CI workflow は変更していません。package verification の代表 path を追加するだけなので、既存挙動への影響はありません。

## 実施した確認

- Default PR Check: open PR を確認し、#2311 は browser-capable visual evidence 待ち、#2351 は docs-track PRで review follow-up なし、その他古い design / public-surface PR は human review gate と分類しました。
- Issue #2350 のラベルを個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- current `main` `b779a3fd06dc7f13f83cb2fbf7044c7f16f93372` から branch `test/2350-host-extension-package-guard` を作成しました。
- compare `main...test/2350-host-extension-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- 変更ファイルは `script/check_gem_package_contents.rb` のみに限定されています。
- local checkout / local gem package verification は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。package contents verification の代表 docs group 追加のみで、公開API・runtime挙動・docs本文は変えていません。

## 補足事項

- #1926 の docs smoke / reverse lookup signal は扱っていません。
- merge は行いません。