### PR TITLE
CI workflow の read-only token permissions を latest main で再提案する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
+    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_workflow_permissions_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/script/test_ci_workflow_permissions_signals.mjs
+++ b/script/test_ci_workflow_permissions_signals.mjs
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs"
+
+const workflowPath = ".github/workflows/ci.yml"
+const workflowSource = readFileSync(workflowPath, "utf8")
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+function topLevelWorkflowPermissions(source) {
+  const match = source.match(/^permissions:\n(?<body>(?:  [a-z-]+: .+\n)+)/m)
+  assert(match, `${workflowPath} must declare top-level GITHUB_TOKEN permissions`)
+  return match.groups.body
+}
+
+const permissionsBlock = topLevelWorkflowPermissions(workflowSource)
+
+assertIncludes(
+  permissionsBlock,
+  "  contents: read\n",
+  `${workflowPath} top-level workflow permissions`
+)
+
+assert(
+  !/^  contents: write$/m.test(permissionsBlock),
+  `${workflowPath} must not request write contents permission for CI jobs`
+)
+
+assert(
+  !/^  pull-requests: write$/m.test(permissionsBlock),
+  `${workflowPath} must not request pull request write permission for CI jobs`
+)
+
+console.log("Checked CI workflow read-only GITHUB_TOKEN permissions.")


### PR DESCRIPTION
CI workflow の read-only GITHUB_TOKEN permissions hardening を latest main 起点で再提案します。

## 対応 Issue / PR

Closes #2478
Supersedes #2481

## 置き換え理由

#2481 はレビュー follow-up で current main への追従が求められていました。connector 経由で conflict 解消は行われていましたが、compare 上は `behind_by:12` / `status:diverged` のまま残っていました。

この PR は latest main `f78b1718bc15aa72985dd69e2da63cba67045a6c` 起点の clean replacement です。旧 PR branch の force push や履歴書き換えは行っていません。

## 変更内容

- `.github/workflows/ci.yml` に workflow-level `permissions: contents: read` を明示します。
- `script/test_ci_workflow_permissions_signals.mjs` を追加し、top-level permissions が read-only contents で、`contents: write` / `pull-requests: write` を要求しないことを確認します。
- `package.json` の `test:ci-policy` に permissions signal を登録します。

## 受け入れ条件との対応

- CI jobs の実行に必要な最小限の permission として `contents: read` を明示しました。
- latest main の CI job routing、`ci_policy_sensitive` routing、Ruby / Node versions、action major versions、required checks、branch protection は変更していません。
- write permission が必要な job はこの変更範囲では追加していません。
- permissions hardening が落ちた場合に `npm run test:ci-policy` で検出できる signal を追加しました。

## 変更範囲

- `.github/workflows/ci.yml`
- `package.json`
- `script/test_ci_workflow_permissions_signals.mjs`

runtime Ruby / JavaScript、public API、docs content、DB、認可、外部サービス契約は変更していません。

## 実施した確認

- review follow-up 対象として #2481 の最新コメントを確認し、main 追従 / fresh CI が残っていることを確認しました。
- Issue #2478 の labels を確認し、現在は `status:needs-human` / `agent:needs-review` として human review gate に置かれていることを確認しました。
- compare `main...quality/2478-ci-token-permissions-clean`: `ahead_by:3` / `behind_by:0` / `status:ahead`。
- changed files は上記3件のみです。
- local git / test 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。CI workflow の token permissions を read-only に明示する devops/security hardening です。ただし `GITHUB_TOKEN` permissions の最終採用判断は human review gate に残します。

## 未対応・補足

- merge は行いません。
- CI 結果は PR 作成後に確認します。