### PR TITLE
CHANGELOG に CI policy docs signal evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ Release preparation notes:
 - `TreeView::PathTree` via `Tree#path_tree_for(items)` for rendering matched items with completed parent paths.
 - `TreeView::ReverseTree` via `Tree#reverse_tree_for(items)` for rendering child-to-parent paths.
 - `TreeView::RenderState` for screen-level rendering options.
+- `tree_view_rows(render_state)` helper.
 - `TreeView::RenderWindow` and opt-in windowed rendering through `tree_view_rows(render_state, window: { offset:, limit: })`.
 - `tree_view_window(render_state, offset:, limit:)` for pagination metadata around visible rows.
 - Static tree rendering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for bilingual CI policy suite docs so packaged gems keep maintainer CI policy guidance available.
 - Consolidated `test:ci-policy` package-script execution around the CI policy suite source of truth while preserving guard registration self-test coverage.
 - Added Docker setup CI docs signal coverage so CI policy docs keep `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` guidance aligned.
+- Added CI policy docs signal coverage for pull request changed-file detection and docs-only check retention so CI policy docs stay aligned with workflow routing evidence.
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
 - Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.
 - Added manifest-backed public surface docs smoke coverage for state / remote-state event detail keys, setup generator output, localized names, and public constants.
@@ -235,7 +236,6 @@ Release preparation notes:
 - `TreeView::PathTree` via `Tree#path_tree_for(items)` for rendering matched items with completed parent paths.
 - `TreeView::ReverseTree` via `Tree#reverse_tree_for(items)` for rendering child-to-parent paths.
 - `TreeView::RenderState` for screen-level rendering options.
-- `tree_view_rows(render_state)` helper.
 - `TreeView::RenderWindow` and opt-in windowed rendering through `tree_view_rows(render_state, window: { offset:, limit: })`.
 - `tree_view_window(render_state, offset:, limit:)` for pagination metadata around visible rows.
 - Static tree rendering.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2629
Refs #2630
Refs #2634

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、PR #2634 で追加された CI policy docs signal guard coverage を release-facing evidence として 1 行追記しました。
- Pull Request changed-file detection と docs-only check retention の docs signal が、workflow routing evidence と揃っていることを記録します。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script、changed-file policy logic は変更していません。

## 確認内容

- current `main` で #2634 が merge 済みであることを確認しました。
- current `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に Pull Request changed-file detection / docs-only check retention guidance があることを確認しました。
- compare `main...docs/changelog-ci-policy-doc-signal-evidence`: `ahead_by:2` / `behind_by:0` / changed files `CHANGELOG.md` 1件。
- net diff: additions 1 / deletions 0。
- GitHub Actions CI #3633 / run `28214724837`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` job で `npm run test:docs-entrypoints` が success、`npm run test:ci-policy` / `test:js:core` / browser smoke は expected skipped。
  - representative Rails lanes は docs-only skip path で success。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- combined status は空でしたが、workflow run で CI 成功を確認しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。merge済み docs signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。