### PR TITLE
public event value export の docs signal を追加する

### DIFF
--- a/script/test_event_names_public_api_signals.mjs
+++ b/script/test_event_names_public_api_signals.mjs
@@ -21,6 +21,10 @@ const jsEventDocs = [
   ["docs/en/js-events.md", read("docs/en/js-events.md")],
   ["docs/ja/js-events.md", read("docs/ja/js-events.md")]
 ]
+const dragAndDropDocs = [
+  ["docs/en/drag-and-drop.md", read("docs/en/drag-and-drop.md")],
+  ["docs/ja/drag-and-drop.md", read("docs/ja/drag-and-drop.md")]
+]
 
 const eventNameManifestSignals = [
   ["state event-name manifest group", "event_names:"],
@@ -68,8 +72,41 @@ const packageRootEventNameSignals = [
   "TreeViewEventNames.remoteState.*"
 ]
 
+const publicEventValueManifestSignals = [
+  ["state-change reason export", "TreeViewStateChangeReasons"],
+  ["state-change reason manifest group", "state_change_reasons:"],
+  ["state-change reason value", "connect: connect"],
+  ["state-change reason value", "refresh: refresh"],
+  ["state-change reason value", "expanded: expanded"],
+  ["state-change reason value", "collapsed: collapsed"],
+  ["transfer drop-position export", "TreeViewTransferDropPositions"],
+  ["transfer drop-position manifest group", "transfer_drop_positions:"],
+  ["transfer drop-position value", "before: before"],
+  ["transfer drop-position value", "inside: inside"],
+  ["transfer drop-position value", "after: after"]
+]
+
+const documentedStateChangeReasonSignals = [
+  "TreeViewStateChangeReasons",
+  "connect",
+  "refresh",
+  "expanded",
+  "collapsed"
+]
+
+const documentedTransferDropPositionSignals = [
+  "TreeViewTransferDropPositions",
+  "before",
+  "inside",
+  "after"
+]
+
 eventNameManifestSignals.forEach(([label, signal]) => {
   assertIncludes(manifest, signal, `config/public_api_manifest.yml ${label}`)
+})
+
+publicEventValueManifestSignals.forEach(([label, signal]) => {
+  assertIncludes(manifest, signal, `config/public_api_manifest.yml public event value docs signal (${label})`)
 })
 
 jsEventDocs.forEach(([relativePath, document]) => {
@@ -81,6 +118,14 @@ jsEventDocs.forEach(([relativePath, document]) => {
     assertIncludes(document, signal, `${relativePath} package-root event-name docs`)
   })
 
+  documentedStateChangeReasonSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} package-root state-change reason value docs`)
+  })
+
+  documentedTransferDropPositionSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} package-root transfer drop-position value docs`)
+  })
+
   assert(
     /raw event strings?|raw event string|event string/.test(document),
     `${relativePath}: event-name docs no longer mention the raw event-name contract`
@@ -89,5 +134,21 @@ jsEventDocs.forEach(([relativePath, document]) => {
   assert(
     document.includes("TreeViewEventDetailKeys") && /payload field|公開payload/.test(document),
     `${relativePath}: event-name docs no longer separate event names from detail-key payload fields`
+  )
+
+  assert(
+    /package-root value set|package-root の value export/.test(document),
+    `${relativePath}: event value docs no longer describe the package-root value export boundary`
+  )
+})
+
+dragAndDropDocs.forEach(([relativePath, document]) => {
+  documentedTransferDropPositionSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} transfer drop-position value docs`)
+  })
+
+  assert(
+    /host-app business rules|host appの業務ルール/.test(document),
+    `${relativePath}: transfer drop-position docs no longer preserve the host-app-owned business boundary`
   )
 })


### PR DESCRIPTION
## 対応 Issue

Closes #2580

## Issue ごとの完了内容

- #2580: `TreeViewStateChangeReasons` / `TreeViewTransferDropPositions` の public value export が manifest と英日 docs から落ちないよう、既存 event-name docs smoke に代表 signal を追加しました。

## 変更内容

- `script/test_event_names_public_api_signals.mjs` に public event value export の manifest signal を追加しました。
- 英日 `docs/*/js-events.md` が `TreeViewStateChangeReasons`、`connect` / `refresh` / `expanded` / `collapsed`、`TreeViewTransferDropPositions`、`before` / `inside` / `after`、package-root value export boundary を説明していることを確認します。
- 英日 `docs/*/drag-and-drop.md` が `TreeViewTransferDropPositions` と `before` / `inside` / `after`、host-app-owned business boundary を保持していることを確認します。

## 改善カテゴリ

- test
- docs signal guard
- public API docs drift prevention

## 既存仕様への影響

- runtime Ruby / JavaScript、package export、TypeScript declaration、manifest schema、event dispatch behavior、drop-position algorithm は変更していません。
- docs 本文も変更せず、現在 main にある public API / docs signal を軽量 smoke で守るだけです。

## 実施した確認

- Issue #2580 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR前 compare `main...chore/2580-value-export-docs-signal`: `ahead_by:1` / `behind_by:0` / changed files 1。
- connector readback で変更ファイルの内容と対象ファイルが `script/test_event_names_public_api_signals.mjs` のみであることを確認しました。
- local checkout / `npm run test:docs-entrypoints` は GitHub HTTPS / raw access 制限により未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 docs signal の smoke 追加のみで、公開挙動やAPI契約を変更しません。

## 補足事項

- merge は行いません。