### PR TITLE
CI policy guard の見える化と permissions smoke を強化する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_workflow_permissions_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
+    "test:ci-policy": "node script/test_ci_policy_suite.mjs --self-test && node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_workflow_permissions_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_policy_suite.mjs --self-test && node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_workflow_permissions_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
+    "test:ci-policy": "node script/test_ci_policy_suite.mjs --self-test && node script/test_ci_policy_suite.mjs && node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_workflow_permissions_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -92,6 +92,7 @@ function isCiPolicySensitivePath(file) {
     file === "AGENTS.md" ||
     file === ".github/workflows/ci.yml" ||
     file === "script/ci_changed_files_policy.mjs" ||
+    file === "script/test_ci_policy_suite.mjs" ||
     file === "script/test_ci_changed_files_policy.mjs" ||
     file === "script/test_ci_workflow_changed_file_detection_signals.mjs" ||
     file === "script/test_ci_workflow_permissions_signals.mjs" ||

--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -1,0 +1,350 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { readdirSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+
+const checks = [
+  {
+    group: "Changed-file policy signals",
+    command: "node",
+    args: ["script/test_ci_changed_files_policy.mjs"]
+  },
+  {
+    group: "Workflow changed-file detection signals",
+    command: "node",
+    args: ["script/test_ci_workflow_changed_file_detection_signals.mjs"]
+  },
+  {
+    group: "Workflow permissions signals",
+    command: "node",
+    args: ["script/test_ci_workflow_permissions_signals.mjs"]
+  },
+  {
+    group: "CI observation guidance signals",
+    command: "node",
+    args: ["script/test_ci_observation_guidance_signals.mjs"]
+  },
+  {
+    group: "Package lock dependency drift",
+    command: "node",
+    args: ["script/test_package_lock_dependency_drift.mjs"]
+  },
+  {
+    group: "Gemfile lock dependency drift",
+    command: "node",
+    args: ["script/test_gemfile_lock_dependency_drift.mjs"]
+  }
+]
+
+const ciPolicyScriptExclusions = new Map([
+  ["test_ci_policy_suite.mjs", "this suite's self-test entrypoint"]
+])
+
+const ciPolicyScriptPatterns = [
+  /^test_ci_.*\.mjs$/,
+  /^test_.*lock_dependency_drift\.mjs$/
+]
+
+function commandLine({ command, args }) {
+  return [command, ...args].join(" ")
+}
+
+function formatDuration(milliseconds) {
+  if (milliseconds < 1000) return `${milliseconds}ms`
+
+  return `${(milliseconds / 1000).toFixed(1)}s`
+}
+
+function formatAvailableGroups() {
+  return checks.map((check, index) => `  ${index + 1}. ${check.group}`).join("\n")
+}
+
+function printCheckList(selectedChecks = checks) {
+  console.log(`[ci-policy] ${selectedChecks.length} checks configured`)
+
+  selectedChecks.forEach((check, index) => {
+    console.log(`[ci-policy] ${index + 1}. ${check.group}: ${commandLine(check)}`)
+  })
+}
+
+function usage() {
+  console.error("[ci-policy] usage: node script/test_ci_policy_suite.mjs [--list] [--only <group-or-index>] [--self-test]")
+  console.error("[ci-policy] use --list to show available groups")
+}
+
+function registeredNodeScriptPaths() {
+  return new Set(
+    checks
+      .filter((check) => check.command === "node" && check.args[0]?.startsWith("script/"))
+      .map((check) => check.args[0])
+  )
+}
+
+function isCiPolicyCandidate(filename) {
+  if (!filename.endsWith(".mjs")) return false
+  if (ciPolicyScriptExclusions.has(filename)) return false
+
+  return ciPolicyScriptPatterns.some((pattern) => pattern.test(filename))
+}
+
+function ciPolicyCandidateScriptPaths() {
+  return readdirSync(scriptDir)
+    .filter(isCiPolicyCandidate)
+    .map((filename) => `script/${filename}`)
+    .sort()
+}
+
+function unregisteredCiPolicyScriptPaths() {
+  const registeredPaths = registeredNodeScriptPaths()
+  return ciPolicyCandidateScriptPaths().filter((scriptPath) => !registeredPaths.has(scriptPath))
+}
+
+function assertCiPolicyScriptsRegistered() {
+  const unregisteredScripts = unregisteredCiPolicyScriptPaths()
+
+  assert.deepEqual(
+    unregisteredScripts,
+    [],
+    [
+      "CI policy suite is missing guard script registrations:",
+      ...unregisteredScripts.map((scriptPath) => `  - ${scriptPath}`),
+      "Add each script to the checks array or document an explicit exclusion."
+    ].join("\n")
+  )
+}
+
+function resolveOnlyGroupResult(groupName) {
+  if (/^\d+$/.test(groupName)) {
+    const groupIndex = Number(groupName) - 1
+    const indexedMatch = checks[groupIndex]
+    if (indexedMatch) return { check: indexedMatch }
+
+    return {
+      error: "out_of_range",
+      message: `[ci-policy] --only index out of range: ${groupName}`
+    }
+  }
+
+  const exactMatches = checks.filter((check) => check.group === groupName)
+  if (exactMatches.length === 1) return { check: exactMatches[0] }
+
+  const normalizedGroupName = groupName.toLowerCase()
+  const caseInsensitiveExactMatches = checks.filter(
+    (check) => check.group.toLowerCase() === normalizedGroupName
+  )
+  if (caseInsensitiveExactMatches.length === 1) return { check: caseInsensitiveExactMatches[0] }
+
+  const partialMatches = checks.filter((check) =>
+    check.group.toLowerCase().includes(normalizedGroupName)
+  )
+
+  if (partialMatches.length === 1) return { check: partialMatches[0] }
+
+  if (partialMatches.length > 1) {
+    return {
+      error: "ambiguous",
+      message: `[ci-policy] ambiguous --only group: ${groupName}`,
+      matches: partialMatches
+    }
+  }
+
+  return {
+    error: "unknown",
+    message: `[ci-policy] unknown --only group: ${groupName}`
+  }
+}
+
+function printOnlyGroupError(result) {
+  console.error(result.message)
+
+  if (result.error === "ambiguous") {
+    console.error("[ci-policy] matching groups:")
+    console.error(result.matches.map((check) => `  - ${check.group}`).join("\n"))
+  }
+
+  console.error("[ci-policy] available groups:")
+  console.error(formatAvailableGroups())
+  console.error("[ci-policy] run with --list to inspect commands")
+}
+
+function resolveOnlyGroup(groupName) {
+  const result = resolveOnlyGroupResult(groupName)
+  if (result.check) return result.check
+
+  printOnlyGroupError(result)
+  process.exit(1)
+}
+
+function runSelfTest() {
+  const availableGroups = formatAvailableGroups()
+
+  assert.match(
+    availableGroups,
+    /1\. Changed-file policy signals/,
+    "available group list should include a stable first index"
+  )
+  assert.ok(
+    availableGroups.includes(`${checks.length}. Gemfile lock dependency drift`),
+    "available group list should include the final lockfile drift group"
+  )
+
+  assert.equal(
+    resolveOnlyGroupResult("1").check.group,
+    "Changed-file policy signals",
+    "numeric --only should resolve a one-based index"
+  )
+  assert.equal(
+    resolveOnlyGroupResult("workflow permissions signals").check.group,
+    "Workflow permissions signals",
+    "case-insensitive exact --only should resolve a group"
+  )
+  assert.equal(
+    resolveOnlyGroupResult("Observation").check.group,
+    "CI observation guidance signals",
+    "unique partial --only should resolve a group"
+  )
+
+  const outOfRange = resolveOnlyGroupResult("999")
+  assert.equal(outOfRange.error, "out_of_range")
+  assert.match(outOfRange.message, /--only index out of range: 999/)
+
+  const unknown = resolveOnlyGroupResult("does-not-exist")
+  assert.equal(unknown.error, "unknown")
+  assert.match(unknown.message, /unknown --only group: does-not-exist/)
+
+  const ambiguous = resolveOnlyGroupResult("workflow")
+  assert.equal(ambiguous.error, "ambiguous")
+  assert.deepEqual(
+    ambiguous.matches.map((check) => check.group),
+    ["Workflow changed-file detection signals", "Workflow permissions signals"],
+    "ambiguous --only should report all matching groups"
+  )
+
+  assert.ok(
+    ciPolicyCandidateScriptPaths().includes("script/test_ci_changed_files_policy.mjs"),
+    "CI policy candidates should include changed-file policy signals"
+  )
+  assert.ok(
+    ciPolicyCandidateScriptPaths().includes("script/test_ci_workflow_permissions_signals.mjs"),
+    "CI policy candidates should include workflow permissions signals"
+  )
+  assert.ok(
+    ciPolicyCandidateScriptPaths().includes("script/test_package_lock_dependency_drift.mjs"),
+    "CI policy candidates should include package lock dependency drift"
+  )
+  assert.ok(
+    !ciPolicyCandidateScriptPaths().includes("script/test_ci_policy_suite.mjs"),
+    "the suite entrypoint should stay out of direct guard registration candidates"
+  )
+  assertCiPolicyScriptsRegistered()
+
+  console.log("[ci-policy] self-test passed")
+}
+
+function parseArgs(argv) {
+  const options = { list: false, only: null, selfTest: false }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+
+    if (arg === "--list") {
+      options.list = true
+      continue
+    }
+
+    if (arg === "--self-test") {
+      options.selfTest = true
+      continue
+    }
+
+    if (arg === "--only") {
+      const groupName = argv[index + 1]
+
+      if (!groupName || groupName.startsWith("--")) {
+        console.error("[ci-policy] --only requires a group name or index")
+        usage()
+        console.error("[ci-policy] available groups:")
+        console.error(formatAvailableGroups())
+        process.exit(1)
+      }
+
+      options.only = resolveOnlyGroup(groupName)
+      index += 1
+      continue
+    }
+
+    console.error(`[ci-policy] unknown argument: ${arg}`)
+    usage()
+    process.exit(1)
+  }
+
+  return options
+}
+
+const options = parseArgs(process.argv.slice(2))
+
+if (options.selfTest) {
+  runSelfTest()
+  process.exit(0)
+}
+
+if (options.list) {
+  printCheckList()
+  process.exit(0)
+}
+
+const selectedChecks = options.only ? [options.only] : checks
+const suiteStartedAt = Date.now()
+const passedChecks = []
+
+printCheckList(selectedChecks)
+
+for (const [index, check] of selectedChecks.entries()) {
+  const checkStartedAt = Date.now()
+
+  console.log(`\n[ci-policy] ${index + 1}/${selectedChecks.length} ${check.group}`)
+  console.log(`$ ${commandLine(check)}`)
+
+  const result = spawnSync(check.command, check.args, { stdio: "inherit" })
+  const elapsed = Date.now() - checkStartedAt
+
+  if (result.error) {
+    console.error(
+      `[ci-policy] ${check.group} failed to start after ${formatDuration(elapsed)}: ${result.error.message}`
+    )
+    console.error(
+      `[ci-policy] summary: ${passedChecks.length}/${selectedChecks.length} checks passed before failure`
+    )
+    process.exit(1)
+  }
+
+  if (result.signal) {
+    console.error(
+      `[ci-policy] ${check.group} stopped by signal ${result.signal} after ${formatDuration(elapsed)}: ${commandLine(check)}`
+    )
+    console.error(
+      `[ci-policy] summary: ${passedChecks.length}/${selectedChecks.length} checks passed before failure`
+    )
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    console.error(
+      `[ci-policy] ${check.group} failed with exit code ${result.status} after ${formatDuration(elapsed)}: ${commandLine(check)}`
+    )
+    console.error(
+      `[ci-policy] summary: ${passedChecks.length}/${selectedChecks.length} checks passed before failure`
+    )
+    process.exit(result.status ?? 1)
+  }
+
+  passedChecks.push(check.group)
+  console.log(`[ci-policy] ${check.group} passed in ${formatDuration(elapsed)}`)
+}
+
+console.log(
+  `\n[ci-policy] all ${selectedChecks.length} checks passed in ${formatDuration(Date.now() - suiteStartedAt)}`
+)

