### PR TITLE
CHANGELOG に event_names docs signal smoke を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@ Release preparation notes:
 - Added nested Public API manifest key parity coverage so Ruby and Node manifest structure guards stay synchronized for option key and integration hook lists.
 - Added release docs signal coverage for release metadata guards and docs-entrypoint sensitive CI routing.
 - Added docs entrypoint suite self-test coverage for unregistered docs smoke / signal scripts.
+- Added event names public API docs signal smoke coverage so manifest event-name groups and documented JavaScript event names stay aligned.
 - Added CHANGELOG-only CI routing coverage to keep `CHANGELOG.md` changes on the docs-entrypoint and package verification paths.
 - Added release note candidate helper contract specs for formatter output, CLI option validation, and since-tag reference collection without network access.
 - Added mockup demo application boundary docs signal coverage for static mockup / future real Rails demo app responsibility boundaries.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2544
Refs #2563

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、#2563 で追加された event names public API docs signal smoke の release-facing evidence を1行追加しました。

## Scope

- docs-only です。
- runtime Ruby / JavaScript、`package.json`、docs signal scripts、CI workflow、Public API manifest は変更していません。
- #2544 自体は #2563 で close 済みのため、この PR は `Refs` に留めます。

## 確認内容

- review follow-up 対象として open PR #2564 / #2565 を確認しました。#2564 / #2565 は green かつ自分の確認コメントのみで、未解決 review thread はありませんでした。
- #2563 が main に merge 済みであることを確認しました。
- current main `a30238a6482606ccc9c0dee7e75f9accd2a99ebe` 起点で branch を作成し直しました。
- compare `main...docs/2544-event-names-changelog-latest`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` のみ。
- commit patch は追加1行・削除0行であることを確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。既に merge 済みの docs signal smoke を CHANGELOG の Tests に記録するだけです。

merge は行いません。