### PR TITLE
CHANGELOG に mockup visual evidence handoff を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Release preparation notes:
 - Corrected Windowed Rendering docs examples and metadata tables to use the implemented `TreeView::RenderWindow#previous?` / `#next?` API names.
 - Clarified mockup copy and language policy exception recording for deliberate review stress cases.
 - Clarified that `docs/mockups/README.md` is the source of truth for mockup technical asset inventory.
+- Added mockup visual evidence handoff guidance so static visual reference PRs distinguish browser smoke success from desktop and narrow viewport readability evidence.
 - Added root docs index entry points for the English and Japanese Rendering Boundaries guides.
 - Added malformed selection params troubleshooting guidance in English and Japanese, including `TreeView.parse_selection_params` error boundaries and host-app-owned request policy.
 - Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.


### PR DESCRIPTION
## 対応 PR

Refs #2477

## 分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、#2477 で追加された mockup visual evidence handoff guidance を 1 行追記しました。
- static visual reference PR では `npm run test:browser` の smoke success と desktop / narrow viewport の readability evidence を分けて扱うことを release-facing evidence として残します。

## 対象範囲

- docs のみ
- 変更ファイルは `CHANGELOG.md` のみ
- runtime Ruby / JavaScript、mockup HTML / CSS、browser smoke、CI workflow、docs signal script は変更していません。

## 確認内容

- Default PR Check: #2476 は open / changed files 1 / CI success ですが、current main から `behind_by:2` / `status:diverged` で、残る gate は browser-capable visual readability evidence。#2271 は draft first slice、#2161 は public API export 採否の human gate、#2481 は quality/CI scope として Docs Sync 対象外確認に留めました。
- #2477 は merge済みで、`docs/mockups/README.md` に `Visual evidence handoff` section が current main に反映済みです。
- compare `main...docs/changelog-mockup-visual-evidence-handoff`: `ahead_by:1` / `behind_by:0` / changed files 1 / additions 1 / deletions 0。
- GitHub Actions CI #3442 / run `27911590644`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job 内で `npm ci` + `npm run test:docs-entrypoints`: success。
  - representative Rails compatibility lanes は docs-only scope として skipped / success。
- ローカル checkout / docs checks は GitHub raw fetch が `403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。CHANGELOG の release-facing docs evidence 1 行追加に閉じています。

merge は行いません。