### PR TITLE
documentation_uri を gem metadata package guard に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -242,6 +242,7 @@ REQUIRED_PACKAGED_PATHS = REQUIRED_PACKAGED_PATH_GROUPS.values.flatten.freeze
 EXPECTED_GEM_METADATA = {
   "homepage_uri" => "https://github.com/matsuo-haruhito/tree_view-rails",
   "source_code_uri" => "https://github.com/matsuo-haruhito/tree_view-rails",
+  "documentation_uri" => "https://github.com/matsuo-haruhito/tree_view-rails/blob/main/docs/README.md",
   "changelog_uri" => "https://github.com/matsuo-haruhito/tree_view-rails/blob/main/CHANGELOG.md",
   "bug_tracker_uri" => "https://github.com/matsuo-haruhito/tree_view-rails/issues"
 }.freeze


### PR DESCRIPTION
## 対応 Issue

Closes #2549

## Issue ごとの完了内容

- #2549: `tree_view.gemspec` に既に存在する `documentation_uri` を、gem artifact metadata verifier の期待値にも追加しました。

## 変更内容

- `script/check_gem_package_contents.rb` の `EXPECTED_GEM_METADATA` に `documentation_uri` を追加しました。
- 期待値は current `tree_view.gemspec` と同じ `https://github.com/matsuo-haruhito/tree_view-rails/blob/main/docs/README.md` です。

## 改善カテゴリ

- test
- devops
- package metadata guard

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、docs URL 構成、Release docs 本文、gem publish automation、CI workflow topology は変更していません。
- gem package verification が `documentation_uri` drift を検出できるようにするだけの挙動不変な guard 追加です。

## 実施した確認

- Issue #2549 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current main `20dba567f4261054d181f6a7caeda48be01897bd` から branch を作成。
- compare `main...quality/2549-documentation-uri-package-guard`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files は `script/check_gem_package_contents.rb` の1件のみ。
- local git checkout は `CONNECT tunnel failed, response 403`、local Ruby は未導入のため、ローカルで `gem build` / verifier 実行はできませんでした。PR CI の `gem_package` job を確認対象にします。

## リスク評価

low。既存 gemspec metadata の artifact-side verifier 期待値を同期するだけで、公開 API や実行時挙動は変えません。

## 補足事項

- #2438 の reader-facing Release docs signal とは分け、package artifact metadata guard のみに閉じています。
- merge は行いません。