### PR TITLE
CHANGELOG に CI routing output evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Release preparation notes:
 - Added GitHub Actions Dependabot lane guidance to the CI policy suite docs, separating automation updates from action-major guard and pinning-policy decisions.
 - Added Docker development setup lane guidance to the CI policy suite docs, covering `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` container-side install smoke boundaries.
 - Added pull request changed-file detection and docs-only check retention guidance to CI policy suite docs, covering merge-base / fallback diff routing and package-facing versus repository-only docs boundaries.
+- Added representative routing output guidance to CI policy suite docs so maintainers can map changed-file routing outputs to expected PR checks.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 
 ### Tests
@@ -139,6 +140,7 @@ Release preparation notes:
 - Consolidated `test:ci-policy` package-script execution around the CI policy suite source of truth while preserving guard registration self-test coverage.
 - Added Docker setup CI docs signal coverage so CI policy docs keep `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` guidance aligned.
 - Added CI policy docs signal coverage for pull request changed-file detection and docs-only check retention so CI policy docs stay aligned with workflow routing evidence.
+- Added CI routing output docs signal coverage for representative changed-file routing output guidance.
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
 - Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.
 - Added manifest-backed public surface docs smoke coverage for state / remote-state event detail keys, setup generator output, localized names, and public constants.


### PR DESCRIPTION
## 対応 Issue

Closes #2643

## 判定分類

- `code-ahead-of-docs`
- `docs-stale`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、CI policy suite docs の representative routing output guidance 追加を release-facing evidence として追記しました。
- `CHANGELOG.md` の `Unreleased > Tests` に、routing output docs signal coverage 追加を追記しました。

## 確認したこと

- 変更対象は `CHANGELOG.md` 1件のみです。
- compare は `ahead_by:1` / `behind_by:0` です。
- diff は additions 2 / deletions 0 で、既存 `0.1.0` section など unrelated changelog entries は変更していません。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script は変更していません。

## リスク

low。#2641 で main に入った docs / docs signal coverage の release evidence を追記するだけです。