### PR TITLE
GitHub Actions Dependabot lane を CI policy note に追記する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -28,4 +28,10 @@ node script/test_ci_policy_suite.mjs --self-test
 
 When adding or renaming a CI policy guard script, update the suite `checks` array or document an explicit exclusion before relying on CI. The self-test scans candidate scripts, confirms that registered scripts stay visible through the suite, and fails with the missing script path when a candidate is not registered.
 
+## GitHub Actions Dependabot lane
+
+`.github/dependabot.yml` is the source of truth for the Dependabot update lanes. It currently includes a `github-actions` lane for GitHub Actions dependency updates with the same weekly Monday 09:00 Asia/Tokyo cadence and open pull request limit of 5 as the Bundler lane.
+
+Keep that automation lane separate from the CI policy guard that watches representative action major versions. Dependabot opens version update pull requests; the action-major guard makes unexpected workflow action-major drift visible during review. The separate SHA pinning / allowed action policy decision remains tracked outside this note, so do not treat the Dependabot lane as a pinning-policy decision.
+
 This note is only about maintainer command routing. It does not change CI workflow jobs, required checks, branch protection, workflow permissions, or lockfile policy.

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -28,4 +28,10 @@ node script/test_ci_policy_suite.mjs --self-test
 
 CI policy guard script を追加または rename した場合は、CI に頼る前に suite の `checks` array を更新するか、明示的な exclusion を残してください。self-test は candidate script を走査し、登録済み script が suite から見えることを確認します。未登録 candidate がある場合は missing script path を表示して失敗します。
 
+## GitHub Actions Dependabot lane
+
+`.github/dependabot.yml` は Dependabot update lane の source of truth です。現在は GitHub Actions dependency update 用の `github-actions` lane を持ち、Bundler lane と同じ weekly Monday 09:00 Asia/Tokyo cadence、open pull request limit 5 で運用されています。
+
+この automation lane は、代表 action major version を監視する CI policy guard とは分けて扱ってください。Dependabot は version update Pull Request を作成し、action-major guard は workflow action-major drift が review 時に見えるようにします。SHA pinning / allowed action policy の判断はこのメモの外で扱うため、Dependabot lane を pinning policy の決定として扱わないでください。
+
 このメモは maintainer command routing だけを扱います。CI workflow jobs、required checks、branch protection、workflow permissions、lockfile policy は変更しません。


### PR DESCRIPTION
## 対応 Issue

Refs #2609

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に GitHub Actions Dependabot lane の短い説明を追加しました。
- `.github/dependabot.yml` が Dependabot update lane の source of truth であること、`github-actions` lane が weekly Monday 09:00 Asia/Tokyo / open PR limit 5 で運用されていることを記載しました。
- Dependabot update lane、CI policy の action-major guard、#2496 の SHA pinning / allowed action policy decision を混同しない境界を明記しました。

## Scope

- docs-only です。
- 変更ファイルは英日 CI policy suite note の2件のみです。
- `.github/dependabot.yml`、`.github/workflows/ci.yml`、action versions、required checks、branch protection、CI job topology、runtime Ruby / JavaScript、script / lightweight signal は変更していません。

## 確認内容

- latest base: `main` `aa189d0005acdf853199a1dc9252473e76bc2799`
- head: `05575b85e044884cd50c121ad2c069a6b4bf6a7f`
- compare `main...docs/2609-actions-dependabot-lane`: `ahead_by:2` / `behind_by:0` / `status:ahead`
- changed files: `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`
- additions/deletions: 追加12行、削除0行
- PR metadata: open / non-draft / `mergeable:true`
- GitHub Actions CI #3598 / run `28172474207`: success
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success
  - `javascript` job で `npm run test:docs-entrypoints` が success、`npm run test:ci-policy` は docs-entrypoint-sensitive path のため expected skipped
  - representative Rails lanes: docs-only skip path で success
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped
- combined status は空でしたが、workflow run で CI 成功を確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## 未対応

- #2609 の lightweight signal 追加は Docs Sync Agent の docs-only 範囲外なので、この PR では実装していません。
- そのため `Closes` ではなく `Refs #2609` に留めます。

## リスク

low。既存 Dependabot config と Planner handoff に基づく maintainer docs の短い追記だけです。

merge は行いません。