### PR TITLE
empty-state mockup の toolbar disabled 表示を整理する

### DIFF
--- a/docs/mockups/empty-state.html
+++ b/docs/mockups/empty-state.html
@@ -217,12 +217,12 @@
         <div class="mock-toolbar" role="toolbar" aria-label="Tree actions while empty">
           <button type="button" disabled>Expand all</button>
           <button type="button" disabled>Collapse all</button>
-          <button type="button" aria-disabled="true">Current path unavailable</button>
+          <button type="button" disabled>Current path unavailable</button>
           <button type="button">Reset filters</button>
         </div>
         <p class="mock-empty-note">
-          Disabled expand/collapse buttons communicate that TreeView has no rendered branches to act on.
-          The reset affordance and final wording are examples of host-app-owned behavior.
+          Disabled expand, collapse, and current-path buttons communicate that TreeView has no rendered
+          branches or current path to act on. Reset filters stays enabled as a host-app-owned recovery example.
         </p>
       </div>
       <table class="tree-view-table">


### PR DESCRIPTION
## 対応Issue

- Closes #2615

## 採用した方針

- スケジュール実行のためユーザー選択待ちはせず、Planner handoff に沿って最も低リスクな copy / attribute 中心の案を採用しました。
- 既存 `empty-state.html` 内の toolbar-adjacent empty state だけを調整し、新規 mockup、README Files table、review-gallery、browser smoke inventory には広げていません。

## 比較した案

- 案A: `Current path unavailable` を native `disabled` に寄せ、expand / collapse と同じ unavailable action として見せる。採用案です。静的HTML上で操作可能に見えにくく、変更範囲も最小です。
- 案B: `aria-disabled="true"` を残して style / note を足す。focus / keyboard の誤読が残りやすく、static mockup としては少し曖昧なため不採用です。
- 案C: toolbar mockup 全体や別 surface まで整理する。影響範囲が広がり、#2615 の単独実装範囲を超えるため不採用です。

## 変更内容

- `Current path unavailable` button を native `disabled` に変更しました。
- 説明文を、expand / collapse / current-path は空ツリーでは実行できない action、`Reset filters` は host-app-owned の有効な recovery example として読めるように更新しました。

## 変更した画面・コンポーネント

- `docs/mockups/empty-state.html`

## 確認内容

- lint: GitHub Actions CI #3610 / run `28184198206` で success。
- typecheck: runtime Ruby / JavaScript は変更していません。GitHub Actions CI #3610 の JavaScript job は success。
- CI: GitHub Actions CI #3610 は success。
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success（`npm run test:browser` success）
  - `gem_package`: success
  - representative Rails compatibility lanes: docs-only skip path で success
- UI表示確認: 実ブラウザ確認はこの実行環境では未実施です。static HTML source review / scoped diff review で代替しました。
- レスポンシブ確認: 実ブラウザ確認はこの実行環境では未実施です。既存 layout / CSS は変更していません。
- アクセシビリティ確認: `Current path unavailable` を native `disabled` に寄せ、静的HTML上でキーボード操作可能に見えすぎないようにしました。支援技術での確認は未実施です。
- 実ブラウザ確認の代替: static HTML fixture / QA handoff note。desktop / narrow viewport で disabled action と enabled reset action が重ならず読めることは browser-capable review に残します。
- latest head: `f14b9a5caa47ebf5e8b601b3f4f85231db00b932`。
- latest base observed: `main` `b120e3623cbaf2ea1ffe8fd925816408940579f7`。
- final compare `main...design/2615-empty-state-disabled-toolbar`: `ahead_by:3` / `behind_by:0` / changed files 1。

## スクリーンショット

<!-- connector-only 実行のため未添付。desktop / narrow viewport の browser-capable visual readability evidence は reviewer / browser-capable pass で確認してください。 -->

## リスク

- low

## 補足

- `docs/mockups/README.md` は既に `empty-state.html` を登録済みで、新規 mockup 追加ではないため更新していません。
- runtime Ruby / JavaScript、toolbar helper API、current-path route policy、authorization、row expansion behavior、host app final copy / reset behavior は変更していません。
- rails_table_preferences #1379 は `track:quality` / `area:security` を含むため、この Design Fixer では対象外としました。
- rails_fields_kit #927 は同じ visual reference lane に browser-capable evidence 待ちPRが残っているため、新規PRを増やさず `status:needs-human` に戻しました。
- merge は行いません。