### PR TITLE
CI policy docs の changed-file / docs-only signal を guard する

### DIFF
--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -155,6 +155,100 @@ function assertCiPolicyDocsDockerSetupSignals() {
   }
 }
 
+function assertCiPolicyDocsChangedFileDetectionSignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        "## Pull request changed-file detection",
+        "fetches the base branch",
+        "merge base",
+        "three-dot diff",
+        'origin/${{ github.base_ref }}...HEAD',
+        "falls back to `git diff --name-only origin/${{ github.base_ref }} HEAD`",
+        "script/ci_changed_files_policy.mjs",
+        "script/test_ci_workflow_changed_file_detection_signals.mjs",
+        "classification logic"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        "## Pull Request changed-file detection",
+        "base branch を fetch",
+        "merge base",
+        "three-dot diff",
+        'origin/${{ github.base_ref }}...HEAD',
+        "fallback として `git diff --name-only origin/${{ github.base_ref }} HEAD`",
+        "script/ci_changed_files_policy.mjs",
+        "script/test_ci_workflow_changed_file_detection_signals.mjs",
+        "classification logic"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} changed-file detection docs signal`)
+    }
+  }
+}
+
+function assertCiPolicyDocsDocsOnlyRetentionSignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        "## Docs-only check retention",
+        "usual CI job names visible",
+        "representative Rails compatibility matrix",
+        "docs-only skip message",
+        "mockups",
+        "browser-smoke files",
+        "docs-entrypoint-sensitive files",
+        "CI-policy-sensitive files",
+        "Package-facing docs",
+        "README.md",
+        "CHANGELOG.md",
+        "docs/**",
+        "AGENTS.md",
+        "Product Profile.md",
+        "not as proof that every heavyweight lane ran"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        "## docs-only check retention",
+        "通常の CI job 名は残します",
+        "representative Rails compatibility matrix",
+        "docs-only skip message",
+        "mockup",
+        "browser-smoke file",
+        "docs-entrypoint-sensitive file",
+        "CI-policy-sensitive file",
+        "package-facing docs",
+        "README.md",
+        "CHANGELOG.md",
+        "docs/**",
+        "AGENTS.md",
+        "Product Profile.md",
+        "すべての heavyweight lane が実行された証明として扱わないでください"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} docs-only retention docs signal`)
+    }
+  }
+}
+
 for (const docsPath of ciPolicyDocsPaths) {
   assert.deepEqual(
     classifyChangedFiles([docsPath]),
@@ -190,8 +284,12 @@ assert.deepEqual(
 assertDependabotLaneSignal()
 assertCiPolicyDocsDependabotSignals()
 assertCiPolicyDocsDockerSetupSignals()
+assertCiPolicyDocsChangedFileDetectionSignals()
+assertCiPolicyDocsDocsOnlyRetentionSignals()
 
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
 console.log("Checked CI policy docs routing guard script routing.")
 console.log("Checked GitHub Actions Dependabot lane config and docs signals.")
 console.log("Checked Docker development setup CI docs signals.")
+console.log("Checked pull request changed-file detection docs signals.")
+console.log("Checked docs-only check retention docs signals.")


### PR DESCRIPTION
## 対応 Issue

Closes #2629
Closes #2630

## Issue ごとの完了内容

- #2629: 英日 `docs/*/ci-policy-suite.md` に入った Pull Request changed-file detection の base fetch、merge-base、three-dot diff、fallback diff、policy script / workflow signal guard の責務差を `script/test_ci_policy_docs_routing.mjs` で代表 signal として確認します。
- #2630: 英日 CI policy docs の docs-only check retention、Rails compatibility check-name retention、JavaScript job の docs-only skip 条件、package-facing docs と repository-only docs の routing 差を同じ guard で確認します。

## 変更内容

- `script/test_ci_policy_docs_routing.mjs` に次の docs signal guard を追加しました。
  - Pull Request changed-file detection section の代表 signal
  - docs-only check retention section の代表 signal
- 既存の Dependabot lane / Docker setup lane / routing guard は維持しています。

## 改善カテゴリ

- test
- docs guard
- CI policy documentation drift prevention

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、CI workflow、changed-file classification、package scripts、required checks、branch protection は変更していません。
- docs 本文も変更していません。既に main に入った docs prose を軽量 smoke で守るだけです。

## 確認内容

- PR 前 compare `main...test/2629-2630-ci-policy-doc-signals`: `ahead_by:1` / `behind_by:0` / changed files 1件。
- 変更ファイルは `script/test_ci_policy_docs_routing.mjs` のみです。
- PR metadata: open / non-draft / `mergeable:true`。
- GitHub Actions CI #3629 / run `28208844689`: success。
  - `changes`, `lint`, `pr_specs`: success。
  - `javascript`: success。`npm run test:ci-policy` と `npm run test:js:core` が success。
  - representative `pr_rails_matrix` lanes: success。
  - `rails_matrix`, `ruby_matrix`, `gem_package`, `docker_development_setup`: expected skipped by changed-file routing。
- combined status は空でしたが、workflow run で CI 成功を確認しました。
- local checkout / local Node 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク評価

low。既存 docs signal guard に代表 assertion を追加するだけで、挙動変更はありません。

merge は行いません。