### PR TITLE
CHANGELOG に Accessibility Semantics package guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Release preparation notes:
 - Added controller registration docs signal coverage to the docs-entrypoint suite so controller registration guides and manifest controller entries stay aligned.
 - Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates stay package-sensitive without Docker or docs-entrypoint routing.
 - Expanded package contents verification coverage for README-linked Host App Extension Points docs so packaged gems keep those public extension guides.
+- Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.
 - Added localized names specs and public API compatibility coverage.
 - Added Turbo Frame option unit and integration specs.
 - Added toolbar helper specs.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2355
Refs #2357

## 分類

- `code-ahead-of-docs`: merge 済み package guard PR #2357 の release-facing evidence が `CHANGELOG.md` に未記録でした。
- `docs-sync`: `CHANGELOG.md` の `Unreleased > Tests` に追従するだけで完結します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、README-linked Accessibility Semantics docs の package contents verification coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- `script/check_gem_package_contents.rb`
- gemspec / package verification logic
- docs prose
- runtime Ruby / JavaScript
- ARIA behavior / public API manifest schema
- CI workflow behavior

## 確認内容

- Default PR Check: #2311 は latest main 追従を更新し、changed files `docs/mockups/filtered-tree-modes.html` 1件、CI #3288 success。残件は browser-capable visual evidence として human review 待ちです。
- recent merged PR #2357 は `script/check_gem_package_contents.rb` に README-linked Accessibility Semantics docs group を追加した package guard PRでした。
- branch base: `main` `a1f6f402c25a2ccf64764beb1e3b306c19769373`。
- compare `main...docs/changelog-accessibility-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- local checkout / local docs check は GitHub HTTPS 制限のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG 1行のみで、コード・設定・CI 挙動には触れていません。

merge は行いません。