### PR TITLE
Bundler lockfile dependency drift guard を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs",
+    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/script/test_gemfile_lock_dependency_drift.mjs
+++ b/script/test_gemfile_lock_dependency_drift.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const gemfilePath = "Gemfile";
+const lockfilePath = "Gemfile.lock";
+
+function stripComments(line) {
+  const commentIndex = line.indexOf("#");
+  return commentIndex === -1 ? line : line.slice(0, commentIndex);
+}
+
+function parseQuotedArguments(source) {
+  return Array.from(source.matchAll(/['"]([^'"]+)['"]/g), (match) => match[1]);
+}
+
+function normalizeRequirement(parts) {
+  return parts.length === 0 ? null : parts.join(", ");
+}
+
+function parseGemfileDirectDependencies(contents) {
+  return contents
+    .split(/\r?\n/)
+    .map((line) => stripComments(line).trim())
+    .filter((line) => line.startsWith("gem "))
+    .map((line) => {
+      const quotedArguments = parseQuotedArguments(line);
+      const [name, ...requirements] = quotedArguments;
+
+      return {
+        name,
+        requirement: normalizeRequirement(requirements.filter((value) => /^[<>=~!]/.test(value)))
+      };
+    })
+    .filter((dependency) => dependency.name)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function parseLockfileDependencies(contents) {
+  const dependencies = new Map();
+  const lines = contents.split(/\r?\n/);
+  const dependenciesIndex = lines.findIndex((line) => line.trim() === "DEPENDENCIES");
+
+  if (dependenciesIndex === -1) return dependencies;
+
+  for (const line of lines.slice(dependenciesIndex + 1)) {
+    if (!line.trim()) break;
+    if (!line.startsWith("  ")) break;
+
+    const entry = line.trim();
+    const match = entry.match(/^([^(!]+?)(?: \(([^)]+)\))?(?:!)?$/);
+    if (!match) continue;
+
+    dependencies.set(match[1].trim(), match[2] || null);
+  }
+
+  return dependencies;
+}
+
+function dependencyMismatch(gemfileDependency, lockDependencies) {
+  const lockRequirement = lockDependencies.get(gemfileDependency.name);
+
+  if (!lockDependencies.has(gemfileDependency.name)) {
+    return {
+      name: gemfileDependency.name,
+      gemfile: gemfileDependency.requirement,
+      lockfile: undefined,
+      reason: "missing from Gemfile.lock DEPENDENCIES"
+    };
+  }
+
+  if (gemfileDependency.requirement !== lockRequirement) {
+    return {
+      name: gemfileDependency.name,
+      gemfile: gemfileDependency.requirement,
+      lockfile: lockRequirement,
+      reason: "requirement mismatch"
+    };
+  }
+
+  return null;
+}
+
+const gemfile = readFileSync(gemfilePath, "utf8");
+const lockfile = readFileSync(lockfilePath, "utf8");
+const gemfileDependencies = parseGemfileDirectDependencies(gemfile);
+const lockDependencies = parseLockfileDependencies(lockfile);
+const mismatches = gemfileDependencies
+  .map((dependency) => dependencyMismatch(dependency, lockDependencies))
+  .filter(Boolean);
+
+assert.deepEqual(
+  mismatches,
+  [],
+  `${lockfilePath} DEPENDENCIES must match direct ${gemfilePath} gem requirements; run bundle install after changing Gemfile dependency metadata`
+);
+
+console.log("tree_view Gemfile.lock dependency drift smoke passed");


### PR DESCRIPTION
## 対応 Issue 一覧

Closes #2437

## Issue ごとの完了内容

- #2437: `Gemfile` の direct gem requirement と `Gemfile.lock` の `DEPENDENCIES` 表記がずれた場合に、CI policy smoke で検出できるようにしました。

## 変更内容

- `script/test_gemfile_lock_dependency_drift.mjs` を追加しました。
  - `Gemfile` の direct `gem` 行から dependency name と requirement を読み取ります。
  - `Gemfile.lock` の `DEPENDENCIES` section と照合します。
  - missing / requirement mismatch がある場合、`bundle install` による lockfile refresh が必要だと分かる failure message を出します。
- `package.json` の `test:ci-policy` に新 script を追加しました。

## 改善カテゴリ

- test
- CI guard
- dependency hygiene
- devops

## 既存仕様への影響

runtime Ruby / JavaScript、public API、Gemfile / Gemfile.lock の依存内容、Dependabot schedule、Bundler frozen mode、CI workflow topology は変更していません。

npm 側の `test_package_lock_dependency_drift.mjs` と同じ位置づけで、Bundler dependency metadata drift を lightweight に検出する guard だけを追加しています。

## 実施した確認

- Issue #2437 の labels を個別確認しました: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:medium`。
- current main `7517979c55808a4df6af8729b76ef325d03015ec` から branch を作成しました。
- PR 前 compare `main...fix/2437-gemfile-lock-drift-guard`: `ahead_by:1` / `behind_by:0` / changed files 2。
- changed files は `package.json` と `script/test_gemfile_lock_dependency_drift.mjs` のみに限定されています。
- connector-only 作業のため local checkout / `npm run test:ci-policy` は GitHub HTTPS `CONNECT tunnel failed, response 403` により未実行です。PR CI を確認対象にします。

## リスク評価

medium。CI policy smoke の実行対象を1つ追加しますが、依存解決や runtime behavior は変更していません。主なリスクは script の Gemfile parsing が過剰に広がることですが、現行 `Gemfile` の direct dependency metadata guard に限定しています。

## 補足事項

- #2150 は Standard/RuboCop autocorrect が必要な checkout-bound baseline drift なので、この PR には含めていません。
- #1825 は docs entrypoint smoke の構造リファクタで別テーマかつ checkout 実行確認が必要なため、この PR には含めていません。
- merge は行いません。