### PR TITLE
docs-entrypoints suite に event names signal を登録する

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",
     "test:public-api-manifest-structure": "node script/test_public_api_manifest_structure.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/test_event_names_public_api_signals.mjs && node script/test_docs_entrypoint_suite.mjs",
+    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -23,6 +23,11 @@ const checks = [
     args: ["script/test_docs_entrypoint_signals.mjs"]
   },
   {
+    group: "Event names docs signals",
+    command: "node",
+    args: ["script/test_event_names_public_api_signals.mjs"]
+  },
+  {
     group: "Host app extension diagnostics signals",
     command: "node",
     args: ["script/test_host_app_extension_diagnostics_signals.mjs"]
@@ -165,6 +170,7 @@ const docsEntrypointScriptExclusions = new Map([
 
 const docsEntrypointScriptPatterns = [
   /^check_controller_registration_docs_signals\.mjs$/,
+  /^test_event_names_public_api_signals\.mjs$/,
   /^test_.*docs.*\.mjs$/,
   /^test_.*readme.*signals\.mjs$/,
   /^test_.*mockup.*signals\.mjs$/,
@@ -334,6 +340,11 @@ function runSelfTest() {
     "case-insensitive exact --only should resolve a group"
   )
   assert.equal(
+    resolveOnlyGroupResult("Event names").check.group,
+    "Event names docs signals",
+    "unique partial --only should resolve the event names docs signal"
+  )
+  assert.equal(
     resolveOnlyGroupResult("Localized and hook").check.group,
     "Localized and hook docs signals",
     "unique partial --only should resolve a group"
@@ -365,6 +376,10 @@ function runSelfTest() {
     "ambiguous --only should report all matching groups"
   )
 
+  assert.ok(
+    docsEntrypointCandidateScriptPaths().includes("script/test_event_names_public_api_signals.mjs"),
+    "docs script registration candidates should include event names public API signals"
+  )
   assert.ok(
     docsEntrypointCandidateScriptPaths().includes("script/test_public_api_docs_signals.mjs"),
     "docs script registration candidates should include public API docs signals"


### PR DESCRIPTION
## 対応 Issue

Closes #2562

## Issue ごとの完了内容

- #2562: `test_event_names_public_api_signals.mjs` を `script/test_docs_entrypoint_suite.mjs` の明示 group として登録し、`--list` / `--only` / `--self-test` から見えるようにしました。

## 変更内容

- `package.json` の `test:docs-entrypoints` を `node script/test_docs_entrypoint_suite.mjs` に戻し、event names guard の直接 pre-run をやめました。
- `script/test_docs_entrypoint_suite.mjs` に `Event names docs signals` group を追加しました。
- suite self-test が `script/test_event_names_public_api_signals.mjs` を docs entrypoint candidate として検出し、未登録なら落ちるようにしました。
- `--only "Event names"` の解決も self-test で確認する形にしました。

## 改善カテゴリ

- test
- docs/CI guard discoverability
- 小さな内部整理

## 既存仕様への影響

runtime Ruby / JavaScript、event name / payload、public API manifest schema、`.github/workflows/ci.yml`、required checks、changed-files policy は変更していません。`npm run test:docs-entrypoints` が実行する guard の意図は維持しつつ、直接 chain ではなく suite group に寄せています。

## 実施した確認

- Issue #2562 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- current main: `a30238a6482606ccc9c0dee7e75f9accd2a99ebe`。
- PR 前 compare `main...quality/2562-docs-entrypoint-suite-discovery`: `ahead_by:2` / `behind_by:0` / changed files 2件。
- connector readback で `package.json`、suite group、candidate pattern、self-test assertion を確認しました。
- local checkout / local npm checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。package script と suite registration の整理に限定され、CI workflow topology や public API surface は変えていません。

## 補足事項

merge は行いません。