### PR TITLE
README-linked docs の package contents guard を追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -129,6 +129,12 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/row-status.md
     docs/ja/row-status.md
   ],
+  "README-linked selection and toolbar docs" => %w[
+    docs/en/selection.md
+    docs/ja/selection.md
+    docs/en/toolbar.md
+    docs/ja/toolbar.md
+  ],
   "README-linked migration guide docs" => %w[
     docs/en/migration.md
     docs/ja/migration.md
@@ -139,9 +145,21 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/rendering-boundaries.md
     docs/ja/rendering-boundaries.md
   ],
+  "README-linked large-tree async interaction docs" => %w[
+    docs/en/lazy-loading.md
+    docs/ja/lazy-loading.md
+    docs/en/children-pagination.md
+    docs/ja/children-pagination.md
+    docs/en/windowed-rendering.md
+    docs/ja/windowed-rendering.md
+  ],
   "Public setup surface docs" => %w[
     docs/en/public-setup-surface.md
     docs/ja/public-setup-surface.md
+  ],
+  "README-linked persisted state docs" => %w[
+    docs/en/persisted-state.md
+    docs/ja/persisted-state.md
   ],
   "Public setup generator files" => %w[
     lib/generators/tree_view/state/install_generator.rb


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2410
Closes #2411
Closes #2412

## Issue ごとの完了内容

- #2410: Selection / Toolbar docs を package contents verification の代表 docs group に追加しました。
- #2411: Persisted State reader docs を Public Setup Surface / generator guard と分けた代表 docs group に追加しました。
- #2412: Lazy Loading / Children Pagination / Windowed Rendering docs を large-tree async interaction の代表 docs group に追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に、README / docs map から辿れる reader-facing docs の代表 group を3つ追加しました。
- docs 本文、runtime Ruby / JavaScript、public API manifest schema、docs smoke suite、CI workflow behavior は変更していません。

## 改善カテゴリ

- test
- docs
- package verification hardening

## 既存仕様への影響

既存仕様への影響はありません。built gem に含めるべき代表 docs の検証対象を増やすだけで、公開 API、UI、DB、認可、状態遷移、外部サービス契約は変更していません。

## 実施した確認

- Issue #2410 / #2411 / #2412 のラベルを個別確認し、いずれも `status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low` であることを確認しました。
- Default PR Check として #2376 を確認しましたが、残る gate は browser-capable visual evidence で、この quality package guard とは別件のため本 PR には含めていません。
- PR 前 compare: `main...test/2410-package-docs-guard` は `ahead_by:1` / `behind_by:0` / changed files 1 / additions 18 / deletions 0。
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。1ファイルの representative package docs guard 追加に限定しています。

## 補足事項

- 同種の README-linked docs package guard なので、3 issue を1つの PR にまとめています。
- merge は行いません。