### PR TITLE
empty-state mockup の toolbar disabled 表示を揃える

### DIFF
--- a/docs/mockups/empty-state.html
+++ b/docs/mockups/empty-state.html
@@ -217,12 +217,12 @@
         <div class="mock-toolbar" role="toolbar" aria-label="Tree actions while empty">
           <button type="button" disabled>Expand all</button>
           <button type="button" disabled>Collapse all</button>
-          <button type="button" aria-disabled="true">Current path unavailable</button>
+          <button type="button" disabled>Current path unavailable</button>
           <button type="button">Reset filters</button>
         </div>
         <p class="mock-empty-note">
-          Disabled expand/collapse buttons communicate that TreeView has no rendered branches to act on.
-          The reset affordance and final wording are examples of host-app-owned behavior.
+          Disabled expand, collapse, and current-path buttons communicate that TreeView has no rendered branches to act on.
+          Reset filters remains an enabled example of host-app-owned behavior and final wording.
         </p>
       </div>
       <table class="tree-view-table">


### PR DESCRIPTION
## 対応 Issue

- Closes #2615

## 分類

- `docs-sync`
- `docs-stale`

## 変更内容

- `docs/mockups/empty-state.html` の「Empty state with nearby toolbar actions」で、`Current path unavailable` を native `disabled` button に揃えました。
- disabled な `Expand all` / `Collapse all` / `Current path unavailable` を同じ「空ツリーでは実行できない toolbar action」として読めるようにしました。
- `Reset filters` は host-app-owned の有効 action 例として分離して見えるよう、説明文を更新しました。

## Scope

- docs/mockup only です。
- 変更ファイルは `docs/mockups/empty-state.html` のみです。
- runtime Ruby / JavaScript、toolbar helper API、current-path route policy、authorization、row expansion behavior、browser smoke inventory、README / gallery は変更していません。
- `docs/mockups/README.md` と `review-gallery.html` には既に `empty-state.html` が登録済みなので、この PR では追従不要と判断しました。

## 確認内容

- latest base: `main` `b120e3623cbaf2ea1ffe8fd925816408940579f7`
- head: `0202dd5177dbf272114a8ada486b0867a56846eb`
- compare `main...docs/2615-empty-state-toolbar-disabled`: `ahead_by:3` / `behind_by:0` / `status:ahead`
- changed files: `docs/mockups/empty-state.html` の1件のみ
- diff: additions 3 / deletions 3
- static HTML source review: toolbar button attributes と explanatory note が Issue #2615 の Planner handoff に沿っていることを確認
- GitHub Actions CI #3609 / run `28184156721`: success
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success
  - `javascript` job で `npm run test:browser` success
  - representative Rails lanes は docs-only skip path で success
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped
- 実ブラウザでの desktop / narrow viewport visual readability evidence はこの connector-only 実行では未実施です。CI smoke とあわせて reviewer gate として確認してください。

## リスク

low。静的 mockup の button attribute と説明文の整理に閉じています。

merge は行いません。