### PR TITLE
test:ci-policy の重複実行を suite に集約する

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "vitest run",
     "test:browser": "playwright test",
-    "test:ci-policy": "node script/test_ci_policy_suite.mjs --self-test && node script/test_ci_policy_suite.mjs && node script/test_ci_changed_files_policy.mjs && node script/test_ci_workflow_changed_file_detection_signals.mjs && node script/test_ci_workflow_permissions_signals.mjs && node script/test_ci_observation_guidance_signals.mjs && node script/test_package_lock_dependency_drift.mjs && node script/test_gemfile_lock_dependency_drift.mjs",
+    "test:ci-policy": "node script/test_ci_policy_suite.mjs --self-test && node script/test_ci_policy_suite.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",
     "test:ruby-version-sources": "node script/test_ruby_version_sources.mjs",
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",

--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -6,6 +6,7 @@ import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
 const workflowPath = ".github/workflows/ci.yml";
 const packagePath = "package.json";
 const policyCliPath = "script/ci_changed_files_policy.mjs";
+const ciPolicySuitePath = "script/test_ci_policy_suite.mjs";
 
 const ciPolicyGuardScriptPaths = [
   "script/test_ci_changed_files_policy.mjs",
@@ -329,6 +330,35 @@ function assertJobMatches(jobBlock, pattern, message) {
   assert.match(jobBlock, pattern, message);
 }
 
+function assertCiPolicyCommandRunsSuite(ciPolicyCommand, suiteArgs, message) {
+  const escapedArgs = suiteArgs.map(escapeRegExp).join("\\s+");
+  const argsPattern = escapedArgs.length > 0 ? `\\s+${escapedArgs}` : "";
+
+  assert.match(
+    ciPolicyCommand,
+    new RegExp(`(?:^|&&\\s*)node ${escapeRegExp(ciPolicySuitePath)}${argsPattern}(?:\\s*&&|$)`),
+    message
+  );
+}
+
+function assertCiPolicySuiteRegistersGuardScripts() {
+  const suiteSource = readFileSync(ciPolicySuitePath, "utf8");
+
+  for (const scriptPath of ciPolicyGuardScriptPaths) {
+    assert.match(
+      suiteSource,
+      new RegExp(`args: \\["${escapeRegExp(scriptPath)}"\\]`),
+      `${ciPolicySuitePath} checks array must register ${scriptPath} so test:ci-policy covers CI policy guard changes`
+    );
+  }
+
+  assert.match(
+    suiteSource,
+    /assertCiPolicyScriptsRegistered\(\);/,
+    `${ciPolicySuitePath} --self-test must keep its registration coverage check`
+  );
+}
+
 function assertCiPolicyScriptRegistration(packageScripts) {
   const ciPolicyCommand = packageScripts["test:ci-policy"];
   assert.equal(
@@ -337,13 +367,17 @@ function assertCiPolicyScriptRegistration(packageScripts) {
     `${packagePath} scripts.test:ci-policy must be a command string`
   );
 
-  for (const scriptPath of ciPolicyGuardScriptPaths) {
-    assert.match(
-      ciPolicyCommand,
-      new RegExp(`(?:^|&&\\s*)node ${escapeRegExp(scriptPath)}(?:\\s*&&|$)`),
-      `${packagePath} scripts.test:ci-policy must run ${scriptPath} so CI policy guard changes validate their own registration`
-    );
-  }
+  assertCiPolicyCommandRunsSuite(
+    ciPolicyCommand,
+    ["--self-test"],
+    `${packagePath} scripts.test:ci-policy must run ${ciPolicySuitePath} --self-test before CI policy guards`
+  );
+  assertCiPolicyCommandRunsSuite(
+    ciPolicyCommand,
+    [],
+    `${packagePath} scripts.test:ci-policy must run ${ciPolicySuitePath} so CI policy guard changes validate their own registration`
+  );
+  assertCiPolicySuiteRegistersGuardScripts();
 }
 
 function policyCliOutput(input) {
@@ -608,11 +642,6 @@ assertJobMatches(gemPackageJob, /run: gem install tree_view-\*\.gem/, `${workflo
 assertJobMatches(gemPackageJob, /run: ruby -e "require 'tree_view'"/, `${workflowPath} jobs.gem_package must keep the installed gem require smoke`);
 
 assertCiPolicyScriptRegistration(packageScripts);
-
-assert.ok(
-  packageScripts["test:ci-policy"].includes("script/test_package_lock_dependency_drift.mjs"),
-  `${packagePath} scripts.test:ci-policy must keep the package lock dependency drift guard`
-);
 
 for (const scriptName of npmRunScripts(workflowSource)) {
   assert.ok(

--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -239,7 +239,7 @@ function runSelfTest() {
     !ciPolicyCandidateScriptPaths().includes("script/test_ci_policy_suite.mjs"),
     "the suite entrypoint should stay out of direct guard registration candidates"
   )
-  assertCiPolicyScriptsRegistered()
+  assertCiPolicyScriptsRegistered();
 
   console.log("[ci-policy] self-test passed")
 }


### PR DESCRIPTION
## 対応 Issue

Closes #2602

## Issue ごとの完了内容

- #2602: `package.json` の `test:ci-policy` を `script/test_ci_policy_suite.mjs --self-test` と suite 本体実行に集約し、suite 内 guard scripts の package script 側重複実行をなくしました。

## 変更内容

- `package.json` の `test:ci-policy` から、suite 実行後に個別 guard scripts を再度呼ぶ部分を削除しました。
- `script/test_ci_changed_files_policy.mjs` の package script 登録検査を、直接 script 名の列挙ではなく suite 実行と suite 内 registration coverage を確認する形に更新しました。
- `script/test_ci_policy_suite.mjs` の self-test registration 呼び出しを source check で明示的に検出できる表記に揃えました。

## 改善カテゴリ

- test
- CI
- 小さな内部整理

## 既存仕様への影響

- CI workflow、required checks、branch protection、guard script implementation、dependency versions は変更していません。
- `test:ci-policy` から実行される guard の source of truth を既存 suite に寄せるだけで、guard coverage は維持します。
- public API、runtime Ruby/JavaScript、docs prose は変更していません。

## 実施した確認

- Issue #2602 の labels を個別確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- connector compare `main...chore/2602-ci-policy-suite-source`: `ahead_by:3` / `behind_by:0` / changed files は `package.json`, `script/test_ci_changed_files_policy.mjs`, `script/test_ci_policy_suite.mjs` の3件のみ。
- GitHub Actions CI #3589: success。
  - `lint` / `pr_specs` / `changes` / `javascript` / `docker_development_setup` / `gem_package` / representative `pr_rails_matrix` lanes all succeeded.
  - `javascript` job で `npm run test:ci-policy` と `npm run test:js:core` が成功しました。
- ローカル checkout / npm 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク評価

low。package script の重複実行を削り、既存 suite の registration self-test を source of truth として検査するだけです。

## 補足事項

- merge は行いません。