### PR TITLE
CHANGELOG に CI policy boundary docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Release preparation notes:
 - Added CI policy suite maintainer note and Release checklist entry points for targeted guard runs, suite self-test behavior, and guard registration expectations.
 - Added GitHub Actions Dependabot lane guidance to the CI policy suite docs, separating automation updates from action-major guard and pinning-policy decisions.
 - Added Docker development setup lane guidance to the CI policy suite docs, covering `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` container-side install smoke boundaries.
+- Added pull request changed-file detection and docs-only check retention guidance to CI policy suite docs, covering merge-base / fallback diff routing and package-facing versus repository-only docs boundaries.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 
 ### Tests


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2629
Refs #2630
Refs #2633

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、PR #2633 で英日 CI policy suite docs へ追加された Pull Request changed-file detection / docs-only check retention guidance を release-facing evidence として追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script、changed-file policy logic は変更していません。

## 確認内容

- current `main` で #2633 が merge 済みであることを確認しました。
- current `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に Pull Request changed-file detection / docs-only check retention guidance があることを確認しました。
- compare `main...docs/changelog-ci-policy-boundary-evidence`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件。
- diff: additions 1 / deletions 0。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs-only PR の release-facing evidence を CHANGELOG に1行記録するだけです。

merge は行いません。