### PR TITLE
FAQ / API docs を package contents guard に含める

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -125,6 +125,20 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/decision-guide.md
     docs/ja/decision-guide.md
   ],
+  "README-linked FAQ and troubleshooting docs" => %w[
+    docs/en/faq.md
+    docs/ja/faq.md
+    docs/en/troubleshooting.md
+    docs/ja/troubleshooting.md
+  ],
+  "README-linked API overview and diagnostics docs" => %w[
+    docs/en/api-overview.md
+    docs/ja/api-overview.md
+    docs/en/api.md
+    docs/ja/api.md
+    docs/en/tree-diagnostics.md
+    docs/ja/tree-diagnostics.md
+  ],
   "README-linked API combination and GraphAdapter docs" => %w[
     docs/en/cookbook.md
     docs/ja/cookbook.md


### PR DESCRIPTION
## 対応 Issue

Closes #2360
Closes #2371

## Issue ごとの完了内容

- #2360: `script/check_gem_package_contents.rb` の representative docs group に `README-linked FAQ and troubleshooting docs` を追加し、英日 `faq.md` / `troubleshooting.md` を package contents guard の確認対象にしました。
- #2371: 同じ package contents guard に `README-linked API overview and diagnostics docs` を追加し、英日 `api-overview.md` / `api.md` / `tree-diagnostics.md` を確認対象にしました。

## 変更内容

- README / docs README から利用者向け entrypoint として案内されている FAQ / Troubleshooting / API Overview / API Reference / Tree diagnostics docs を、built gem の representative packaged docs group に追加しました。
- failure output は既存の group 名表示により、README-linked FAQ / troubleshooting docs、または README-linked API overview / diagnostics docs の欠落として読めます。

## 改善カテゴリ

- test / package guard hardening
- docs packaging drift guard

## 既存仕様への影響

- docs prose、runtime Ruby / JavaScript、public API manifest schema、docs smoke suite、CI workflow behavior は変更していません。
- package verifier を full docs inventory に広げていません。README / language README で first-class reader entrypoint として扱われる representative docs の追加に限定しています。

## 実施した確認

- #2360 / #2371 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- #2359 はすでに merged で、Decision guide docs group は current `main` に入っていることを確認しました。
- branch base: `main` `45750c71a4f4830b1b9c143d03de6fcb30a80585`。
- compare `main...chore/2360-2371-package-docs-guard`: `ahead_by:1`, `behind_by:0`。
- changed files は `script/check_gem_package_contents.rb` 1件のみ、追加14行 / 削除0行です。
- local checkout / local package build は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI の `gem_package` lane を確認対象にします。

## リスク評価

low。既存 package verifier の代表 docs group 追加のみで、公開挙動や docs semantics には影響しません。

## 補足事項

- #2052 / #1886 の reader journey docs smoke scope、full-site link checker、docs本文 rewrite は非対象です。
- merge は行いません。