### PR TITLE
README-linked docs を package contents guard に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -87,6 +87,18 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/selection-checkbox-hooks.md
     docs/ja/selection-checkbox-hooks.md
   ],
+  "README-linked Turbo Frame docs" => %w[
+    docs/en/turbo-frame.md
+    docs/ja/turbo-frame.md
+  ],
+  "README-linked direction-aware styling docs" => %w[
+    docs/en/direction-aware-styling.md
+    docs/ja/direction-aware-styling.md
+  ],
+  "README-linked public name decision docs" => %w[
+    docs/en/public-name-decisions.md
+    docs/ja/public-name-decisions.md
+  ],
   "README-linked host app extension docs" => %w[
     docs/en/host-app-extension-points.md
     docs/ja/host-app-extension-points.md


### PR DESCRIPTION
## 対応 Issue 一覧

- Closes #2424
- Closes #2425
- Closes #2426

## Issue ごとの完了内容

- #2424: Turbo Frame option docs の英日ペアを gem package contents guard の代表 docs group に追加しました。
- #2425: Direction-aware styling boundary docs の英日ペアを代表 docs group に追加しました。
- #2426: Public Name Decisions docs の英日ペアを代表 docs group に追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に、README-linked docs として3つの小さな docs group を追加しました。
- 追加した group 名から、どの docs evidence が不足しているか failure message 上で分かる形にしています。

## 改善カテゴリ

- test
- docs
- release/package guard

## 既存仕様への影響

runtime Ruby / JavaScript、public API、manifest schema、Turbo behavior、CSS behavior、builder behavior、docs 本文は変更していません。gem package verification の代表 docs coverage だけを広げています。

## 実施した確認

- 各 Issue の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- compare `main...fix/2424-docs-package-guards`: `ahead_by:1` / `behind_by:0` / changed files 1。
- changed files は `script/check_gem_package_contents.rb` のみに限定されています。
- ローカル checkout / local gem build は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存の package contents verifier に README-linked docs の代表 path を追加するだけで、公開挙動や docs 本文には触れていません。

## 補足事項

- #2431 は Dependabot branch / lockfile drift の扱いが必要な別 medium-risk lane なので、この docs package guard PR には含めていません。
- #2150 / #1825 は checkout-capable autocorrect / refactor 実行が必要なため、この connector-only PR には含めていません。
- merge は行いません。