### PR TITLE
Decision guide docs を package contents guard に含める

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -91,6 +91,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/accessibility-semantics.md
     docs/ja/accessibility-semantics.md
   ],
+  "README-linked decision guide docs" => %w[
+    docs/en/decision-guide.md
+    docs/ja/decision-guide.md
+  ],
   "Public setup surface docs" => %w[
     docs/en/public-setup-surface.md
     docs/ja/public-setup-surface.md


### PR DESCRIPTION
## 対応 Issue

- Closes #2358

## Issue ごとの完了内容

- #2358: `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に `README-linked decision guide docs` group を追加し、英日 `docs/en/decision-guide.md` / `docs/ja/decision-guide.md` を representative packaged docs として確認対象にしました。

## 変更内容

- package contents verification の代表 docs group に Decision guide docs を独立 group として追加しました。
- failure output では既存の group 出力により `README-linked decision guide docs` として欠落対象が分かります。

## 改善カテゴリ

- test / package guard hardening
- docs packaging drift guard

## 既存仕様への影響

- docs prose、runtime Ruby / JavaScript、public API manifest schema、docs smoke script、CI workflow behavior は変更していません。
- gemspec glob、full-site link checker、Cookbook / Decision guide common combination docs smoke scope (#1837) には触れていません。

## 実施した確認

- Issue #2358 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Planner handoff を確認し、単独 Issue として扱う指定に従いました。
- branch base: `main` `a1f6f402c25a2ccf64764beb1e3b306c19769373`。
- compare `main...chore/2358-decision-guide-package-guard`: `ahead_by:1`, `behind_by:0`。
- changed files は `script/check_gem_package_contents.rb` 1件のみ、追加4行 / 削除0行です。
- local checkout / local package build は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI の `gem_package` lane を確認対象にします。

## リスク評価

low。既存 package verifier の代表 docs group 追加のみで、公開挙動や docs semantics には影響しません。

## 補足事項

- 直前の #2357 merge 後の current main を base にしています。
- merge は行いません。