### PR TITLE
public constants の docs signal guard を追加する

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -208,6 +208,20 @@ const pathTreeBuilderNodeShapeSignals = [
   "record_node?"
 ]
 
+const publicConstantSignals = [
+  "TreeView::Error",
+  "TreeView::ConfigurationError",
+  "TreeView::InvalidTreeError",
+  "TreeView::DuplicateNodeKeyError",
+  "TreeView::CycleDetectedError",
+  "TreeView::InvalidRenderWindowError",
+  "TreeView::RenderState",
+  "TreeView::ResourceTableRenderState",
+  "TreeView::VisibleRows",
+  "TreeView::RenderWindow",
+  "TreeView::Diagnostics"
+]
+
 const developmentManifestTrackingSignals = [
   "config/public_api_manifest.yml",
   "RenderState callback builder keys",
@@ -227,6 +241,7 @@ const developmentEntrypointGuardSignals = [
 
 const manifestBackedDocsSignalSurfaces = [
   ["RenderState callback builder keys", "render_state_callback_builder_keys:"],
+  ["public constants", "public_constants:"],
   ["host lifecycle no-detail events", "event_names_without_detail:"],
   ["host lifecycle event names", "host_lifecycle:"],
   ["remote-state values", "remote_state_values:"],
@@ -288,6 +303,10 @@ pathTreeBuilderNodeShapeSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest PathTreeBuilder node shape surface")
 })
 
+publicConstantSignals.forEach((signal) => {
+  assertIncludes(manifest, signal.replace("TreeView::", "- "), "public API manifest public constants surface")
+})
+
 assertIncludes(manifest, "event_names_without_detail", "public API manifest no-detail event surface")
 assertIncludes(manifest, "host_lifecycle", "public API manifest no-detail event surface")
 hostLifecycleSignals.slice(1, 5).forEach((signal) => {
@@ -295,6 +314,10 @@ hostLifecycleSignals.slice(1, 5).forEach((signal) => {
 })
 
 publicApiDocs.forEach(([relativePath, document]) => {
+  publicConstantSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} public constant docs from config/public_api_manifest.yml public_constants`)
+  })
+
   callbackBuilderSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} RenderState callback builder docs`)
   })


### PR DESCRIPTION
## 対応 Issue

- Closes #2598

## Issue ごとの完了内容

- #2598: `config/public_api_manifest.yml` の `public_constants:` を manifest-backed docs signal surface に追加し、英日 `docs/*/public-api.md` の stable public entry points から代表的な error constants / non-error constants が落ちた場合に `script/test_public_api_docs_signals.mjs` が失敗するようにしました。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に `publicConstantSignals` を追加
- manifest 側では `public_constants:` と代表 constants の存在を確認
- docs 側では `TreeView::Error`, documented error subclasses, `TreeView::RenderState`, `TreeView::ResourceTableRenderState`, `TreeView::VisibleRows`, `TreeView::RenderWindow`, `TreeView::Diagnostics` を英日 Public API docs で確認

## 改善カテゴリ

- test
- docs signal hardening
- maintenance

## 既存仕様への影響

- Ruby runtime、public constants、manifest schema、Public API docs 本文は変更していません。
- 既存の公開挙動、API 契約、UI、DB、認可、外部サービス契約への影響はありません。

## 実施した確認

- GitHub connector で対象 Issue のラベルと Planner handoff を個別確認
- 自分の open PR の review follow-up を確認し、今回自動対応できる外部レビュー指摘がないことを確認
- `main` の現在 SHA からブランチを作成し、PR 前に `main` から behind なしを確認
- `main...quality/2598-public-constants-docs-signal` の差分が `script/test_public_api_docs_signals.mjs` 1 ファイルのみであることを確認
- PR CI green を確認
  - `pr_specs`: success
  - `lint`: success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `javascript`: success
  - `javascript` job の `npm run test:js:core` 内で `npm run test:docs-entrypoints` が実行され、`Public API docs signals` が success

## リスク評価

- risk: low
- docs smoke の assertion 追加のみで、失敗時の検出範囲を `public_constants` の代表 signal に限定しています。

## 補足

- raw GitHub fetch / git clone はこの実行環境から 403 で利用できなかったため、GitHub connector の file update で最小差分を作成しました。