### PR TITLE
JavaScript event_names docs signal を smoke で守る

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",
     "test:public-api-manifest-structure": "node script/test_public_api_manifest_structure.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
+    "test:docs-entrypoints": "node script/test_event_names_public_api_signals.mjs && node script/test_docs_entrypoint_suite.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_event_names_public_api_signals.mjs
+++ b/script/test_event_names_public_api_signals.mjs
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const manifest = read("config/public_api_manifest.yml")
+const jsEventDocs = [
+  ["docs/en/js-events.md", read("docs/en/js-events.md")],
+  ["docs/ja/js-events.md", read("docs/ja/js-events.md")]
+]
+
+const eventNameManifestSignals = [
+  ["state event-name manifest group", "event_names:"],
+  ["state event-name manifest group", "state_changed: tree-view-state:state-changed"],
+  ["selection event-name manifest group", "change: tree-view-selection:change"],
+  ["selection event-name manifest group", "selected: tree-view-selection:selected"],
+  ["selection event-name manifest group", "limit_exceeded: tree-view-selection:limit-exceeded"],
+  ["selection event-name manifest group", "invalid_payload: tree-view-selection:invalid-payload"],
+  ["remote-state event-name manifest group", "change: tree-view-remote-state:change"],
+  ["remote-state event-name manifest group", "retry: tree-view-remote-state:retry"],
+  ["host lifecycle event-name manifest group", "loading: tree-view:loading"],
+  ["host lifecycle event-name manifest group", "loaded: tree-view:loaded"],
+  ["host lifecycle event-name manifest group", "error: tree-view:error"],
+  ["host lifecycle event-name manifest group", "retry: tree-view:retry"],
+  ["transfer event-name manifest group", "drag_start: tree-view-transfer:drag-start"],
+  ["transfer event-name manifest group", "drag_over: tree-view-transfer:drag-over"],
+  ["transfer event-name manifest group", "drop: tree-view-transfer:drop"],
+  ["transfer event-name manifest group", "invalid_transfer: tree-view-transfer:invalid-transfer"]
+]
+
+const documentedEventNameSignals = [
+  "tree-view-state:state-changed",
+  "tree-view-selection:change",
+  "tree-view-selection:selected",
+  "tree-view-selection:limit-exceeded",
+  "tree-view-selection:invalid-payload",
+  "tree-view-remote-state:change",
+  "tree-view-remote-state:retry",
+  "tree-view:loading",
+  "tree-view:loaded",
+  "tree-view:error",
+  "tree-view:retry",
+  "tree-view-transfer:drag-start",
+  "tree-view-transfer:drag-over",
+  "tree-view-transfer:drop",
+  "tree-view-transfer:invalid-payload",
+  "tree-view-transfer:invalid-transfer"
+]
+
+const packageRootEventNameSignals = [
+  "TreeViewEventNames",
+  "TreeViewEventNames.selection.change",
+  "TreeViewEventNames.remoteState.change",
+  "TreeViewEventNames.hostLifecycle.*",
+  "TreeViewEventNames.remoteState.*"
+]
+
+eventNameManifestSignals.forEach(([label, signal]) => {
+  assertIncludes(manifest, signal, `config/public_api_manifest.yml ${label}`)
+})
+
+jsEventDocs.forEach(([relativePath, document]) => {
+  documentedEventNameSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} canonical event-name docs`)
+  })
+
+  packageRootEventNameSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} package-root event-name docs`)
+  })
+
+  assert(
+    /raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string/.test(document) || /raw event string|raw event strings|raw event name|raw event names|event name string|event name strings|event 名/.test(document),
+    `${relativePath}: event-name docs no longer separate raw event names from package-root constants`
+  )
+
+  assert(
+    /TreeViewEventDetailKeys|event.detail|event\.detail|event detail|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field/.test(document) || /TreeViewEventDetailKeys|event\.detail|event.detail|payload field|payload fields|公開payload/.test(document),
+    `${relativePath}: event-name docs no longer separate event names from detail-key payload fields`
+  )
+})

--- a/script/test_event_names_public_api_signals.mjs
+++ b/script/test_event_names_public_api_signals.mjs
@@ -68,13 +68,6 @@ const packageRootEventNameSignals = [
   "TreeViewEventNames.remoteState.*"
 ]
 
-const eventNameBoundarySignals = [
-  ["English raw-string boundary", /raw event strings? above remain the public contract/],
-  ["Japanese raw-string boundary", /raw event string は引き続き公開契約/],
-  ["English event-detail boundary", /TreeViewEventDetailKeys lists documented payload field names/],
-  ["Japanese event-detail boundary", /TreeViewEventDetailKeys は documented payload field 名/]
-]
-
 eventNameManifestSignals.forEach(([label, signal]) => {
   assertIncludes(manifest, signal, `config/public_api_manifest.yml ${label}`)
 })
