### PR TITLE
Controller registration docs signal guard を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",
     "test:public-api-manifest-structure": "node script/test_public_api_manifest_structure.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
+    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs && node script/check_controller_registration_docs_signals.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/check_controller_registration_docs_signals.mjs
+++ b/script/check_controller_registration_docs_signals.mjs
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const manifest = read("config/public_api_manifest.yml")
+const controllerRegistrationDocs = [
+  ["docs/en/controller-registration.md", read("docs/en/controller-registration.md")],
+  ["docs/ja/controller-registration.md", read("docs/ja/controller-registration.md")]
+]
+
+const manifestSignals = [
+  "javascript_package_root:",
+  "TreeViewControllerEntries",
+  "controller_registrations:",
+  "key: state",
+  "identifier: tree-view-state",
+  "export: TreeViewStateController",
+  "key: client",
+  "identifier: tree-view-client",
+  "export: TreeViewClientController",
+  "key: selection",
+  "identifier: tree-view-selection",
+  "export: TreeViewSelectionController",
+  "key: transfer",
+  "identifier: tree-view-transfer",
+  "export: TreeViewTransferController",
+  "key: remoteState",
+  "identifier: tree-view-remote-state",
+  "export: TreeViewRemoteStateController"
+]
+
+manifestSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest controller registration surface")
+})
+
+controllerRegistrationDocs.forEach(([relativePath, document]) => {
+  assertIncludes(
+    document,
+    "registerTreeViewControllers(application)",
+    `${relativePath} default registration helper docs`
+  )
+  assertIncludes(
+    document,
+    "TreeViewControllerEntries",
+    `${relativePath} controller entries export docs`
+  )
+  assertIncludes(
+    document,
+    "application.register(identifier, controller)",
+    `${relativePath} custom registration example docs`
+  )
+
+  assert(
+    /state.*client.*selection.*transfer.*remote state/s.test(document),
+    `${relativePath}: controller registration docs no longer preserve the documented controller order`
+  )
+
+  assert(
+    /host app.*filter.*reorder|host app.*boot sequence|host app 側.*boot sequence|host app は entry を filter \/ reorder/.test(document),
+    `${relativePath}: controller registration docs no longer preserve the host-app-owned custom boot boundary`
+  )
+
+  assert(
+    /does not rename identifiers|identifier の rename/.test(document),
+    `${relativePath}: controller registration docs no longer state that identifiers and behavior are unchanged`
+  )
+})

--- a/script/check_controller_registration_docs_signals.mjs
+++ b/script/check_controller_registration_docs_signals.mjs
@@ -70,7 +70,7 @@ controllerRegistrationDocs.forEach(([relativePath, document]) => {
   )
 
   assert(
-    /host app.*filter.*reorder|host app.*boot sequence|host app 側.*boot sequence|host app は entry を filter \/ reorder/.test(document),
+    /filter.*reorder.*host app|host app.*filter.*reorder|host app.*boot sequence|host app 側.*boot sequence|host app は entry を filter \/ reorder/.test(document),
     `${relativePath}: controller registration docs no longer preserve the host-app-owned custom boot boundary`
   )
 


### PR DESCRIPTION
## 対応 Issue

Closes #2353

## Issue ごとの完了内容

- #2353: `docs/en/controller-registration.md` / `docs/ja/controller-registration.md` の代表 wording と、`config/public_api_manifest.yml` の controller registration surface を lightweight checker で守るようにしました。

## 変更内容

- `script/check_controller_registration_docs_signals.mjs` を追加しました。
  - manifest の `TreeViewControllerEntries` / `controller_registrations` / documented controller identifier-export pairing を確認します。
  - 英日 controller registration docs の `registerTreeViewControllers(application)`、`TreeViewControllerEntries`、custom registration example、documented order、host-app-owned custom boot boundary、identifier / behavior unchanged boundary を確認します。
- `npm run test:docs-entrypoints` から新 checker を実行するようにしました。

## 改善カテゴリ

- test
- docs drift guard
- CI guard hardening

## 既存仕様への影響

- runtime Ruby / JavaScript、controller implementation、package-root export names、manifest schema、Stimulus identifiers は変更していません。
- PR #2351 の docs README 導線 slice とは分け、#2353 の quality/test guard だけに閉じています。

## 実施した確認

- Issue #2353 の labels を直接確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- PR #2351 は現在 `mergeable:true`、changed files は docs README 2件のみで、#2353 は後続 quality/test lane として独立していることを確認しました。
- branch freshness: `main...chore/2353-controller-registration-docs-signal` は `behind_by:0`。
- changed files は `package.json` と `script/check_controller_registration_docs_signals.mjs` の 2 件のみ。
- local checkout / local `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs signal checker と package script のみの変更で、公開挙動や API 契約には触れていません。

## 補足事項

- 新 checker は brittle な全文一致ではなく、controller registration docs の代表 signal と manifest surface に限定しています。
- merge は行いません。