### PR TITLE
CI policy docs に changed-file / docs-only 境界を追記する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -28,6 +28,20 @@ node script/test_ci_policy_suite.mjs --self-test
 
 When adding or renaming a CI policy guard script, update the suite `checks` array or document an explicit exclusion before relying on CI. The self-test scans candidate scripts, confirms that registered scripts stay visible through the suite, and fails with the missing script path when a candidate is not registered.
 
+## Pull request changed-file detection
+
+For pull requests, the `changes` job fetches the base branch, then tries to find a merge base between `origin/${{ github.base_ref }}` and `HEAD`. When the merge base is available, the workflow uses the three-dot diff, `origin/${{ github.base_ref }}...HEAD`, so routing is based on the pull request changes. If the merge base cannot be resolved, it falls back to `git diff --name-only origin/${{ github.base_ref }} HEAD`.
+
+The resulting file list is passed to `script/ci_changed_files_policy.mjs`, which is the source of truth for the `docs_only`, `package_sensitive`, `docker_setup_sensitive`, `docs_entrypoint_sensitive`, and `ci_policy_sensitive` outputs. `script/test_ci_workflow_changed_file_detection_signals.mjs` protects the workflow command signals; this note explains the maintainer-facing meaning of that routing and does not change the classification logic.
+
+## Docs-only check retention
+
+Docs-only pull requests keep the usual CI job names visible even when heavyweight work is intentionally skipped. The representative Rails compatibility matrix keeps its check surface but prints the docs-only skip message instead of running the Rails command when `docs_only` is true.
+
+The JavaScript job skips its install and checks only for docs-only pull requests that do not touch mockups, browser-smoke files, docs-entrypoint-sensitive files, or CI-policy-sensitive files. Package-facing docs such as `README.md`, `CHANGELOG.md`, and `docs/**` still route through the package/docs-entrypoint confidence path; `AGENTS.md` is repository-only docs but remains CI-policy-sensitive; `Product Profile.md` is repository-only docs and is not package- or docs-entrypoint-sensitive.
+
+Treat these retained check names as review and merge-decision context, not as proof that every heavyweight lane ran. Skipped lanes should still be read together with the changed-file routing outputs and the workflow run conclusion.
+
 ## GitHub Actions Dependabot lane
 
 `.github/dependabot.yml` is the source of truth for the Dependabot update lanes. It currently includes a `github-actions` lane for GitHub Actions dependency updates with the same weekly Monday 09:00 Asia/Tokyo cadence and open pull request limit of 5 as the Bundler lane.

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -28,6 +28,20 @@ node script/test_ci_policy_suite.mjs --self-test
 
 CI policy guard script を追加または rename した場合は、CI に頼る前に suite の `checks` array を更新するか、明示的な exclusion を残してください。self-test は candidate script を走査し、登録済み script が suite から見えることを確認します。未登録 candidate がある場合は missing script path を表示して失敗します。
 
+## Pull Request changed-file detection
+
+Pull Request では、`changes` job が base branch を fetch し、`origin/${{ github.base_ref }}` と `HEAD` の merge base を探します。merge base を取得できる場合、workflow は three-dot diff の `origin/${{ github.base_ref }}...HEAD` を使い、Pull Request で変わった file を基準に routing します。merge base を解決できない場合は、fallback として `git diff --name-only origin/${{ github.base_ref }} HEAD` を使います。
+
+得られた file list は `script/ci_changed_files_policy.mjs` に渡されます。この script が `docs_only`、`package_sensitive`、`docker_setup_sensitive`、`docs_entrypoint_sensitive`、`ci_policy_sensitive` output の source of truth です。`script/test_ci_workflow_changed_file_detection_signals.mjs` は workflow command signal を守ります。このメモは、その routing の保守者向けの意味を説明するだけで、classification logic は変更しません。
+
+## docs-only check retention
+
+docs-only Pull Request でも、重い処理を意図的に skip する場合に通常の CI job 名は残します。representative Rails compatibility matrix は check surface を残し、`docs_only` が true の場合は Rails command を実行せず docs-only skip message を出します。
+
+JavaScript job は、docs-only Pull Request かつ mockup、browser-smoke file、docs-entrypoint-sensitive file、CI-policy-sensitive file に触れていない場合だけ install と checks を skip します。`README.md`、`CHANGELOG.md`、`docs/**` のような package-facing docs は package / docs-entrypoint confidence path を通ります。`AGENTS.md` は repository-only docs ですが CI-policy-sensitive です。`Product Profile.md` は repository-only docs で、package-sensitive / docs-entrypoint-sensitive ではありません。
+
+これらの保持された check 名は review / merge 判断の文脈として扱い、すべての heavyweight lane が実行された証明として扱わないでください。skipped lane は changed-file routing output と workflow run conclusion と合わせて確認します。
+
 ## GitHub Actions Dependabot lane
 
 `.github/dependabot.yml` は Dependabot update lane の source of truth です。現在は GitHub Actions dependency update 用の `github-actions` lane を持ち、Bundler lane と同じ weekly Monday 09:00 Asia/Tokyo cadence、open pull request limit 5 で運用されています。


### PR DESCRIPTION
## 対応 Issue

Refs #2629
Refs #2630

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に Pull Request changed-file detection の説明を追加しました。
  - base branch fetch
  - merge-base が取れる場合の three-dot diff
  - merge-base が取れない場合の fallback diff
  - `script/ci_changed_files_policy.mjs` と workflow signal guard の責務差
- 同じ英日 docs に docs-only PR の check-name retention / heavy lane skip 境界を追加しました。
  - representative Rails lane は check surface を残して docs-only skip message を出すこと
  - JavaScript job の docs-only skip 条件
  - package-facing docs と repository-only docs (`AGENTS.md`, `Product Profile.md`) の routing 差

## Scope

- docs-only です。
- 変更ファイルは英日 `docs/*/ci-policy-suite.md` の2件のみです。
- `.github/workflows/ci.yml`、`script/ci_changed_files_policy.mjs`、CI policy guard scripts、package scripts、required checks、branch protection は変更していません。
- #2629 / #2630 の lightweight docs signal 追加は script/test 変更を含むため、この PR では扱わず `Refs` に留めます。

## 確認内容

- open PR 検索で #2629 / #2630 の重複 docs PR がないことを確認しました。
- current main の `.github/workflows/ci.yml` と `script/ci_changed_files_policy.mjs` を確認し、docs の追記内容が実装済み routing と矛盾しないことを確認しました。
- compare `main...docs/2629-2630-ci-policy-boundaries`: `ahead_by:2` / `behind_by:0` / changed files 2件。
- diff は additions 28 / deletions 0。
- PR metadata: `mergeable:true`。
- GitHub Actions CI #3626 / run `28206223226`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`: success。
  - representative `pr_rails_matrix` lanes は docs-only skip path で success。
  - `javascript`: success。`npm run test:docs-entrypoints` と `npm run test:ci-policy` が success、`npm run test:js:core` / browser smoke は expected skipped。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- combined status は空でしたが、workflow run で CI 成功を確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。既存 CI routing の保守者向け説明を英日 CI policy docs に同期するだけです。

merge は行いません。