### PR TITLE
CHANGELOG に release / CI guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Release preparation notes:
 - Clarified `npm ci` install path guidance across README, installation, development, and release checklist docs so local setup, PR CI, Docker setup smoke, and main-push JavaScript checks share lockfile-backed evidence.
 - Clarified Development docs for edited Dependabot branch rebase / recreate handling and keeping broad baseline cleanups out of overlapping dependency PRs.
 - Clarified Development docs for package-lock dependency drift guard guidance so dependency and Node engine metadata updates use `npm install` before returning to the lockfile-backed `npm ci` path.
+- Clarified Release docs for the Ruby support source guard and release checklist relationship across README, gemspec, CI workflow, Dockerfile Ruby base image, Development docs, and package script sources.
 - Clarified that RenderState current-branch examples should prefer `current_item` / `current_key` with `auto_expand_ancestors` when only the current path should start open.
 - Clarified that RenderWindow and windowed rendering limit HTML output only, while Lazy Loading, Children Pagination, and host-app virtual scrolling handle data-loading and DOM-virtualization concerns.
 - Updated lazy-loading docs in Japanese and English to use helper-based children and remote-state placeholder examples.
@@ -190,6 +191,8 @@ Release preparation notes:
 - Added Ruby version source guard coverage for the Rails 7.1 main-push matrix signal so workflow, Gemfile, Ruby version, and Development docs wording stay aligned.
 - Added release docs signal coverage for controller registration troubleshooting and public setup generator packaging guidance.
 - Added release and CI docs signal coverage for workflow action major versions, Ruby / Rails release evidence, and gem package install / require checks.
+- Added CI observation guidance signal coverage so maintainers verify GitHub Actions workflow runs when combined status is empty.
+- Expanded package contents verification coverage for README-linked Turbo Frame option, Direction-aware styling, and Public Name Decisions docs so packaged gems keep those public guides available.
 
 ## 0.1.0 - 2026-05-07
 


### PR DESCRIPTION
## 対応 Issue

Closes #2435

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、Ruby support source guard と Release checklist の関係を Release docs に追記した evidence を1行追加しました。
- `Unreleased > Tests` に、CI observation guidance signal と README-linked docs package contents guard coverage の evidence を2行追加しました。

## 判定分類

- `code-ahead-of-docs` / `docs-sync`
- recent merged PR #2427 / #2423 / #2432 の release-facing evidence 追従です。

## 変更範囲

- `CHANGELOG.md` のみ

runtime Ruby / JavaScript、CI workflow、package scripts、AGENTS本文、Release docs本文は変更していません。

## 確認内容

- Default PR Check: #2376 は open / review commentあり / changed files 1 ですが、残件は browser-capable visual evidence のためこの環境では対応不可。current main から behind が残るため merge前 refresh が必要です。
- Issue #2435 と関連コメントを確認しました。
- PR #2427 / #2423 / #2432 が merge済みであることを確認しました。
- compare `main...docs/2435-changelog-release-ci-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 3 / deletions 0。
- GitHub Actions CI #3372 / run `27863817864`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` は `npm ci` + `npm run test:docs-entrypoints`。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。CHANGELOG-only の短い追記です。

merge は行いません。