### PR TITLE
README-linked docs を package contents guard に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -109,6 +109,26 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/errors.md
     docs/ja/errors.md
   ],
+  "README-linked path and reverse tree docs" => %w[
+    docs/en/path-tree-builder.md
+    docs/ja/path-tree-builder.md
+    docs/en/reverse-tree.md
+    docs/ja/reverse-tree.md
+  ],
+  "README-linked first-time usage docs" => %w[
+    docs/en/minimal-usage.md
+    docs/ja/minimal-usage.md
+    docs/en/usage.md
+    docs/ja/usage.md
+  ],
+  "README-linked helper-adjacent row docs" => %w[
+    docs/en/breadcrumb.md
+    docs/ja/breadcrumb.md
+    docs/en/depth-labels.md
+    docs/ja/depth-labels.md
+    docs/en/row-status.md
+    docs/ja/row-status.md
+  ],
   "README-linked migration guide docs" => %w[
     docs/en/migration.md
     docs/ja/migration.md


### PR DESCRIPTION
## 対応 Issue

Closes #2405
Closes #2406
Closes #2407

## Issue ごとの完了内容

- #2405: PathTreeBuilder / ReverseTree の英日 docs を package contents guard の代表 docs group に追加しました。
- #2406: Minimal Usage / Usage の英日 docs を first-time user usage docs group として追加しました。
- #2407: Breadcrumb / Depth Labels / Row Status の英日 docs を helper-adjacent row docs group として追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に README-linked docs の代表グループを3つ追加しました。
- 既存の package verification script / failure reporter をそのまま使い、docs 本文・runtime Ruby / JavaScript・public API manifest schema・CI workflow behavior は変更していません。

## 改善カテゴリ

- test
- docs guard
- package contents verification hardening

## 既存仕様への影響

既存仕様への影響はありません。gem package contents verification の代表パスを増やすだけで、公開 API、runtime behavior、DB、認可、外部サービス契約、docs prose は変更していません。

## 実施した確認

- Default PR Check: #2376 には review follow-up が残っていますが、desktop / narrow viewport の browser-capable visual evidence 要求であり、この環境では自動解消できないため新規 quality issue 側を進めました。
- #2405 / #2406 / #2407 の labels を個別確認し、`status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low` を満たすことを確認しました。
- current main `78044919c49fe4f772ede25e81c08b76f8033f5c` から branch を作成しました。
- compare `main...quality/2405-readme-docs-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 20 / deletions 0。
- local checkout / local `gem build` / package verification は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

risk: low。package guard の代表 docs group 追加のみで、既存の verification reporter と CI 経路に乗せています。

## 補足

- CHANGELOG は別の open docs-sync PR #2408 と同じ領域に触れるため、この PR では変更していません。
- merge は行いません。