--- a/script/test_ci_workflow_permissions_signals.mjs
+++ b/script/test_ci_workflow_permissions_signals.mjs
@@ -17,7 +17,15 @@ function topLevelWorkflowPermissions(source) {
   return match.groups.body
 }
 
+function jobLevelWorkflowPermissions(source) {
+  return source
+    .split(/\r?\n/)
+    .map((line, index) => ({ line, number: index + 1 }))
+    .filter(({ line }) => /^    permissions:\s*$/.test(line))
+}
+
 const permissionsBlock = topLevelWorkflowPermissions(workflowSource)
+const jobLevelPermissions = jobLevelWorkflowPermissions(workflowSource)
 
 assertIncludes(
   permissionsBlock,
@@ -33,6 +41,14 @@ assert(
 assert(
   !/^  pull-requests: write$/m.test(permissionsBlock),
   `${workflowPath} must not request pull request write permission for CI jobs`
+)
+
+assert(
+  jobLevelPermissions.length === 0,
+  [
+    `${workflowPath} must not declare job-level GITHUB_TOKEN permissions overrides; keep CI read-only at the workflow top level.`,
+    ...jobLevelPermissions.map(({ number }) => `  - job-level permissions block starts on line ${number}`)
+  ].join("\n")
 )
 
 console.log("Checked CI workflow read-only GITHUB_TOKEN permissions.")


### PR DESCRIPTION
## 対応 Issue

Closes #2584
Closes #2586

## Issue ごとの完了内容

- #2584: `script/test_ci_workflow_permissions_signals.mjs` に job-level `permissions:` block 検出を追加し、CI workflow が top-level `contents: read` に閉じることを確認できるようにしました。
- #2586: `script/test_ci_policy_suite.mjs` を追加し、CI policy guard scripts を `--list` / `--only` / `--self-test` で見える化しました。`test:ci-policy` は既存 direct chain の前に suite self-test を実行し、登録漏れを早期に検出します。

## 変更内容

- `script/test_ci_policy_suite.mjs` を追加
  - guard group 一覧表示
  - group/index 指定での個別実行
  - candidate script registration の self-test
- `package.json` の `test:ci-policy` に suite self-test を追加
- `script/ci_changed_files_policy.mjs` に suite script を CI policy-sensitive path として追加
- `script/test_ci_workflow_permissions_signals.mjs` に job-level permissions override の禁止 smoke を追加

## 改善カテゴリ

- CI guard hardening
- test / maintenance script discoverability
- security-adjacent permissions smoke

## 既存仕様への影響

- `.github/workflows/ci.yml`、job topology、required checks、branch protection、repository settings は変更していません。
- 既存の CI policy guard script 実行順は維持しています。
- runtime Ruby / JavaScript、public API、docs content は変更していません。

## 実施した確認

- Issue #2584 / #2586 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- compare `main...chore/2584-ci-policy-suite-permissions`: `ahead_by:4` / `behind_by:0` / `status:ahead`。
- changed files は上記4件のみです。
- connector-only 実行環境では GitHub HTTPS が `CONNECT tunnel failed, response 403` のため local checkout / `npm run test:ci-policy` は未実行です。PR CI を確認対象にします。

## リスク評価

low。CI policy smoke と package script の自己検証追加に閉じており、workflow behavior や repository 権限設定は変更していません。

## 補足

- `test:ci-policy` は既存 direct chain を維持し、suite self-test を先頭に足しています。これにより、今回の変更では実行順を変えずに `--list` / `--only` / registration self-test を導入します。
- merge は行いません。