### PR TITLE
docs entrypoint suite に controller registration signal を登録する

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",
     "test:public-api-manifest-structure": "node script/test_public_api_manifest_structure.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs && node script/check_controller_registration_docs_signals.mjs",
+    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -2,8 +2,10 @@ import { readFileSync } from "node:fs"
 
 const workflowPath = ".github/workflows/ci.yml"
 const packagePath = "package.json"
+const docsEntrypointSuitePath = "script/test_docs_entrypoint_suite.mjs"
 const workflowSource = readFileSync(workflowPath, "utf8")
 const packageJson = JSON.parse(readFileSync(packagePath, "utf8"))
+const docsEntrypointSuiteSource = readFileSync(docsEntrypointSuitePath, "utf8")
 
 function assert(condition, message) {
   if (!condition) throw new Error(message)
@@ -216,14 +218,14 @@ javascriptJobNpmScripts.forEach((scriptName) => {
 })
 
 const docsEntrypointsScript = packageScript("test:docs-entrypoints")
-const docsEntrypointsScriptSignals = [
-  ["docs entrypoint suite", "node script/test_docs_entrypoint_suite.mjs"],
-  ["standalone controller registration docs signal", "node script/check_controller_registration_docs_signals.mjs"]
+const docsEntrypointsSignals = [
+  ["package script uses docs entrypoint suite", docsEntrypointsScript, "node script/test_docs_entrypoint_suite.mjs"],
+  ["suite registers controller registration docs signal", docsEntrypointSuiteSource, "script/check_controller_registration_docs_signals.mjs"]
 ]
 
-docsEntrypointsScriptSignals.forEach(([label, signal]) => {
+docsEntrypointsSignals.forEach(([label, source, signal]) => {
   assertIncludes(
-    docsEntrypointsScript,
+    source,
     signal,
     `${packagePath} scripts.test:docs-entrypoints ${label}`
   )
@@ -234,4 +236,4 @@ console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pul
 console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)
 console.log(`Checked ${rubyMatrixVersionSignals.length} representative Ruby workflow version signals.`)
 console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)
-console.log(`Checked ${docsEntrypointsScriptSignals.length} docs-entrypoints package script command signals.`)
+console.log(`Checked ${docsEntrypointsSignals.length} docs-entrypoints package and suite command signals.`)

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -128,6 +128,11 @@ const checks = [
     args: ["script/test_public_api_entrypoint_guard_signals.mjs"]
   },
   {
+    group: "Controller registration docs signals",
+    command: "node",
+    args: ["script/check_controller_registration_docs_signals.mjs"]
+  },
+  {
     group: "Render window and resource table docs signals",
     command: "node",
     args: ["script/test_render_window_resource_table_docs_signals.mjs"]
@@ -159,6 +164,7 @@ const docsEntrypointScriptExclusions = new Map([
 ])
 
 const docsEntrypointScriptPatterns = [
+  /^check_controller_registration_docs_signals\.mjs$/,
   /^test_.*docs.*\.mjs$/,
   /^test_.*readme.*signals\.mjs$/,
   /^test_.*mockup.*signals\.mjs$/,
@@ -332,6 +338,11 @@ function runSelfTest() {
     "Localized and hook docs signals",
     "unique partial --only should resolve a group"
   )
+  assert.equal(
+    resolveOnlyGroupResult("Controller registration").check.group,
+    "Controller registration docs signals",
+    "unique partial --only should resolve the controller registration docs signal"
+  )
 
   const outOfRange = resolveOnlyGroupResult("999")
   assert.equal(outOfRange.error, "out_of_range")
@@ -357,6 +368,10 @@ function runSelfTest() {
   assert.ok(
     docsEntrypointCandidateScriptPaths().includes("script/test_public_api_docs_signals.mjs"),
     "docs script registration candidates should include public API docs signals"
+  )
+  assert.ok(
+    docsEntrypointCandidateScriptPaths().includes("script/check_controller_registration_docs_signals.mjs"),
+    "docs script registration candidates should include controller registration docs signals"
   )
   assert.ok(
     !docsEntrypointCandidateScriptPaths().includes("script/test_docs_i18n_parity.mjs"),


### PR DESCRIPTION
## 対応 Issue

- Closes #2373

## Issue ごとの完了内容

- #2373: `script/check_controller_registration_docs_signals.mjs` を docs entrypoint suite の checks に登録し、`--list` / `--only` の対象として扱えるようにしました。

## 変更内容

- `package.json` の `test:docs-entrypoints` を `node script/test_docs_entrypoint_suite.mjs` 単独に整理しました。
- `script/test_docs_entrypoint_suite.mjs` に `Controller registration docs signals` group を追加しました。
- suite self-test / candidate detection に controller registration docs signal を含め、登録漏れを検知できるようにしました。
- `script/test_ci_workflow_changed_file_detection_signals.mjs` の package-script signal を新しい構成に合わせ、package script と suite 登録の両方を確認するようにしました。

## 改善カテゴリ

- test / CI guard hardening
- docs signal 運用の保守性改善

## 既存仕様への影響

- runtime JavaScript、controller registration API、docs 本文、CI workflow job 構成は変更していません。
- 既存の controller registration docs signal coverage は維持し、suite 経由で同じ script を実行する構成に寄せています。

## 実施した確認

- Issue #2373 の `status:ready-for-agent` / `track:quality` / `agent:planned` / `risk:low` を個別確認しました。
- `main` と作業ブランチの比較で、差分が `package.json`、`script/test_docs_entrypoint_suite.mjs`、`script/test_ci_workflow_changed_file_detection_signals.mjs` の 3 ファイルに限定されていることを確認しました。
- 作業ブランチ作成前に `main` が current head `1029dce4e93550c690fc8e69bb4573572c033aec` であることを確認しました。

## リスク評価

- low: package script と Node-based guard の整理に閉じており、公開 API / UI / DB / 認可 / 状態遷移 / 外部サービス契約には触れていません。

## 補足

- この実行環境ではローカルから GitHub への直接 clone / fetch が 403 で遮断されるため、connector 経由で差分作成と確認を行いました。PR CI で `npm run test:docs-entrypoints -- --list` / `--only` を含む JavaScript lane の実行結果を確認します。