### PR TITLE
Register docs guard signals in entrypoint suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",
     "test:public-api-manifest-structure": "node script/test_public_api_manifest_structure.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/guard_public_api_transfer_integration_signals.mjs && node script/test_manifest_backed_public_surface_signals.mjs && node script/test_docs_entrypoint_suite.mjs",
+    "test:docs-entrypoints": "node script/guard_public_api_transfer_integration_signals.mjs && node script/test_docs_entrypoint_suite.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -316,8 +316,8 @@ const jsCoreScript = packageScript("test:js:core")
 
 const docsEntrypointsSignals = [
   ["package script runs public API transfer guard", docsEntrypointsScript, "node script/guard_public_api_transfer_integration_signals.mjs"],
-  ["package script runs manifest-backed public surface guard", docsEntrypointsScript, "node script/test_manifest_backed_public_surface_signals.mjs"],
   ["package script uses docs entrypoint suite", docsEntrypointsScript, "node script/test_docs_entrypoint_suite.mjs"],
+  ["suite registers manifest-backed public surface guard", docsEntrypointSuiteSource, "script/test_manifest_backed_public_surface_signals.mjs"],
   ["suite registers controller registration docs signal", docsEntrypointSuiteSource, "script/check_controller_registration_docs_signals.mjs"]
 ]
 
@@ -353,10 +353,10 @@ assertOrdered(
   `${packagePath} scripts.test:docs-entrypoints must run public API transfer guard before docs entrypoint suite`
 )
 assertOrdered(
-  docsEntrypointsScript,
-  "node script/test_manifest_backed_public_surface_signals.mjs",
-  "node script/test_docs_entrypoint_suite.mjs",
-  `${packagePath} scripts.test:docs-entrypoints must run manifest-backed public surface guard before docs entrypoint suite`
+  docsEntrypointSuiteSource,
+  "script/test_public_api_docs_signals.mjs",
+  "script/test_manifest_backed_public_surface_signals.mjs",
+  `${docsEntrypointSuitePath} must run public API docs signals before manifest-backed public surface signals`
 )
 assertOrdered(
   ciPolicyScript,

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -103,6 +103,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "Manifest-backed public surface signals",
+    command: "node",
+    args: ["script/test_manifest_backed_public_surface_signals.mjs"]
+  },
+  {
     group: "Public API exported controller class docs signals",
     command: "node",
     args: ["script/test_public_api_exported_controller_class_docs_signals.mjs"]
@@ -339,6 +344,11 @@ function runSelfTest() {
     resolveOnlyGroupResult("public api docs signals").check.group,
     "Public API docs signals",
     "case-insensitive exact --only should resolve a group"
+  )
+  assert.equal(
+    resolveOnlyGroupResult("Manifest-backed public surface").check.group,
+    "Manifest-backed public surface signals",
+    "unique partial --only should resolve the manifest-backed public surface docs signal"
   )
   assert.equal(
     resolveOnlyGroupResult("Event names").check.group,

--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -381,6 +381,13 @@ lazyLoadingDocs.forEach(([relativePath, document]) => {
     `${relativePath}: Lazy Loading docs no longer preserve the host-app-owned remote loading boundary`
   )
 
+  assertIncludes(document, "authorize!", `${relativePath} lazy-loading authorization guard docs`)
+  assertIncludes(document, "visible_to(current_user)", `${relativePath} lazy-loading authorization query docs`)
+  assert(
+    /Do not treat lazy loading as authorization|lazy loadingをauthorizationの代わりに使わないでください/.test(document),
+    `${relativePath}: Lazy Loading docs no longer preserve the server-side authorization warning`
+  )
+
   assert(
     /separate surface|別 surface/.test(document),
     `${relativePath}: Lazy Loading docs no longer separate host lifecycle events from remote-state controller events`


### PR DESCRIPTION
## 対応 Issue

- Closes #2632
- Closes #2611

## Issue ごとの完了内容

- #2632: `script/test_manifest_backed_public_surface_signals.mjs` を docs entrypoint suite の `checks` に登録し、`--list` / `--only` / `--self-test` から見えるようにしました。`package.json` の `test:docs-entrypoints` から同 guard の直接 prelude 実行を外し、suite registration との二重管理を減らしています。
- #2611: 既存の lazy-loading docs 本文に含まれる `authorize!`、`visible_to(current_user)`、authorization 代替禁止の警告を `script/test_public_api_docs_signals.mjs` で確認するようにしました。

## 変更内容

- `package.json`
  - `test:docs-entrypoints` を `guard_public_api_transfer_integration_signals.mjs` + docs entrypoint suite に整理
- `script/test_docs_entrypoint_suite.mjs`
  - `Manifest-backed public surface signals` group を追加
  - `--only` self-test に manifest-backed group の解決確認を追加
- `script/test_public_api_docs_signals.mjs`
  - lazy-loading docs の server-side authorization boundary signal を追加
- `script/test_ci_workflow_changed_file_detection_signals.mjs`
  - manifest-backed public surface guard の検出先を package prelude から docs entrypoint suite registration に合わせて更新

## 改善カテゴリ

- docs guard hardening
- test / smoke signal registration
- CI entrypoint visibility improvement

## 既存仕様への影響

runtime Ruby / JavaScript behavior、Public API manifest schema、docs 本文、UI/API 契約は変更していません。既存 docs と guard の到達性・検出性だけを改善しています。

## 確認内容

- Issue label eligibility を個別確認済み
- branch freshness: `main` から作成し、compare 上 `behind_by: 0`
- diff scope: `package.json`、`script/test_docs_entrypoint_suite.mjs`、`script/test_public_api_docs_signals.mjs`、`script/test_ci_workflow_changed_file_detection_signals.mjs` の4ファイルのみ
- PR CI run #3647: 初回は JavaScript job の `test:ci-policy` で、CI policy signal が旧 package prelude 期待のままだったため失敗。CI policy smoke を suite registration 方針に合わせて修正済み。最新 head の CI を確認中です。
- local checkout / test 実行: 実行環境の GitHub raw/codeload access が 403 のため不可。PR 上の CI で確認します。

## リスク評価

低。実行対象の登録、既存 docs signal の追加、CI policy smoke の期待更新のみで、公開挙動・schema・本文は変更していません。

## 補足

#2574 の `guard_*` 系登録方針には踏み込まず、#2632 の `test_manifest_backed_public_surface_signals.mjs` 専用の小さな follow-up に限定しています。