### PR TITLE
README-linked docs の package contents guard を追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -129,6 +129,26 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/row-status.md
     docs/ja/row-status.md
   ],
+  "README-linked integration boundary docs" => %w[
+    docs/en/resource-table-bridge.md
+    docs/ja/resource-table-bridge.md
+    docs/en/form-editing.md
+    docs/ja/form-editing.md
+  ],
+  "README-linked row partial and identifier docs" => %w[
+    docs/en/node-presenter-row-partials.md
+    docs/ja/node-presenter-row-partials.md
+    docs/en/glossary.md
+    docs/ja/glossary.md
+    docs/en/node-keys.md
+    docs/ja/node-keys.md
+  ],
+  "README-linked filter and transfer docs" => %w[
+    docs/en/filtered-trees.md
+    docs/ja/filtered-trees.md
+    docs/en/drag-and-drop.md
+    docs/ja/drag-and-drop.md
+  ],
   "README-linked selection and toolbar docs" => %w[
     docs/en/selection.md
     docs/ja/selection.md


### PR DESCRIPTION
## 対応 Issue

Closes #2415
Closes #2416
Closes #2417

## Issue ごとの完了内容

- #2415: Resource table bridge / Forms and editing rows の英日 docs を package contents guard に追加しました。
- #2416: NodePresenter row partial patterns / Glossary / Node keys の英日 docs を package contents guard に追加しました。
- #2417: Filtered Trees / Drag and Drop の英日 docs を package contents guard に追加しました。

## まとめた理由

3件とも `docs/en/README.md` / `docs/ja/README.md` から辿れる user-facing docs が built gem から落ちた場合に検出できるようにする、同じ `script/check_gem_package_contents.rb` の representative docs group hardening です。docs 本文や runtime behavior には触れず、1つの package verification 改善として扱えます。

## 変更内容

- `README-linked integration boundary docs` group を追加し、Resource table bridge / Forms and editing rows docs を含めました。
- `README-linked row partial and identifier docs` group を追加し、NodePresenter row partial / Glossary / Node keys docs を含めました。
- `README-linked filter and transfer docs` group を追加し、Filtered Trees / Drag and Drop docs を含めました。

## 改善カテゴリ

- test
- docs package verification
- CI / release guard hardening

## 既存仕様への影響

runtime Ruby / JavaScript、docs prose、public API manifest schema、CI workflow behavior、gemspec glob は変更していません。package contents verification の代表 docs group 追加のみです。

## 実施した確認

- Issue #2415 / #2416 / #2417 の labels を個別確認し、`status:ready-for-agent`、`agent:planned`、`track:quality`、`risk:low` を確認しました。
- 対象 docs の代表 path が current `main` に存在することを確認しました。
- compare `main...quality/2415-readme-docs-package-guard`: `ahead_by:1` / `behind_by:0` / changed files 1。
- changed files は `script/check_gem_package_contents.rb` のみに限定しています。
- local checkout / local `gem build` / package check は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存仕様や docs 本文を変えず、built gem package verification の missing-file guard を広げるだけです。

merge は行いません。