### PR TITLE
CI lint job の Standard signal smoke を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: npm ci
       - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.mockups_changed != 'true' && needs.changes.outputs.browser_smoke_changed != 'true' && needs.changes.outputs.docs_entrypoint_sensitive == 'true'
         run: npm run test:docs-entrypoints
-      - if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.ci_policy_sensitive == 'true'
+      - if: github.event_name == 'pull_request' && needs.changes.outputs.ci_policy_sensitive == 'true'
         run: npm run test:ci-policy
       - if: github.event_name != 'pull_request' || needs.changes.outputs.docs_only != 'true'
         run: npm run test:js:core

--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -88,7 +88,16 @@ function isDocsEntrypointSensitivePath(file) {
 }
 
 function isCiPolicySensitivePath(file) {
-  return file === "AGENTS.md";
+  return (
+    file === "AGENTS.md" ||
+    file === ".github/workflows/ci.yml" ||
+    file === "script/ci_changed_files_policy.mjs" ||
+    file === "script/test_ci_changed_files_policy.mjs" ||
+    file === "script/test_ci_workflow_changed_file_detection_signals.mjs" ||
+    file === "script/test_ci_observation_guidance_signals.mjs" ||
+    file === "script/test_package_lock_dependency_drift.mjs" ||
+    file === "script/test_gemfile_lock_dependency_drift.mjs"
+  );
 }
 
 function isDockerSetupSensitivePath(file) {

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -118,7 +118,7 @@ const cases = [
     }
   },
   {
-    name: "workflow changes are package- and Docker-sensitive full CI changes",
+    name: "workflow changes are package-, Docker-, and CI policy-sensitive full CI changes",
     files: [".github/workflows/ci.yml"],
     expected: {
       docs_only: false,
@@ -126,7 +126,21 @@ const cases = [
       browser_smoke_changed: false,
       package_sensitive: true,
       docker_setup_sensitive: true,
-      docs_entrypoint_sensitive: false
+      docs_entrypoint_sensitive: false,
+      ci_policy_sensitive: true
+    }
+  },
+  {
+    name: "CI policy scripts request CI policy guard",
+    files: ["script/ci_changed_files_policy.mjs", "script/test_ci_workflow_changed_file_detection_signals.mjs"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: false,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false,
+      ci_policy_sensitive: true
     }
   },
   {
@@ -355,6 +369,11 @@ assertPolicyCliOutput(
   classifyChangedFiles(["AGENTS.md"]),
   `${policyCliPath} must emit CI policy-sensitive routing for AGENTS.md changes`
 );
+assertPolicyCliOutput(
+  "script/test_ci_workflow_changed_file_detection_signals.mjs\n",
+  classifyChangedFiles(["script/test_ci_workflow_changed_file_detection_signals.mjs"]),
+  `${policyCliPath} must emit CI policy-sensitive routing for CI policy smoke changes`
+);
 
 assertSameMembers(
   workflowOutputKeys,
@@ -486,8 +505,8 @@ assert.match(
 );
 assert.match(
   javascriptJob,
-  /run: npm run test:ci-policy/,
-  `${workflowPath} jobs.javascript must run CI policy checks for ci_policy_sensitive docs-only changes`
+  /if: github\.event_name == 'pull_request' && needs\.changes\.outputs\.ci_policy_sensitive == 'true'\n        run: npm run test:ci-policy/,
+  `${workflowPath} jobs.javascript must run CI policy checks for any ci_policy_sensitive pull request change`
 );
 assertJobMatches(javascriptJob, /uses: ruby\/setup-ruby@v1/, `${workflowPath} jobs.javascript must keep Ruby setup for manifest-loading Node smokes`);
 assertJobMatches(javascriptJob, /ruby-version: "3\.3"/, `${workflowPath} jobs.javascript must keep Ruby 3.3 for manifest-loading Node smokes`);

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -175,6 +175,19 @@ workflowActionMajorSignals.forEach(([jobName, jobSource, action]) => {
   )
 })
 
+const lintJobSignals = [
+  ["representative Ruby version", 'ruby-version: "3.3"'],
+  ["Standard command", "run: bundle exec standardrb"]
+]
+
+lintJobSignals.forEach(([label, signal]) => {
+  assertIncludes(
+    lintJob,
+    signal,
+    `${workflowPath} jobs.lint ${label}`
+  )
+})
+
 assertIncludes(
   javascriptJob,
   'node-version: "22"',
@@ -235,6 +248,7 @@ docsEntrypointsSignals.forEach(([label, source, signal]) => {
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
 console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)
+console.log(`Checked ${lintJobSignals.length} CI lint job representative signals.`)
 console.log(`Checked ${rubyMatrixVersionSignals.length} representative Ruby workflow version signals.`)
 console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)
 console.log(`Checked ${docsEntrypointsSignals.length} docs-entrypoints package and suite command signals.`)


### PR DESCRIPTION
## 対応 Issue

- Closes #2554

## Issue ごとの完了内容

- #2554: 既存の CI policy smoke で `jobs.lint` の representative signal を確認するようにしました。
  - `workflowJobBlock(workflowSource, "lint")` による lint job 存在確認は既存のまま利用しています。
  - `ruby-version: "3.3"` を lint job block 内で確認します。
  - `run: bundle exec standardrb` を lint job block 内で確認します。
  - failure message は `.github/workflows/ci.yml jobs.lint ...` から欠落 signal が読める形にしています。
- review follow-up: CI policy smoke 自身を変更した場合に `npm run test:ci-policy` が CI 上で実行されるよう、changed-file routing と workflow condition を同期しました。

## 変更内容

- `script/test_ci_workflow_changed_file_detection_signals.mjs` に `lintJobSignals` を追加しました。
- summary output に lint job representative signal の確認件数を追加しました。
- `script/ci_changed_files_policy.mjs` が CI policy script / workflow 変更を `ci_policy_sensitive` として扱うようにしました。
- `.github/workflows/ci.yml` の `npm run test:ci-policy` step を、docs-only に限らず `ci_policy_sensitive` pull request change で実行するようにしました。
- `script/test_ci_changed_files_policy.mjs` に CI policy script routing と workflow condition の regression guard を追加しました。

## 改善カテゴリ

- test
- CI policy smoke
- devops guard
- review follow-up

## 既存仕様への影響

- runtime behavior、public API、UI、DB、認可、外部サービス契約への変更はありません。
- CI workflow の job topology / trigger / required-check 相当の意味は変更していません。
- CI policy 関連ファイルを変更する PR では、該当 policy smoke が明示的に実行されるようになります。

## 実施した確認

- Issue #2554 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- main head: `c27ca5a1aac208d39e9cae6346121718ba8eed76` を基点に branch 作成。
- review follow-up 後の head: `15bf4966bf17420f5465512c256bc8e513126581`。
- compare: `main...quality/2554-lint-job-signal-smoke` は ahead 4 / behind 0。
- changed files: `.github/workflows/ci.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs`, `script/test_ci_workflow_changed_file_detection_signals.mjs`。
- GitHub Actions CI #3522 / run `28057780802`: success。
  - `javascript` job で `npm run test:ci-policy`: success。
  - `javascript` job で `npm run test:js:core`: success。
  - `lint`, `pr_specs`, `gem_package`, `docker_development_setup`: success。
  - representative Rails lanes 7.0 / 7.2 / 8.0: success。
- ローカル checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` で失敗するため未実行です。PR CI を実行証拠にしています。

## リスク評価

low。既存 script の文字列 signal guard と CI routing guard に沿った変更です。lint rules、dependency versions、Standard 実行内容、workflow trigger、job topology は変更していません。

## 補足事項

- Dependabot / lint baseline / `.standard.yml` / RuboCop configuration / dependency updates は対象外です。
- merge は行いません。