### PR TITLE
CI routing output docs signal を代表 fixture と同期する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -34,6 +34,22 @@ For pull requests, the `changes` job fetches the base branch, then tries to find
 
 The resulting file list is passed to `script/ci_changed_files_policy.mjs`, which is the source of truth for the `docs_only`, `package_sensitive`, `docker_setup_sensitive`, `docs_entrypoint_sensitive`, and `ci_policy_sensitive` outputs. `script/test_ci_workflow_changed_file_detection_signals.mjs` protects the workflow command signals; this note explains the maintainer-facing meaning of that routing and does not change the classification logic.
 
+## Representative routing outputs
+
+The changed-file policy exposes representative output flags rather than a full repository inventory. Use these examples as review guidance when reading a pull request's `changes` output:
+
+| Output | Representative path signals | Maintainer meaning |
+| --- | --- | --- |
+| `docs_only` | `README.md`, `docs/**`, `AGENTS.md`, `Product Profile.md` | The pull request is documentation-shaped, although other outputs may still request focused confidence checks. |
+| `package_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `config/public_api_manifest.yml` | The packaged gem or package-facing docs confidence path should run. |
+| `docs_entrypoint_sensitive` | `README.md`, `docs/**`, `config/public_api_manifest.yml` | Docs entrypoint signals should run because reader-facing docs or public manifest signals changed. |
+| `ci_policy_sensitive` | `AGENTS.md`, `.github/workflows/ci.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs` | CI policy guards should run because workflow routing or maintainer policy signals changed. |
+| `docker_setup_sensitive` | `Dockerfile`, `docker-compose.yml`, `package.json`, `package-lock.json`, `.nvmrc` | Docker-based maintainer setup confidence should run. |
+| `mockups_changed` | `docs/mockups/**` | Static mockup routes changed and may need browser-smoke or gallery review. |
+| `browser_smoke_changed` | `test/browser/**` | Browser smoke definitions changed and should be treated as executable test-surface changes. |
+
+Keep this table representative. Do not turn it into a full changed-file classifier mirror; `script/test_ci_changed_files_policy.mjs` remains the executable fixture source of truth.
+
 ## Docs-only check retention
 
 Docs-only pull requests keep the usual CI job names visible even when heavyweight work is intentionally skipped. The representative Rails compatibility matrix keeps its check surface but prints the docs-only skip message instead of running the Rails command when `docs_only` is true.

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -34,6 +34,22 @@ Pull Request では、`changes` job が base branch を fetch し、`origin/${{ 
 
 得られた file list は `script/ci_changed_files_policy.mjs` に渡されます。この script が `docs_only`、`package_sensitive`、`docker_setup_sensitive`、`docs_entrypoint_sensitive`、`ci_policy_sensitive` output の source of truth です。`script/test_ci_workflow_changed_file_detection_signals.mjs` は workflow command signal を守ります。このメモは、その routing の保守者向けの意味を説明するだけで、classification logic は変更しません。
 
+## Representative routing outputs
+
+changed-file policy は、repository 全体の file inventory ではなく代表的な output flag を公開します。Pull Request の `changes` output を読む時は、次の例を review guidance として扱ってください。
+
+| Output | Representative path signals | Maintainer meaning |
+| --- | --- | --- |
+| `docs_only` | `README.md`, `docs/**`, `AGENTS.md`, `Product Profile.md` | Pull Request は docs 形状です。ただし、他の output が focused confidence check を要求する場合があります。 |
+| `package_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `config/public_api_manifest.yml` | packaged gem または package-facing docs confidence path を実行します。 |
+| `docs_entrypoint_sensitive` | `README.md`, `docs/**`, `config/public_api_manifest.yml` | reader-facing docs または public manifest signal が変わったため、docs entrypoint signal を実行します。 |
+| `ci_policy_sensitive` | `AGENTS.md`, `.github/workflows/ci.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs` | workflow routing または maintainer policy signal が変わったため、CI policy guard を実行します。 |
+| `docker_setup_sensitive` | `Dockerfile`, `docker-compose.yml`, `package.json`, `package-lock.json`, `.nvmrc` | Docker-based maintainer setup confidence を実行します。 |
+| `mockups_changed` | `docs/mockups/**` | static mockup route が変わり、browser-smoke または gallery review が必要になる場合があります。 |
+| `browser_smoke_changed` | `test/browser/**` | browser smoke definition が変わったため、executable test-surface change として扱います。 |
+
+この表は代表例に留めます。full changed-file classifier mirror にはしないでください。executable fixture の source of truth は引き続き `script/test_ci_changed_files_policy.mjs` です。
+
 ## docs-only check retention
 
 docs-only Pull Request でも、重い処理を意図的に skip する場合に通常の CI job 名は残します。representative Rails compatibility matrix は check surface を残し、`docs_only` が true の場合は Rails command を実行せず docs-only skip message を出します。

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -196,6 +196,49 @@ function assertCiPolicyDocsChangedFileDetectionSignals() {
   }
 }
 
+function assertCiPolicyDocsRoutingOutputSignals() {
+  const sharedSignals = [
+    "## Representative routing outputs",
+    "`docs_only`",
+    "`package_sensitive`",
+    "`docs_entrypoint_sensitive`",
+    "`ci_policy_sensitive`",
+    "`docker_setup_sensitive`",
+    "`mockups_changed`",
+    "`browser_smoke_changed`",
+    "README.md",
+    "docs/**",
+    "AGENTS.md",
+    "Product Profile.md",
+    "CHANGELOG.md",
+    "config/public_api_manifest.yml",
+    ".github/workflows/ci.yml",
+    "script/ci_changed_files_policy.mjs",
+    "script/test_ci_changed_files_policy.mjs",
+    "Dockerfile",
+    "docker-compose.yml",
+    "package.json",
+    "package-lock.json",
+    ".nvmrc",
+    "docs/mockups/**",
+    "test/browser/**",
+    "script/test_ci_changed_files_policy.mjs remains the executable fixture source of truth"
+  ]
+
+  const docsSignals = [
+    ["docs/en/ci-policy-suite.md", sharedSignals],
+    ["docs/ja/ci-policy-suite.md", sharedSignals]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} routing output docs signal`)
+    }
+  }
+}
+
 function assertCiPolicyDocsDocsOnlyRetentionSignals() {
   const docsSignals = [
     [
@@ -285,6 +328,7 @@ assertDependabotLaneSignal()
 assertCiPolicyDocsDependabotSignals()
 assertCiPolicyDocsDockerSetupSignals()
 assertCiPolicyDocsChangedFileDetectionSignals()
+assertCiPolicyDocsRoutingOutputSignals()
 assertCiPolicyDocsDocsOnlyRetentionSignals()
 
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
@@ -292,4 +336,5 @@ console.log("Checked CI policy docs routing guard script routing.")
 console.log("Checked GitHub Actions Dependabot lane config and docs signals.")
 console.log("Checked Docker development setup CI docs signals.")
 console.log("Checked pull request changed-file detection docs signals.")
+console.log("Checked representative routing output docs signals.")
 console.log("Checked docs-only check retention docs signals.")

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -222,7 +222,8 @@ function assertCiPolicyDocsRoutingOutputSignals() {
     ".nvmrc",
     "docs/mockups/**",
     "test/browser/**",
-    "script/test_ci_changed_files_policy.mjs remains the executable fixture source of truth"
+    "executable fixture",
+    "source of truth"
   ]
 
   const docsSignals = [


### PR DESCRIPTION
## 対応 Issue

Closes #2637

## Issue ごとの完了内容

- #2637: 英日 `docs/*/ci-policy-suite.md` に representative routing outputs の表を追加し、`docs_only` / `package_sensitive` / `docs_entrypoint_sensitive` / `ci_policy_sensitive` / `docker_setup_sensitive` / `mockups_changed` / `browser_smoke_changed` の代表 path と reviewer 向け意味を明確化しました。
- #2637: `script/test_ci_policy_docs_routing.mjs` に routing output docs signal を追加し、docs 側の代表 path と executable fixture source-of-truth の説明が落ちた時に検出できるようにしました。

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md`
  - Representative routing outputs section を追加。
  - 代表 path は README/docs/AGENTS/Product Profile、package-facing docs、public manifest、workflow / CI policy scripts、Docker setup files、mockups、browser smoke に限定。
  - full classifier mirror ではなく、`script/test_ci_changed_files_policy.mjs` を executable fixture source of truth とする境界を明記。
- `script/test_ci_policy_docs_routing.mjs`
  - 英日 docs の representative routing output signal を確認する smoke を追加。

## 改善カテゴリ

- docs guard hardening
- CI policy smoke の代表 signal 追加
- 小さな保守性改善

## 既存仕様への影響

- CI workflow topology、routing behavior、required checks、branch protection、runtime Ruby / JavaScript、public API は変更していません。
- docs と smoke のみの変更です。

## 実施した確認

- Issue #2637 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- PR 前 compare: `main...chore/2637-ci-routing-docs-signals` は `ahead_by:4` / `behind_by:0` / changed files 3 件。
- ローカル checkout / npm 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs と smoke signal の追加に閉じており、実際の changed-file classifier や workflow 動作は変えていません。

## 補足事項

- merge は行いません。