### PR TITLE
CHANGELOG に package guard / lockfile guidance evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Release preparation notes:
 - Clarified Development docs for public constants package guard mapping and Release docs for public setup generator package checklist / repository-only packaged-doc link boundaries.
 - Clarified `npm ci` install path guidance across README, installation, development, and release checklist docs so local setup, PR CI, Docker setup smoke, and main-push JavaScript checks share lockfile-backed evidence.
 - Clarified Development docs for edited Dependabot branch rebase / recreate handling and keeping broad baseline cleanups out of overlapping dependency PRs.
+- Clarified Development docs for package-lock dependency drift guard guidance so dependency and Node engine metadata updates use `npm install` before returning to the lockfile-backed `npm ci` path.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
@@ -120,6 +121,7 @@ Release preparation notes:
 - Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates stay package-sensitive without Docker or docs-entrypoint routing.
 - Expanded package contents verification coverage for README-linked Host App Extension Points docs so packaged gems keep those public extension guides.
 - Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.
+- Expanded package contents verification coverage for README-linked Decision guide, Migration guide, Render Scale, and Rendering Boundaries docs so packaged gems keep those docs available.
 - Added localized names specs and public API compatibility coverage.
 - Added Turbo Frame option unit and integration specs.
 - Added toolbar helper specs.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2367
Refs #2358
Refs #2364
Refs #2366

## 分類

- `code-ahead-of-docs`: merge 済み docs / quality PR の release-facing evidence が `CHANGELOG.md` に一部未記録でした。
- `docs-sync`: `CHANGELOG.md` の `Unreleased` に追従するだけで完結します。

## 変更内容

- `Unreleased > Documentation` に、Development docs の package-lock dependency drift guard guidance を1行追加しました。
- `Unreleased > Tests` に、README-linked Decision guide / Migration guide / Render Scale / Rendering Boundaries docs の package contents verification coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- `docs/en/development.md` / `docs/ja/development.md` 本文
- `script/check_gem_package_contents.rb`
- package scripts / CI workflow
- dependency versions / package-lock contents
- runtime Ruby / JavaScript

## 確認内容

- Default PR Check: #2376 は open / `behind_by:0` / CI browser smoke success ですが、desktop / narrow viewport の browser-capable visual evidence が必要で、この実行環境では Chromium 取得が 403 のため未解消と確認しました。
- current `main` は `83167bc378011347cf73db931e9b075b2fb238b9`。
- compare `main...docs/changelog-package-guard-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 2 / deletions 0。
- local checkout / local docs tests は GitHub HTTPS / npm registry が 403 のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG 2行のみで、コード・設定・CI 挙動には触れていません。

merge は行いません。