### PR TITLE
CHANGELOG に documentation_uri metadata の release evidence を追加する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Release preparation notes:
 - Clarified Public API docs for the shared `data-tree-children-url` hook boundary between `TreeViewRemoteStateDataHooks` and `TreeViewIntegrationHooks`.
 - Clarified Public API docs and README package-root examples for `TreeViewTransferDataAttributes`, including transfer payload and disabled-row data attribute boundaries.
 - Documented CI-policy-sensitive docs-only routing in AGENTS.md and Release docs so maintainers know when `npm run test:ci-policy` runs for repository-maintainer docs.
+- Added RubyGems `documentation_uri` metadata release evidence so package users can find the docs entrypoint from gem metadata.
 
 ### Tests
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2543
Refs #2547

## 変更内容

- `CHANGELOG.md` の `Unreleased` / `Documentation` に、RubyGems `documentation_uri` metadata が docs entrypoint を指すことを release-facing evidence として1行追加しました。

## 変更範囲

- `CHANGELOG.md` のみ

runtime Ruby / JavaScript、`tree_view.gemspec`、metadata value、release automation、CI workflow、package checker は変更していません。

## 分類

- `code-ahead-of-docs` / `docs-sync`

## 確認内容

- current main: `702c6d131a0e18ec51d4e9fba5d63f3d2b1ffc9f`
- compare `main...docs/2543-documentation-uri-changelog`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files: `CHANGELOG.md` 1件
- additions: 1 / deletions: 0
- 追加箇所の前後と末尾セクションを readback し、既存セクションの欠落がないことを確認しました。

## リスク

low。CHANGELOG-only の追従です。

merge は行いません。