@@ -88,9 +81,13 @@ jsEventDocs.forEach(([relativePath, document]) => {
     assertIncludes(document, signal, `${relativePath} package-root event-name docs`)
   })
 
-  const boundaryMatches = eventNameBoundarySignals.filter(([, pattern]) => pattern.test(document))
   assert(
-    boundaryMatches.length >= 2,
-    `${relativePath}: event-name docs no longer separate raw event names, package-root constants, and detail-key payload fields`
+    /raw event strings?|raw event string|event string/.test(document),
+    `${relativePath}: event-name docs no longer mention the raw event-name contract`
+  )
+
+  assert(
+    document.includes("TreeViewEventDetailKeys") && /payload field|公開payload/.test(document),
+    `${relativePath}: event-name docs no longer separate event names from detail-key payload fields`
   )
 })

--- a/script/test_event_names_public_api_signals.mjs
+++ b/script/test_event_names_public_api_signals.mjs
@@ -68,6 +68,13 @@ const packageRootEventNameSignals = [
   "TreeViewEventNames.remoteState.*"
 ]
 
+const eventNameBoundarySignals = [
+  ["English raw-string boundary", /raw event strings? above remain the public contract/],
+  ["Japanese raw-string boundary", /raw event string は引き続き公開契約/],
+  ["English event-detail boundary", /TreeViewEventDetailKeys lists documented payload field names/],
+  ["Japanese event-detail boundary", /TreeViewEventDetailKeys は documented payload field 名/]
+]
+
 eventNameManifestSignals.forEach(([label, signal]) => {
   assertIncludes(manifest, signal, `config/public_api_manifest.yml ${label}`)
 })
@@ -81,13 +88,9 @@ jsEventDocs.forEach(([relativePath, document]) => {
     assertIncludes(document, signal, `${relativePath} package-root event-name docs`)
   })
 
+  const boundaryMatches = eventNameBoundarySignals.filter(([, pattern]) => pattern.test(document))
   assert(
-    /raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string|raw event string/.test(document) || /raw event string|raw event strings|raw event name|raw event names|event name string|event name strings|event 名/.test(document),
-    `${relativePath}: event-name docs no longer separate raw event names from package-root constants`
-  )
-
-  assert(
-    /TreeViewEventDetailKeys|event.detail|event\.detail|event detail|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field|payload field/.test(document) || /TreeViewEventDetailKeys|event\.detail|event.detail|payload field|payload fields|公開payload/.test(document),
-    `${relativePath}: event-name docs no longer separate event names from detail-key payload fields`
+    boundaryMatches.length >= 2,
+    `${relativePath}: event-name docs no longer separate raw event names, package-root constants, and detail-key payload fields`
   )
 })


### PR DESCRIPTION
## 対応 Issue

Closes #2544

## Issue ごとの完了内容

- #2544: `javascript_package_root.event_names` の代表 event name が manifest と英日 JS Events docs から落ちた場合に検出できる lightweight smoke を追加しました。

## 変更内容

- `script/test_event_names_public_api_signals.mjs` を追加しました。
  - `config/public_api_manifest.yml` の `event_names` 代表 group を確認します。
  - 英日 `docs/*/js-events.md` の canonical event name、`TreeViewEventNames` の package-root usage、event name / detail-key の責務境界を確認します。
- `package.json` の `test:docs-entrypoints` から新しい smoke を実行するようにしました。

## 改善カテゴリ

- quality / test
- docs smoke hardening
- public JavaScript docs guard

## 既存仕様への影響

既存仕様への影響はありません。Runtime Ruby / JavaScript、event dispatch behavior、event payload shape、manifest schema、docs 本文は変更していません。既存 docs と manifest にある代表 signal を検出対象に追加しただけです。

## 実施した確認

- Issue #2544 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` から branch を作成しました。
- compare `main...quality/2544-event-names-docs-smoke`: `ahead_by:3` / `behind_by:0` / `status:ahead`。
- changed files は `package.json` と `script/test_event_names_public_api_signals.mjs` の2件のみです。
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR 作成後に GitHub Actions CI を確認します。

## リスク評価

low。docs smoke の追加と package script の実行対象追加に閉じています。公開 API、DB、認可、外部サービス契約、CI workflow topology、required checks は変更していません。

## 補足事項

merge は行いません。