### PR TITLE
CHANGELOG に Public API docs 同期を current main で追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Release preparation notes:
 - Added a status-heavy row composition mockup section for dense business columns, row status cues, and host-app-owned action availability.
 - Added a current-branch sidebar breadcrumb mockup for reviewing route context and row-local hierarchy cues in narrow panes.
 - Added direction-aware styling boundary docs for host-app-owned RTL, writing direction, current-row cues, hierarchy connectors, and toggle spacing overrides.
+- Added CSS custom property token guidance to direction-aware styling docs for selection, current-row, loading, error, focus, and branch-line state cues.
 - Added Decision guide guidance for choosing Static, Turbo, or Client-side toggle mode before tuning render depth or loading strategy.
 - Clarified docs index entry points for PathTreeBuilder, Children Pagination, and large-tree reading paths.
 - Added docs index entry points for Accessibility Semantics so ARIA placement, keyboard boundaries, and automated check allowances are easier to find before review.
@@ -117,6 +118,7 @@ Release preparation notes:
 - Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.
 - Clarified README package-root JavaScript surface examples for controller entries, integration hooks, and documented data hook objects.
 - Clarified Public API docs for the shared `data-tree-children-url` hook boundary between `TreeViewRemoteStateDataHooks` and `TreeViewIntegrationHooks`.
+- Clarified Public API docs and README package-root examples for `TreeViewTransferDataAttributes`, including transfer payload and disabled-row data attribute boundaries.
 
 ### Tests
 
@@ -174,7 +176,7 @@ Release preparation notes:
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
 - Added `npm ci` CI and Docker setup smoke coverage so workflow routing, JavaScript setup, and docs install guidance stay aligned.
 - Added a standalone Public API manifest structure command and docs entrypoint suite wiring for manifest structure smoke.
-- Added Development docs command signal smoke coverage for maintainer npm command guidance.
+- Added Development docs command smoke coverage for maintainer npm command guidance.
 - Added Development docs package verification coverage to the gem package contents guard.
 - Added release:check package contents verification plus gem metadata URI and public runtime packaging guard coverage.
 - Added Public API manifest runtime surface guard coverage for documented module methods, constants, and helper methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked FAQ / Troubleshooting / API Overview / API Reference / Tree diagnostics docs so packaged gems keep those public reader guides available.
 - Added controller registration docs signal coverage to the docs-entrypoint suite so controller registration guides and manifest controller entries stay aligned.
 - Added CI changed-file detection workflow guard coverage for docs-entrypoints package script wiring so controller registration docs signals stay connected to `npm run test:docs-entrypoints`.
-- Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates stay package-sensitive without Docker or docs-entrypoint routing.
+- Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates package-sensitive without Docker or docs-entrypoint routing.
 - Expanded package contents verification coverage for README-linked Host App Extension Points docs so packaged gems keep those public extension guides.
 - Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.
 - Expanded package contents verification coverage for README-linked Decision guide, Migration guide, Render Scale, and Rendering Boundaries docs so packaged gems keep those docs available.
@@ -176,7 +176,7 @@ Release preparation notes:
 - Added Docker development setup workflow wiring coverage to the CI changed-file policy guard.
 - Added `npm ci` CI and Docker setup smoke coverage so workflow routing, JavaScript setup, and docs install guidance stay aligned.
 - Added a standalone Public API manifest structure command and docs entrypoint suite wiring for manifest structure smoke.
-- Added Development docs command smoke coverage for maintainer npm command guidance.
+- Added Development docs command signal smoke coverage for maintainer npm command guidance.
 - Added Development docs package verification coverage to the gem package contents guard.
 - Added release:check package contents verification plus gem metadata URI and public runtime packaging guard coverage.
 - Added Public API manifest runtime surface guard coverage for documented module methods, constants, and helper methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked FAQ / Troubleshooting / API Overview / API Reference / Tree diagnostics docs so packaged gems keep those public reader guides available.
 - Added controller registration docs signal coverage to the docs-entrypoint suite so controller registration guides and manifest controller entries stay aligned.
 - Added CI changed-file detection workflow guard coverage for docs-entrypoints package script wiring so controller registration docs signals stay connected to `npm run test:docs-entrypoints`.
-- Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates package-sensitive without Docker or docs-entrypoint routing.
+- Added CI changed-file policy coverage for Dependabot configuration changes so dependency automation config updates stay package-sensitive without Docker or docs-entrypoint routing.
 - Expanded package contents verification coverage for README-linked Host App Extension Points docs so packaged gems keep those public extension guides.
 - Expanded package contents verification coverage for README-linked Accessibility Semantics docs so packaged gems keep those public semantics guides.
 - Expanded package contents verification coverage for README-linked Decision guide, Migration guide, Render Scale, and Rendering Boundaries docs so packaged gems keep those docs available.


### PR DESCRIPTION
CHANGELOG の Public API docs evidence 追記を latest main 起点の clean replacement として再提案します。

## 対応 PR / 関連 Issue

Supersedes #2505
Refs #2498
Refs #2500

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、#2498 で追加された CSS custom property token guidance を 1 行追記しました。
- `CHANGELOG.md` の `Unreleased > Documentation` に、#2500 で同期された `TreeViewTransferDataAttributes` の README / Public API docs guidance を 1 行追記しました。

## 受け入れ条件・レビュー指摘との対応

- 旧 #2505 は current main から `behind_by:1` / `status:diverged` になっていたため、latest `main` 起点の replacement branch に同じ intended diff だけを載せ直しました。
- 変更範囲は `CHANGELOG.md` の 2 行追加のみです。
- runtime Ruby / JavaScript、public API manifest、TypeScript declaration、CI workflow、docs signal script は変更していません。

## 変更範囲

- `CHANGELOG.md`

## 実施した確認

- compare `main...docs/2505-changelog-public-api-docs-sync-current-main`: `ahead_by:3` / `behind_by:0` / `status:ahead`。
- changed files は `CHANGELOG.md` の 1 件のみ、最終 diff は追加 2 行 / 削除 0 行です。
- connector readback と commit diff で、途中の範囲外文言差分を解消済みであることを確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。CHANGELOG の release-facing docs evidence 2 行追加に閉じています。

## 未対応・補足

- 旧 #2505 はこの PR で supersede します。マージは行いません。