### PR TITLE
CHANGELOG に CI policy suite docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ Release preparation notes:
 - Documented `Security` as an allowed CHANGELOG category for vulnerability fixes and security hardening notes.
 - Added mockup review task chooser release evidence so reviewers can choose baseline, responsive, interaction, accessibility, selection, and toolbar/table boundary entry points from `docs/mockups/README.md`.
 - Added repository maintainer CI policy suite guidance release evidence for listing, targeting, and self-testing CI policy guard groups from `AGENTS.md`.
+- Added CI policy suite maintainer note and Release checklist entry points for targeted guard runs, suite self-test behavior, and guard registration expectations.
+- Added GitHub Actions Dependabot lane guidance to the CI policy suite docs, separating automation updates from action-major guard and pinning-policy decisions.
 
 ### Tests
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2599
Refs #2609
Refs #2610
Refs #2613

## 分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、直近 merge 済み docs PR の release-facing evidence を2行追記しました。
- #2610: CI policy suite maintainer note / Release checklist entrypoint
- #2613: GitHub Actions Dependabot lane guidance in CI policy suite docs

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、spec、CI workflow、package scripts、Dependabot config、public API、仕様判断には触れていません。

## 確認内容

- latest base: `main` `702b79ceb60872346424e13a104e514246ebdb13`
- head: `d4d4844f6e4239cb2df3b4df41b4ff6182d3b5f0`
- compare `main...docs/changelog-ci-policy-suite-doc-evidence`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files: `CHANGELOG.md` の1件のみ
- additions/deletions: 追加2行、削除0行
- GitHub Actions CI #3601 / run `28180248922`: success
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success
  - `javascript` job で `npm run test:docs-entrypoints` が success、`npm run test:ci-policy` / `test:js:core` / browser smoke は expected skipped
  - representative Rails lanes: docs-only skip path で success
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped
- combined status は空でしたが、workflow run で CI 成功を確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。既に main に merge 済みの docs-only PR を CHANGELOG に記録するだけです。

merge は行いません。