### PR TITLE
CI policy に runtime / locale package-sensitive case を追加する

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -153,6 +153,30 @@ const cases = [
     }
   },
   {
+    name: "Ruby runtime files are package-sensitive full CI changes",
+    files: ["lib/tree_view/engine.rb"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false
+    }
+  },
+  {
+    name: "locale files are package-sensitive full CI changes",
+    files: ["config/locales/en.yml"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: true,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false
+    }
+  },
+  {
     name: "Ruby dependency files are package-sensitive full CI changes",
     files: ["Gemfile", "Gemfile.lock"],
     expected: {


### PR DESCRIPTION
## 対応 Issue

Closes #2381

## Issue ごとの完了内容

- #2381: `script/test_ci_changed_files_policy.mjs` に `lib/tree_view/engine.rb` と `config/locales/en.yml` の代表 case を追加し、どちらも `package_sensitive: true` / `docs_only: false` になることを固定しました。

## 変更内容

- Ruby runtime file の package-sensitive CI routing regression case を追加しました。
- locale file の package-sensitive CI routing regression case を追加しました。
- failure message / case name から runtime / locale path の routing が壊れたことが分かるようにしました。

## 改善カテゴリ

- test
- CI policy guard hardening

## 既存仕様への影響

- `script/ci_changed_files_policy.mjs`、`.github/workflows/ci.yml`、runtime Ruby code、locale 内容は変更していません。
- 既存の CI routing 仕様を変えず、現在の挙動を regression test で固定するだけの変更です。

## 確認内容

- Issue label を個別確認: `status:ready-for-agent` / `track:quality` / `agent:planned` / `risk:low`。
- compare `main...quality/2381-runtime-locale-policy-cases`: `ahead_by:1` / `behind_by:0` / changed files 1。
- GitHub Actions CI run `27834276660` は success です。
- local checkout / local tests は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク評価

- Low。テストケース追加のみで、公開挙動・API・DB・認可・UI・外部サービス契約には影響しません。

## 補足事項

- merge は行いません。