### PR TITLE
CI policy suite の保守者向け導線を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ Maintainer entry points には、gem に同梱される `docs/**` と repository
 - [Design policy](en/design-policy.md) / [設計思想と責務範囲](ja/design-policy.md): repository scope, responsibility boundaries, and non-goals.
 - [Demo application boundary](en/demo-application-boundary.md) / [Demo application boundary](ja/demo-application-boundary.md): handoff policy between static gem mockups and a future public Rails demo application.
 - [Development](en/development.md) / [開発・保守方針](ja/development.md): CI, local checks, documentation update workflow, and maintenance habits.
+- [CI policy suite](en/ci-policy-suite.md) / [CI policy suite](ja/ci-policy-suite.md): targeted CI policy guard runs, suite self-test behavior, and guard registration expectations.
 - [Dependabot Bundler recovery](en/dependabot-bundler-recovery.md) / [Dependabot Bundler 復旧手順](ja/dependabot-bundler-recovery.md): lockfile metadata drift triage and scoped recovery paths for Bundler dependency PRs.
 - [Code quality](en/code-quality.md) / [コード品質](ja/code-quality.md): lint, tests, error message quality, and documentation quality policy.
 - [Release checklist](en/release.md) / [リリースチェックリスト](ja/release.md): release workflow, CI and package verification, and changelog expectations.

--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -1,0 +1,31 @@
+# CI policy suite
+
+This note explains the narrow CI policy suite used by maintainers when a pull request changes workflow routing, CI observation guidance, lockfile drift guards, or CI-policy-sensitive maintainer docs.
+
+## When to use it
+
+Run the full CI policy suite when you need to confirm the policy guards without running the broader JavaScript entrypoint suite:
+
+```bash
+npm run test:ci-policy
+```
+
+The package script runs the suite self-test first and then runs the configured CI policy guard groups. Treat `script/test_ci_policy_suite.mjs` as the source of truth for the group list, even if `package.json` still includes direct guard commands for compatibility while the suite migration is being reviewed.
+
+## Targeted runs
+
+Use the suite options when you are narrowing one guard failure:
+
+```bash
+node script/test_ci_policy_suite.mjs --list
+node script/test_ci_policy_suite.mjs --only <group-or-index>
+node script/test_ci_policy_suite.mjs --self-test
+```
+
+`--list` prints the available guard groups in order. `--only` accepts the 1-based index, exact group name, case-insensitive group name, or a unique partial group name. Unknown, ambiguous, or out-of-range values fail and print the available groups plus the `--list` hint.
+
+## Registration self-test
+
+When adding or renaming a CI policy guard script, update the suite `checks` array or document an explicit exclusion before relying on CI. The self-test scans candidate scripts, confirms that registered scripts stay visible through the suite, and fails with the missing script path when a candidate is not registered.
+
+This note is only about maintainer command routing. It does not change CI workflow jobs, required checks, branch protection, workflow permissions, or lockfile policy.

