### PR TITLE
CI matrix fail-fast policy を smoke で守る

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -40,6 +40,14 @@ function assertOrdered(source, earlier, later, label) {
   assert(earlierIndex < laterIndex, `${label}: expected ${earlier} before ${later}`)
 }
 
+function assertMatrixFailFastPolicy(jobName, jobSource) {
+  assertIncludes(
+    jobSource,
+    "strategy:\n      fail-fast: false\n",
+    `${workflowPath} jobs.${jobName} matrix fail-fast policy`
+  )
+}
+
 function workflowTopLevelTriggerBlock(workflowSource) {
   const match = workflowSource.match(/^on:\n(?<body>[\s\S]*?)\n\njobs:\n/m)
 
@@ -235,6 +243,16 @@ lintJobSignals.forEach(([label, signal]) => {
   )
 })
 
+const matrixFailFastPolicyJobs = [
+  ["pr_rails_matrix", prRailsMatrixJob],
+  ["ruby_matrix", rubyMatrixJob],
+  ["rails_matrix", railsMatrixJob]
+]
+
+matrixFailFastPolicyJobs.forEach(([jobName, jobSource]) => {
+  assertMatrixFailFastPolicy(jobName, jobSource)
+})
+
 assertIncludes(
   javascriptJob,
   'node-version: "22"',
@@ -297,6 +315,7 @@ console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
 console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)
 console.log(`Checked ${lintJobSignals.length} CI lint job representative signals.`)
+console.log(`Checked ${matrixFailFastPolicyJobs.length} CI matrix fail-fast policy signals.`)
 console.log(`Checked ${rubyMatrixVersionSignals.length} representative Ruby workflow version signals.`)
 console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)
 console.log(`Checked ${docsEntrypointsSignals.length} docs-entrypoints package and suite command signals.`)


### PR DESCRIPTION
## 対応 Issue

Closes #2491

## Issue ごとの完了内容

- #2491: `pr_rails_matrix` / `ruby_matrix` / `rails_matrix` の `strategy.fail-fast: false` が CI policy smoke で検出されるようにしました。

## 変更内容

- `script/test_ci_workflow_changed_file_detection_signals.mjs` に matrix fail-fast policy の helper と代表ジョブ一覧を追加しました。
- 対象は compatibility matrix の3ジョブに限定し、`.github/workflows/ci.yml` 本体、matrix version set、job routing、required checks、branch protection、Ruby / Rails support policy は変更していません。

## 改善カテゴリ

- quality / test
- CI policy smoke hardening
- low-risk maintenance

## 既存仕様への影響

既存仕様への影響はありません。CI workflow の挙動や実行条件は変えず、現行 workflow が持つ `fail-fast: false` policy を lightweight smoke で守るだけです。

## 実施した確認

- Issue #2491 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 既存 PR 検索で #2491 対応の open / closed PR がないことを確認しました。
- current `main` から branch を作成しました。
- compare `main...quality/2491-ci-matrix-fail-fast-smoke`: `ahead_by:1` / `behind_by:0` / changed files 1件。
- changed file は `script/test_ci_workflow_changed_file_detection_signals.mjs` のみです。
- local checkout / `npm run test:ci-policy` は GitHub HTTPS 制限により未実行です。PR 作成後に GitHub Actions CI を確認します。

## リスク評価

low。既存 workflow の matrix policy を検知対象に追加するだけで、CI topology や runtime Ruby / JavaScript、public API、DB、認可、外部サービス契約には触れていません。

## 補足事項

merge は行いません。