### PR TITLE
CI policy suite 導線を release checklist から補強する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ Maintainer entry points には、gem に同梱される `docs/**` と repository
 - [Design policy](en/design-policy.md) / [設計思想と責務範囲](ja/design-policy.md): repository scope, responsibility boundaries, and non-goals.
 - [Demo application boundary](en/demo-application-boundary.md) / [Demo application boundary](ja/demo-application-boundary.md): handoff policy between static gem mockups and a future public Rails demo application.
 - [Development](en/development.md) / [開発・保守方針](ja/development.md): CI, local checks, documentation update workflow, and maintenance habits.
+- [CI policy suite](en/ci-policy-suite.md) / [CI policy suite](ja/ci-policy-suite.md): targeted CI policy guard runs, suite self-test behavior, and guard registration expectations.
 - [Dependabot Bundler recovery](en/dependabot-bundler-recovery.md) / [Dependabot Bundler 復旧手順](ja/dependabot-bundler-recovery.md): lockfile metadata drift triage and scoped recovery paths for Bundler dependency PRs.
 - [Code quality](en/code-quality.md) / [コード品質](ja/code-quality.md): lint, tests, error message quality, and documentation quality policy.
 - [Release checklist](en/release.md) / [リリースチェックリスト](ja/release.md): release workflow, CI and package verification, and changelog expectations.

--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -1,0 +1,31 @@
+# CI policy suite
+
+This note explains the narrow CI policy suite used by maintainers when a pull request changes workflow routing, CI observation guidance, lockfile drift guards, or CI-policy-sensitive maintainer docs.
+
+## When to use it
+
+Run the full CI policy suite when you need to confirm the policy guards without running the broader JavaScript entrypoint suite:
+
+```bash
+npm run test:ci-policy
+```
+
+The package script runs the suite self-test first and then runs the configured CI policy guard groups. Treat `script/test_ci_policy_suite.mjs` as the source of truth for the group list.
+
+## Targeted runs
+
+Use the suite options when you are narrowing one guard failure:
+
+```bash
+node script/test_ci_policy_suite.mjs --list
+node script/test_ci_policy_suite.mjs --only <group-or-index>
+node script/test_ci_policy_suite.mjs --self-test
+```
+
+`--list` prints the available guard groups in order. `--only` accepts the 1-based index, exact group name, case-insensitive group name, or a unique partial group name. Unknown, ambiguous, or out-of-range values fail and print the available groups plus the `--list` hint.
+
+## Registration self-test
+
+When adding or renaming a CI policy guard script, update the suite `checks` array or document an explicit exclusion before relying on CI. The self-test scans candidate scripts, confirms that registered scripts stay visible through the suite, and fails with the missing script path when a candidate is not registered.
+
+This note is only about maintainer command routing. It does not change CI workflow jobs, required checks, branch protection, workflow permissions, or lockfile policy.

--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -75,6 +75,10 @@ When Ruby support wording or source files change, keep the release checklist ali
 
 Use the release checklist to confirm that Ruby support evidence is visible before tagging, while leaving Ruby major/minor support changes, Rails matrix changes, workflow behavior, and gemspec metadata updates to the PR that owns the actual support-policy change.
 
+### CI policy suite
+
+When release preparation or a CI-sensitive documentation change needs targeted CI policy guard evidence, start from [CI policy suite](ci-policy-suite.md). Use `node script/test_ci_policy_suite.mjs --list` to see available guard groups, `node script/test_ci_policy_suite.mjs --only <group-or-index>` to narrow one guard, and `node script/test_ci_policy_suite.mjs --self-test` to confirm guard registration coverage before relying on release evidence.
+
 Local checks:
 
 ```bash

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -1,0 +1,31 @@
+# CI policy suite
+
+このメモは、workflow routing、CI observation guidance、lockfile drift guard、CI-policy-sensitive な maintainer docs を変更する Pull Request で使う、保守者向けの狭い CI policy suite を説明します。
+
+## 使う場面
+
+広い JavaScript entrypoint suite ではなく、CI policy guard だけを確認したい場合は full suite を実行します。
+
+```bash
+npm run test:ci-policy
+```
+
+package script は先に suite self-test を実行し、その後に設定済みの CI policy guard group を実行します。group list の source of truth は `script/test_ci_policy_suite.mjs` として扱ってください。
+
+## 絞り込み実行
+
+1つの guard failure を切り分ける場合は、suite option を使います。
+
+```bash
+node script/test_ci_policy_suite.mjs --list
+node script/test_ci_policy_suite.mjs --only <group-or-index>
+node script/test_ci_policy_suite.mjs --self-test
+```
+
+`--list` は利用できる guard group を順番付きで表示します。`--only` は 1-based index、完全一致の group 名、大文字小文字を問わない group 名、または一意に絞れる部分一致の group 名を受け付けます。unknown、ambiguous、範囲外の値は非 0 終了し、available groups と `--list` の案内を表示します。
+
+## 登録 self-test
+
+CI policy guard script を追加または rename した場合は、CI に頼る前に suite の `checks` array を更新するか、明示的な exclusion を残してください。self-test は candidate script を走査し、登録済み script が suite から見えることを確認します。未登録 candidate がある場合は missing script path を表示して失敗します。
+
+このメモは maintainer command routing だけを扱います。CI workflow jobs、required checks、branch protection、workflow permissions、lockfile policy は変更しません。

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -75,6 +75,10 @@ Ruby support wording や source files を変更する場合は、`npm run test:r
 
 release checklist では tag 前に Ruby support evidence が見えることを確認します。一方で、Ruby major/minor support の変更、Rails matrix の変更、workflow behavior、gemspec metadata 更新は、実際の support-policy change を担当する PR に閉じてください。
 
