### PR TITLE
CHANGELOG に README-linked docs package guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.
 - Expanded package contents verification coverage for README-linked Decision guide, Migration guide, Render Scale, and Rendering Boundaries docs so packaged gems keep those docs available.
 - Expanded package contents verification coverage for README-linked Error hierarchy, Cookbook, and GraphAdapter docs so packaged gems keep those public guides available.
+- Expanded package contents verification coverage for README-linked PathTreeBuilder, ReverseTree, first-time usage, and helper-adjacent row docs so packaged gems keep those public guides available.
 - Added ReleaseCheck metadata validation and tag alignment focused specs for representative release failure paths.
 - Added CI changed-file policy coverage for runtime Ruby and locale paths so package-sensitive routing remains guarded.
 - Expanded package contents verification coverage for README-linked Localized Names docs so packaged gems keep those public localization guides.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2405
Refs #2406
Refs #2407
Refs #2409

## 分類

- `code-ahead-of-docs`: merge 済み package guard PR #2409 の release-facing evidence が `CHANGELOG.md` に未記録でした。
- `docs-sync`: `CHANGELOG.md` の `Unreleased > Tests` に追従するだけで完結します。

## 変更内容

- `Unreleased > Tests` に、README-linked PathTreeBuilder / ReverseTree / first-time usage / helper-adjacent row docs の package contents verification coverage を1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

## 非対象

- `script/check_gem_package_contents.rb`
- docs 本文
- package verification logic
- CI workflow / package scripts
- runtime Ruby / JavaScript

## 確認内容

- Default PR Check: #2376 は open / CI success ですが、残件は desktop / narrow viewport の browser-capable visual evidence で、この環境では作成できないため追加更新していません。
- #2414 は open / CI success / review thread なしで、コメントは確認メモのみのため修正対応は不要と判断しました。
- PR #2409 が merge 済みであることを確認しました。
- current `CHANGELOG.md` の `Unreleased > Tests` に #2409 の release-facing evidence が未記録であることを確認しました。
- compare `main...docs/changelog-path-usage-package-guard`: `ahead_by:2` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- GitHub Actions CI #3344 / run `27855711293`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job は `npm run test:docs-entrypoints` を実行し、`test:js:core` / Playwright / `test:browser` は skipped。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。
- local checkout / local docs check は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。CHANGELOG 1行のみで、コード・設定・CI 挙動には触れていません。

merge は行いません。