--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -10,7 +10,7 @@ Run the full CI policy suite when you need to confirm the policy guards without 
 npm run test:ci-policy
 ```
 
-The package script runs the suite self-test first and then runs the configured CI policy guard groups. Treat `script/test_ci_policy_suite.mjs` as the source of truth for the group list, even if `package.json` still includes direct guard commands for compatibility while the suite migration is being reviewed.
+The package script runs the suite self-test first and then runs the configured CI policy guard groups. Treat `script/test_ci_policy_suite.mjs` as the source of truth for the group list.
 
 ## Targeted runs
 

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -1,0 +1,31 @@
+# CI policy suite
+
+このメモは、workflow routing、CI observation guidance、lockfile drift guard、CI-policy-sensitive な maintainer docs を変更する Pull Request で使う、保守者向けの狭い CI policy suite を説明します。
+
+## 使う場面
+
+広い JavaScript entrypoint suite ではなく、CI policy guard だけを確認したい場合は full suite を実行します。
+
+```bash
+npm run test:ci-policy
+```
+
+package script は先に suite self-test を実行し、その後に設定済みの CI policy guard group を実行します。suite 移行の review 中に `package.json` 側へ互換用の直接 guard command が残っていても、group list の source of truth は `script/test_ci_policy_suite.mjs` として扱ってください。
+
+## 絞り込み実行
+
+1つの guard failure を切り分ける場合は、suite option を使います。
+
+```bash
+node script/test_ci_policy_suite.mjs --list
+node script/test_ci_policy_suite.mjs --only <group-or-index>
+node script/test_ci_policy_suite.mjs --self-test
+```
+
+`--list` は利用できる guard group を順番付きで表示します。`--only` は 1-based index、完全一致の group 名、大文字小文字を問わない group 名、または一意に絞れる部分一致の group 名を受け付けます。unknown、ambiguous、範囲外の値は非 0 終了し、available groups と `--list` の案内を表示します。
+
+## 登録 self-test
+
+CI policy guard script を追加または rename した場合は、CI に頼る前に suite の `checks` array を更新するか、明示的な exclusion を残してください。self-test は candidate script を走査し、登録済み script が suite から見えることを確認します。未登録 candidate がある場合は missing script path を表示して失敗します。
+
+このメモは maintainer command routing だけを扱います。CI workflow jobs、required checks、branch protection、workflow permissions、lockfile policy は変更しません。

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -10,7 +10,7 @@
 npm run test:ci-policy
 ```
 
-package script は先に suite self-test を実行し、その後に設定済みの CI policy guard group を実行します。suite 移行の review 中に `package.json` 側へ互換用の直接 guard command が残っていても、group list の source of truth は `script/test_ci_policy_suite.mjs` として扱ってください。
+package script は先に suite self-test を実行し、その後に設定済みの CI policy guard group を実行します。group list の source of truth は `script/test_ci_policy_suite.mjs` として扱ってください。
 
 ## 絞り込み実行
 

--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -6,6 +6,10 @@ const docs = [
   ["docs/en/development.md", fs.readFileSync("docs/en/development.md", "utf8")],
   ["docs/ja/development.md", fs.readFileSync("docs/ja/development.md", "utf8")]
 ]
+const ciPolicySuiteDocs = [
+  ["docs/en/ci-policy-suite.md", fs.readFileSync("docs/en/ci-policy-suite.md", "utf8")],
+  ["docs/ja/ci-policy-suite.md", fs.readFileSync("docs/ja/ci-policy-suite.md", "utf8")]
+]
 
 const requiredMaintenanceScripts = [
   "test:docs-entrypoints",
@@ -31,6 +35,15 @@ const requiredDockerSetupSignals = [
   "Node 22",
   "npm",
   "lockfile-backed install path"
+]
+
+const requiredCiPolicySuiteSignals = [
+  "npm run test:ci-policy",
+  "node script/test_ci_policy_suite.mjs --list",
+  "node script/test_ci_policy_suite.mjs --only <group-or-index>",
+  "node script/test_ci_policy_suite.mjs --self-test",
+  "checks",
+  "explicit exclusion"
 ]
 
 const missingSignals = []
@@ -64,6 +77,14 @@ for (const signal of requiredDockerSetupSignals) {
   }
 }
 
+for (const signal of requiredCiPolicySuiteSignals) {
+  for (const [docPath, doc] of ciPolicySuiteDocs) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: CI policy suite docs signal ${signal}`)
+    }
+  }
+}
+
 if (missingSignals.length > 0) {
   console.error("[development-docs-command-signals] missing maintenance command signals:")
   for (const signal of missingSignals) {
@@ -73,5 +94,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, and ${requiredDockerSetupSignals.length} Docker setup signals are present in package.json and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, and ${requiredCiPolicySuiteSignals.length} CI policy suite docs signals are present in package.json and docs`
 )

