### PR TITLE
Accessibility Semantics docs を package contents guard に含める

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -87,6 +87,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/host-app-extension-points.md
     docs/ja/host-app-extension-points.md
   ],
+  "README-linked accessibility semantics docs" => %w[
+    docs/en/accessibility-semantics.md
+    docs/ja/accessibility-semantics.md
+  ],
   "Public setup surface docs" => %w[
     docs/en/public-setup-surface.md
     docs/ja/public-setup-surface.md


### PR DESCRIPTION
## 対応 Issue

- Closes #2355

## Issue ごとの完了内容

- #2355: `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に `README-linked accessibility semantics docs` group を追加し、英日 `docs/en/accessibility-semantics.md` / `docs/ja/accessibility-semantics.md` を representative packaged docs として確認対象にしました。

## 変更内容

- package contents verification の代表 docs group に Accessibility Semantics docs を独立 group として追加しました。
- failure message では既存の group 出力により `README-linked accessibility semantics docs` として欠落対象が分かります。

## 改善カテゴリ

- test / package guard hardening
- docs packaging drift guard

## 既存仕様への影響

- docs prose、runtime Ruby / JavaScript、ARIA attribute behavior、public API manifest schema は変更していません。
- gemspec glob、CI workflow、browser smoke、visual regression、automated accessibility checker は変更していません。

## 実施した確認

- Issue #2355 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff を確認し、単独 Issue として扱う指定に従いました。
- branch base: `main` `292ca2b1457eb272c3a848a42732476ad6f82b83`。
- compare `main...chore/2355-accessibility-semantics-package-guard`: `ahead_by:1`, `behind_by:0`。
- changed files は `script/check_gem_package_contents.rb` 1件のみ、追加4行 / 削除0行です。
- local checkout / local package build は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI の `gem_package` lane を確認対象にします。

## リスク評価

low。既存 package verifier の代表 docs group 追加のみで、公開挙動や docs semantics には影響しません。

## 補足事項

- 同 repo の #1825 は checkout-bound の大きめ refactor、#2150 は repo-wide Standard autocorrect が必要なため、今回の connector-only 実行では触れていません。
- `rails_table_preferences` #490 は既存メモどおり checkout-bound の controller/source spec 変更が必要なため、重複コメントや unsafe connector replacement は行っていません。
- `rails_fields_kit` の候補 #1028 / #1024 は別 repo・別 write set の docs drift guard なので、この PR には混ぜていません。