### PR TITLE
manifest-backed docs surface smoke を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",
     "test:public-api-manifest-structure": "node script/test_public_api_manifest_structure.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/guard_public_api_transfer_integration_signals.mjs && node script/test_docs_entrypoint_suite.mjs",
+    "test:docs-entrypoints": "node script/guard_public_api_transfer_integration_signals.mjs && node script/test_manifest_backed_public_surface_signals.mjs && node script/test_docs_entrypoint_suite.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_manifest_backed_public_surface_signals.mjs
+++ b/script/test_manifest_backed_public_surface_signals.mjs
@@ -1,0 +1,170 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+function assertAll(source, needles, label) {
+  needles.forEach((needle) => assertIncludes(source, needle, label))
+}
+
+function assertDocs(paths, needles, label) {
+  paths.forEach((relativePath) => {
+    assertAll(read(relativePath), needles, `${relativePath} ${label}`)
+  })
+}
+
+const manifest = read("config/public_api_manifest.yml")
+
+const publicConstantSignals = [
+  "public_constants:",
+  "- Error",
+  "- ConfigurationError",
+  "- InvalidTreeError",
+  "- DuplicateNodeKeyError",
+  "- CycleDetectedError",
+  "- InvalidRenderWindowError"
+]
+
+const publicConstantDocsSignals = [
+  "TreeView::Error",
+  "TreeView::ConfigurationError",
+  "TreeView::InvalidTreeError",
+  "TreeView::DuplicateNodeKeyError",
+  "TreeView::CycleDetectedError",
+  "TreeView::InvalidRenderWindowError"
+]
+
+const localizedNameManifestSignals = [
+  "localized_name_i18n_keys:",
+  "helper: model_name_for",
+  "activerecord.models",
+  "activemodel.models",
+  "helper: attribute_name_for",
+  "activerecord.attributes",
+  "activemodel.attributes",
+  "helper: type_name_for",
+  "tree_view.node_types",
+  "fallback: humanized_node_type_or_default"
+]
+
+const localizedNameDocsSignals = [
+  "TreeView.model_name_for",
+  "TreeView.attribute_name_for",
+  "TreeView.type_name_for",
+  "activerecord.models",
+  "activemodel.models",
+  "activerecord.attributes",
+  "activemodel.attributes",
+  "tree_view.node_types",
+  "fallback"
+]
+
+const setupGeneratorManifestSignals = [
+  "setup_generators:",
+  "persisted_state_install:",
+  "name: tree_view:state:install",
+  "class_name: TreeView::Generators::State::InstallGenerator",
+  "banner: OWNER_MODEL",
+  "db/migrate/*_create_tree_view_states.rb",
+  "app/models/tree_view_state.rb",
+  "app/models/concerns/tree_view_state_owner.rb"
+]
+
+const setupGeneratorDocsSignals = [
+  "tree_view:state:install",
+  "bin/rails generate tree_view:state:install User",
+  "config/public_api_manifest.yml",
+  "db/migrate/*_create_tree_view_states.rb",
+  "app/models/tree_view_state.rb",
+  "app/models/concerns/tree_view_state_owner.rb",
+  "host app"
+]
+
+const stateEventDetailManifestSignals = [
+  "event_detail_keys:",
+  "state_changed:",
+  "- viewKey",
+  "- expandedKeys",
+  "- reason",
+  "remote_state:",
+  "change:",
+  "retry:",
+  "- row",
+  "- state",
+  "- childrenUrl",
+  "- nodeKey"
+]
+
+const stateEventDocsSignals = [
+  "tree-view-state:state-changed",
+  "viewKey",
+  "expandedKeys",
+  "reason",
+  "tree-view-remote-state:change",
+  "tree-view-remote-state:retry",
+  "childrenUrl",
+  "nodeKey",
+  "TreeViewEventDetailKeys"
+]
+
+const lazyLoadingRemoteStateSignals = [
+  "data-tree-children-url",
+  "TreeViewEventNames.remoteState.*",
+  "TreeViewEventNames.hostLifecycle",
+  "TreeViewRemoteStateValues",
+  "host app"
+]
+
+assertAll(manifest, publicConstantSignals, "public API manifest public constants surface")
+assertAll(manifest, localizedNameManifestSignals, "public API manifest localized-name surface")
+assertAll(manifest, setupGeneratorManifestSignals, "public API manifest setup-generator surface")
+assertAll(manifest, stateEventDetailManifestSignals, "public API manifest state and remote-state event detail surface")
+
+assertDocs(
+  ["docs/en/errors.md", "docs/ja/errors.md"],
+  publicConstantDocsSignals,
+  "public error hierarchy docs"
+)
+
+assertDocs(
+  ["docs/en/public-api.md", "docs/ja/public-api.md"],
+  [...publicConstantDocsSignals, "TreeView.model_name_for", "TreeView.attribute_name_for", "TreeView.type_name_for"],
+  "public API manifest-backed public surface docs"
+)
+
+assertDocs(
+  ["docs/en/localized-names.md", "docs/ja/localized-names.md"],
+  localizedNameDocsSignals,
+  "localized-name lookup and fallback docs"
+)
+
+assertDocs(
+  ["docs/en/public-setup-surface.md", "docs/ja/public-setup-surface.md"],
+  setupGeneratorDocsSignals,
+  "setup generator public surface docs"
+)
+
+assertDocs(
+  ["docs/en/js-events.md", "docs/ja/js-events.md"],
+  stateEventDocsSignals,
+  "state and remote-state event detail docs"
+)
+
+assertDocs(
+  ["docs/en/lazy-loading.md", "docs/ja/lazy-loading.md"],
+  lazyLoadingRemoteStateSignals,
+  "lazy-loading remote-state boundary docs"
+)