+### CI policy suite
+
+release preparation や CI-sensitive docs 変更で、CI policy guard の絞り込み証跡が必要な場合は [CI policy suite](ci-policy-suite.md) から確認してください。`node script/test_ci_policy_suite.mjs --list` で guard group を確認し、`node script/test_ci_policy_suite.mjs --only <group-or-index>` で 1つの guard に絞り込み、`node script/test_ci_policy_suite.mjs --self-test` で release evidence に頼る前の registration coverage を確認します。
+
 ローカル確認:
 
 ```bash

--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -6,6 +6,22 @@ const docs = [
   ["docs/en/development.md", fs.readFileSync("docs/en/development.md", "utf8")],
   ["docs/ja/development.md", fs.readFileSync("docs/ja/development.md", "utf8")]
 ]
+const releaseDocs = [
+  ["docs/en/release.md", fs.readFileSync("docs/en/release.md", "utf8")],
+  ["docs/ja/release.md", fs.readFileSync("docs/ja/release.md", "utf8")]
+]
+const ciPolicySuiteDocs = [
+  [
+    "docs/en/ci-policy-suite.md",
+    fs.readFileSync("docs/en/ci-policy-suite.md", "utf8"),
+    ["checks", "explicit exclusion"]
+  ],
+  [
+    "docs/ja/ci-policy-suite.md",
+    fs.readFileSync("docs/ja/ci-policy-suite.md", "utf8"),
+    ["checks", "明示的な exclusion"]
+  ]
+]
 
 const requiredMaintenanceScripts = [
   "test:docs-entrypoints",
@@ -31,6 +47,20 @@ const requiredDockerSetupSignals = [
   "Node 22",
   "npm",
   "lockfile-backed install path"
+]
+
+const requiredCiPolicySuiteCommandSignals = [
+  "npm run test:ci-policy",
+  "node script/test_ci_policy_suite.mjs --list",
+  "node script/test_ci_policy_suite.mjs --only <group-or-index>",
+  "node script/test_ci_policy_suite.mjs --self-test"
+]
+
+const requiredReleaseCiPolicySuiteSignals = [
+  "ci-policy-suite.md",
+  "node script/test_ci_policy_suite.mjs --list",
+  "node script/test_ci_policy_suite.mjs --only <group-or-index>",
+  "node script/test_ci_policy_suite.mjs --self-test"
 ]
 
 const missingSignals = []
@@ -64,6 +94,28 @@ for (const signal of requiredDockerSetupSignals) {
   }
 }
 
+for (const [docPath, doc, registrationSignals] of ciPolicySuiteDocs) {
+  for (const signal of requiredCiPolicySuiteCommandSignals) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: CI policy suite docs command signal ${signal}`)
+    }
+  }
+
+  for (const signal of registrationSignals) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: CI policy suite registration signal ${signal}`)
+    }
+  }
+}
+
+for (const [docPath, doc] of releaseDocs) {
+  for (const signal of requiredReleaseCiPolicySuiteSignals) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: CI policy suite release entrypoint signal ${signal}`)
+    }
+  }
+}
+
 if (missingSignals.length > 0) {
   console.error("[development-docs-command-signals] missing maintenance command signals:")
   for (const signal of missingSignals) {
@@ -73,5 +125,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, and ${requiredDockerSetupSignals.length} Docker setup signals are present in package.json and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, and ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals are present in package.json and docs`
 )


### PR DESCRIPTION
CI policy suite note を latest main からの clean replacement として載せ直し、Release docs から targeted run / self-test へ辿れる導線を追加します。

## 対応 Issue / PR

Refs #2599

Supersedes #2604

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` を追加し、`npm run test:ci-policy`、`--list`、`--only`、`--self-test`、guard registration expectation を保守者向けに整理しました。
- `docs/README.md` の Maintainer entry points から CI policy suite note へ到達できるようにしました。
- `docs/en/release.md` / `docs/ja/release.md` に CI policy suite section を追加し、release checklist 側から targeted run と registration self-test に辿れるようにしました。
- `script/test_development_docs_command_signals.mjs` に、CI policy suite note と release checklist entrypoint の lightweight signal を追加しました。

## 受け入れ条件との対応

- 英日 Release docs から CI policy suite note、`node script/test_ci_policy_suite.mjs --list`、`--only <group-or-index>`、`--self-test` へ辿れるようにしました。
- CI policy suite note 側には command role と registration self-test expectation を英日で明記しました。
- lightweight signal により、note 側の command / registration signal と release checklist 側の entrypoint signal の欠落を検出します。
- workflow、package script、runtime Ruby / JavaScript、branch protection、required checks は変更していません。

## 変更範囲

- `docs/README.md`
- `docs/en/ci-policy-suite.md`
- `docs/ja/ci-policy-suite.md`
- `docs/en/release.md`
- `docs/ja/release.md`
- `script/test_development_docs_command_signals.mjs`

## 実施した確認

- latest base: `main` `632e82c59f65c9cb981a670dfbd84ad2893bfd08`
- compare `main...docs/2599-ci-policy-suite-entrypoints-refresh`: `ahead_by:6` / `behind_by:0` / `status:ahead`
- changed files は上記6件のみです。
- local checkout / local npm は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。docs と docs signal guard のみの変更で、runtime、workflow、package script、public API には触れていません。

## 未対応・補足

- この PR は #2604 の clean replacement です。#2604 は `ahead_by:7` / `behind_by:2` の diverged branch だったため、latest main から scoped diff だけを載せ直しました。
- merge は行いません。