### PR TITLE
Release docs に docs-only Rails skip 境界を追記する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -98,7 +98,7 @@ Pull request CI checks:
 
 - Ruby lint through `bundle exec standardrb`
 - Ruby specs through `bundle exec rspec`
-- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`
+- Representative Rails compatibility checks through `gemfiles/rails_7_0.gemfile`, `gemfiles/rails_7_2.gemfile`, and `gemfiles/rails_8_0.gemfile`. These representative Rails lanes run for non-docs PRs. When the changed-files policy marks a PR as docs-only, each lane emits `Docs-only PR: skipping representative Rails compatibility lane.` and skips checkout, Ruby setup, and `bundle exec rake` so docs-only changes avoid runtime-heavy Rails compatibility work.
 - JavaScript checks through the changed-files policy: docs-entrypoint-sensitive docs-only PRs run `npm run test:docs-entrypoints`, non-docs PRs run `npm run test:js:core`, and mockup or browser-smoke-sensitive PRs install Playwright Chromium and run `npm run test:browser`
 - Gem package verification when the PR touches package-sensitive paths
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -98,7 +98,7 @@ Pull Request CI の確認項目:
 
 - Ruby lint: `bundle exec standardrb`
 - Ruby specs: `bundle exec rspec`
-- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`
+- representative Rails compatibility checks: `gemfiles/rails_7_0.gemfile`、`gemfiles/rails_7_2.gemfile`、`gemfiles/rails_8_0.gemfile`。これらの representative Rails lane は docs-only ではない PR で実行します。changed-files policy が PR を docs-only と判定した場合、各 lane は `Docs-only PR: skipping representative Rails compatibility lane.` を出し、checkout、Ruby setup、`bundle exec rake` を skip して docs-only 変更では runtime-heavy な Rails compatibility work を避けます。
 - JavaScript checks: changed-files policy に従い、docs-entrypoint-sensitive な docs-only PR では `npm run test:docs-entrypoints`、docs-only ではない PR では `npm run test:js:core`、mockup / browser-smoke sensitive な PR では Playwright Chromium setup と `npm run test:browser` を実行する
 - package-sensitive path を触るPRでの Gem package verification
 


### PR DESCRIPTION
## 対応 Issue

Refs #2509

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/release.md` / `docs/ja/release.md` の Pull request CI checks に、docs-only PR では representative Rails compatibility lanes が skip される境界を追記しました。
- current `.github/workflows/ci.yml` の `Docs-only PR: skipping representative Rails compatibility lane.` と、checkout / Ruby setup / `bundle exec rake` を skip する挙動に合わせています。

## Scope

- docs-only の reader-facing Release docs 追従に閉じます。
- `.github/workflows/ci.yml`、`script/test_ci_workflow_changed_file_detection_signals.mjs`、`script/test_release_docs_signals.mjs`、Rails matrix、required checks、branch protection は変更していません。
- #2509 の受け入れ条件には lightweight smoke 追加も含まれるため、この PR は `Refs` に留め、Issue は close しません。

## 確認内容

- current main: `ab90605da4dbeade7ed2514a78e392322e101ea5`
- head: `97d3c5a3b4425534787108040c989bd6c6f8de46`
- compare `main...docs/2509-rails-skip-release-docs`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files は docs 2件のみです。
- PR metadata: open / non-draft / `mergeable:true`
- GitHub Actions CI #3470 / run `27935937429`: success
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success
  - `javascript` job 内で `npm run test:docs-entrypoints`: success
  - representative Rails compatibility lanes 7.0 / 7.2 / 8.0 は docs-only scope として skip message を出して success
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。既存 CI workflow behavior の説明追加だけで、workflow や test signal は変更していません。

merge は行いません。