### PR TITLE
CHANGELOG Security category を release docs に同期する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog uses the following categories when applicable:
 - `Fixed` for bug fixes.
 - `Deprecated` for features planned for removal.
 - `Removed` for removed features.
+- `Security` for vulnerability fixes and security hardening notes.
 - `Documentation` for docs-only changes.
 - `Tests` for test, CI, and package verification changes.
 
@@ -121,6 +122,7 @@ Release preparation notes:
 - Clarified Public API docs and README package-root examples for `TreeViewTransferDataAttributes`, including transfer payload and disabled-row data attribute boundaries.
 - Documented CI-policy-sensitive docs-only routing in AGENTS.md and Release docs so maintainers know when `npm run test:ci-policy` runs for repository-maintainer docs.
 - Added RubyGems `documentation_uri` metadata release evidence so package users can find the docs entrypoint from gem metadata.
+- Documented `Security` as an allowed CHANGELOG category for vulnerability fixes and security hardening notes.
 
 ### Tests
 

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -166,10 +166,11 @@ Use these categories:
 - Fixed
 - Deprecated
 - Removed
+- Security
 - Documentation
 - Tests
 
-Record test, CI, docs smoke, and package verification changes under Tests. Record public API manifest changes by their user-visible effect. Use Added or Changed for backward-compatible public surface updates, Deprecated or Removed for compatibility changes that require migration notes, and Documentation only when the manifest or docs guidance changed without a runtime contract change.
+Use Security for vulnerability fixes and security hardening notes. Record test, CI, docs smoke, and package verification changes under Tests. Record public API manifest changes by their user-visible effect. Use Added or Changed for backward-compatible public surface updates, Deprecated or Removed for compatibility changes that require migration notes, and Documentation only when the manifest or docs guidance changed without a runtime contract change.
 
 Include migration notes for breaking changes or deprecations.
 

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -166,10 +166,11 @@ releaseごとに `CHANGELOG.md` へ日付付きentryを追加します。
 - Fixed
 - Deprecated
 - Removed
+- Security
 - Documentation
 - Tests
 
-test、CI、docs smoke、package verification の変更は Tests に記録します。public API manifest の変更は、user-visible な影響に合わせて記録します。後方互換な public surface 追加や変更は Added / Changed、migration note が必要な互換性変更は Deprecated / Removed、runtime contract を変えない manifest や docs guidance の変更は Documentation に入れてください。
+Security は vulnerability fix や security hardening note に使います。test、CI、docs smoke、package verification の変更は Tests に記録します。public API manifest の変更は、user-visible な影響に合わせて記録します。後方互換な public surface 追加や変更は Added / Changed、migration note が必要な互換性変更は Deprecated / Removed、runtime contract を変えない manifest や docs guidance の変更は Documentation に入れてください。
 
 breaking changeやdeprecationにはmigration noteを書きます。
 

--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -29,6 +29,7 @@ const categories = [
   "Fixed",
   "Deprecated",
   "Removed",
+  "Security",
   "Documentation",
   "Tests"
 ]


### PR DESCRIPTION
## 対応 Issue

Refs #2377

## 変更内容

- `CHANGELOG.md` の category policy に `Security` を追加しました。
- 英日 `docs/*/release.md` の CHANGELOG policy に `Security` category と用途を追加しました。
- `CHANGELOG.md` の `Unreleased > Documentation` に、この release-policy docs 追従を1行で記録しました。
- `script/test_release_docs_signals.mjs` の category signal に `Security` を追加しました。

## 判定分類

- `code-ahead-of-docs`
- `docs-stale`
- docs/test signal sync

## 根拠

- current `lib/tree_view/release_check.rb` の `CHANGELOG_CATEGORY_HEADINGS` は `Security` を許可しています。
- 一方で `CHANGELOG.md` 冒頭、英日 Release docs、release docs signal の category list は `Security` を説明・検出していませんでした。

## 確認内容

- current main: `609166cb0716533baf2be86559b8c267356a28cf`
- head: `ae0e68e6c1a90224bac50b361ff5942bf1c47abe`
- compare `main...docs/2377-security-changelog-category-clean`: `ahead_by:2` / `behind_by:0` / `status:ahead`
- changed files: `CHANGELOG.md`, `docs/en/release.md`, `docs/ja/release.md`, `script/test_release_docs_signals.mjs` の4件のみ
- GitHub Actions CI #3566 / run `28123379348`: success
  - `lint`, `pr_specs`, `javascript`, `gem_package`: success
  - representative Rails lanes: docs-only skip path で success
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped
- local checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしています。

## 非対象

- `lib/tree_view/release_check.rb`
- release automation / versioning policy / gem publish policy

#2377 は現在 review/human gate 中のため、この PR は `Closes` ではなく `Refs` に留めます。merge は行いません。