### PR TITLE
ReverseTree / GraphAdapter visual reference を clean branch で再提案する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Release preparation notes:
 - Added JavaScript public event contract specs for selection, remote state, and transfer events.
 - Added package-root frozen object contract coverage for public JavaScript object exports.
 - Added `TreeViewEventDetailKeys` manifest/export guard coverage in entrypoint smoke and focused Ruby specs.
+- Added entrypoint smoke coverage for `TreeViewTransferDataAttributes` so the package-root export stays aligned with the manifest `transfer_data_attributes` contract.
 - Added entrypoint smoke coverage that rejects package-root exports missing from `config/public_api_manifest.yml`.
 - Added Node version source drift guard coverage for `.nvmrc`, `package.json` `engines.node`, workflow `node-version`, and development docs.
 - Improved entrypoint smoke diagnostics for Ruby manifest loader and JSON parse failures without changing public export assertions.

--- a/docs/mockups/filtered-tree-modes.html
+++ b/docs/mockups/filtered-tree-modes.html
@@ -125,6 +125,18 @@
   background: #eef2ff;
 }
 
+.tree-row.is-reverse-root {
+  background: #f0fdf4;
+}
+
+.tree-row.is-reverse-ancestor {
+  background: #f8fafc;
+}
+
+.tree-row.is-shared-path {
+  background: #fefce8;
+}
+
 .tree-node-badge--match {
   background: #dcfce7;
   color: #166534;
@@ -138,6 +150,16 @@
 .tree-node-badge--descendant {
   background: #e0e7ff;
   color: #4338ca;
+}
+
+.tree-node-badge--reverse {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.tree-node-badge--shared {
+  background: #fef9c3;
+  color: #854d0e;
 }
 
 .mock-filtered-table {
@@ -522,6 +544,170 @@
       </div>
     </section>
 
+    <section class="mock-section mock-filtered-grid" aria-labelledby="reverse-path-heading">
+      <div class="mock-filtered-state">
+        <div class="mock-filtered-state__header">
+          <p class="mock-filtered-state__eyebrow">ReverseTree reference</p>
+          <h2 id="reverse-path-heading">Reverse path from matched leaf to ancestors</h2>
+          <p class="mock-filtered-note">
+            Use this focused section when the review question is child-to-parent path readability rather than search filtering, breadcrumbs, or route navigation.
+          </p>
+        </div>
+
+        <div class="mock-filtered-frame">
+          <div class="mock-filtered-toolbar">
+            <div class="mock-filtered-toolbar__copy">
+              <p class="mock-filtered-toolbar__title">Matched leaf becomes the visible root of the review path</p>
+            </div>
+            <div class="mock-filtered-toolbar__meta" aria-label="Representative ReverseTree context">
+              <span class="mock-filtered-chip">surface: ReverseTree</span>
+              <span class="mock-filtered-chip mock-filtered-chip--mode">path: leaf_to_root</span>
+            </div>
+          </div>
+          <div class="mock-filtered-summary">
+            <p class="mock-filtered-callout">
+              The matched item is first, then ancestor rows continue underneath it. TreeView owns the row cues; host apps own breadcrumbs, route wording, and final navigation policy.
+            </p>
+            <table class="tree-view-table" aria-label="ReverseTree leaf-to-root visual reference">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">node</th>
+                  <th scope="col">path role</th>
+                  <th scope="col">review cue</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-reverse-root" aria-level="1" aria-current="page">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Matched leaf as reverse path root">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-depth-label">leaf root</span></span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--reverse">matched leaf</span>
+                  </td>
+                  <td>Invoice aging report</td>
+                  <td>Reverse path starting point</td>
+                  <td><span class="mock-status mock-status--active">current</span></td>
+                </tr>
+                <tr class="tree-row is-reverse-ancestor" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Finance reports ancestor">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">ancestor</span></span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--context">ancestor</span>
+                  </td>
+                  <td>Finance reports</td>
+                  <td>Parent of the matched leaf</td>
+                  <td><span class="mock-status">context</span></td>
+                </tr>
+                <tr class="tree-row is-reverse-ancestor" aria-level="3">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Operations root ancestor">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__level">root</span></span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--context">top ancestor</span>
+                  </td>
+                  <td>Operations</td>
+                  <td>Shared ancestor shown once for this reverse path</td>
+                  <td><span class="mock-status mock-status--pending">context</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-filtered-state">
+        <div class="mock-filtered-state__header">
+          <p class="mock-filtered-state__eyebrow">GraphAdapter reference</p>
+          <h2>Shared and duplicate path boundary</h2>
+          <p class="mock-filtered-note">
+            Use this focused section when the same logical node can appear through more than one parent path and reviewers need to see where node-key strategy matters.
+          </p>
+        </div>
+
+        <div class="mock-filtered-frame">
+          <div class="mock-filtered-toolbar">
+            <div class="mock-filtered-toolbar__copy">
+              <p class="mock-filtered-toolbar__title">Two paths can point to one logical node without choosing a dedup policy here</p>
+            </div>
+            <div class="mock-filtered-toolbar__meta" aria-label="Representative GraphAdapter context">
+              <span class="mock-filtered-chip">surface: GraphAdapter</span>
+              <span class="mock-filtered-chip mock-filtered-chip--mode">node keys: namespaced</span>
+            </div>
+          </div>
+          <div class="mock-filtered-summary">
+            <p class="mock-filtered-callout">
+              This sample keeps both graph paths visible and labels the shared node boundary. Resolver output, traversal policy, dedup decisions, and authorization stay in the host app.
+            </p>
+            <table class="tree-view-table" aria-label="GraphAdapter shared duplicate path visual reference">
+              <thead>
+                <tr>
+                  <th scope="col">tree</th>
+                  <th scope="col">node</th>
+                  <th scope="col">path role</th>
+                  <th scope="col">review cue</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="tree-row is-expanded" aria-level="1" aria-expanded="true">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Projects path expanded">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__action tree-toggle__action--pending">open</span><span class="tree-toggle__level">path A</span></span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--context">parent path</span>
+                  </td>
+                  <td>Projects</td>
+                  <td>First graph parent</td>
+                  <td><span class="mock-status">visible path</span></td>
+                </tr>
+                <tr class="tree-row is-shared-path" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Shared compliance node under projects">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-depth-label">shared</span></span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--shared">shared node</span>
+                  </td>
+                  <td>Compliance review</td>
+                  <td>Same logical node under Projects</td>
+                  <td><span class="mock-status mock-status--pending">key: graph:projects:compliance</span></td>
+                </tr>
+                <tr class="tree-row is-expanded" aria-level="1" aria-expanded="true">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Teams path expanded">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot is-current is-middle"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-toggle__action tree-toggle__action--pending">open</span><span class="tree-toggle__level">path B</span></span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--context">parent path</span>
+                  </td>
+                  <td>Teams</td>
+                  <td>Second graph parent</td>
+                  <td><span class="mock-status">visible path</span></td>
+                </tr>
+                <tr class="tree-row is-shared-path" aria-level="2">
+                  <td class="tree-toggle-cell">
+                    <span class="tree-toggle" aria-label="Shared compliance node under teams">
+                      <span class="tree-toggle__branches" aria-hidden="true"><span class="tree-toggle__branch-slot has-line"></span><span class="tree-toggle__branch-slot is-current is-last"></span></span>
+                      <span class="tree-toggle__control"><span class="tree-depth-label">shared</span></span>
+                    </span>
+                    <span class="tree-node-badge tree-node-badge--shared">shared node</span>
+                  </td>
+                  <td>Compliance review</td>
+                  <td>Same logical node under Teams</td>
+                  <td><span class="mock-status mock-status--pending">key: graph:teams:compliance</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="mock-section" aria-labelledby="filtered-boundary-heading">
       <h2 id="filtered-boundary-heading">What this mock compares</h2>
       <table class="mock-filtered-table">
@@ -553,10 +739,21 @@
             <td>Keeping both the path to the match and the rows below the matched branch visible.</td>
             <td>Search UI, ranked explanations, text highlighting, permission copy, or authorization-aware filtering.</td>
           </tr>
+          <tr>
+            <td><code>ReverseTree</code></td>
+            <td>Reviewing child-to-parent path cues with the matched leaf as the first visible row.</td>
+            <td>Breadcrumb routes, navigation IA, or ReverseTree API changes.</td>
+          </tr>
+          <tr>
+            <td><code>GraphAdapter</code></td>
+            <td>Reviewing shared logical nodes across duplicate graph paths and node-key namespacing cues.</td>
+            <td>Traversal policy, dedup behavior, resolver implementation, authorization, or database query choices.</td>
+          </tr>
         </tbody>
       </table>
       <ul>
         <li><code>:with_ancestors_and_descendants</code> combines the ancestor and descendant retention cues in one filtered output.</li>
+        <li><code>ReverseTree</code> and <code>GraphAdapter</code> samples are focused visual references on this existing page, so no new mockup inventory entry is needed.</li>
         <li>This focused page keeps product behavior outside the mock so reviewers can inspect mode differences without extra search workflow decisions.</li>
       </ul>
     </section>


### PR DESCRIPTION
ReverseTree / GraphAdapter visual reference を、latest main 起点の clean docs-only diff として再提案します。

## 対応 Issue / PR

Closes #949
Closes #1830
Supersedes #2376
Supersedes #2311
Supersedes #2304

## 置き換え理由

PR #2376 は Docs Sync follow-up で current `main` へ追従しましたが、merge-style refresh の履歴により GitHub の PR file list が main 側の `script/test_entrypoints.mjs` まで表示する状態になりました。

この PR は latest `main` `768dadabbe373625b2186c44710a69877d31b33f` から single-parent clean branch を作り、#2376 と同じ intended HTML blob だけを載せ直した replacement です。旧 PR branch の force push や履歴書き換えは行っていません。

## 変更内容

- `docs/mockups/filtered-tree-modes.html` に ReverseTree reference section を追加します。
- matched leaf を最初の visible root とし、ancestor rows が下へ続く child-to-parent path を静的に比較できるようにします。
- GraphAdapter reference section を追加し、同じ logical node が Projects / Teams の2つの parent path に現れる状態を node-key namespacing cue とともに比較できるようにします。
- comparison table に `ReverseTree` と `GraphAdapter` の review surface / scope boundary を追加します。
- 既存 page 内 focused visual reference なので、新規 mockup inventory entry は不要であることを明記します。

## 変更範囲

- `docs/mockups/filtered-tree-modes.html` のみ

runtime Ruby / JavaScript、ReverseTree / GraphAdapter implementation、public API、resolver behavior、authorization、database query policy は変更していません。

## 直近の確認

- compare `main...docs/2376-filtered-tree-modes-clean-v3`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files は `docs/mockups/filtered-tree-modes.html` の1件のみです。
- GitHub Actions CI #3414 / run `27881039289`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job 内で `npx playwright install --with-deps chromium` と `npm run test:browser`: success。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。

## 未対応・補足

- desktop / narrow viewport の screenshot または同等の browser-capable visual readability evidence は、この実行環境では作成できませんでした。
- CI browser smoke success は確認済みですが、static visual mockup の最終 readability evidence の代替にはしません。
- merge 直前に current main への再追従、fresh CI、browser-capable visual evidence を確認してください。

## リスク

low。static mockup HTML 1ファイルの visual reference 追加に閉じています。

merge は行いません。