### PR TITLE
CHANGELOG に CI guard suite evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Release preparation notes:
 - Added Docker setup CI docs signal coverage so CI policy docs keep `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` guidance aligned.
 - Added CI policy docs signal coverage for pull request changed-file detection and docs-only check retention so CI policy docs stay aligned with workflow routing evidence.
 - Added CI routing output docs signal coverage for representative changed-file routing output guidance.
+- Added CI guard suite smoke coverage for the PR specs RSpec command and package guard suite composition signals.
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
 - Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.
 - Added manifest-backed public surface docs smoke coverage for state / remote-state event detail keys, setup generator output, localized names, and public constants.


### PR DESCRIPTION
## 対応 Issue / PR

Related to #2640
Related to #2642
Related to #2644

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、PR #2644 で追加された CI guard suite smoke coverage を release-facing evidence として 1 行追記しました。
- `pr_specs` の RSpec command signal と package guard suite composition signal が、release preparation 時に Tests evidence として見えるようにしました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script は変更していません。

## 確認内容

- current `main` で #2644 が merge 済みであることを確認しました。
- compare `main...docs/changelog-ci-guard-suite-evidence`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件。
- diff は additions 1 / deletions 0 で、既存 `0.1.0` section など unrelated changelog entries は変更していません。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み quality PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。