### PR TITLE
CHANGELOG に CI-policy-sensitive docs evidence を追加する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@ Release preparation notes:
 - Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.
 - Clarified README package-root JavaScript surface examples for controller entries, integration hooks, and documented data hook objects.
 - Clarified Public API docs for the shared `data-tree-children-url` hook boundary between `TreeViewRemoteStateDataHooks` and `TreeViewIntegrationHooks`.
-- Clarified Public API docs and README package-root examples for `TreeViewTransferDataAttributes`, including transfer payload and disabled-row data attribute boundaries.
+- Documented CI-policy-sensitive docs-only routing in AGENTS.md and Release docs so maintainers know when `npm run test:ci-policy` runs for repository-maintainer docs.
 
 ### Tests
 
@@ -201,6 +201,7 @@ Release preparation notes:
 - Added release docs signal coverage for controller registration troubleshooting and public setup generator packaging guidance.
 - Added release and CI docs signal coverage for workflow action major versions, Ruby / Rails release evidence, and gem package install / require checks.
 - Added CI observation guidance signal coverage so maintainers verify GitHub Actions workflow runs when combined status is empty.
+- Added CI policy smoke coverage for AGENTS.md routing and non-PR `ci_policy_sensitive` defaults so CI-policy-sensitive docs changes stay guarded.
 - Expanded package contents verification coverage for README-linked Turbo Frame option, Direction-aware styling, and Public Name Decisions docs so packaged gems keep those public guides available.
 
 ## 0.1.0 - 2026-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Release preparation notes:
 - Clarified Public API docs for `TreeViewControllerEntries` as a manifest-backed controller entry list while keeping `registerTreeViewControllers(application)` as the standard registration path.
 - Clarified README package-root JavaScript surface examples for controller entries, integration hooks, and documented data hook objects.
 - Clarified Public API docs for the shared `data-tree-children-url` hook boundary between `TreeViewRemoteStateDataHooks` and `TreeViewIntegrationHooks`.
+- Clarified Public API docs and README package-root examples for `TreeViewTransferDataAttributes`, including transfer payload and disabled-row data attribute boundaries.
 - Documented CI-policy-sensitive docs-only routing in AGENTS.md and Release docs so maintainers know when `npm run test:ci-policy` runs for repository-maintainer docs.
 
 ### Tests


### PR DESCRIPTION
## 対応 Issue

Closes #2535

## 変更内容

- `CHANGELOG.md` の `Unreleased` に CI-policy-sensitive docs-only routing の Documentation evidence を追加しました。
- `CHANGELOG.md` の `Unreleased` に AGENTS.md routing / non-PR `ci_policy_sensitive` default を守る CI policy smoke の Tests evidence を追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

runtime Ruby / JavaScript、CI workflow、package scripts、Release / Development / AGENTS docs本文は変更していません。

## 確認内容

- current main `716c4409435e1c6e2d3bb7b83ef2e8297d64f4a2` 起点で branch を作成しました。
- compare `main...docs/2535-ci-policy-sensitive-changelog`: `ahead_by:2` / `behind_by:0` / changed files `CHANGELOG.md` の1件のみ。
- 初回更新で直前の既存 bullet を置き換えていたため、追加 commit で既存 entry と末尾 newline を復元し、最終 diff を2行追加だけに戻しました。

## リスク

low。release-facing evidence の追記だけです。

merge は行いません。