### PR TITLE
CHANGELOG に直近 maintenance test evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ Release preparation notes:
 
 ### Tests
 
+- Added public constants docs signal guard coverage for representative Public API constants so public constants stay aligned with `config/public_api_manifest.yml`.
+- Added stylesheet state cue selector source-spec coverage for selected, collapsed, loading, error, disabled-drop, and drop-target cues in the packaged stylesheet.
+- Consolidated `test:ci-policy` package-script execution around the CI policy suite source of truth while preserving guard registration self-test coverage.
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
 - Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.
 - Added manifest-backed public surface docs smoke coverage for state / remote-state event detail keys, setup generator output, localized names, and public constants.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2598
Refs #942
Refs #2602

## 分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、直近 merge 済み PR の release-facing evidence を3行追記しました。
- #2601: public constants docs signal guard coverage
- #2603: stylesheet state cue selector source-spec coverage
- #2605: `test:ci-policy` package-script execution の CI policy suite source-of-truth 集約

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、spec、CI workflow、package scripts、public API、仕様判断には触れていません。

## 確認内容

- latest base: `main` `aa189d0005acdf853199a1dc9252473e76bc2799`
- head: `bf849f362045613cade4ebd3e8906911cf4b301f`
- compare `main...docs/changelog-maintenance-evidence-2601-2605`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files: `CHANGELOG.md` の1件のみ
- additions/deletions: 追加3行、削除0行
- GitHub Actions CI #3597 / run `28169199900`: success
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success
  - representative Rails lanes: docs-only skip pathで success
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。既に main に merge 済みの maintenance test / docs-signal PR を CHANGELOG に記録するだけです。

merge は行いません。