### PR TITLE
CHANGELOG に transfer attributes smoke evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Release preparation notes:
 - Added JavaScript public event contract specs for selection, remote state, and transfer events.
 - Added package-root frozen object contract coverage for public JavaScript object exports.
 - Added `TreeViewEventDetailKeys` manifest/export guard coverage in entrypoint smoke and focused Ruby specs.
+- Added entrypoint smoke coverage for `TreeViewTransferDataAttributes` so the package-root export stays aligned with the manifest `transfer_data_attributes` contract.
 - Added entrypoint smoke coverage that rejects package-root exports missing from `config/public_api_manifest.yml`.
 - Added Node version source drift guard coverage for `.nvmrc`, `package.json` `engines.node`, workflow `node-version`, and development docs.
 - Improved entrypoint smoke diagnostics for Ruby manifest loader and JSON parse failures without changing public export assertions.


### PR DESCRIPTION
## 対応 PR

Refs #2457

## 分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、#2457 で追加された `TreeViewTransferDataAttributes` entrypoint smoke coverage を 1 行追記しました。
- package-root export と `config/public_api_manifest.yml` の `transfer_data_attributes` contract が drift しないことを release-facing evidence として残します。

## 確認した根拠

- #2457 が main に merge 済みで、`script/test_entrypoints.mjs` に `TreeViewTransferDataAttributes` と manifest `transfer_data_attributes` の deep equality / frozen object check が追加されています。
- current `CHANGELOG.md` の `Unreleased > Tests` には同 coverage の release-facing evidence が未反映でした。

## 対象範囲

- docs のみ
- 変更ファイルは `CHANGELOG.md` のみ
- additions 1 / deletions 0

## 非対象

- `script/test_entrypoints.mjs`
- `config/public_api_manifest.yml`
- runtime Ruby / JavaScript
- public API docs 本文
- CI workflow

## 確認内容

- Default PR Check: #2459 は open / fresh / changed files 1 / CI success / browser-capable visual evidence 待ち、#2271 は design proposal の `needs-human`、#2161 は public API adoption の `needs-human` と判定し、この docs-only CHANGELOG 追従へ進みました。
- compare `main...docs/2457-changelog-transfer-attributes-smoke`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- ローカル checkout / docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG の release-facing test evidence 1 行追加に閉じています。

merge は行いません。