### PR TITLE
CHANGELOG に Docker setup CI docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Release preparation notes:
 - Added repository maintainer CI policy suite guidance release evidence for listing, targeting, and self-testing CI policy guard groups from `AGENTS.md`.
 - Added CI policy suite maintainer note and Release checklist entry points for targeted guard runs, suite self-test behavior, and guard registration expectations.
 - Added GitHub Actions Dependabot lane guidance to the CI policy suite docs, separating automation updates from action-major guard and pinning-policy decisions.
+- Added Docker development setup lane guidance to the CI policy suite docs, covering `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` container-side install smoke boundaries.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 
 ### Tests
@@ -135,6 +136,7 @@ Release preparation notes:
 - Added stylesheet state cue selector source-spec coverage for selected, collapsed, loading, error, disabled-drop, and drop-target cues in the packaged stylesheet.
 - Expanded package contents verification coverage for bilingual CI policy suite docs so packaged gems keep maintainer CI policy guidance available.
 - Consolidated `test:ci-policy` package-script execution around the CI policy suite source of truth while preserving guard registration self-test coverage.
+- Added Docker setup CI docs signal coverage so CI policy docs keep `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` guidance aligned.
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
 - Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.
 - Added manifest-backed public surface docs smoke coverage for state / remote-state event detail keys, setup generator output, localized names, and public constants.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2626
Refs #2627
Refs #2628

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、CI policy suite docs へ追加された Docker development setup lane guidance を release-facing evidence として追記しました。
- `CHANGELOG.md` の `Unreleased > Tests` に、Docker setup CI docs signal guard coverage を release-facing evidence として追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、Dockerfile、docker-compose、docs signal script は変更していません。

## 確認内容

- current main で #2627 / #2628 が merge 済みであることを確認しました。
- current `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に Docker development setup lane guidance があることを確認しました。
- PR compare `main...docs/changelog-docker-setup-ci-evidence`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件。
- diff: additions 2 / deletions 0。
- GitHub Actions CI #3625 / run `28203747728`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job で `npm run test:docs-entrypoints` が success、`npm run test:ci-policy` / `test:js:core` / browser smoke は expected skipped。
  - representative Rails lanes は docs-only skip path で success。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- combined status は空でしたが、workflow run で CI 成功を確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。merge済み docs / docs-signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。