### PR TITLE
test:ci-policy の登録漏れを CI policy smoke で守る

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -94,6 +94,7 @@ function isCiPolicySensitivePath(file) {
     file === "script/ci_changed_files_policy.mjs" ||
     file === "script/test_ci_changed_files_policy.mjs" ||
     file === "script/test_ci_workflow_changed_file_detection_signals.mjs" ||
+    file === "script/test_ci_workflow_permissions_signals.mjs" ||
     file === "script/test_ci_observation_guidance_signals.mjs" ||
     file === "script/test_package_lock_dependency_drift.mjs" ||
     file === "script/test_gemfile_lock_dependency_drift.mjs"

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -10,6 +10,7 @@ const policyCliPath = "script/ci_changed_files_policy.mjs";
 const ciPolicyGuardScriptPaths = [
   "script/test_ci_changed_files_policy.mjs",
   "script/test_ci_workflow_changed_file_detection_signals.mjs",
+  "script/test_ci_workflow_permissions_signals.mjs",
   "script/test_ci_observation_guidance_signals.mjs",
   "script/test_package_lock_dependency_drift.mjs",
   "script/test_gemfile_lock_dependency_drift.mjs"
@@ -141,6 +142,19 @@ const cases = [
   {
     name: "CI policy scripts request CI policy guard",
     files: ["script/ci_changed_files_policy.mjs", "script/test_ci_workflow_changed_file_detection_signals.mjs"],
+    expected: {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: false,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false,
+      ci_policy_sensitive: true
+    }
+  },
+  {
+    name: "CI workflow permissions signals request CI policy guard",
+    files: ["script/test_ci_workflow_permissions_signals.mjs"],
     expected: {
       docs_only: false,
       mockups_changed: false,
@@ -398,6 +412,11 @@ assertPolicyCliOutput(
   "script/test_ci_workflow_changed_file_detection_signals.mjs\n",
   classifyChangedFiles(["script/test_ci_workflow_changed_file_detection_signals.mjs"]),
   `${policyCliPath} must emit CI policy-sensitive routing for CI policy smoke changes`
+);
+assertPolicyCliOutput(
+  "script/test_ci_workflow_permissions_signals.mjs\n",
+  classifyChangedFiles(["script/test_ci_workflow_permissions_signals.mjs"]),
+  `${policyCliPath} must emit CI policy-sensitive routing for CI workflow permissions smoke changes`
 );
 
 assertSameMembers(

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -7,6 +7,14 @@ const workflowPath = ".github/workflows/ci.yml";
 const packagePath = "package.json";
 const policyCliPath = "script/ci_changed_files_policy.mjs";
 
+const ciPolicyGuardScriptPaths = [
+  "script/test_ci_changed_files_policy.mjs",
+  "script/test_ci_workflow_changed_file_detection_signals.mjs",
+  "script/test_ci_observation_guidance_signals.mjs",
+  "script/test_package_lock_dependency_drift.mjs",
+  "script/test_gemfile_lock_dependency_drift.mjs"
+];
+
 const cases = [
   {
     name: "gem-packaged docs stay docs-only and request package and docs entrypoint guards",
@@ -307,6 +315,23 @@ function assertJobMatches(jobBlock, pattern, message) {
   assert.match(jobBlock, pattern, message);
 }
 
+function assertCiPolicyScriptRegistration(packageScripts) {
+  const ciPolicyCommand = packageScripts["test:ci-policy"];
+  assert.equal(
+    typeof ciPolicyCommand,
+    "string",
+    `${packagePath} scripts.test:ci-policy must be a command string`
+  );
+
+  for (const scriptPath of ciPolicyGuardScriptPaths) {
+    assert.match(
+      ciPolicyCommand,
+      new RegExp(`(?:^|&&\\s*)node ${escapeRegExp(scriptPath)}(?:\\s*&&|$)`),
+      `${packagePath} scripts.test:ci-policy must run ${scriptPath} so CI policy guard changes validate their own registration`
+    );
+  }
+}
+
 function policyCliOutput(input) {
   return execFileSync(process.execPath, [policyCliPath], {
     input,
@@ -563,6 +588,8 @@ assertJobMatches(
 assertJobMatches(gemPackageJob, /run: gem install tree_view-\*\.gem/, `${workflowPath} jobs.gem_package must install the built gem`);
 assertJobMatches(gemPackageJob, /run: ruby -e "require 'tree_view'"/, `${workflowPath} jobs.gem_package must keep the installed gem require smoke`);
 
+assertCiPolicyScriptRegistration(packageScripts);
+
 assert.ok(
   packageScripts["test:ci-policy"].includes("script/test_package_lock_dependency_drift.mjs"),
   `${packagePath} scripts.test:ci-policy must keep the package lock dependency drift guard`
@@ -577,4 +604,5 @@ for (const scriptName of npmRunScripts(workflowSource)) {
 
 console.log(`Checked ${cases.length} CI changed-file policy cases.`);
 console.log(`Checked ${workflowOutputKeys.length} workflow output keys and ${npmRunScripts(workflowSource).length} JavaScript npm commands.`);
+console.log(`Checked ${ciPolicyGuardScriptPaths.length} CI policy script registrations.`);
 console.log("Checked representative CI workflow setup surfaces.");


### PR DESCRIPTION
## 対応 Issue

Closes #2577
Supersedes #2578

## Issue ごとの完了内容

- #2577: `test:ci-policy` に代表 CI policy guard scripts が登録され続けることを `script/test_ci_changed_files_policy.mjs` で確認する assertion を追加しました。
- review follow-up: `script/test_ci_workflow_permissions_signals.mjs` も同じ CI policy guard family として registration guard と changed-files routing の `ci_policy_sensitive` 対象に含めました。

## 置き換え理由

#2578 作成後に `main` が進み、追従用の merge-style 更新で PR の changed-files 表示が広がりました。この PR は current main 起点の clean replacement です。旧 PR branch の force push や履歴書き換えは行っていません。

## 変更内容

- CI policy guard script の代表リストを `ciPolicyGuardScriptPaths` として定義しました。
- `package.json` の `scripts.test:ci-policy` が各 guard script を `node ...` として実行していることを確認する `assertCiPolicyScriptRegistration` を追加しました。
- `script/test_ci_workflow_permissions_signals.mjs` を registration guard と `isCiPolicySensitivePath` に追加しました。
- permissions signal script 単体の changed-files CLI assertion を追加しました。
- smoke 成功時の出力に確認した registration 数を追加しました。

## 改善カテゴリ

- test
- CI guard hardening
- 小さな内部整理

## 既存仕様への影響

既存仕様への影響はありません。CI workflow、package scripts、runtime Ruby / JavaScript、public API、docs content、DB、認可、外部サービス契約は変更していません。

`script/test_ci_workflow_permissions_signals.mjs` を触った PR でも `ci_policy_sensitive` として `npm run test:ci-policy` を走らせるようにし、既存の CI policy guard family との整合を取っています。

## 実施した確認

- Issue #2577 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- review follow-up コメントを確認し、permissions signal script の registration / sensitive path 漏れを修正しました。
- current main: `99141bce207b38e7c9ab8445a1d906fd9e9ba182`。
- head: `c9f6d162af36a649133c3c4c8eaf8dcf6ed6621a`。
- compare `main...quality/2577-ci-policy-registration-guard-v2`: `ahead_by:4` / `behind_by:0` / `status:ahead`。
- changed files: `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs` の2件のみ。
- local git checkout は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存の CI policy smoke と changed-files routing に、既に `test:ci-policy` で実行されている permissions signal script を揃えるだけです。CI workflow、package scripts、runtime code は変更していません。

## 補足事項

- rails_table_preferences の #490 / #614 / #1567 / #1576 はラベル上は eligible ですが、既存コメント通り checkout / browser / system smoke 証跡または大きな controller patch が必要なため、この review follow-up を優先しました。
- tree_view-rails の #1825 / #2150 は checkout / executable proof が必要な既存 blocker です。
- rails_fields_kit の ready/planned quality issues は source PR の final merge state や browser evidence に依存するものが中心で、この修正には束ねていません。

merge は行いません。