### PR TITLE
README の Development command list を guard scripts と同期する

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,13 @@ bundle exec rspec
 bundle exec rake build
 npm ci
 npm run test:js
+npm run test:entrypoints
+npm run test:docs-entrypoints
+npm run test:ci-policy
 ```
 
 Use Node 22 for local JavaScript work. The repository root `.nvmrc` matches the CI JavaScript lane and is the source of truth for the recommended local Node major version.
 
-`npm run test:js` runs the documented JavaScript pull-request checks together: entrypoint smoke (`npm run test:entrypoints`), Vitest (`npm test`), and Playwright browser smoke (`npm run test:browser`). See the [English development guide](docs/en/development.md) and [日本語の開発・保守方針](docs/ja/development.md) for details.
+`npm run test:js` runs the documented JavaScript pull-request checks together: entrypoint smoke (`npm run test:entrypoints`), Vitest (`npm test`), and Playwright browser smoke (`npm run test:browser`). Use the focused guard commands when you are narrowing maintenance failures: `npm run test:entrypoints` covers package-root exports, controller registrations, docs entrypoints, CI policy, and version-source guards; `npm run test:docs-entrypoints` covers README/docs/Public API/i18n signals without the broader JavaScript suite; and `npm run test:ci-policy` covers changed-file routing, workflow detection, CI observation guidance, and lockfile drift. See the [English development guide](docs/en/development.md) and [日本語の開発・保守方針](docs/ja/development.md) for details.
 
 Use `npm ci` for local JavaScript setup. The committed `package-lock.json` is the source of truth for repeatable installs, and CI/Docker setup use the same lockfile-backed install path.

--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs"
 
 const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"))
+const readme = fs.readFileSync("README.md", "utf8")
 const docs = [
   ["docs/en/development.md", fs.readFileSync("docs/en/development.md", "utf8")],
   ["docs/ja/development.md", fs.readFileSync("docs/ja/development.md", "utf8")]
@@ -13,6 +14,13 @@ const requiredMaintenanceScripts = [
   "test:ruby-version-sources",
   "test:public-api-manifest-structure",
   "test:docs-i18n"
+]
+
+const requiredReadmeDevelopmentCommands = [
+  "npm run test:js",
+  "npm run test:entrypoints",
+  "npm run test:docs-entrypoints",
+  "npm run test:ci-policy"
 ]
 
 const requiredDockerSetupSignals = [
@@ -42,6 +50,12 @@ for (const scriptName of requiredMaintenanceScripts) {
   }
 }
 
+for (const command of requiredReadmeDevelopmentCommands) {
+  if (!readme.includes(command)) {
+    missingSignals.push(`README.md Development command: ${command}`)
+  }
+}
+
 for (const signal of requiredDockerSetupSignals) {
   for (const [docPath, doc] of docs) {
     if (!doc.includes(signal)) {
@@ -59,5 +73,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands and ${requiredDockerSetupSignals.length} Docker setup signals are present in package.json and both Development docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, and ${requiredDockerSetupSignals.length} Docker setup signals are present in package.json and docs`
 )


### PR DESCRIPTION
## 対応 Issue

Closes #2541

## 変更内容

- root `README.md` の Development command list に `npm run test:entrypoints`、`npm run test:docs-entrypoints`、`npm run test:ci-policy` を追加しました。
- `npm run test:js` と focused guard commands の役割差を短く補足し、詳細は英日 Development docs に委ねました。
- `script/test_development_docs_command_signals.mjs` に README Development command の代表 signal を追加し、root README 側の入口が今後 drift したときに検出できるようにしました。

## Issue ごとの完了内容

- #2541: root README の短い Development command list を current guard scripts と同期し、lightweight docs signal で `npm run test:js` / `npm run test:entrypoints` / `npm run test:docs-entrypoints` / `npm run test:ci-policy` を確認するようにしました。

## 変更範囲

- `README.md`
- `script/test_development_docs_command_signals.mjs`

`package.json` scripts、CI workflow、Ruby / Node support policy、public API manifest schema、runtime Ruby / JavaScript は変更していません。

## 改善カテゴリ

- docs stale / code-ahead-of-docs guard
- lightweight docs signal hardening

## 既存仕様への影響

なし。reader-facing docs と既存 signal script の確認対象を同期しただけで、runtime behavior、public API、CI job topology、package scripts の実行内容は変更していません。

## 確認

- connector compare `main...docs/2541-readme-development-guards`: `ahead_by:2` / `behind_by:0` / changed files `README.md`, `script/test_development_docs_command_signals.mjs`
- local git / tests は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。
- 最新 head `d618cfe387660450695678ffff30991b135d7ab7` の GitHub Actions CI #3497 / run `27999641535`: success
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`, representative `pr_rails_matrix` checks: success
  - `javascript` job は `npm run test:js:core` を実行し、browser smoke は skipped
  - push-only `ruby_matrix` / `rails_matrix` / `docker_development_setup` は skipped

## リスク

low。docs と docs-signal script の小さな同期に閉じています。

## 補足

merge は行いません。