### PR TITLE
stylesheet state cue selector を source spec で guard する

### DIFF
--- a/spec/assets/tree_view_stylesheet_source_spec.rb
+++ b/spec/assets/tree_view_stylesheet_source_spec.rb
@@ -64,4 +64,27 @@ RSpec.describe "tree_view stylesheet source" do
       }
     CSS
   end
+
+  it "keeps representative row state cue selectors available for quick-start imports" do
+    aggregate_failures do
+      expect(stylesheet_source).to include(<<~CSS.strip)
+        .tree-row.is-selected,
+        .tree-row[aria-selected="true"]{
+      CSS
+      expect(stylesheet_source).to include(<<~CSS.strip)
+        .tree-row.is-collapsed,
+        .tree-row[aria-expanded="false"]{
+      CSS
+      expect(stylesheet_source).to include(<<~CSS.strip)
+        .tree-row.is-loading{
+      CSS
+      expect(stylesheet_source).to include(<<~CSS.strip)
+        .tree-row.is-error,
+        .tree-row.is-drop-disabled{
+      CSS
+      expect(stylesheet_source).to include(<<~CSS.strip)
+        .tree-row.is-drop-target{
+      CSS
+    end
+  end
 end


### PR DESCRIPTION
## 対応 Issue

Closes #942

## Issue ごとの完了内容

- #942: packaged stylesheet の selected / collapsed / loading / error / drop target 代表 selector を `spec/assets/tree_view_stylesheet_source_spec.rb` で確認する source-level guard を追加しました。

## 変更内容

- 既存の stylesheet source spec に、quick-start import 向け row state cue selector の representative assertion を追加しました。
- `.tree-row.is-selected` / `[aria-selected="true"]`
- `.tree-row.is-collapsed` / `[aria-expanded="false"]`
- `.tree-row.is-loading`
- `.tree-row.is-error` / `.tree-row.is-drop-disabled`
- `.tree-row.is-drop-target`

## 改善カテゴリ

- test
- regression guard
- small maintenance hardening

## 既存仕様への影響

既存仕様への影響はありません。runtime Ruby / JavaScript、stylesheet 本体、docs、public API、CSS token / color value は変更していません。色値の細部固定や visual regression には広げず、representative selector が消えた時に気づける最小 guard に閉じています。

## 実施した確認

- Issue #942 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- compare `main...quality/942-state-cue-selector-spec`: `ahead_by:1` / `behind_by:0` / changed files 1。
- changed files は `spec/assets/tree_view_stylesheet_source_spec.rb` のみです。
- ローカル `bundle exec rspec spec/assets/tree_view_stylesheet_source_spec.rb` は、この実行環境に Ruby / Bundler が無いため未実行です。PR CI を確認対象にします。

## リスク評価

low。source-level spec の追加のみで、runtime behavior や packaged stylesheet の表示は変えていません。

## 補足事項

- #2150 は同じ repo の eligible quality issue ですが、`standardrb --fix` 相当の多数ファイル整形と Ruby/Bundler 実行が必要です。今回の環境では GitHub checkout が `CONNECT tunnel failed, response 403`、Ruby も未提供のため、この PR には混ぜていません。
- 既存 draft PR #2271 は design / browser evidence 待ちで、今回の品質 spec 追加とは別扱いです。
- merge は行いません。