### PR TITLE
CI observation guidance を lightweight signal で守る

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,8 @@ Pushes to `main` also run the broader compatibility and release checks:
 - JavaScript checks outside the pull request docs-only shortcut
 - gem package verification
 
+CI observation rule: do not treat an empty GitHub combined status as proof that CI did not run. This repository can have pull request heads where combined status is empty while a GitHub Actions workflow run exists and carries the real status/conclusion. When reporting PR readiness, inspect the workflow run for the head SHA, note whether jobs were success, failure, or intentionally skipped by changed-files routing, and only then summarize CI state.
+
 ## Issue / Work Item Guidance
 
 Open GitHub Issues are the source of planned feature work.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_package_lock_dependency_drift.mjs",
+    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/script/test_ci_observation_guidance_signals.mjs
+++ b/script/test_ci_observation_guidance_signals.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+
+const agentsPath = "AGENTS.md"
+const workflowPath = ".github/workflows/ci.yml"
+
+const agentsSource = readFileSync(agentsPath, "utf8")
+const workflowSource = readFileSync(workflowPath, "utf8")
+
+function assertIncludes(source, needle, label) {
+  assert.ok(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const guidanceSignals = [
+  "CI observation rule",
+  "combined status is empty",
+  "GitHub Actions workflow run",
+  "status/conclusion",
+  "changed-files routing",
+  "skipped jobs"
+]
+
+guidanceSignals.forEach((signal) => {
+  assertIncludes(agentsSource, signal, `${agentsPath} CI observation guidance`)
+})
+
+const workflowSignals = [
+  "name: CI",
+  "jobs:",
+  "changes:",
+  "docs_only:",
+  "package_sensitive:",
+  "docs_entrypoint_sensitive:",
+  "run: npm run test:docs-entrypoints",
+  "run: npm run test:browser"
+]
+
+workflowSignals.forEach((signal) => {
+  assertIncludes(workflowSource, signal, `${workflowPath} workflow run observation source`)
+})
+
+console.log("Checked CI observation guidance signals.")
+console.log(`Checked ${guidanceSignals.length} maintainer guidance signals.`)
+console.log(`Checked ${workflowSignals.length} workflow source signals for observation context.`)

--- a/script/test_ci_observation_guidance_signals.mjs
+++ b/script/test_ci_observation_guidance_signals.mjs
@@ -17,7 +17,7 @@ const guidanceSignals = [
   "GitHub Actions workflow run",
   "status/conclusion",
   "changed-files routing",
-  "skipped jobs"
+  "intentionally skipped"
 ]
 
 guidanceSignals.forEach((signal) => {


### PR DESCRIPTION
## 対応 Issue

Closes #2422

## Issue ごとの完了内容

- #2422: combined status が空でも GitHub Actions workflow run を確認する運用を `AGENTS.md` に明記し、`npm run test:ci-policy` 配下の lightweight signal で落ちにくくしました。

## 変更内容

- `AGENTS.md` に CI observation rule を追加しました。
  - combined status が空でも CI 未実行と断定しないこと
  - head SHA の GitHub Actions workflow run の status/conclusion を見ること
  - changed-files routing による skipped jobs を区別して報告すること
- `script/test_ci_observation_guidance_signals.mjs` を追加し、運用ガイダンスと workflow の観測対象 signal を確認します。
- `package.json` の `test:ci-policy` に新しい signal script を登録しました。

## 改善カテゴリ

- docs
- test
- CI / devops

## 既存仕様への影響

- CI workflow の job 構成、required checks、branch protection、runtime Ruby / JavaScript、public API は変更していません。
- 変更は maintainer guidance と lightweight signal の追加に閉じています。

## 実施した確認

- Issue #2422 の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- Default PR Check として #2376 の review follow-up を確認しました。残件は browser-capable visual evidence で、この環境では対応不可のため新規 quality issue に進みました。
- compare `main...chore/2422-ci-observation-guidance`: `ahead_by:3` / `behind_by:0` / changed files 3。
- ローカル checkout / `npm run test:ci-policy` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

risk: low。運用ドキュメントと signal script のみで、workflow 挙動自体は変えていません。

## 補足事項

- combined status が空でも workflow run で CI success / failure を確認する、という既存運用上の注意を明文化する PR です。
- merge は行いません。