### PR TITLE
CI policy suite docs を package verification の代表 group に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -79,6 +79,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/development.md
     docs/ja/development.md
   ],
+  "Bilingual CI policy suite docs" => %w[
+    docs/en/ci-policy-suite.md
+    docs/ja/ci-policy-suite.md
+  ],
   "README-linked public JavaScript docs" => %w[
     docs/en/js-events.md
     docs/ja/js-events.md


### PR DESCRIPTION
## 対応 Issue

Closes #2614

## Issue ごとの完了内容

- #2614: `docs/README.md` の Maintainer entry point から辿れる英日 CI policy suite docs を、gem package verification の代表 docs group として明示的に guard するようにしました。

## 変更内容

- `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に `Bilingual CI policy suite docs` group を追加しました。
- group には `docs/en/ci-policy-suite.md` と `docs/ja/ci-policy-suite.md` だけを含め、missing file failure から maintainer CI policy docs の packaged-file 欠落だと分かるようにしました。

## 改善カテゴリ

- test
- docs guard
- package verification

## 既存仕様への影響

- runtime Ruby / JavaScript、CI workflow、package scripts、Dependabot lane、release policy、public API は変更していません。
- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` 本文も変更していません。
- 既存の `docs/**/*` packaging 方針を広げず、代表 package verification group の明示だけに閉じています。

## 実施した確認

- Issue #2614 の `status:ready-for-agent` / `track:quality` / `agent:planned` / `risk:low` ラベルを個別確認しました。
- PR 前 compare `main...test/2614-ci-policy-docs-package-guard`: `ahead_by:1` / `behind_by:0` / changed files は `script/check_gem_package_contents.rb` の1件のみ。
- ローカル GitHub access は `CONNECT tunnel failed, response 403` のため checkout / local test は未実行です。PR CI で `gem_package` と docs/package verification を確認します。

## リスク評価

low。package verification script の代表 docs group 追加のみで、公開挙動や release procedure は変わりません。

merge は行いません。