### PR TITLE
Dependabot Bundler 復旧手順を docs index に追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ Maintainer entry points には、gem に同梱される `docs/**` と repository
 - [Design policy](en/design-policy.md) / [設計思想と責務範囲](ja/design-policy.md): repository scope, responsibility boundaries, and non-goals.
 - [Demo application boundary](en/demo-application-boundary.md) / [Demo application boundary](ja/demo-application-boundary.md): handoff policy between static gem mockups and a future public Rails demo application.
 - [Development](en/development.md) / [開発・保守方針](ja/development.md): CI, local checks, documentation update workflow, and maintenance habits.
+- [Dependabot Bundler recovery](en/dependabot-bundler-recovery.md) / [Dependabot Bundler 復旧手順](ja/dependabot-bundler-recovery.md): lockfile metadata drift triage and scoped recovery paths for Bundler dependency PRs.
 - [Code quality](en/code-quality.md) / [コード品質](ja/code-quality.md): lint, tests, error message quality, and documentation quality policy.
 - [Release checklist](en/release.md) / [リリースチェックリスト](ja/release.md): release workflow, CI and package verification, and changelog expectations.
 - [Release note candidate collector](en/release-note-candidates.md) / [Release note candidate collector](ja/release-note-candidates.md): maintainer review aid for collecting merged PR and closed Issue candidates without replacing `CHANGELOG.md` or release notes decisions.


### PR DESCRIPTION
## 対応 PR

Refs #2506

## 分類

- `docs-sync`
- `docs-missing`

## 変更内容

- `docs/README.md` の Maintainer entry points に、#2506 で追加された英日 `dependabot-bundler-recovery` docs への導線を追加しました。
- Dependabot Bundler PR の lockfile metadata drift triage と scoped recovery path を、root docs index から見つけられるようにしました。

## 根拠

- #2506 で `docs/en/dependabot-bundler-recovery.md` と `docs/ja/dependabot-bundler-recovery.md` が追加済みです。
- 新規 docs ファイル追加後、root `docs/README.md` の Maintainer entry points からはまだ辿れませんでした。
- 既存の Development / Release docs は Bundler drift guard の概要を説明しており、この PR は新規 recovery note への索引追加だけに閉じています。

## 範囲外

- `Gemfile` / `Gemfile.lock` / dependency versions の変更
- CI workflow、Dependabot schedule、lockfile drift script の変更
- recovery note 本文の仕様変更
- `AGENTS.md` / `Product Profile.md` の変更

## 確認内容

- compare `main...docs/2506-dependabot-recovery-index`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files は `docs/README.md` の 1 件のみ、追加 1 行 / 削除 0 行です。
- connector readback で英日 recovery note へのリンク行が入っていることを確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。root docs index の maintainer-facing link 追加だけです。

merge は行いません。