### PR TITLE
AGENTS.md 変更時に CI policy smoke を走らせる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       package_sensitive: ${{ steps.detect.outputs.package_sensitive }}
       docker_setup_sensitive: ${{ steps.detect.outputs.docker_setup_sensitive }}
       docs_entrypoint_sensitive: ${{ steps.detect.outputs.docs_entrypoint_sensitive }}
+      ci_policy_sensitive: ${{ steps.detect.outputs.ci_policy_sensitive }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -30,6 +31,7 @@ jobs:
             echo "package_sensitive=true" >> "$GITHUB_OUTPUT"
             echo "docker_setup_sensitive=true" >> "$GITHUB_OUTPUT"
             echo "docs_entrypoint_sensitive=true" >> "$GITHUB_OUTPUT"
+            echo "ci_policy_sensitive=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -149,23 +151,25 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true' && needs.changes.outputs.docs_entrypoint_sensitive != 'true'
-        run: 'echo "Docs-only PR without package-facing docs, mockup, or browser-smoke changes: skipping JavaScript checks."'
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true' && needs.changes.outputs.docs_entrypoint_sensitive != 'true' && needs.changes.outputs.ci_policy_sensitive != 'true'
+        run: 'echo "Docs-only PR without package-facing docs, CI-policy, mockup, or browser-smoke changes: skipping JavaScript checks."'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true' || needs.changes.outputs.ci_policy_sensitive == 'true'
         uses: actions/checkout@v7
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true' || needs.changes.outputs.ci_policy_sensitive == 'true'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true' || needs.changes.outputs.ci_policy_sensitive == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
-      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true'
+      - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true' || needs.changes.outputs.docs_entrypoint_sensitive == 'true' || needs.changes.outputs.ci_policy_sensitive == 'true'
         run: npm ci
       - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true' && needs.changes.outputs.docs_entrypoint_sensitive == 'true'
         run: npm run test:docs-entrypoints
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.ci_policy_sensitive == 'true'
+        run: npm run test:ci-policy
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js:core
       - if: github.event_name != 'pull_request' || needs.changes.outputs.mockups_changed == 'true' || needs.changes.outputs.browser_smoke_changed == 'true'

--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -5,7 +5,8 @@ export function classifyChangedFiles(files) {
     browser_smoke_changed: false,
     package_sensitive: false,
     docker_setup_sensitive: false,
-    docs_entrypoint_sensitive: false
+    docs_entrypoint_sensitive: false,
+    ci_policy_sensitive: false
   };
 
   for (const file of files.map((entry) => entry.trim()).filter(Boolean)) {
@@ -31,6 +32,10 @@ export function classifyChangedFiles(files) {
 
     if (isDocsEntrypointSensitivePath(file)) {
       result.docs_entrypoint_sensitive = true;
+    }
+
+    if (isCiPolicySensitivePath(file)) {
+      result.ci_policy_sensitive = true;
     }
   }
 
@@ -80,6 +85,10 @@ function isDocsEntrypointSensitivePath(file) {
     file.startsWith("docs/") ||
     file === "config/public_api_manifest.yml"
   );
+}
+
+function isCiPolicySensitivePath(file) {
+  return file === "AGENTS.md";
 }
 
 function isDockerSetupSensitivePath(file) {

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -69,8 +69,8 @@ const cases = [
     }
   },
   {
-    name: "repository-only docs stay docs-only without package or docs entrypoint guard",
-    files: ["Product Profile.md", "AGENTS.md"],
+    name: "repository profile docs stay docs-only without package, docs entrypoint, or CI policy guard",
+    files: ["Product Profile.md"],
     expected: {
       docs_only: true,
       mockups_changed: false,
@@ -78,6 +78,19 @@ const cases = [
       package_sensitive: false,
       docker_setup_sensitive: false,
       docs_entrypoint_sensitive: false
+    }
+  },
+  {
+    name: "AGENTS guidance stays docs-only but requests CI policy guard",
+    files: ["AGENTS.md"],
+    expected: {
+      docs_only: true,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: false,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false,
+      ci_policy_sensitive: true
     }
   },
   {
@@ -311,8 +324,15 @@ function assertPolicyCliOutput(input, expected, message) {
   assert.deepEqual(parsedOutput, expected, message);
 }
 
+function expectedPolicyFlags(expected) {
+  return {
+    ci_policy_sensitive: false,
+    ...expected
+  };
+}
+
 for (const testCase of cases) {
-  assert.deepEqual(classifyChangedFiles(testCase.files), testCase.expected, testCase.name);
+  assert.deepEqual(classifyChangedFiles(testCase.files), expectedPolicyFlags(testCase.expected), testCase.name);
 }
 
 const policyKeys = Object.keys(classifyChangedFiles([])).sort();
@@ -329,6 +349,11 @@ assertPolicyCliOutput(
   "Dockerfile\npackage-lock.json\n",
   classifyChangedFiles(["Dockerfile", "package-lock.json"]),
   `${policyCliPath} must emit Docker and package-sensitive workflow output values from stdin`
+);
+assertPolicyCliOutput(
+  "AGENTS.md\n",
+  classifyChangedFiles(["AGENTS.md"]),
+  `${policyCliPath} must emit CI policy-sensitive routing for AGENTS.md changes`
 );
 
 assertSameMembers(
@@ -451,8 +476,18 @@ assert.match(
 );
 assert.match(
   javascriptJob,
+  /needs\.changes\.outputs\.ci_policy_sensitive == 'true'/,
+  `${workflowPath} jobs.javascript must keep ci_policy_sensitive in its CI policy guard condition`
+);
+assert.match(
+  javascriptJob,
   /run: npm run test:docs-entrypoints/,
   `${workflowPath} jobs.javascript must still run docs entrypoint checks for docs_entrypoint_sensitive changes`
+);
+assert.match(
+  javascriptJob,
+  /run: npm run test:ci-policy/,
+  `${workflowPath} jobs.javascript must run CI policy checks for ci_policy_sensitive docs-only changes`
 );
 assertJobMatches(javascriptJob, /uses: ruby\/setup-ruby@v1/, `${workflowPath} jobs.javascript must keep Ruby setup for manifest-loading Node smokes`);
 assertJobMatches(javascriptJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.javascript must keep Ruby 3.3 for manifest-loading Node smokes`);


### PR DESCRIPTION
## 対応 Issue

Closes #2515

## Issue ごとの完了内容

- #2515: `AGENTS.md` だけを変更した docs-only PR でも、CI observation guidance を読む `test_ci_observation_guidance_signals.mjs` を含む `npm run test:ci-policy` が JavaScript job で実行される routing にしました。
- #2515: `Product Profile.md` など他の repository-only docs は従来通り package / docs entrypoint / CI policy guard を要求しないことを policy test で固定しました。

## 変更内容

- `script/ci_changed_files_policy.mjs` に `ci_policy_sensitive` output を追加し、`AGENTS.md` をその対象にしました。
- `.github/workflows/ci.yml` の `changes` output と `javascript` job 条件を同期し、docs-only かつ `ci_policy_sensitive` の場合は checkout / Ruby / Node setup / `npm ci` の後に `npm run test:ci-policy` を実行します。
- `script/test_ci_changed_files_policy.mjs` に `AGENTS.md` routing、workflow output、JavaScript job の `test:ci-policy` 実行条件を確認する signal を追加しました。

## 改善カテゴリ

- CI 改善
- test signal 追加
- changed-files routing hardening

## 既存仕様への影響

runtime Ruby / JavaScript、public API、docs prose、package metadata、DB、認可、外部サービス契約は変更していません。CI の changed-files routing と policy smoke 実行条件だけの変更です。

## 実施した確認

- Issue #2515 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR 前 compare `main...quality/2515-agents-ci-policy-routing`: `ahead_by:3` / `behind_by:0` / `status:ahead`。
- changed files は以下3件のみです。
  - `.github/workflows/ci.yml`
  - `script/ci_changed_files_policy.mjs`
  - `script/test_ci_changed_files_policy.mjs`
- connector readback で `ci_policy_sensitive` output、`AGENTS.md` classification、docs-only `npm run test:ci-policy` route、Product Profile の軽量 routing case を確認しました。
- local checkout / local npm 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。`AGENTS.md` 変更時の CI policy smoke を追加で走らせるだけで、required checks / branch protection / Rails matrix / dependency versions は変更していません。

## 補足事項

既存 open PR #2514 は #2509 向けの Release docs PRで、変更ファイルは `docs/en/release.md` / `docs/ja/release.md` の2件のみです。本PRとは対象Issue・差分が異なるため分けています。

merge は行いません。