### PR TITLE
CHANGELOG に FAQ / API docs package guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Release preparation notes:
 
 ### Tests
 
+- Expanded package contents verification coverage for README-linked FAQ / Troubleshooting / API Overview / API Reference / Tree diagnostics docs so packaged gems keep those public reader guides available.
 - Added controller registration docs signal coverage to the docs-entrypoint suite so controller registration guides and manifest controller entries stay aligned.
 - Added CI changed-file detection workflow guard coverage for docs-entrypoints package script wiring so controller registration docs signals stay connected to `npm run test:docs-entrypoints`.
 - Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates stay package-sensitive without Docker or docs-entrypoint routing.


### PR DESCRIPTION
## 対応 Issue

Closes #2471

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、#2468 で追加された README-linked FAQ / Troubleshooting / API Overview / API Reference / Tree diagnostics docs の package contents verification coverage を 1 行追記しました。

## 変更範囲

- `CHANGELOG.md` のみ

`script/check_gem_package_contents.rb`、docs 本文、runtime Ruby / JavaScript、CI workflow は変更していません。

## 確認内容

- #2468 が merged / closed で、package contents guard に `README-linked FAQ and troubleshooting docs` と `README-linked API overview and diagnostics docs` を追加済みであることを確認しました。
- current main `dd0d44e0dd6e9b4ebddff06acbb8d26f01ccad5c` から branch を作成しました。
- compare `main...docs/2471-changelog-package-guard-evidence`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- GitHub Actions CI #3429 / run `27895599994`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job 内で `npm run test:docs-entrypoints`: success。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。
- ローカル checkout / lint は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## 分類

- `docs-sync` / `code-ahead-of-docs`

## リスク

low。release-facing CHANGELOG の package verification evidence 追記に閉じています。

merge は行いません。