### PR TITLE
package contents guard に追加の README-linked docs group を加える

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -99,6 +99,20 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/public-name-decisions.md
     docs/ja/public-name-decisions.md
   ],
+  "README-linked styling state cue docs" => %w[
+    docs/en/styling-state-cues.md
+    docs/ja/styling-state-cues.md
+  ],
+  "README-linked maintainer policy docs" => %w[
+    docs/en/design-policy.md
+    docs/ja/design-policy.md
+    docs/en/code-quality.md
+    docs/ja/code-quality.md
+  ],
+  "README-linked demo application boundary docs" => %w[
+    docs/en/demo-application-boundary.md
+    docs/ja/demo-application-boundary.md
+  ],
   "README-linked host app extension docs" => %w[
     docs/en/host-app-extension-points.md
     docs/ja/host-app-extension-points.md

--- a/script/test_declaration_literal_shapes.mjs
+++ b/script/test_declaration_literal_shapes.mjs
@@ -171,6 +171,10 @@ const literalExportsByManifestGroup = {
     exportName: "TreeViewTransferDropPositions",
     expectedShape: manifest.transfer_drop_positions
   },
+  transfer_data_attributes: {
+    exportName: "TreeViewTransferDataAttributes",
+    expectedShape: deepCamelizeKeys(manifest.transfer_data_attributes)
+  },
   transfer_data_mime_types: {
     exportName: "TreeViewTransferDataMimeTypes",
     expectedShape: deepCamelizeKeys(manifest.transfer_data_mime_types)


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2433
Closes #2434
Closes #2439

## Issue ごとの完了内容

- #2433: Styling state cues docs の英日ペアを package contents guard の代表 docs group に追加しました。
- #2434: Design policy / Code quality docs の英日ペアを packaged maintainer policy docs group として追加しました。
- #2439: Demo application boundary docs の英日ペアを demo application boundary docs group として追加しました。

## まとめた理由

3件とも current `main` の `script/check_gem_package_contents.rb` に README / docs README から辿る代表 docs path を追加するだけの同系統 quality guard です。docs 本文や runtime には触れず、Issue ごとの group 名と完了条件を分けたまま1つの小さな差分にまとめました。

## 変更内容

- `REQUIRED_PACKAGED_PATH_GROUPS` に次の focused group を追加しました。
  - `README-linked styling state cue docs`
  - `README-linked maintainer policy docs`
  - `README-linked demo application boundary docs`
- PR CI の `javascript` lane で既存 manifest group `transfer_data_attributes` の declaration literal smoke coverage 漏れが検出されたため、`script/test_declaration_literal_shapes.mjs` を manifest / `.d.ts` と同期しました。

## 改善カテゴリ

- test
- docs
- release/package guard
- CI guard maintenance

## 既存仕様への影響

runtime Ruby / JavaScript、public API、manifest schema、stylesheet behavior、docs prose、mockup visual design、CI workflow、gemspec glob は変更していません。gem package contents verifier と declaration literal smoke の代表 coverage だけを広げています。

## 実施した確認

- #2433 / #2434 / #2439 の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- #2432 は merge 済みで、current `main` から作業してよいことを確認しました。
- compare `main...fix/2433-docs-package-guards`: `ahead_by:2` / `behind_by:0` / changed files 2。
- changed files は `script/check_gem_package_contents.rb` と `script/test_declaration_literal_shapes.mjs` のみに限定されています。
- 初回 PR CI では対象の `gem_package` lane は success でした。`javascript` lane は `transfer_data_attributes` coverage 漏れで失敗したため、manifest shape smoke を同期しました。
- ローカル checkout / local gem build は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。最新 PR CI を確認対象にします。

## リスク評価

low。既存 package verifier の representative docs group 追加と、既存 manifest / declaration export を検証する smoke test の同期のみです。公開挙動や packaged files の glob には影響しません。

## 補足事項

- #2437 は Bundler lockfile drift guard で別テーマの medium-risk CI guard なので、この PR には含めていません。
- #2150 / #1825 は checkout-capable autocorrect / refactor 実行が必要なため、この connector-only PR には含めていません。
- merge は行いません。