### PR TITLE
static mockup PR の visual evidence handoff を明確にする

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -102,6 +102,13 @@ When a review starts from the gallery or a focused mockup page, confirm this sta
 - `npm run test:browser` opens every HTML mockup listed in the Files table and checks the review gallery, local links, main headings, back-to-gallery links, representative sample regions, and the existing lazy-loading viewport overflow smoke.
 - The smoke coverage is intentionally narrow. It catches broken HTML, blank pages, missing review links, and missing representative regions without adding screenshot baselines or visual diff review.
 
+## Visual evidence handoff
+
+- Treat `npm run test:browser` success as smoke coverage, not as final visual readability approval.
+- For static mockup pull requests that add or change focused visual references, include a short PR note or comment that names the target mockup file, the desktop and narrow viewport used for review, and whether the relevant rows, labels, tables, and state cues remain readable without overlap or clipping.
+- Screenshots are acceptable evidence, but an equivalent browser-capable review note is also fine when it clearly names the checked viewport and surface. Keep this evidence in the pull request discussion instead of committing generated screenshot assets by default.
+- If the authoring environment cannot produce browser-capable evidence, say so in the PR and leave the visual readability check as a reviewer gate rather than treating CI smoke success as a substitute.
+
 ## Copy and language policy
 
 - Mockups use short, product-neutral English copy so reviewers can compare layout and state cues without language changes becoming visual noise.


### PR DESCRIPTION
## 対応 Issue

Closes #2473

## 変更内容

- `docs/mockups/README.md` に `Visual evidence handoff` 節を追加しました。
- `npm run test:browser` は smoke coverage であり、static mockup の最終 readability approval の代替ではないことを明記しました。
- static mockup PR で reviewer に渡す evidence として、対象 mockup file、desktop / narrow viewport、overlap / clipping / readability の確認観点を短く整理しました。
- screenshot は許容されるが必須ではなく、同等の browser-capable review note でもよいこと、generated screenshot asset は原則 commit しないことを明記しました。
- authoring environment で browser-capable evidence を作れない場合は、PR 上で不足を明記し reviewer gate として残す方針にしました。

## 変更範囲

- `docs/mockups/README.md` のみ

runtime Ruby / JavaScript、mockup HTML / CSS、browser smoke implementation、screenshot baseline、visual regression workflow は変更していません。

## 確認内容

- current main: `f162368f91be8ea62b02e37770cff65f84923f6a`
- head: `48e1b7e6e4b681e9c58143199edde51eabece3dc`
- compare `main...docs/2473-mockup-visual-evidence-handoff`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 7 / deletions 0。
- PR metadata: `mergeable:true`
- GitHub Actions CI #3434 / run `27897093071`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job 内で `npx playwright install --with-deps chromium` と `npm run test:browser`: success。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。
- ローカル checkout / docs lint は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## 分類

- `docs-sync` / `docs-missing`

## リスク

low。mockup review handoff の説明追加に閉じています。

merge は行いません。