### PR TITLE
CHANGELOG に documentation_uri package guard の evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ Release preparation notes:
 - Added Development docs command signal smoke coverage for maintainer npm command guidance.
 - Added Development docs package verification coverage to the gem package contents guard.
 - Added release:check package contents verification plus gem metadata URI and public runtime packaging guard coverage.
+- Added package contents verification coverage for RubyGems `documentation_uri` metadata so packaged gems keep the docs entrypoint URI aligned with the gemspec.
 - Added Public API manifest runtime surface guard coverage for documented module methods, constants, and helper methods.
 - Added CI changed-file policy CLI output guard coverage for workflow `key=value` handoff formatting and stdin trimming.
 - Added dependency spec, non-PR workflow output, public API manifest unknown-key, and duplicate YAML-key guard coverage for package-lock, CI changed-file policy, and manifest structure smoke.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2549
Refs #2550

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `CHANGELOG.md` の `Unreleased` / `Tests` に、RubyGems `documentation_uri` metadata を package contents verification で確認するようになったことを1行追記しました。

## Scope

- docs-only / CHANGELOG-only です。
- `script/check_gem_package_contents.rb`、`tree_view.gemspec`、Release docs本文、CI workflow、package checker behavior は変更していません。
- #2549 は #2550 で既に close 済みのため、この PR は release-facing evidence の follow-up として `Refs` に留めます。

## 確認内容

- current main: `746f85a91815e5648c949413009c2b534a44bca6`
- head: `bcc2176cc960d1b85aff12704385e5c30f9620f0`
- compare `main...docs/2549-documentation-uri-changelog`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files は `CHANGELOG.md` の1件のみです。
- compare 上の差分は additions 1 / deletions 0 です。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merged #2550 の package verification guard 追加に対する CHANGELOG 追従だけです。

merge は行いません。