### PR TITLE
CHANGELOG に docs-entrypoints signal wiring guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Release preparation notes:
 ### Tests
 
 - Added controller registration docs signal coverage to the docs-entrypoint suite so controller registration guides and manifest controller entries stay aligned.
+- Added CI changed-file detection workflow guard coverage for docs-entrypoints package script wiring so controller registration docs signals stay connected to `npm run test:docs-entrypoints`.
 - Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates stay package-sensitive without Docker or docs-entrypoint routing.
 - Expanded package contents verification coverage for README-linked Host App Extension Points docs so packaged gems keep those public extension guides.
 - Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2361
Refs #2363

## 分類

- `code-ahead-of-docs`: merge 済み quality / CI guard PR #2363 の release-facing evidence が `CHANGELOG.md` に未記録でした。
- `docs-sync`: `CHANGELOG.md` の `Unreleased > Tests` に追従するだけで完結します。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、docs-entrypoints package script wiring を CI changed-file detection workflow guard で守る coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- `script/test_ci_workflow_changed_file_detection_signals.mjs`
- `package.json`
- `script/test_docs_entrypoint_suite.mjs`
- `script/check_controller_registration_docs_signals.mjs`
- CI workflow behavior
- runtime Ruby / JavaScript
- docs prose

## 確認内容

- Default PR Check: #2311 は latest main 追従 / fresh CI を更新済みで、残件は desktop / narrow viewport の browser-capable visual evidence と確認しました。
- recent merged PR #2363 は `script/test_ci_workflow_changed_file_detection_signals.mjs` の quality / CI guard PRでした。
- branch base: latest `main` `f6997e6b810f2551a8b5098d6dc51edea10d62ee`。
- head: `05d845d65c15cd3dbf07a62d10f76b09266a5bc2`。
- compare `main...docs/changelog-docs-entrypoints-signal-wiring`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- PR metadata: `mergeable:true` / `merged:false`。
- GitHub Actions CI #3298 / run `27819602812`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - `javascript` job は `npm run test:docs-entrypoints` を実行し、`test:js:core` / Playwright / `test:browser` は skipped。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。
- local checkout / local docs check は GitHub HTTPS 制限のため未実行です。PR CI を確認対象にしました。

## リスク

low。CHANGELOG 1行のみで、コード・設定・CI 挙動には触れていません。

merge は行いません。