### PR TITLE
release-note-candidates docs の package guard signal を追加する

### DIFF
--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -236,6 +236,39 @@ packageContentsVerificationSignals.forEach(([sourcePath, signals]) => {
   assertSignals(sourcePath, "Gem package release docs category signal", signals)
 })
 
+const releaseNoteCandidatePackageGuardSignals = [
+  [
+    "script/check_gem_package_contents.rb",
+    [
+      "Release note candidate docs",
+      "docs/en/release-note-candidates.md",
+      "docs/ja/release-note-candidates.md"
+    ]
+  ],
+  [
+    "docs/en/release.md",
+    [
+      "Release note candidate collector",
+      "release-note-candidates.md",
+      "package-sensitive",
+      "docs/**"
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "Release note candidate collector",
+      "release-note-candidates.md",
+      "package-sensitive",
+      "docs/**"
+    ]
+  ]
+]
+
+releaseNoteCandidatePackageGuardSignals.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Release note candidate package guard signal", signals)
+})
+
 const controllerRegistrationDocsSignals = [
   [
     "config/public_api_manifest.yml",


### PR DESCRIPTION
## 対応 Issue

Closes #2555

## Issue ごとの完了内容

- #2555: `release-note-candidates.md` が package contents guard の代表 docs group に含まれていることを、release docs signal smoke で検出できるようにしました。

## 変更内容

- `script/test_release_docs_signals.mjs` に `releaseNoteCandidatePackageGuardSignals` を追加しました。
- `script/check_gem_package_contents.rb` の `Release note candidate docs` group と英日 `release-note-candidates.md` path を代表 signal として確認します。
- 英日 Release docs 側は current main に既にある release-note candidate collector 導線と package-sensitive docs guidance を代表 signal として確認します。

## 改善カテゴリ

- quality / test
- docs smoke hardening
- package verification signal guard

## 既存仕様への影響

既存仕様への影響はありません。Runtime Ruby / JavaScript、release helper behavior、release automation、GitHub API integration、final release notes 判断、gemspec metadata、CI workflow は変更していません。

## 実施した確認

- Issue #2555 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current `main` `91f3fdca2fa329b5be187ac8fa0238b6965fc919` から branch を作成しました。
- compare `main...quality/2555-release-note-candidates-package-signal`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files は `script/test_release_docs_signals.mjs` の1件のみです。
- local checkout は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。
- local `node script/test_release_docs_signals.mjs` は repository checkout がないため未実行です。PR 作成後に GitHub Actions CI を確認します。

## リスク評価

low。既存の package contents guard と Release docs の既存導線を文字列 signal として結び直すだけです。#1709 の docs entrypoint / discoverability smoke には広げていません。

## 補足事項

- #2557 も eligible でしたが、英日 `docs/*/development.md` の本文に安全な部分 patch が必要であり、同じ blocker が既に issue comment に記録されています。この PR には混ぜていません。
- merge は行いません。