### PR TITLE
TreeViewTransferDataAttributes を entrypoint smoke で manifest 同期する

### DIFF
--- a/script/test_entrypoints.mjs
+++ b/script/test_entrypoints.mjs
@@ -376,6 +376,14 @@ assertDeepEqualExport(
 )
 assertFrozenObject(entrypointModule.TreeViewTransferDropPositions, "TreeViewTransferDropPositions")
 
+const expectedTransferDataAttributes = deepCamelizeKeys(javascriptPackageManifest.transfer_data_attributes)
+assertDeepEqualExport(
+  entrypointModule.TreeViewTransferDataAttributes,
+  expectedTransferDataAttributes,
+  "TreeViewTransferDataAttributes"
+)
+assertFrozenObject(entrypointModule.TreeViewTransferDataAttributes, "TreeViewTransferDataAttributes")
+
 const expectedTransferDataMimeTypes = deepCamelizeKeys(javascriptPackageManifest.transfer_data_mime_types)
 assertDeepEqualExport(
   entrypointModule.TreeViewTransferDataMimeTypes,


### PR DESCRIPTION
## 対応 Issue

Closes #2455

## Issue ごとの完了内容

- #2455: `TreeViewTransferDataAttributes` の runtime export が `config/public_api_manifest.yml` の `transfer_data_attributes` と drift した場合に entrypoint smoke で検出できるようにしました。

## 変更内容

- `script/test_entrypoints.mjs` に `TreeViewTransferDataAttributes` の deep equality check を追加しました。
- manifest 側の snake_case key を既存 helper と同じ `deepCamelizeKeys` で package-root export shape に合わせています。
- export object が frozen であることも既存の transfer constants と同じ形で確認します。

## 改善カテゴリ

- test / public API guard
- package-root entrypoint smoke hardening

## 既存仕様への影響

なし。`app/javascript/tree_view/index.js`、`index.d.ts`、`config/public_api_manifest.yml`、transfer controller behavior、docs prose は変更していません。

## 実施した確認

- Issue #2455 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- Default PR Check: #2376 は browser-capable visual evidence 待ちで、この環境では安全に解消できないため新規 low-risk quality issue へ進みました。
- compare `main...quality/2455-transfer-attributes-entrypoint-smoke`: `ahead_by:1` / `behind_by:0` / changed files 1。
- ローカル checkout / `npm run test:js` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 public export と manifest の同期検査を追加するだけで、runtime behavior は変更していません。

merge は行いません。