### PR TITLE
RubyGems metadata に documentation_uri を追加する

### DIFF
--- a/tree_view.gemspec
+++ b/tree_view.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["documentation_uri"] = "#{spec.homepage}/blob/main/docs/README.md"
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
 


### PR DESCRIPTION
## 対応 Issue

- Closes #2543

## Issue ごとの完了内容

- #2543: RubyGems metadata から repository 内の docs entrypoint に辿れるよう、`documentation_uri` を追加しました。

## 変更内容

- `tree_view.gemspec` に `spec.metadata["documentation_uri"]` を追加しました。
- URL は packaged docs の入口である `docs/README.md` を指す repository URL にしています。

## 改善カテゴリ

- docs discoverability
- package metadata maintenance

## 既存仕様への影響

- runtime Ruby / JavaScript、public API manifest、CI workflow、release credential policy は変更していません。
- RubyGems metadata の追加のみで、既存の `homepage_uri` / `source_code_uri` / `changelog_uri` / `bug_tracker_uri` は維持しています。

## 確認内容

- GitHub connector で Issue #2543 の labels が `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low` を満たすことを個別確認しました。
- branch は current `main` から作成し、PR 前 compare で `behind_by: 0` を確認しました。
- 差分が `tree_view.gemspec` の 1 ファイルだけであることを確認しました。
- local clone は環境のネットワーク制限で実行できなかったため、gem build / package verification は GitHub Actions 側に委ねます。

## リスク評価

- risk: low
- package metadata の追加のみで、実行時挙動は変わりません。

## 補足

- 同 repo では #2531 / #2532 / #2533 / #2537 / #2544 も ready-for-agent の quality/docs smoke 系 Issue として確認しましたが、今回は docs metadata discoverability の #2543 に限定しました。public API docs signal の追加群は、別 PR としてまとめる方がレビューしやすいと判断しています。