### PR TITLE
CHANGELOG に maintenance docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,10 +123,14 @@ Release preparation notes:
 - Documented CI-policy-sensitive docs-only routing in AGENTS.md and Release docs so maintainers know when `npm run test:ci-policy` runs for repository-maintainer docs.
 - Added RubyGems `documentation_uri` metadata release evidence so package users can find the docs entrypoint from gem metadata.
 - Documented `Security` as an allowed CHANGELOG category for vulnerability fixes and security hardening notes.
+- Added mockup review task chooser release evidence so reviewers can choose baseline, responsive, interaction, accessibility, selection, and toolbar/table boundary entry points from `docs/mockups/README.md`.
+- Added repository maintainer CI policy suite guidance release evidence for listing, targeting, and self-testing CI policy guard groups from `AGENTS.md`.
 
 ### Tests
 
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
+- Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.
+- Added manifest-backed public surface docs smoke coverage for state / remote-state event detail keys, setup generator output, localized names, and public constants.
 - Expanded package contents verification coverage for README-linked FAQ / Troubleshooting / API Overview / API Reference / Tree diagnostics docs so packaged gems keep those public reader guides available.
 - Added controller registration docs signal coverage to the docs-entrypoint suite so controller registration guides and manifest controller entries stay aligned.
 - Added CI changed-file detection workflow guard coverage for docs-entrypoints package script wiring so controller registration docs signals stay connected to `npm run test:docs-entrypoints`.


### PR DESCRIPTION
## 対応 Issue

Closes #2596

## 分類

- `code-ahead-of-docs`
- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md > Unreleased > Documentation` に、直近 merged PR の以下を release-facing evidence として追記しました。
  - mockup review task chooser guidance (#2593)
  - repository maintainer CI policy suite guidance in `AGENTS.md` (#2595)
- `CHANGELOG.md > Unreleased > Tests` に、直近 merged PR の以下を release-facing evidence として追記しました。
  - CI policy suite / permissions smoke (#2588)
  - manifest-backed public surface docs smoke (#2594)

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、package scripts、CI workflow、docs signal scripts、公開 API、仕様判断には触れていません。

## 確認内容

- current `main` 起点で branch を作成しました。
- compare `main...docs/2596-changelog-maintenance-evidence`: `ahead_by:1` / `behind_by:0` / `status:ahead`。
- changed files: `CHANGELOG.md` の1件のみ。
- additions/deletions: 追加4行、削除0行。
- 追加箇所は `Unreleased > Documentation` と `Unreleased > Tests` のみで、末尾の `0.1.0` section は保持されています。
- PR metadata: `mergeable:true`。
- GitHub Actions CI #3580 / run `28142233965`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success。
  - representative Rails lanes: docs-only skip path で success。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。既に main に merge 済みの maintenance docs / docs-signal PR を CHANGELOG に記録するだけです。

merge は行いません。