### PR TITLE
Strengthen CI guard suite smoke signals

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -243,6 +243,19 @@ lintJobSignals.forEach(([label, signal]) => {
   )
 })
 
+const prSpecsJobSignals = [
+  ["representative Ruby version", 'ruby-version: "3.3"'],
+  ["RSpec command", "run: bundle exec rspec"]
+]
+
+prSpecsJobSignals.forEach(([label, signal]) => {
+  assertIncludes(
+    prSpecsJob,
+    signal,
+    `${workflowPath} jobs.pr_specs ${label}`
+  )
+})
+
 const matrixFailFastPolicyJobs = [
   ["pr_rails_matrix", prRailsMatrixJob],
   ["ruby_matrix", rubyMatrixJob],
@@ -297,7 +310,13 @@ javascriptJobNpmScripts.forEach((scriptName) => {
 })
 
 const docsEntrypointsScript = packageScript("test:docs-entrypoints")
+const ciPolicyScript = packageScript("test:ci-policy")
+const entrypointsScript = packageScript("test:entrypoints")
+const jsCoreScript = packageScript("test:js:core")
+
 const docsEntrypointsSignals = [
+  ["package script runs public API transfer guard", docsEntrypointsScript, "node script/guard_public_api_transfer_integration_signals.mjs"],
+  ["package script runs manifest-backed public surface guard", docsEntrypointsScript, "node script/test_manifest_backed_public_surface_signals.mjs"],
   ["package script uses docs entrypoint suite", docsEntrypointsScript, "node script/test_docs_entrypoint_suite.mjs"],
   ["suite registers controller registration docs signal", docsEntrypointSuiteSource, "script/check_controller_registration_docs_signals.mjs"]
 ]
@@ -310,12 +329,56 @@ docsEntrypointsSignals.forEach(([label, source, signal]) => {
   )
 })
 
+const packageGuardSuiteCompositionSignals = [
+  ["test:entrypoints runs docs entrypoint guard suite", entrypointsScript, "npm run test:docs-entrypoints"],
+  ["test:entrypoints runs CI policy guard suite", entrypointsScript, "npm run test:ci-policy"],
+  ["test:entrypoints keeps Node source guard", entrypointsScript, "npm run test:node-version-sources"],
+  ["test:entrypoints keeps Ruby source guard", entrypointsScript, "npm run test:ruby-version-sources"],
+  ["test:js:core runs entrypoint guard suite before npm test", jsCoreScript, "npm run test:entrypoints"],
+  ["test:js:core reaches npm test", jsCoreScript, "npm test"]
+]
+
+packageGuardSuiteCompositionSignals.forEach(([label, source, signal]) => {
+  assertIncludes(
+    source,
+    signal,
+    `${packagePath} guard suite script composition ${label}`
+  )
+})
+
+assertOrdered(
+  docsEntrypointsScript,
+  "node script/guard_public_api_transfer_integration_signals.mjs",
+  "node script/test_docs_entrypoint_suite.mjs",
+  `${packagePath} scripts.test:docs-entrypoints must run public API transfer guard before docs entrypoint suite`
+)
+assertOrdered(
+  docsEntrypointsScript,
+  "node script/test_manifest_backed_public_surface_signals.mjs",
+  "node script/test_docs_entrypoint_suite.mjs",
+  `${packagePath} scripts.test:docs-entrypoints must run manifest-backed public surface guard before docs entrypoint suite`
+)
+assertOrdered(
+  ciPolicyScript,
+  "node script/test_ci_policy_suite.mjs --self-test",
+  "node script/test_ci_policy_suite.mjs",
+  `${packagePath} scripts.test:ci-policy must run the suite self-test before the CI policy suite`
+)
+assertOrdered(
+  jsCoreScript,
+  "npm run test:entrypoints",
+  "npm test",
+  `${packagePath} scripts.test:js:core must run entrypoint guards before npm test`
+)
+
 console.log("Checked CI workflow trigger policy signals.")
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
 console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)
 console.log(`Checked ${lintJobSignals.length} CI lint job representative signals.`)
+console.log(`Checked ${prSpecsJobSignals.length} CI pr_specs job representative signals.`)
 console.log(`Checked ${matrixFailFastPolicyJobs.length} CI matrix fail-fast policy signals.`)
 console.log(`Checked ${rubyMatrixVersionSignals.length} representative Ruby workflow version signals.`)
 console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)
 console.log(`Checked ${docsEntrypointsSignals.length} docs-entrypoints package and suite command signals.`)
+console.log(`Checked ${packageGuardSuiteCompositionSignals.length} package guard suite composition signals.`)

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -33,10 +33,10 @@ function workflowJobBlock(workflowSource, jobName) {
 
 function assertOrdered(source, earlier, later, label) {
   const earlierIndex = source.indexOf(earlier)
-  const laterIndex = source.indexOf(later)
+  const laterIndex = earlierIndex === -1 ? source.indexOf(later) : source.indexOf(later, earlierIndex + earlier.length)
 
   assert(earlierIndex !== -1, `${label}: missing ${earlier}`)
-  assert(laterIndex !== -1, `${label}: missing ${later}`)
+  assert(laterIndex !== -1, `${label}: missing ${later} after ${earlier}`)
   assert(earlierIndex < laterIndex, `${label}: expected ${earlier} before ${later}`)
 }
 


### PR DESCRIPTION
## 対応 Issue
- Closes #2642
- Closes #2640

## Issue ごとの完了内容
- #2642: `script/test_ci_workflow_changed_file_detection_signals.mjs` に `pr_specs` job の代表シグナルを追加し、Ruby `3.3` と `bundle exec rspec` の維持を smoke で検知できるようにしました。
- #2640: package script の guard suite 構成を同じ smoke で確認し、`test:docs-entrypoints`、`test:ci-policy`、`test:entrypoints`、`test:js:core` の代表的な連結と順序を検知できるようにしました。

## 変更内容
- `jobs.pr_specs` の Ruby version / RSpec command signal を追加。
- docs-entrypoint guard の package script と suite 登録シグナルを拡張。
- `test:ci-policy` が `--self-test` を suite 実行前に走らせることを順序込みで検証。
- `test:entrypoints` と `test:js:core` の代表的な guard suite composition を検証。

## 改善カテゴリ
- test
- CI smoke coverage
- maintenance

## 既存仕様への影響
- CI workflow、package script、公開 API、UI、DB、認可、外部サービス契約は変更していません。
- 既存の挙動を変えず、既存構成の drift 検知だけを強化しています。

## 実施した確認
- GitHub connector で対象 Issue のラベルを個別確認しました。
- branch freshness: `main` から behind なしを確認しました。
- diff scope: `script/test_ci_workflow_changed_file_detection_signals.mjs` 1 ファイルのみを確認しました。
- final newline: 更新内容は trailing newline 付きです。
- CI は PR 作成後に確認します。

## リスク評価
- low。既存の smoke test に assertion を追加するだけで、実行対象や仕様は変更していません。

## 補足
- #2632 / #2574 の docs-entrypoint suite 登録方針整理は、suite 側の登録変更を伴うため今回の最小 PR には含めていません。