### PR TITLE
CHANGELOG に Error / Cookbook / GraphAdapter package guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Release preparation notes:
 - Added Turbo Frame option docs in Japanese and English.
 - Added NodePresenter row partial cookbook docs and clarified criteria for promoting app-specific UI patterns into TreeView.
 - Added toolbar helper docs in Japanese and English.
-- Added README adoption guidance to help users decide whether TreeView fits your use case and to clarify the virtual scrolling boundary.
+- Added README adoption guidance to help users decide whether TreeView fits their use case and to clarify the virtual scrolling boundary.
 - Promoted accessibility semantics as a first-class capability in the README and docs indexes, including ARIA placement, keyboard boundaries, and host-app responsibilities.
 - Added accessibility semantics docs for table-first TreeView rows and ARIA placement policy.
 - Added client-side toggle mode docs in Japanese and English, including static / Turbo / client-side mode comparison and CSS customization guidance using `aria-expanded`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Release preparation notes:
 - Added Turbo Frame option docs in Japanese and English.
 - Added NodePresenter row partial cookbook docs and clarified criteria for promoting app-specific UI patterns into TreeView.
 - Added toolbar helper docs in Japanese and English.
-- Added README adoption guidance to help users decide whether TreeView fits their use case and to clarify the virtual scrolling boundary.
+- Added README adoption guidance to help users decide whether TreeView fits your use case and to clarify the virtual scrolling boundary.
 - Promoted accessibility semantics as a first-class capability in the README and docs indexes, including ARIA placement, keyboard boundaries, and host-app responsibilities.
 - Added accessibility semantics docs for table-first TreeView rows and ARIA placement policy.
 - Added client-side toggle mode docs in Japanese and English, including static / Turbo / client-side mode comparison and CSS customization guidance using `aria-expanded`.
@@ -122,6 +122,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked Host App Extension Points docs so packaged gems keep those public extension guides.
 - Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.
 - Expanded package contents verification coverage for README-linked Decision guide, Migration guide, Render Scale, and Rendering Boundaries docs so packaged gems keep those docs available.
+- Expanded package contents verification coverage for README-linked Error hierarchy, Cookbook, and GraphAdapter docs so packaged gems keep those public guides available.
 - Added ReleaseCheck metadata validation and tag alignment focused specs for representative release failure paths.
 - Added CI changed-file policy coverage for runtime Ruby and locale paths so package-sensitive routing remains guarded.
 - Expanded package contents verification coverage for README-linked Localized Names docs so packaged gems keep those public localization guides.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2400
Refs #2401
Refs #2402

## 分類

- `code-ahead-of-docs`: merge 済み package guard PR #2402 の release-facing evidence が `CHANGELOG.md` に未記録でした。
- `docs-sync`: `CHANGELOG.md` の `Unreleased > Tests` に追従するだけで完結します。

## 変更内容

- `Unreleased > Tests` に、README-linked Error hierarchy / Cookbook / GraphAdapter docs の package contents verification coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- `script/check_gem_package_contents.rb`
- docs 本文
- package verification logic
- CI workflow / package scripts
- runtime Ruby / JavaScript

## 確認内容

- Default PR Check: #2376 は open / `behind_by:0` / CI success ですが、残件は desktop / narrow viewport の browser-capable visual evidence で、この環境では作成できないため追加更新していません。
- PR #2402 が merge 済みであることを確認しました。
- current `CHANGELOG.md` の `Unreleased > Tests` に #2402 の release-facing evidence が未記録であることを確認しました。
- compare `main...docs/changelog-error-cookbook-package-guard`: `ahead_by:2` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- local checkout / local docs check は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG 1行のみで、コード・設定・CI 挙動には触れていません。

merge は行いません。