### PR TITLE
release-note-candidates docs に package guard 境界を追記する

### DIFF
--- a/docs/en/release-note-candidates.md
+++ b/docs/en/release-note-candidates.md
@@ -9,6 +9,10 @@ It is intentionally a candidate collector only:
 - It does not tag, publish, or create a GitHub Release.
 - It does not replace the release preparation PR described in `docs/en/release.md`.
 
+## Package verification boundary
+
+This document is also part of the gem package verification surface. `script/check_gem_package_contents.rb` keeps the English and Japanese release-note candidate docs in the `Release note candidate docs` representative group so the built gem includes the maintainer review aid alongside the Release checklist. That package guard only checks that the docs are shipped; it does not turn the collector output into final release notes or release automation.
+
 ## Date window
 
 Use a date window when you want GitHub Search to return merged pull requests and closed issues directly:

--- a/docs/ja/release-note-candidates.md
+++ b/docs/ja/release-note-candidates.md
@@ -9,6 +9,10 @@
 - tag 作成、gem publish、GitHub Release 作成は行いません。
 - `docs/ja/release.md` に書かれている release preparation PR の代わりにはしません。
 
+## Package verification boundary
+
+この文書は gem package verification の確認対象でもあります。`script/check_gem_package_contents.rb` は英日 release-note candidate docs を `Release note candidate docs` の representative group に含め、built gem に release checklist と一緒に maintainer review aid が入っていることを確認します。この package guard が確認するのは docs が同梱されていることだけであり、collector output を最終 release notes や release automation に変えるものではありません。
+
 ## Date window
 
 期間が決まっている場合は、GitHub Search から merged pull request と closed issue を直接集めます。


### PR DESCRIPTION
## 対応 Issue

Refs #2555

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- 英日 `docs/*/release-note-candidates.md` に `Package verification boundary` 節を追加しました。
- `script/check_gem_package_contents.rb` の `Release note candidate docs` representative group が、英日 release-note candidate docs を built gem に含める package guard であることを明記しました。
- candidate collector は `CHANGELOG.md`、最終 release notes、tag、gem publish、GitHub Release 作成を自動判断しない、という既存境界を維持しています。

## Scope

- docs-only です。
- `script/check_gem_package_contents.rb`、`script/test_release_docs_signals.mjs`、release automation、GitHub Release notes 作成、CHANGELOG 本文は変更していません。
- #2555 の受け入れ条件には lightweight signal 追加も含まれるため、この PR は `Refs` に留め、Issue は close しません。

## 確認内容

- current main: `c27ca5a1aac208d39e9cae6346121718ba8eed76`
- compare `main...docs/2555-release-note-candidates-package-guard`: `ahead_by:2` / `behind_by:0` / `status:ahead`
- changed files は `docs/en/release-note-candidates.md` / `docs/ja/release-note-candidates.md` の2件のみです。
- connector readback で英日両方の追記箇所を確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既存 package contents guard と release-note candidate collector の役割境界を説明するだけで、実装・release policy・automation は変えていません。

merge は行いません。