### PR TITLE
TreeViewTransferDataAttributes を Public API docs に同期する

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Add the importmap pin when needed:
 pin "tree_view", to: "tree_view/index.js"
 ```
 
-Host apps that write tests or custom renderers against TreeView browser hooks can avoid raw event names, data attributes, and controller identifiers by using the package-root exports from `tree_view/index.js`, such as `TreeViewEventNames`, `TreeViewEventDetailKeys`, `TreeViewControllerEntries`, `TreeViewIntegrationHooks`, and documented data hook objects like `TreeViewRemoteStateDataHooks`, `TreeViewToolbarDataHooks`, `TreeViewSelectionCheckboxHooks`, and `TreeViewEmptyStateHooks`. See the [Public API JavaScript surface](docs/en/public-api.md#javascript-surface) / [日本語](docs/ja/public-api.md#javascript-surface) and the [JavaScript event contract](docs/en/js-events.md) / [日本語](docs/ja/js-events.md).
+Host apps that write tests or custom renderers against TreeView browser hooks can avoid raw event names, data attributes, and controller identifiers by using the package-root exports from `tree_view/index.js`, such as `TreeViewEventNames`, `TreeViewEventDetailKeys`, `TreeViewControllerEntries`, `TreeViewIntegrationHooks`, and documented data hook objects like `TreeViewRemoteStateDataHooks`, `TreeViewToolbarDataHooks`, `TreeViewTransferDataAttributes`, `TreeViewSelectionCheckboxHooks`, and `TreeViewEmptyStateHooks`. See the [Public API JavaScript surface](docs/en/public-api.md#javascript-surface) / [日本語](docs/ja/public-api.md#javascript-surface) and the [JavaScript event contract](docs/en/js-events.md) / [日本語](docs/ja/js-events.md).
 
 See [Installation](docs/en/installation.md) for details.
 

--- a/docs/en/public-api.md
+++ b/docs/en/public-api.md
@@ -205,6 +205,7 @@ Stable enough for host apps to use:
 - `TreeViewEventNames`
 - `TreeViewEventDetailKeys`
 - `TreeViewTransferDropPositions`
+- `TreeViewTransferDataAttributes`
 - `TreeViewTransferDataMimeTypes`
 - `TreeViewRemoteStateValues`
 - `TreeViewRemoteStateDataHooks`
@@ -229,6 +230,7 @@ Stable enough for host apps to use:
 `TreeViewEventNames` exposes the documented event names as a machine-readable package-root export. Use it when wiring host-app listeners and you want to avoid hand-copying event-name strings such as `TreeViewEventNames.selection.change` or `TreeViewEventNames.transfer.drop`.
 `TreeViewEventDetailKeys` exposes the documented `event.detail` key lists as a machine-readable package-root export. Use it when host-app tests or listeners need to compare against the documented key names without changing the payload shape; the field meanings still live in [JavaScript event contract](js-events.md).
 `TreeViewTransferDropPositions` exposes the documented coarse drop-position values for transfer events: `before`, `inside`, and `after`. `TreeViewEventNames.transfer.*` names transfer events, `TreeViewEventDetailKeys.transfer.*` lists the documented `event.detail` keys, and `TreeViewTransferDropPositions` carries the position values described in [Drag and Drop](drag-and-drop.md#drop-behavior).
+`TreeViewTransferDataAttributes` exposes the documented transfer payload and disabled-row DOM attribute names. Use `TreeViewTransferDataAttributes.payload` for `data-tree-transfer-payload` and `TreeViewTransferDataAttributes.disabled` for `data-tree-transfer-disabled` when host-app JavaScript, browser tests, or shared helpers need transfer wiring attributes without hand-copying strings. These exports name DOM wiring attributes only; payload shape, authorization, persistence, and final drop behavior still live in [Drag and Drop](drag-and-drop.md#drop-behavior).
 `TreeViewTransferDataMimeTypes` exposes the documented TreeView transfer MIME type values: `application/json` for the primary JSON payload and `text/plain` as the browser compatibility fallback. Use it when host-app JavaScript or tests need to read or assert TreeView transfer data without hand-copying MIME strings; drag/drop behavior, payload shape, and final business handling still live in [Drag and Drop](drag-and-drop.md#drop-behavior).
 `TreeViewRemoteStateValues` exposes the documented remote-state value set for lazy-loading rows: `loading`, `loaded`, and `error`. Use it when host-app JavaScript or tests need to compare `data-tree-remote-state` values without hand-copying strings; `TreeViewEventNames.remoteState.*` still names controller-emitted events, and `TreeViewEventDetailKeys.remoteState.*` still lists their `event.detail` keys.
 `TreeViewRemoteStateDataHooks` exposes the documented lazy-loading and remote-state data attribute names as a machine-readable package-root export. Use it when custom lazy-loading markup, tests, or copied host-app partials need to reference `data-tree-lazy`, `data-tree-children-url`, `data-tree-loaded`, or `data-tree-remote-state` without hand-copying strings; request dispatch, response handling, retry UI, and authorization-safe copy stay with the host app and [Lazy Loading](lazy-loading.md).
@@ -251,6 +253,11 @@ Within `TreeViewEventNames`, lazy-loading request lifecycle names live under `ho
 - `retry`
 
 Use `TreeViewEventNames.hostLifecycle.*` only for the host-app dispatch surface described in [Lazy Loading](lazy-loading.md). TreeView's own controller-emitted remote-state events remain under `TreeViewEventNames.remoteState.*`.
