### PR TITLE
CI policy smoke に push default output の ci_policy_sensitive を追加する

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -91,7 +91,8 @@ const nonPullRequestDefaultOutputs = {
   browser_smoke_changed: false,
   package_sensitive: true,
   docker_setup_sensitive: true,
-  docs_entrypoint_sensitive: true
+  docs_entrypoint_sensitive: true,
+  ci_policy_sensitive: true
 }
 const nonPullRequestDefaultOutputBlock = workflowNonPullRequestDefaultOutputBlock(changesJob)
 Object.entries(nonPullRequestDefaultOutputs).forEach(([key, value]) => {


### PR DESCRIPTION
## 対応 Issue

Closes #2525

## Issue ごとの完了内容

- #2525: `script/test_ci_workflow_changed_file_detection_signals.mjs` の non-pull-request default output 期待値に `ci_policy_sensitive: true` を追加し、`.github/workflows/ci.yml` の push path default output と smoke script を同期しました。

## 変更内容

- `nonPullRequestDefaultOutputs` に `ci_policy_sensitive: true` を追加しました。
- 既存の `assertDefaultWorkflowOutput` 経由で、workflow の `echo "ci_policy_sensitive=true" >> "$GITHUB_OUTPUT"` が落ちた場合に `npm run test:ci-policy` で検出できるようにしました。

## 改善カテゴリ

- test
- CI guard hardening

## 既存仕様への影響

- `.github/workflows/ci.yml`、job topology、changed-file classification、required checks、action versions、branch protection は変更していません。
- runtime Ruby / JavaScript、public API、docs prose、DB、認可、外部サービス契約には影響しません。

## 実施した確認

- Issue #2525 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` の `.github/workflows/ci.yml` に `ci_policy_sensitive=true` の non-pull-request default output があることを確認しました。
- compare `main...quality/2525-ci-policy-push-default-output`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files は `script/test_ci_workflow_changed_file_detection_signals.mjs` の1件のみです。
- connector readback で `ci_policy_sensitive: true` が追加されていることを確認しました。
- GitHub Actions CI #3486 / run `27955620928` succeeded。

## リスク評価

low。既存 workflow output をテスト期待値に追加するだけの guard 同期で、実行時の CI routing 自体は変更していません。

## 補足事項

- merge は行いません。