### PR TITLE
Add CI trigger policy smoke

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -15,6 +15,10 @@ function assertIncludes(source, needle, label) {
   assert(source.includes(needle), `${label}: missing ${needle}`)
 }
 
+function assertAbsent(source, needle, label) {
+  assert(!source.includes(needle), `${label}: unexpected ${needle}`)
+}
+
 function workflowJobBlock(workflowSource, jobName) {
   const marker = `  ${jobName}:\n`
   const start = workflowSource.indexOf(marker)
@@ -34,6 +38,47 @@ function assertOrdered(source, earlier, later, label) {
   assert(earlierIndex !== -1, `${label}: missing ${earlier}`)
   assert(laterIndex !== -1, `${label}: missing ${later}`)
   assert(earlierIndex < laterIndex, `${label}: expected ${earlier} before ${later}`)
+}
+
+function workflowTopLevelTriggerBlock(workflowSource) {
+  const match = workflowSource.match(/^on:\n(?<body>[\s\S]*?)\n\njobs:\n/m)
+
+  assert(
+    match,
+    `${workflowPath} CI trigger policy must define a top-level on block before jobs`
+  )
+
+  return match.groups.body
+}
+
+function assertWorkflowTriggerPolicy(workflowSource) {
+  const triggerBlock = workflowTopLevelTriggerBlock(workflowSource)
+
+  assertIncludes(
+    triggerBlock,
+    "  pull_request:\n",
+    `${workflowPath} CI trigger policy pull_request trigger`
+  )
+  assertIncludes(
+    triggerBlock,
+    "  push:\n",
+    `${workflowPath} CI trigger policy push trigger`
+  )
+  assertIncludes(
+    triggerBlock,
+    "    branches:\n",
+    `${workflowPath} CI trigger policy push branches`
+  )
+  assertIncludes(
+    triggerBlock,
+    "      - main\n",
+    `${workflowPath} CI trigger policy push main branch`
+  )
+  assertAbsent(
+    triggerBlock,
+    "pull_request_target",
+    `${workflowPath} CI trigger policy privilege boundary trigger`
+  )
 }
 
 function workflowNonPullRequestDefaultOutputBlock(changesJob) {
@@ -74,6 +119,8 @@ function packageScript(scriptName) {
 
   return script
 }
+
+assertWorkflowTriggerPolicy(workflowSource)
 
 const changesJob = workflowJobBlock(workflowSource, "changes")
 const lintJob = workflowJobBlock(workflowSource, "lint")
@@ -245,6 +292,7 @@ docsEntrypointsSignals.forEach(([label, source, signal]) => {
   )
 })
 
+console.log("Checked CI workflow trigger policy signals.")
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
 console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -71,7 +71,7 @@ function assertWorkflowTriggerPolicy(workflowSource) {
   )
   assertIncludes(
     triggerBlock,
-    "      - main\n",
+    "      - main",
     `${workflowPath} CI trigger policy push main branch`
   )
   assertAbsent(


### PR DESCRIPTION
## 対応 Issue

- Closes #2485

## Issue ごとの完了内容

### #2485

- `script/test_ci_workflow_changed_file_detection_signals.mjs` に top-level workflow trigger policy の smoke を追加しました。
- `.github/workflows/ci.yml` の current policy として `pull_request`、`push.branches: [main]`、`pull_request_target` 不在を確認します。
- failure message から `.github/workflows/ci.yml` と CI trigger policy の missing / unexpected signal が分かるようにしました。

## 変更内容

- 既存の `npm run test:ci-policy` 導線に入っている CI workflow signal script へ、trigger policy 専用の小さな assertion block を追加しました。
- workflow 本体、job routing、permissions、concurrency、Ruby / Node versions、required checks、branch protection は変更していません。

## 改善カテゴリ

- test
- CI guard hardening
- 小さな内部整理

## 既存仕様への影響

- runtime / public API / UI / DB / 認可 / 外部サービス契約への影響はありません。
- GitHub Actions の trigger policy 自体は変更していません。現在の policy を smoke で検出するだけです。

## 確認内容

- GitHub connector で `main` から branch を作成し、PR 前に `main` との差分を確認しました。
- `main` に対して behind なし、変更ファイルは `script/test_ci_workflow_changed_file_detection_signals.mjs` のみです。
- PR CI run #3526: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success (`npm run test:ci-policy` success)
  - representative Rails matrix lanes: success
- local checkout / raw fetch は GitHub HTTPS 403 により利用できなかったため、ローカル実行ではなく PR CI で確認しました。

## リスク評価

low。既存 workflow の文字列 signal guard 追加に閉じており、CI behavior は変えていません。

## 補足

- #2478 の token permissions guard、#2483 の concurrency 検討、action major docs 同期は scope 外として扱っています。