### PR TITLE
Localized Names docs を package guard に含める

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -67,6 +67,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/public-api.md
     docs/ja/public-api.md
   ],
+  "README-linked localized names docs" => %w[
+    docs/en/localized-names.md
+    docs/ja/localized-names.md
+  ],
   "README-linked render log level docs" => %w[
     docs/en/render-log-level.md
     docs/ja/render-log-level.md


### PR DESCRIPTION
## 対応 Issue

Closes #2386

## Issue ごとの完了内容

- #2386: README / 英日 docs README から利用者向け key document として案内されている Localized Names docs を、gem package contents guard の代表 docs group に追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に `README-linked localized names docs` を追加しました。
- `docs/en/localized-names.md` と `docs/ja/localized-names.md` を package verification の代表対象に含めました。

## 改善カテゴリ

- test
- docs
- CI/package guard hardening

## 既存仕様への影響

- docs 本文、runtime Ruby / JavaScript、public API manifest schema、docs smoke script、gemspec glob は変更していません。
- package contents guard の代表 docs group 追加のみで、既存の公開挙動や API 契約への影響はありません。

## 実施した確認

- Issue #2386 の対象ラベルを個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` は `2864197e42942ecc9d39c1e9f1abfb7f9c72c892` で、branch 作成前に main 同士の compare が identical であることを確認しました。
- `README.md`, `docs/en/README.md`, `docs/ja/README.md` に Localized names への利用者向け導線があることを確認しました。
- compare `main...chore/2386-localized-names-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local test は GitHub HTTPS 制限のため未実行です。PR CI を確認対象にします。

## リスク評価

risk: low。1ファイルの package guard 追加に閉じており、失敗時も missing packaged files group として原因を追いやすい変更です。

## 補足

- #2385 の docs signal smoke とは混ぜず、built gem package contents guard だけを扱っています。
- merge は行いません。