+
+Documented keys on `TreeViewTransferDataAttributes`:
+
+- `payload`
+- `disabled`
 
 Documented keys on `TreeViewTransferDataMimeTypes`:
 
@@ -326,7 +333,7 @@ The `tree-view-selection` controller's documented host-element value attributes 
 
 Use those attributes when configuring the controller on the host element. Use the `selection:` render-state builders for row payload generation, disabled-state decisions, and checkbox visibility. Generated hidden input marker attributes and source-id attributes are managed by TreeView and are not host-authored public hooks. See [Selection](selection.md) and [Host app extension points](host-app-extension-points.md#selection-builders).
 
-The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, controller entry list, transfer drop-position values, transfer data MIME type values, remote-state values, remote-state data hook values, toolbar data hook values, integration hook values, selection data hook values, selection checkbox hook values, and empty-state hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
+The machine-readable source of truth for the package-root JavaScript exports, bundled controller identifiers, controller entry list, transfer drop-position values, transfer data attribute values, transfer data MIME type values, remote-state values, remote-state data hook values, toolbar data hook values, integration hook values, selection data hook values, selection checkbox hook values, and empty-state hook values lives in `config/public_api_manifest.yml`. The compatibility spec and entrypoint smoke check read that contract to detect drift.
 
 Internal by default:
 

--- a/docs/ja/public-api.md
+++ b/docs/ja/public-api.md
@@ -205,6 +205,7 @@ host app が使ってよい入口:
 - `TreeViewEventNames`
 - `TreeViewEventDetailKeys`
 - `TreeViewTransferDropPositions`
+- `TreeViewTransferDataAttributes`
 - `TreeViewTransferDataMimeTypes`
 - `TreeViewRemoteStateValues`
 - `TreeViewRemoteStateDataHooks`
@@ -229,6 +230,7 @@ host app が使ってよい入口:
 `TreeViewEventNames` は documented event names を machine-readable に参照するための package-root export です。host app 側で listener を配線するとき、`TreeViewEventNames.selection.change` や `TreeViewEventNames.transfer.drop` のように使うことで event name string の写経を避けられます。
 `TreeViewEventDetailKeys` は documented `event.detail` key list を machine-readable に参照するための package-root export です。host app の test や listener が documented key name と照合したい場合に使えますが、payload shape 自体は変えません。各 field の意味は [JavaScript event contract](js-events.md) を正本にしてください。
 `TreeViewTransferDropPositions` は transfer event の粗い drop-position value として、`before`、`inside`、`after` を公開します。`TreeViewEventNames.transfer.*` は transfer event 名、`TreeViewEventDetailKeys.transfer.*` は documented な `event.detail` key、`TreeViewTransferDropPositions` は [Drag and Drop](drag-and-drop.md#drop処理) で説明している position value を表します。
+`TreeViewTransferDataAttributes` は documented な transfer payload / disabled-row DOM attribute 名を公開します。host app の JavaScript、browser test、shared helper が transfer wiring attribute を raw string で写経したくない場合は、`data-tree-transfer-payload` に `TreeViewTransferDataAttributes.payload`、`data-tree-transfer-disabled` に `TreeViewTransferDataAttributes.disabled` を使ってください。これらの export は DOM wiring attribute 名だけを指します。payload shape、authorization、保存、最終的な drop behavior は引き続き [Drag and Drop](drag-and-drop.md#drop処理) を正本にしてください。
 `TreeViewTransferDataMimeTypes` は documented な TreeView transfer MIME type value として、primary JSON payload 用の `application/json` と browser compatibility fallback 用の `text/plain` を公開します。host app の JavaScript や test が MIME string を写経せずに TreeView transfer data を読み取ったり assert したりしたい場合に使えます。drag/drop behavior、payload shape、最終的な業務処理は引き続き [Drag and Drop](drag-and-drop.md#drop処理) を正本にしてください。
 `TreeViewRemoteStateValues` は lazy-loading row の documented remote-state value set として、`loading`、`loaded`、`error` を公開します。host app の JavaScript や test が `data-tree-remote-state` の値を string の写経なしに照合したい場合に使えます。controller が emit する remote-state event 名は引き続き `TreeViewEventNames.remoteState.*`、その `event.detail` key は `TreeViewEventDetailKeys.remoteState.*` で扱います。
 `TreeViewRemoteStateDataHooks` は、documented された lazy-loading / remote-state data attribute names を machine-readable に参照するための package-root export です。custom lazy-loading markup、test、copied host-app partial が `data-tree-lazy`、`data-tree-children-url`、`data-tree-loaded`、`data-tree-remote-state` を写経せず参照したい場合に使えます。request dispatch、response handling、retry UI、authorization-safe copy は [Lazy Loading](lazy-loading.md) に沿って host app 側に残ります。
@@ -251,6 +253,11 @@ host app が使ってよい入口:
 - `retry`
 
 `TreeViewEventNames.hostLifecycle.*` は [Lazy Loading](lazy-loading.md) で説明している host app 側の request-state dispatch surface 専用です。TreeView controller 自身が emit する remote-state event は引き続き `TreeViewEventNames.remoteState.*` に置きます。
+
+`TreeViewTransferDataAttributes` の documented key:
+
+- `payload`
+- `disabled`
 
 `TreeViewTransferDataMimeTypes` の documented key:
 
@@ -326,7 +333,7 @@ host app が使ってよい入口:
 
 これらの attribute は host element 上で controller を設定するときに使います。row ごとの payload 生成、disabled-state 判定、checkbox visibility は `selection:` render-state builder 側の責務です。generated hidden input marker attribute と source-id attribute は TreeView が生成・管理する内部寄りの属性であり、host app が authoring する public hook ではありません。詳しくは [Selection](selection.md) と [Host app extension points](host-app-extension-points.md#selection-builders) を参照してください。
 
-package-root の JavaScript export、bundled controller identifier、controller entry list、transfer drop-position value、transfer data MIME type value、remote-state value、remote-state data hook value、toolbar data hook value、integration hook value、selection data hook value、selection checkbox hook value、empty-state hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
+package-root の JavaScript export、bundled controller identifier、controller entry list、transfer drop-position value、transfer data attribute value、transfer data MIME type value、remote-state value、remote-state data hook value、toolbar data hook value、integration hook value、selection data hook value、selection checkbox hook value、empty-state hook value の machine-readable な source of truth は `config/public_api_manifest.yml` に置きます。compatibility spec と entrypoint smoke check はその contract を参照して drift を検知します。
 
 内部扱い:
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2083
Refs #2466

## 分類

- code-ahead-of-docs

## 変更内容

- root `README.md` の package-root export 例に `TreeViewTransferDataAttributes` を追加しました。
- 英日 `docs/*/public-api.md` の JavaScript surface 一覧に `TreeViewTransferDataAttributes` を追加しました。
- 英日 `docs/*/public-api.md` に `payload` / `disabled` key と、`data-tree-transfer-payload` / `data-tree-transfer-disabled` の責務境界を追記しました。

## 根拠

- merged #2083 で `TreeViewTransferDataAttributes` が `tree_view/index.js` の package-root export、`index.d.ts`、`config/public_api_manifest.yml` に追加済みです。
- 英日 Drag and Drop docs は同 export を説明済みですが、Public API の JS surface 一覧と README の短い export 例が未追従でした。

## 範囲外

- runtime JavaScript / TypeScript declaration / manifest / specs / CI workflow の変更
- transfer payload shape、authorization、persistence、drop behavior の変更
- docs signal script の追加

## 確認内容

- compare `main...docs/2083-transfer-data-attributes-public-api`: `ahead_by:3` / `behind_by:0` / changed files 3件。
- 変更ファイルは以下のみです。
  - `README.md`
  - `docs/en/public-api.md`
  - `docs/ja/public-api.md`
- connector readback で README と英日 Public API に `TreeViewTransferDataAttributes`、`payload`、`disabled`、transfer attribute boundary が入っていることを確認しました。
- PR CI #3447 は success です。
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `gem_package`: success
  - `javascript`: success (`npm run test:docs-entrypoints` 実行)
  - docs-only 判定により代表 Rails matrix は skip/success 扱いです。
- local checkout / test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## 残件

#2466 の受け入れ条件には lightweight docs smoke / signal guard 追加も含まれます。この Agent は script/test 変更を行わないため、この PR は Issue を close せず、reader-facing docs 追従部分だけを扱います。

merge は行いません。