### PR TITLE
CSS custom property tokens の docs guidance を追加する

### DIFF
--- a/docs/en/direction-aware-styling.md
+++ b/docs/en/direction-aware-styling.md
@@ -16,12 +16,25 @@ Host apps may rely on the documented helper methods, JavaScript exports, control
 
 For styling, rely on documented feature-level hooks where the relevant guide names them. Mockup-only classes and internal stylesheet selectors are review aids unless they are explicitly documented as public hooks and, when needed, added to the manifest-backed compatibility checks.
 
+The packaged stylesheet also exposes a small manifest-backed CSS custom property surface for reusable state cues. `config/public_api_manifest.yml` tracks the current `css_custom_property_tokens` list so release and docs checks can notice when those documented styling hooks drift from the shipped CSS.
+
+Representative tokens include:
+
+| Purpose | Tokens |
+|---|---|
+| Selection and current-row cues | `--tree-view-selected-row-background`, `--tree-view-current-row-accent-color` |
+| Collapsed, loading, error, and drop-target rows | `--tree-view-collapsed-row-background`, `--tree-view-loading-row-background`, `--tree-view-loading-action-color`, `--tree-view-error-row-background`, `--tree-view-drop-target-row-background` |
+| Focus rings and toggle hover states | `--tree-view-focus-outline-color`, `--tree-view-focus-background`, `--tree-view-focus-ring-contrast-color`, `--tree-view-toggle-hover-background` |
+| Hierarchy connectors and depth markers | `--tree-view-branch-line-color`, `--tree-view-current-branch-line-color`, `--tree-view-level-background`, `--tree-view-level-color`, `--tree-view-hidden-count-background`, `--tree-view-hidden-count-color` |
+
+These tokens are override hooks for TreeView-provided state cues. Host apps still own the final palette, typography, density, dark-mode policy, contrast review, and brand styling.
+
 ## Host-app override guidance
 
 When a host app needs RTL, vertical writing, or design-system-specific cues:
 
 - keep TreeView's row semantics and documented data hooks intact;
-- override current-row, hierarchy connector, and toggle spacing CSS in the host app stylesheet;
+- override current-row, hierarchy connector, toggle spacing, and documented CSS custom property values in the host app stylesheet;
 - prefer CSS logical properties for new host-app overrides;
 - keep business-specific row state, badges, colors, and routing decisions in the host app.
 
@@ -34,4 +47,4 @@ A direction-aware styling hook should be promoted to public API only when all of
 - the English and Japanese docs name the supported hook and its responsibility boundary;
 - manifest-backed compatibility checks are updated when the hook must be machine-readable.
 
-Complete RTL support, theme tokens, a CSS custom property system, and exporting every stylesheet selector remain outside this decision.
+Complete RTL support, a broader theme system, and exporting every stylesheet selector remain outside this decision. New CSS custom properties should be added to the manifest-backed token list only when they are intended as stable host-app override hooks.

--- a/docs/ja/direction-aware-styling.md
+++ b/docs/ja/direction-aware-styling.md
@@ -16,12 +16,25 @@ host app が依存してよいのは、`public-api.md` と `config/public_api_ma
 
 styling では、各 feature guide が明示している documented hook に依存してください。mockup-only class や internal stylesheet selector は、public hook として明記され、必要なら manifest-backed compatibility check に追加されるまでは review aid として扱います。
 
+packaged stylesheet は、reusable state cue 用の小さな manifest-backed CSS custom property surface も公開しています。`config/public_api_manifest.yml` は current `css_custom_property_tokens` list を追跡し、documented styling hook と shipped CSS の drift を release / docs check で気づけるようにします。
+
+代表 token は次のとおりです。
+
+| 目的 | tokens |
+|---|---|
+| selection / current-row cue | `--tree-view-selected-row-background`, `--tree-view-current-row-accent-color` |
+| collapsed / loading / error / drop-target rows | `--tree-view-collapsed-row-background`, `--tree-view-loading-row-background`, `--tree-view-loading-action-color`, `--tree-view-error-row-background`, `--tree-view-drop-target-row-background` |
+| focus ring / toggle hover state | `--tree-view-focus-outline-color`, `--tree-view-focus-background`, `--tree-view-focus-ring-contrast-color`, `--tree-view-toggle-hover-background` |
+| hierarchy connector / depth marker | `--tree-view-branch-line-color`, `--tree-view-current-branch-line-color`, `--tree-view-level-background`, `--tree-view-level-color`, `--tree-view-hidden-count-background`, `--tree-view-hidden-count-color` |
+
+これらの token は TreeView が提供する state cue の override hook です。最終的な palette、typography、density、dark-mode policy、contrast review、brand styling は引き続き host app が所有します。
+
 ## host app override guidance
 
 host app が RTL、vertical writing、design-system-specific cue を必要とする場合:
 
 - TreeView の row semantics と documented data hook は維持する
-- current-row、hierarchy connector、toggle spacing の CSS は host app stylesheet で override する
+- current-row、hierarchy connector、toggle spacing、documented CSS custom property value は host app stylesheet で override する
 - 新しい host-app override では CSS logical properties を優先する
 - business-specific row state、badge、color、routing decision は host app 側に残す
 
@@ -34,4 +47,4 @@ direction-aware styling hook を public API に昇格するのは、少なくと
 - 英日 docs が supported hook と responsibility boundary を明記している
 - machine-readable contract が必要な hook では manifest-backed compatibility check も更新されている
 
-complete RTL support、theme token、CSS custom property system、全 stylesheet selector の export はこの判断の範囲外です。
+complete RTL support、より広い theme system、全 stylesheet selector の export はこの判断の範囲外です。新しい CSS custom property は、stable な host-app override hook として扱う意図がある場合にだけ manifest-backed token list へ追加してください。


### PR DESCRIPTION
## 対応 Issue

Refs #2490

## 分類

- code-ahead-of-docs

## 変更内容

- 英日 `docs/*/direction-aware-styling.md` に、manifest-backed CSS custom property tokens の代表表を追加しました。
- `config/public_api_manifest.yml` の `css_custom_property_tokens` と packaged stylesheet の `var(--tree-view-...)` surface を根拠に、selection / current-row、loading / error、focus、branch line などの代表 token を読めるようにしました。
- host app が最終 palette、typography、density、dark-mode policy、contrast review、brand styling を所有する境界も明記しました。

## 範囲外

- `app/assets/stylesheets/tree_view.scss` の変更
- `config/public_api_manifest.yml` の変更
- docs signal script / CI workflow / package script の変更
- theme system / dark mode / visual redesign の追加

## 確認内容

- compare `main...docs/2490-css-custom-property-tokens`: `ahead_by:2` / `behind_by:0` / changed files 2件。
- 変更ファイルは以下のみです。
  - `docs/en/direction-aware-styling.md`
  - `docs/ja/direction-aware-styling.md`
- connector readback で英日双方に代表 token 表と host-app-owned styling boundary が入っていることを確認しました。
- PR metadata: `mergeable:true`。
- GitHub Actions CI #3446 / run `27919065847`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job は docs-entrypoint-sensitive docs-only path として `npm run test:docs-entrypoints` を実行。
  - representative Rails lanes は docs-only scope として skipped / success。
- local checkout / test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## 残件

#2490 の受け入れ条件には lightweight docs smoke / signal guard 追加も含まれています。この Agent は script/test 変更を行わないため、この PR は Issue を close せず、reader-facing docs 追従部分だけを扱います。

merge は行いません。