### PR TITLE
CHANGELOG に public API / StateStore 追加 evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release preparation notes:
 - Added `TreeView::NodePresenter` as a thin adapter for node-level resolver hooks and `RenderState` row class/data/icon/badge builders.
 - Added owner model argument support to the persisted state install generator so `tree_view:state:install User` can include `TreeViewStateOwner` in an existing owner model.
 - Added `TreeView::StateStore#clear!` so host apps can clear saved expansion state for an owner and tree instance key.
+- Added `TreeView::StateStore#clear_owner!` so host apps can clear all saved expansion state records for one owner while keeping per-tree-instance clear behavior separate.
 - Added `RenderState` current node ancestor expansion via `current_item` / `current_key` and `auto_expand_ancestors`.
 - Added `TreeView::PathTreeBuilder` for building generated folder nodes and record nodes from path-like record values.
 - Added `TreeView.configuration.render_log_level`, defaulting to `:warn`, so TreeView helper-rendered partial logs can be silenced without changing the host app's global Rails logger level.
@@ -38,6 +39,7 @@ Release preparation notes:
 - Added `TreeView::Diagnostics.run` as a consolidated diagnostics entrypoint for node keys, DOM IDs, orphans, and cycles.
 - Added `tree_children_container_dom_id`, `tree_remote_state_placeholder_dom_id`, and `tree_remote_state_placeholder_attributes` so host apps can reuse stable lazy-loading placeholder IDs and data attributes.
 - Added `TreeViewEventDetailKeys` as a package-root JavaScript export for host app tests that need machine-readable documented event detail key names.
+- Added `TreeViewTransferDataAttributes` as a package-root JavaScript export for documented transfer payload and disabled-row data attributes.
 - Added `toggle_icons` to the manifest-backed grouped option compatibility surface while keeping the existing RenderState option behavior unchanged.
 
 ### Changed


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2071
Refs #2083

## 判定分類

- `code-ahead-of-docs`
- merged PR #2071 / #2083 の reader-facing release evidence が `CHANGELOG.md > Unreleased > Added` に不足していました。

## 変更内容

- `TreeView::StateStore#clear_owner!` の追加を `CHANGELOG.md` に追記しました。
- `TreeViewTransferDataAttributes` package-root export の追加を `CHANGELOG.md` に追記しました。

## 変更範囲

- `CHANGELOG.md` のみ
- additions 2 / deletions 0

runtime Ruby / JavaScript、public API manifest、docs本文、CI workflow、package scripts は変更していません。

## 確認内容

- Default PR Check: #2376 の review follow-up を優先確認し、current main refresh commit `77efee8b5e5b5c220f146618dc3a7948049ae212` と CI #3378 success まで回復しました。残る gate は browser-capable visual evidence です。
- recent merged PR #2071 / #2083 と current `CHANGELOG.md` を確認しました。
- Dependabot merge #2428 / #2429 後の current main `9c4ae92c28ac5d59cb7da884b7df39780f26b22e` へ refresh commit `9d02fbe0518d0f751f5c13e7670c8a31af9c2b08` を追加しました。
- compare `main...docs/changelog-public-api-statestore-evidence`: `ahead_by:3` / `behind_by:0` / changed files 1 / additions 2 / deletions 0。
- GitHub Actions CI #3383 / run `27866740508`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job は `npm ci` + `npm run test:docs-entrypoints` が success、core JS / browser smoke は skipped。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。

## リスク

low。CHANGELOG-only の短い追記です。

merge は行いません。