### PR TITLE
docs-entrypoints signal wiring を CI guard で守る

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -61,6 +61,18 @@ function assertPackageScript(scriptName) {
   )
 }
 
+function packageScript(scriptName) {
+  assertPackageScript(scriptName)
+
+  const script = packageJson.scripts[scriptName]
+  assert(
+    typeof script === "string" && script.length > 0,
+    `${packagePath} scripts.${scriptName} must be a non-empty command string`
+  )
+
+  return script
+}
+
 const changesJob = workflowJobBlock(workflowSource, "changes")
 const lintJob = workflowJobBlock(workflowSource, "lint")
 const prSpecsJob = workflowJobBlock(workflowSource, "pr_specs")
@@ -203,8 +215,23 @@ javascriptJobNpmScripts.forEach((scriptName) => {
   assertPackageScript(scriptName)
 })
 
+const docsEntrypointsScript = packageScript("test:docs-entrypoints")
+const docsEntrypointsScriptSignals = [
+  ["docs entrypoint suite", "node script/test_docs_entrypoint_suite.mjs"],
+  ["standalone controller registration docs signal", "node script/check_controller_registration_docs_signals.mjs"]
+]
+
+docsEntrypointsScriptSignals.forEach(([label, signal]) => {
+  assertIncludes(
+    docsEntrypointsScript,
+    signal,
+    `${packagePath} scripts.test:docs-entrypoints ${label}`
+  )
+})
+
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
 console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)
 console.log(`Checked ${rubyMatrixVersionSignals.length} representative Ruby workflow version signals.`)
 console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)
+console.log(`Checked ${docsEntrypointsScriptSignals.length} docs-entrypoints package script command signals.`)


### PR DESCRIPTION
## 対応 Issue

- Closes #2361

## Issue ごとの完了内容

- #2361: `script/test_ci_workflow_changed_file_detection_signals.mjs` に `package.json` の `scripts["test:docs-entrypoints"]` body assertion を追加し、`script/test_docs_entrypoint_suite.mjs` と `script/check_controller_registration_docs_signals.mjs` の両方が実行配線に残ることを検出できるようにしました。

## 変更内容

- package script の存在確認に加えて、script body を non-empty string として取得する helper を追加しました。
- `test:docs-entrypoints` に次の2つの command signal が含まれることを確認します。
  - `node script/test_docs_entrypoint_suite.mjs`
  - `node script/check_controller_registration_docs_signals.mjs`
- 検証件数の console output に docs-entrypoints package script command signals を追加しました。

## 改善カテゴリ

- test / CI policy signal hardening
- docs entrypoint execution wiring guard

## 既存仕様への影響

- `.github/workflows/ci.yml`、`package.json`、controller registration docs、runtime Ruby / JavaScript、public API manifest、controller identifiers は変更していません。
- 既存の `npm run test:docs-entrypoints` 実行経路そのものは変えず、read-only signal の検査だけを強化しています。

## 実施した確認

- Issue #2361 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 自分の open PR #2359 は確認しましたが、コメントは自分の検証コメントのみで外部 review follow-up ではありませんでした。
- #2360 は #2359 と同じ `script/check_gem_package_contents.rb` を触るため、Planner handoff の通り #2359 merge 後 main または明示 stack まで今回は未着手です。
- branch base: `main` `a1f6f402c25a2ccf64764beb1e3b306c19769373`。
- compare `main...chore/2361-docs-entrypoints-signal-guard`: `ahead_by:1`, `behind_by:0`。
- changed files は `script/test_ci_workflow_changed_file_detection_signals.mjs` 1件のみです。
- local checkout / local `npm run test:ci-policy` は GitHub HTTPS が `CONNECT tunnel failed, response 403` で利用できないため未実行です。PR CI の `javascript` / `lint` を確認対象にします。

## リスク評価

low。既存 signal script の read-only assertion 追加のみで、CI workflow behavior や公開挙動には影響しません。

## 補足事項

- merge は行いません。