### PR TITLE
CHANGELOG に CI policy package guard と empty-state mockup 追従を記録する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,11 +127,13 @@ Release preparation notes:
 - Added repository maintainer CI policy suite guidance release evidence for listing, targeting, and self-testing CI policy guard groups from `AGENTS.md`.
 - Added CI policy suite maintainer note and Release checklist entry points for targeted guard runs, suite self-test behavior, and guard registration expectations.
 - Added GitHub Actions Dependabot lane guidance to the CI policy suite docs, separating automation updates from action-major guard and pinning-policy decisions.
+- Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 
 ### Tests
 
 - Added public constants docs signal guard coverage for representative Public API constants so public constants stay aligned with `config/public_api_manifest.yml`.
 - Added stylesheet state cue selector source-spec coverage for selected, collapsed, loading, error, disabled-drop, and drop-target cues in the packaged stylesheet.
+- Expanded package contents verification coverage for bilingual CI policy suite docs so packaged gems keep maintainer CI policy guidance available.
 - Consolidated `test:ci-policy` package-script execution around the CI policy suite source of truth while preserving guard registration self-test coverage.
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
 - Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.


### PR DESCRIPTION
## 対応 Issue

Closes #2621

## 分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、PR #2618 の empty-state mockup toolbar disabled-action 追従を release evidence として追記しました。
- `CHANGELOG.md` の `Unreleased > Tests` に、PR #2617 の bilingual CI policy suite docs package verification coverage を release evidence として追記しました。

## Scope

- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、spec、CI workflow、package checker behavior、mockup HTML は変更していません。
- 既存の CHANGELOG entry の削除、並べ替え、release section 分割は行っていません。

## 確認内容

- PR #2617 / #2618 が merge 済みであることを確認しました。
- current main `CHANGELOG.md` に該当 release evidence が未記録であることを確認しました。
- head: `753806247c8e5a547ef788b55f8f50c65540098e`
- compare `main...docs/2621-changelog-ci-policy-empty-state`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files: `CHANGELOG.md` 1件のみ
- diff: additions 2 / deletions 0
- GitHub Actions CI #3612 / run `28190706477`: success
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`: success
  - `javascript` job で `npm run test:docs-entrypoints` success、`npm run test:ci-policy` expected skipped
  - representative Rails lanes は docs-only skip path で success
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped
- local checkout は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク

low。CHANGELOG の release evidence 追記のみです。

merge は行いません。