### PR TITLE
CI policy docs 変更時に test:ci-policy を走らせる

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -91,6 +91,8 @@ function isCiPolicySensitivePath(file) {
   return (
     file === "AGENTS.md" ||
     file === ".github/workflows/ci.yml" ||
+    file === "docs/en/ci-policy-suite.md" ||
+    file === "docs/ja/ci-policy-suite.md" ||
     file === "script/ci_changed_files_policy.mjs" ||
     file === "script/test_ci_policy_suite.mjs" ||
     file === "script/test_ci_changed_files_policy.mjs" ||

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { classifyChangedFiles } from "./ci_changed_files_policy.mjs"
+
+const ciPolicyDocsPaths = [
+  "docs/en/ci-policy-suite.md",
+  "docs/ja/ci-policy-suite.md"
+]
+
+const expected = {
+  docs_only: true,
+  mockups_changed: false,
+  browser_smoke_changed: false,
+  package_sensitive: true,
+  docker_setup_sensitive: false,
+  docs_entrypoint_sensitive: true,
+  ci_policy_sensitive: true
+}
+
+function policyCliOutput(input) {
+  return execFileSync(process.execPath, ["script/ci_changed_files_policy.mjs"], {
+    input,
+    encoding: "utf8"
+  })
+}
+
+function parsePolicyCliOutput(output) {
+  return Object.fromEntries(
+    output.trim().split(/\r?\n/).map((line) => {
+      assert.match(line, /^[a-z_]+=(true|false)$/)
+      const [key, value] = line.split("=")
+
+      return [key, value === "true"]
+    })
+  )
+}
+
+for (const docsPath of ciPolicyDocsPaths) {
+  assert.deepEqual(
+    classifyChangedFiles([docsPath]),
+    expected,
+    `${docsPath} changes must run docs entrypoint, package, and CI policy guards while staying docs-only`
+  )
+}
+
+assert.deepEqual(
+  classifyChangedFiles(ciPolicyDocsPaths),
+  expected,
+  "bilingual CI policy docs changes must keep the same routing as each individual docs path"
+)
+
+assert.deepEqual(
+  parsePolicyCliOutput(policyCliOutput(`${ciPolicyDocsPaths.join("\n")}\n`)),
+  expected,
+  "changed-file policy CLI must emit CI policy-sensitive routing for bilingual CI policy docs changes"
+)
+
+console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)

--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -28,6 +28,11 @@ const checks = [
     args: ["script/test_ci_observation_guidance_signals.mjs"]
   },
   {
+    group: "CI policy docs routing signals",
+    command: "node",
+    args: ["script/test_ci_policy_docs_routing.mjs"]
+  },
+  {
     group: "Package lock dependency drift",
     command: "node",
     args: ["script/test_package_lock_dependency_drift.mjs"]

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -160,6 +160,7 @@ const checks = [
 ]
 
 const docsEntrypointScriptExclusions = new Map([
+  ["test_ci_policy_docs_routing.mjs", "registered through npm run test:ci-policy"],
   [
     "test_development_docs_command_signals.mjs",
     "registered through npm run test:development-docs-commands"


### PR DESCRIPTION
## 対応 Issue

Closes #2620

## Issue ごとの完了内容

- #2620: `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` を `ci_policy_sensitive` として分類し、CI policy docs 変更時に `npm run test:ci-policy` が走る routing にしました。

## 変更内容

- `script/ci_changed_files_policy.mjs` に CI policy suite docs の英日 path を追加しました。
- `script/test_ci_policy_docs_routing.mjs` を追加し、英日 docs path が docs-only のまま package / docs entrypoint / CI policy guard を要求することを確認します。
- `script/test_ci_policy_suite.mjs` に新しい smoke を登録しました。
- `script/test_docs_entrypoint_suite.mjs` では、この CI policy 専用 smoke が docs entrypoint suite の自動登録検査に拾われないよう明示除外しました。

## 改善カテゴリ

- CI / changed-files routing guard
- test hardening
- docs-maintenance safety

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、docs 本文、CI workflow topology、required checks、branch protection は変更していません。
- 既存 docs entrypoint routing は維持し、CI policy docs の変更時だけ CI policy guard も走るようにしています。

## 実施した確認

- Issue #2620 の labels を確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR 前 compare `main...chore/2620-ci-policy-docs-routing`: `ahead_by:4` / `behind_by:0` / `status:ahead`。
- changed files は次の4件のみです。
  - `script/ci_changed_files_policy.mjs`
  - `script/test_ci_policy_docs_routing.mjs`
  - `script/test_ci_policy_suite.mjs`
  - `script/test_docs_entrypoint_suite.mjs`
- 初回 CI で `test:ci-policy` は通過し、`test:js:core` 内の docs entrypoint suite self-test が新しい smoke の所属明記を要求したため、CI policy suite 側に所属する明示除外を追加しました。
- local checkout / local npm test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。CI changed-files policy とその自己検証だけの変更で、実行対象を広げるのは CI policy docs path に限定しています。

## 補足事項

merge は行いません。