### PR TITLE
CHANGELOG に recent quality guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked Host App Extension Points docs so packaged gems keep those public extension guides.
 - Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.
 - Expanded package contents verification coverage for README-linked Decision guide, Migration guide, Render Scale, and Rendering Boundaries docs so packaged gems keep those docs available.
+- Added ReleaseCheck metadata validation and tag alignment focused specs for representative release failure paths.
+- Added CI changed-file policy coverage for runtime Ruby and locale paths so package-sensitive routing remains guarded.
+- Expanded package contents verification coverage for README-linked Localized Names docs so packaged gems keep those public localization guides.
 - Added localized names specs and public API compatibility coverage.
 - Added Turbo Frame option unit and integration specs.
 - Added toolbar helper specs.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2378
Refs #2381
Refs #2386

## 分類

- `code-ahead-of-docs`: merge 済み quality / package guard PR の release-facing evidence が `CHANGELOG.md` に未記録でした。
- `docs-sync`: `CHANGELOG.md` の `Unreleased > Tests` に追従するだけで完結します。

## 変更内容

- `Unreleased > Tests` に ReleaseCheck metadata / tag alignment focused specs の evidence を1行追加しました。
- `Unreleased > Tests` に runtime Ruby / locale path の package-sensitive CI routing guard evidence を1行追加しました。
- `Unreleased > Tests` に README-linked Localized Names docs の package contents verification coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- `spec/lib/tree_view/release_check_spec.rb`
- `script/test_ci_changed_files_policy.mjs`
- `script/check_gem_package_contents.rb`
- docs 本文
- CI workflow / package scripts
- runtime Ruby / JavaScript

## 確認内容

- Default PR Check: #2376 は open のまま、changed files は `docs/mockups/filtered-tree-modes.html` のみです。残件は desktop / narrow viewport の browser-capable visual evidence と latest main 追従で、この環境では screenshot を作れないため新規コメントは重複させていません。
- PR #2380 / #2383 / #2387 が merge 済みであることを確認しました。
- current `CHANGELOG.md` の `Unreleased > Tests` に上記3件の release-facing evidence が未記録であることを確認しました。
- compare `main...docs/changelog-recent-quality-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 3 / deletions 0。
- GitHub Actions CI #3327 / run `27841616552`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - `javascript` job は `npm run test:docs-entrypoints` を実行し、`test:js:core` / Playwright / `test:browser` は skipped。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。
- local checkout / local docs test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。CHANGELOG 3行のみで、コード・設定・CI 挙動には触れていません。

merge は行いません。