### PR TITLE
CHANGELOG に Public API docs 同期を clean branch で追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Release preparation notes:
 - Added a status-heavy row composition mockup section for dense business columns, row status cues, and host-app-owned action availability.
 - Added a current-branch sidebar breadcrumb mockup for reviewing route context and row-local hierarchy cues in narrow panes.
 - Added direction-aware styling boundary docs for host-app-owned RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing overrides.
+- Added CSS custom property token guidance to direction-aware styling docs for selection, current-row, loading, error, focus, and branch-line state cues.
 - Added Decision guide guidance for choosing Static, Turbo, or Client-side toggle mode before tuning render depth or loading strategy.
 - Clarified docs index entry points for PathTreeBuilder, Children Pagination, and large-tree reading paths.
 - Added docs index entry points for Accessibility Semantics so ARIA placement, keyboard boundaries, and automated check allowances are easier to find before review.
@@ -117,6 +118,7 @@ Release preparation notes:
 - Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.
 - Clarified README package-root JavaScript surface examples for controller entries, integration hooks, and documented data hook objects.
 - Clarified Public API docs for the shared `data-tree-children-url` hook boundary between `TreeViewRemoteStateDataHooks` and `TreeViewIntegrationHooks`.
+- Clarified Public API docs and README package-root examples for `TreeViewTransferDataAttributes`, including transfer payload and disabled-row data attribute boundaries.
 
 ### Tests
 


### PR DESCRIPTION
## 対応 PR

Refs #2498
Refs #2500
Supersedes #2505

## 分類

- `docs-sync`
- `docs-stale`

## 置き換え理由

#2505 は #2506 merge 後に `main...docs/changelog-public-api-docs-sync` が `behind_by:1` / `status:diverged` になり、review で current main 追従と fresh CI の取り直しを求められていました。

この PR は current main `35495ccad21d14d2677a8379c95d8f3f148ccf7d` から clean branch を作成し、#2505 と同じ intended `CHANGELOG.md` 2 行だけを載せ直した replacement です。旧 branch の force push やコード / CI / script 差分の取り込みは行っていません。

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、#2498 で追加された CSS custom property token guidance を 1 行追記しました。
- `CHANGELOG.md` の `Unreleased > Documentation` に、#2500 で同期された `TreeViewTransferDataAttributes` の README / Public API docs guidance を 1 行追記しました。

## 根拠

- #2498 は英日 `docs/*/direction-aware-styling.md` に reader-facing な CSS custom property token guidance を追加済みです。
- #2500 は `README.md` と英日 `docs/*/public-api.md` に `TreeViewTransferDataAttributes` の package-root example / transfer data attribute boundary を同期済みです。
- どちらも docs-only / reader-facing guidance で、release preparation 時に `Documentation` evidence として追える方が安全です。

## 範囲外

- runtime Ruby / JavaScript の変更
- public API manifest / TypeScript declaration / docs signal script / CI workflow の変更
- #2490 / #2466 の smoke guard 残件の実装

## 確認内容

- compare `main...docs/changelog-public-api-docs-sync-clean`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files: `CHANGELOG.md` の1件のみ。
- diff: `Unreleased > Documentation` への2行追加 / 削除0行。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG の release-facing docs evidence 2 行追加に閉じています。

merge は行いません。