### PR TITLE
CHANGELOG に Public API docs signal evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ Release preparation notes:
 
 ### Tests
 
+- Added helper method manifest-backed docs signal coverage so Public API helper signatures stay aligned with `config/public_api_manifest.yml`.
+- Added docs-entrypoint suite registration and lazy-loading authorization docs signal coverage so manifest-backed public surface guards stay visible through `npm run test:docs-entrypoints`.
 - Added public constants docs signal guard coverage for representative Public API constants so public constants stay aligned with `config/public_api_manifest.yml`.
 - Added stylesheet state cue selector source-spec coverage for selected, collapsed, loading, error, disabled-drop, and drop-target cues in the packaged stylesheet.
 - Expanded package contents verification coverage for bilingual CI policy suite docs so packaged gems keep maintainer CI policy guidance available.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2639
Refs #2647
Refs #2650

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、merge済み PR #2647 の helper method manifest-backed docs signal coverage を release-facing evidence として追記しました。
- 同じ `Tests` 節に、merge済み PR #2650 の docs-entrypoint suite registration / lazy-loading authorization docs signal coverage を追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script は変更していません。

## 確認内容

- current `main` で #2647 と #2650 が merge 済みであることを確認しました。
- compare `main...docs/changelog-helper-method-docs-signal`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件。
- commit patch は additions 2 / deletions 0 で、`Unreleased > Tests` への2行追記のみです。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み quality/docs-signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。