--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -7,8 +7,16 @@ const docs = [
   ["docs/ja/development.md", fs.readFileSync("docs/ja/development.md", "utf8")]
 ]
 const ciPolicySuiteDocs = [
-  ["docs/en/ci-policy-suite.md", fs.readFileSync("docs/en/ci-policy-suite.md", "utf8")],
-  ["docs/ja/ci-policy-suite.md", fs.readFileSync("docs/ja/ci-policy-suite.md", "utf8")]
+  [
+    "docs/en/ci-policy-suite.md",
+    fs.readFileSync("docs/en/ci-policy-suite.md", "utf8"),
+    ["checks", "explicit exclusion"]
+  ],
+  [
+    "docs/ja/ci-policy-suite.md",
+    fs.readFileSync("docs/ja/ci-policy-suite.md", "utf8"),
+    ["checks", "明示的な exclusion"]
+  ]
 ]
 
 const requiredMaintenanceScripts = [
@@ -37,13 +45,11 @@ const requiredDockerSetupSignals = [
   "lockfile-backed install path"
 ]
 
-const requiredCiPolicySuiteSignals = [
+const requiredCiPolicySuiteCommandSignals = [
   "npm run test:ci-policy",
   "node script/test_ci_policy_suite.mjs --list",
   "node script/test_ci_policy_suite.mjs --only <group-or-index>",
-  "node script/test_ci_policy_suite.mjs --self-test",
-  "checks",
-  "explicit exclusion"
+  "node script/test_ci_policy_suite.mjs --self-test"
 ]
 
 const missingSignals = []
@@ -77,10 +83,16 @@ for (const signal of requiredDockerSetupSignals) {
   }
 }
 
-for (const signal of requiredCiPolicySuiteSignals) {
-  for (const [docPath, doc] of ciPolicySuiteDocs) {
+for (const [docPath, doc, registrationSignals] of ciPolicySuiteDocs) {
+  for (const signal of requiredCiPolicySuiteCommandSignals) {
     if (!doc.includes(signal)) {
-      missingSignals.push(`${docPath}: CI policy suite docs signal ${signal}`)
+      missingSignals.push(`${docPath}: CI policy suite docs command signal ${signal}`)
+    }
+  }
+
+  for (const signal of registrationSignals) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: CI policy suite registration signal ${signal}`)
     }
   }
 }
@@ -94,5 +106,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, and ${requiredCiPolicySuiteSignals.length} CI policy suite docs signals are present in package.json and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, and ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals are present in package.json and docs`
 )


### PR DESCRIPTION
## 対応 Issue

Refs #2599

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` を追加し、CI policy suite の `--list` / `--only` / `--self-test` の使い分けを保守者向けに整理しました。
- `docs/README.md` の Maintainer entry points から英日 note へ到達できるようにしました。
- `script/test_development_docs_command_signals.mjs` の lightweight signal により、専用 note 側の command / registration wording が欠けた場合に検出できるようになっています。
- #2605 merge 後の current `test:ci-policy` 実態に合わせ、専用 note から互換用 direct guard command が残っている前提の wording を削りました。

## 判定分類

- `docs-missing`
- `code-ahead-of-docs`

## スコープ

- #2599 の部分同期です。
- `.github/workflows/**`、`package.json`、runtime Ruby / JavaScript、branch protection、required checks は変更していません。
- この PR は #2610 に supersede されました。#2610 は latest main からの clean replacement で、Release docs entrypoint も含むため、以後の review / merge 判断は #2610 に集約してください。

## 確認

- PR metadata: open / non-draft / `mergeable:true`
- GitHub compare `main...docs/2599-ci-policy-suite-note`: `ahead_by:7` / `behind_by:2` / changed files 4
- changed files は `docs/README.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `script/test_development_docs_command_signals.mjs`
- GitHub Actions CI #3594 / run `28159461457`: success on head `1c37bd18159988996dae20814ef2e4bf686f11da`
  - `lint`, `pr_specs`, `changes`, `javascript`, `gem_package`, representative `pr_rails_matrix` lanes: success
- local checkout / docs tests は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。workflow / package script / runtime 挙動は変えず、保守者向け docs 導線と lightweight docs signal の範囲に閉じています。

## Superseded

Superseded by #2610.