### PR TITLE
GitHub Actions Dependabot lane の CI policy signal を追加する

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -96,6 +96,7 @@ function isCiPolicySensitivePath(file) {
     file === "script/ci_changed_files_policy.mjs" ||
     file === "script/test_ci_policy_suite.mjs" ||
     file === "script/test_ci_changed_files_policy.mjs" ||
+    file === "script/test_ci_policy_docs_routing.mjs" ||
     file === "script/test_ci_workflow_changed_file_detection_signals.mjs" ||
     file === "script/test_ci_workflow_permissions_signals.mjs" ||
     file === "script/test_ci_observation_guidance_signals.mjs" ||

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
 import { classifyChangedFiles } from "./ci_changed_files_policy.mjs"
 
+const dependabotPath = ".github/dependabot.yml"
 const ciPolicyDocsPaths = [
   "docs/en/ci-policy-suite.md",
   "docs/ja/ci-policy-suite.md"
@@ -35,6 +37,68 @@ function parsePolicyCliOutput(output) {
   )
 }
 
+function dependabotUpdateBlock(source, ecosystem) {
+  const marker = `  - package-ecosystem: "${ecosystem}"\n`
+  const start = source.indexOf(marker)
+
+  assert.notEqual(start, -1, `${dependabotPath} must define a ${ecosystem} update lane`)
+
+  const remaining = source.slice(start + marker.length)
+  const nextUpdateOffset = remaining.search(/\n  - package-ecosystem: /)
+  return nextUpdateOffset === -1 ? remaining : remaining.slice(0, nextUpdateOffset + 1)
+}
+
+function assertIncludes(source, needle, label) {
+  assert.ok(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+function assertDependabotLaneSignal() {
+  const dependabotSource = readFileSync(dependabotPath, "utf8")
+  const githubActionsLane = dependabotUpdateBlock(dependabotSource, "github-actions")
+
+  assertIncludes(githubActionsLane, 'directory: "/"', `${dependabotPath} github-actions lane directory`)
+  assertIncludes(githubActionsLane, 'interval: "weekly"', `${dependabotPath} github-actions lane schedule interval`)
+  assertIncludes(githubActionsLane, 'day: "monday"', `${dependabotPath} github-actions lane schedule day`)
+  assertIncludes(githubActionsLane, 'time: "09:00"', `${dependabotPath} github-actions lane schedule time`)
+  assertIncludes(githubActionsLane, 'timezone: "Asia/Tokyo"', `${dependabotPath} github-actions lane schedule timezone`)
+  assertIncludes(githubActionsLane, "open-pull-requests-limit: 5", `${dependabotPath} github-actions lane open PR limit`)
+}
+
+function assertCiPolicyDocsDependabotSignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        ".github/dependabot.yml",
+        "github-actions",
+        "weekly Monday 09:00 Asia/Tokyo",
+        "open pull request limit of 5",
+        "action-major guard",
+        "SHA pinning / allowed action policy"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        ".github/dependabot.yml",
+        "github-actions",
+        "weekly Monday 09:00 Asia/Tokyo",
+        "open pull request limit 5",
+        "action-major guard",
+        "SHA pinning / allowed action policy"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} GitHub Actions Dependabot lane docs signal`)
+    }
+  }
+}
+
 for (const docsPath of ciPolicyDocsPaths) {
   assert.deepEqual(
     classifyChangedFiles([docsPath]),
@@ -55,4 +119,8 @@ assert.deepEqual(
   "changed-file policy CLI must emit CI policy-sensitive routing for bilingual CI policy docs changes"
 )
 
+assertDependabotLaneSignal()
+assertCiPolicyDocsDependabotSignals()
+
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
+console.log("Checked GitHub Actions Dependabot lane config and docs signals.")

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -8,6 +8,7 @@ const ciPolicyDocsPaths = [
   "docs/en/ci-policy-suite.md",
   "docs/ja/ci-policy-suite.md"
 ]
+const ciPolicyDocsRoutingScriptPath = "script/test_ci_policy_docs_routing.mjs"
 
 const expected = {
   docs_only: true,
@@ -16,6 +17,16 @@ const expected = {
   package_sensitive: true,
   docker_setup_sensitive: false,
   docs_entrypoint_sensitive: true,
+  ci_policy_sensitive: true
+}
+
+const expectedCiPolicyScriptChange = {
+  docs_only: false,
+  mockups_changed: false,
+  browser_smoke_changed: false,
+  package_sensitive: false,
+  docker_setup_sensitive: false,
+  docs_entrypoint_sensitive: false,
   ci_policy_sensitive: true
 }
 
@@ -114,13 +125,26 @@ assert.deepEqual(
 )
 
 assert.deepEqual(
+  classifyChangedFiles([ciPolicyDocsRoutingScriptPath]),
+  expectedCiPolicyScriptChange,
+  `${ciPolicyDocsRoutingScriptPath} changes must run the CI policy guard directly`
+)
+
+assert.deepEqual(
   parsePolicyCliOutput(policyCliOutput(`${ciPolicyDocsPaths.join("\n")}\n`)),
   expected,
   "changed-file policy CLI must emit CI policy-sensitive routing for bilingual CI policy docs changes"
+)
+
+assert.deepEqual(
+  parsePolicyCliOutput(policyCliOutput(`${ciPolicyDocsRoutingScriptPath}\n`)),
+  expectedCiPolicyScriptChange,
+  "changed-file policy CLI must emit CI policy-sensitive routing for CI policy docs routing guard changes"
 )
 
 assertDependabotLaneSignal()
 assertCiPolicyDocsDependabotSignals()
 
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
+console.log("Checked CI policy docs routing guard script routing.")
 console.log("Checked GitHub Actions Dependabot lane config and docs signals.")


### PR DESCRIPTION
## 対応 Issue

Closes #2609

## Issue ごとの完了内容

- #2609: `docs/*/ci-policy-suite.md` に既に入っている GitHub Actions Dependabot lane 説明を、CI policy guard から代表 signal として確認できるようにしました。
- CI policy guard 自身を変更した場合にも `ci_policy_sensitive` として扱われ、`npm run test:ci-policy` が明示的に実行されることを確認できるようにしました。

## 変更内容

- `script/test_ci_policy_docs_routing.mjs` に `.github/dependabot.yml` の `github-actions` lane確認を追加しました。
- 同 guard で英日 `docs/*/ci-policy-suite.md` の代表文言も確認し、Dependabot update lane、action-major guard、SHA pinning / allowed action policy を混同しない説明が落ちた場合に検出できるようにしました。
- `script/ci_changed_files_policy.mjs` で `script/test_ci_policy_docs_routing.mjs` を CI policy sensitive path に含めました。
- 既存の CI policy docs routing check の中に収め、新規 suite や package script は増やしていません。

## 改善カテゴリ

- docs / CI policy signal hardening
- test coverage improvement
- CI routing guard hardening

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、`.github/dependabot.yml`、`.github/workflows/ci.yml`、action versions、required checks、branch protection、repository settings は変更していません。
- package scripts も変更していません。
- CI policy の検出対象を guard script へ 1 件追加しただけで、公開挙動には影響しません。

## 実施した確認

- Issue #2609 の labels を直接確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- PR compare `main...fix/2609-actions-dependabot-ci-signal`: `ahead_by:3` / `behind_by:0` / changed files 2。
- GitHub Actions CI run #3619: success。
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success; `npm run test:ci-policy` and `npm run test:js:core` both ran successfully
  - representative `pr_rails_matrix` lanes: success
- local checkout / local `npm run test:ci-policy` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク評価

low。既存 guard script と CI changed-files classifier の assertion / path 判定追加だけで、設定・workflow・runtime behavior には触れていません。

## 補足事項

- docs prose は #2613 で main に入っているため、この PR では重複追加していません。
- merge は行いません。