### PR TITLE
Docker setup CI docs signal を smoke で守る

### DIFF
--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -110,6 +110,51 @@ function assertCiPolicyDocsDependabotSignals() {
   }
 }
 
+function assertCiPolicyDocsDockerSetupSignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        "docker_setup_sensitive",
+        "Dockerfile",
+        "docker-compose.yml",
+        "package.json",
+        "package-lock.json",
+        ".nvmrc",
+        ".github/workflows/ci.yml",
+        "docker_development_setup",
+        "Node 22",
+        "npm ci",
+        "Docker image design"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        "docker_setup_sensitive",
+        "Dockerfile",
+        "docker-compose.yml",
+        "package.json",
+        "package-lock.json",
+        ".nvmrc",
+        ".github/workflows/ci.yml",
+        "docker_development_setup",
+        "Node 22",
+        "npm ci",
+        "Docker image design"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} Docker development setup lane docs signal`)
+    }
+  }
+}
+
 for (const docsPath of ciPolicyDocsPaths) {
   assert.deepEqual(
     classifyChangedFiles([docsPath]),
@@ -144,7 +189,9 @@ assert.deepEqual(
 
 assertDependabotLaneSignal()
 assertCiPolicyDocsDependabotSignals()
+assertCiPolicyDocsDockerSetupSignals()
 
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
 console.log("Checked CI policy docs routing guard script routing.")
 console.log("Checked GitHub Actions Dependabot lane config and docs signals.")
+console.log("Checked Docker development setup CI docs signals.")


### PR DESCRIPTION
## 対応 Issue

Closes #2626

## Issue ごとの完了内容

- #2626: `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に入った Docker development setup lane の代表 signal を、CI policy docs routing smoke で確認するようにしました。

## 変更内容

- `script/test_ci_policy_docs_routing.mjs` に Docker setup docs signal guard を追加しました。
- EN/JA docs の `docker_setup_sensitive`、代表 path (`Dockerfile`, `docker-compose.yml`, `package.json`, `package-lock.json`, `.nvmrc`, `.github/workflows/ci.yml`)、`docker_development_setup`、Node 22、`npm ci`、Docker image design 非対象の代表文言を確認します。

## 改善カテゴリ

- test
- CI policy guard
- docs signal hardening

## 既存仕様への影響

なし。Dockerfile、docker-compose、CI workflow、package scripts、Node / Ruby support policy、runtime Ruby / JavaScript は変更していません。

## 実施した確認

- Issue #2626 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR 前 compare: `ahead_by:1` / `behind_by:0` / changed files 1。
- GitHub Actions CI #3623 / run `28197821149`: success。
  - `changes`: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success; `npm run test:ci-policy` and `npm run test:js:core` ran successfully
  - representative `pr_rails_matrix` lanes: success
  - `gem_package`: skipped because this PR does not touch package-sensitive files
  - `docker_development_setup`: skipped because this PR does not touch Docker setup sensitive paths
- ローカル checkout / npm 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク評価

low。既存 docs と既存 CI policy suite に対する smoke assertion の追加のみです。

## 補足事項

- 先行 docs-only PR #2627 は確認中に main へ merge 済みでした。この PR はその current main を土台に、残っていた lightweight smoke guard だけを追加しています。
- merge は行いません。