### PR TITLE
helper_methods の Public API docs signal を追加する

### DIFF
--- a/script/test_manifest_backed_public_surface_signals.mjs
+++ b/script/test_manifest_backed_public_surface_signals.mjs
@@ -128,10 +128,43 @@ const lazyLoadingRemoteStateSignals = [
   "host app"
 ]
 
+const helperMethodManifestSignals = [
+  "helper_methods:",
+  "- tree_view_rows",
+  "- tree_view_window",
+  "- tree_node_dom_id",
+  "- tree_children_container_dom_id",
+  "- tree_remote_state_placeholder_dom_id",
+  "- tree_remote_state_placeholder_attributes",
+  "- tree_selection_value",
+  "- tree_view_breadcrumb",
+  "- tree_view_toolbar",
+  "- tree_view_toolbar_supported_actions",
+  "- tree_view_toolbar_actions",
+  "- tree_view_toolbar_action_metadata"
+]
+
+const helperMethodDocsSignals = [
+  "tree_view_rows(render_state)",
+  "tree_view_rows(render_state, window: { offset:, limit: })",
+  "tree_view_window(render_state, offset:, limit:)",
+  "tree_node_dom_id(item_or_id, ui: @tree_ui)",
+  "tree_children_container_dom_id(item, ui: @tree_ui)",
+  "tree_remote_state_placeholder_dom_id(item, ui: @tree_ui)",
+  "tree_remote_state_placeholder_attributes(item, state: nil, ui: @tree_ui)",
+  "tree_selection_value(item, tree, builder = nil)",
+  "tree_view_breadcrumb(tree, item, ...)",
+  "tree_view_toolbar(render_state, ...)",
+  "tree_view_toolbar_supported_actions",
+  "tree_view_toolbar_actions(render_state, ...)",
+  "tree_view_toolbar_action_metadata(render_state, action, ...)"
+]
+
 assertAll(manifest, publicConstantSignals, "public API manifest public constants surface")
 assertAll(manifest, localizedNameManifestSignals, "public API manifest localized-name surface")
 assertAll(manifest, setupGeneratorManifestSignals, "public API manifest setup-generator surface")
 assertAll(manifest, stateEventDetailManifestSignals, "public API manifest state and remote-state event detail surface")
+assertAll(manifest, helperMethodManifestSignals, "public API manifest helper method surface")
 
 assertDocs(
   ["docs/en/errors.md", "docs/ja/errors.md"],
@@ -143,6 +176,12 @@ assertDocs(
   ["docs/en/public-api.md", "docs/ja/public-api.md"],
   [...publicConstantDocsSignals, "TreeView.model_name_for", "TreeView.attribute_name_for", "TreeView.type_name_for"],
   "public API manifest-backed public surface docs"
+)
+
+assertDocs(
+  ["docs/en/public-api.md", "docs/ja/public-api.md"],
+  helperMethodDocsSignals,
+  "manifest-backed public helper method docs"
 )
 
 assertDocs(


### PR DESCRIPTION
## 対応 Issue

Closes #2639

## Issue ごとの完了内容

- #2639: `config/public_api_manifest.yml` の `helper_methods` と英日 `docs/*/public-api.md` の helper surface が drift したときに検出できる lightweight signal を追加しました。

## 変更内容

- `script/test_manifest_backed_public_surface_signals.mjs` に helper method manifest signals を追加しました。
- 同じ script で、英日 Public API docs に documented helper method signatures が残っていることを確認する representative signal を追加しました。
- 既存の toolbar option / breadcrumb / tree_view_rows behavior guard とは分け、helper method list の docs surface だけを確認します。

## 改善カテゴリ

- docs signal guard
- test hardening
- manifest-backed public surface drift detection

## 既存仕様への影響

- runtime Ruby / JavaScript は変更していません。
- public helper method set、manifest schema、Public API docs 本文、CI workflow、package scripts は変更していません。
- 既存の docs-entrypoint command に含まれる smoke scriptへ assertion を足すだけです。

## 確認内容

- Issue #2639 の labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- compare `main...test/2639-helper-method-docs-signal`: `ahead_by:1` / `behind_by:0` / changed files 1。
- 変更ファイルは `script/test_manifest_backed_public_surface_signals.mjs` のみです。
- PR metadata: `mergeable:true`。
- head: `cfb6f02988743b92b0d251d6ad272e1c1b4a4eee`。
- GitHub Actions CI #3643 / run `28228991451`: success。
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success（`npm run test:js:core` success）
  - PR Rails compatibility 7.0 / 7.2 / 8.0: success
  - `gem_package` / `docker_development_setup`: skipped by routing
- local checkout / local `node script/test_manifest_backed_public_surface_signals.mjs` は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク評価

low。既存の manifest-backed docs smoke を拡張するだけで、公開 API や挙動は変更しません。

## 補足

- #1825 / #2150 は引き続き checkout/test 実行が必要な別テーマのため、この PR には含めていません。
- rails_fields_kit #2233 は同じ Product Profile を触る open PR #2242 が未マージのため、今回は issue comment で merge 順を引き継ぎ、`status:needs-human` に移しました。
- merge は行いません。