### PR DESCRIPTION
## 対応 Issue

- Closes #2531
- Closes #2532
- Closes #2533
- Closes #2537

## Issue ごとの完了内容

- #2531: State / Remote-state event detail keys について、manifest と英日 `docs/*/js-events.md`、Lazy Loading docs の代表 signal を smoke で確認するようにしました。
- #2532: `setup_generators.persisted_state_install` について、manifest の generator 名 / `OWNER_MODEL` / generated paths と英日 Public Setup Surface docs の代表 signal を確認するようにしました。
- #2533: `localized_name_i18n_keys` について、helper 名、delegated lookup prefixes、fallback boundary と英日 Localized Names docs の代表 signal を確認するようにしました。
- #2537: `public_constants` / error hierarchy について、manifest と英日 Public API / Errors docs の代表 signal を確認するようにしました。

## 変更内容

- `script/test_manifest_backed_public_surface_signals.mjs` を追加しました。
- `npm run test:docs-entrypoints` から上記 smoke を実行するようにしました。

## 改善カテゴリ

- test / docs smoke
- public API manifest drift guard
- CI docs-entrypoint hardening

## 既存仕様への影響

- runtime Ruby / JavaScript、manifest schema、docs 本文、public API、event payload、generator behavior は変更していません。
- 既存の reader-facing docs にある代表 signal を確認するだけの品質改善です。

## 実施した確認

- Issue #2531 / #2532 / #2533 / #2537 は個別に label を確認し、`status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low` を満たすことを確認しました。
- PR 作成前に `main` の最新 SHA を確認し、branch が `behind_by:0` であることを確認しました。
- 差分が `package.json` と `script/test_manifest_backed_public_surface_signals.mjs` のみに限定されていることを確認しました。
- ローカル checkout は `CONNECT tunnel failed, response 403` で不可だったため、実行確認は GitHub Actions CI で確認します。

## リスク評価

- risk: low
- docs smoke の追加のみで挙動変更はありません。
- assertion は完全な prose 固定ではなく、manifest-backed public surface の代表 signal に限定しています。

## 補足

- 既存の大きな `script/test_public_api_docs_signals.mjs` を置き換えず、対象 Issue 群に対応する focused smoke として追加しています。