### PR TITLE
README-linked docs を gem package contents guard に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -99,6 +99,16 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/decision-guide.md
     docs/ja/decision-guide.md
   ],
+  "README-linked API combination and GraphAdapter docs" => %w[
+    docs/en/cookbook.md
+    docs/ja/cookbook.md
+    docs/en/graph-adapter.md
+    docs/ja/graph-adapter.md
+  ],
+  "README-linked error hierarchy docs" => %w[
+    docs/en/errors.md
+    docs/ja/errors.md
+  ],
   "README-linked migration guide docs" => %w[
     docs/en/migration.md
     docs/ja/migration.md


### PR DESCRIPTION
## 対応 Issue

Closes #2400
Closes #2401

## Issue ごとの完了内容

- #2400: README-linked Error hierarchy docs として `docs/en/errors.md` / `docs/ja/errors.md` を gem package contents guard の代表 docs group に追加しました。
- #2401: README-linked API combination / GraphAdapter docs として `docs/en/cookbook.md` / `docs/ja/cookbook.md` / `docs/en/graph-adapter.md` / `docs/ja/graph-adapter.md` を gem package contents guard の代表 docs group に追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に2つの focused group を追加しました。
- docs 本文、runtime Ruby / JavaScript、public API manifest、docs smoke suite、CI workflow behavior は変更していません。

## 改善カテゴリ

- test
- docs guard
- package contents verification

## 既存仕様への影響

- 既存仕様への影響はありません。
- built gem に含めるべき README-linked public docs の検証対象を増やすだけで、実行時挙動や公開 API には触れていません。

## 実施した確認

- Issue #2400 / #2401 の labels を個別確認し、どちらも `status:ready-for-agent` / `track:quality` / `agent:planned` / `risk:low` であることを確認しました。
- `docs/en/README.md` / `docs/ja/README.md` で Error hierarchy、Cookbook、GraphAdapter が reader entrypoint として案内されていることを確認しました。
- compare `main...chore/2400-docs-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- local checkout / local gem build / local `ruby script/check_gem_package_contents.rb` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

- risk: low
- 変更は package contents guard の代表 docs list 追加のみです。

## 補足

- #2150 の Standard/RuboCop baseline drift は repo-wide 59件規模の別テーマのため、この PR には含めていません。
- browser/visual evidence 待ちの既存 PR follow-up は、この環境では解消できないため重複対応していません。