### PR TITLE
Migration guide docs を package contents guard に含める

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -95,6 +95,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/decision-guide.md
     docs/ja/decision-guide.md
   ],
+  "README-linked migration guide docs" => %w[
+    docs/en/migration.md
+    docs/ja/migration.md
+  ],
   "Public setup surface docs" => %w[
     docs/en/public-setup-surface.md
     docs/ja/public-setup-surface.md


### PR DESCRIPTION
## 対応 Issue

Closes #2364

## Issue ごとの完了内容

- #2364: `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に `README-linked migration guide docs` group を追加し、英日 `docs/en/migration.md` / `docs/ja/migration.md` を representative packaged docs として確認対象にしました。

## 変更内容

- package contents verification の代表 docs group に Migration guide docs を独立 group として追加しました。
- failure output では既存の group 出力により `README-linked migration guide docs` として欠落対象が分かります。

## 改善カテゴリ

- test / package guard hardening
- docs packaging drift guard

## 既存仕様への影響

- docs prose、runtime Ruby / JavaScript、public API manifest schema、CI workflow behavior、docs smoke suite、gemspec glob は変更していません。
- FAQ / Troubleshooting package guard scope (#2360) とは混ぜていません。

## 実施した確認

- Issue #2364 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR #2359 は merge 済み、Issue #2360 は `status:needs-human` で今回の対象外であることを確認しました。
- branch base: `main` `2a4b9f37f59aeba5ca9f0acf1fe560cfccafbad5`。
- compare `main...chore/2364-migration-guide-package-guard`: `ahead_by:1`, `behind_by:0`。
- changed files は `script/check_gem_package_contents.rb` 1件のみ、追加4行 / 削除0行です。
- local checkout / local package build は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI の `gem_package` lane を確認対象にします。

## リスク評価

low。既存 package verifier の代表 docs group 追加のみで、公開挙動や docs semantics には影響しません。

## 補足事項

- merge は行いません。