### PR TITLE
CHANGELOG に CI policy suite routing evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ Release preparation notes:
 - Added Docker development setup lane guidance to the CI policy suite docs, covering `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` container-side install smoke boundaries.
 - Added pull request changed-file detection and docs-only check retention guidance to CI policy suite docs, covering merge-base / fallback diff routing and package-facing versus repository-only docs boundaries.
 - Added representative routing output guidance to CI policy suite docs so maintainers can map changed-file routing outputs to expected PR checks.
+- Clarified CI policy suite docs self-routing guidance so bilingual CI policy suite notes are represented in `ci_policy_sensitive` checks.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 
 ### Tests
@@ -143,6 +144,7 @@ Release preparation notes:
 - Added Docker setup CI docs signal coverage so CI policy docs keep `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` guidance aligned.
 - Added CI policy docs signal coverage for pull request changed-file detection and docs-only check retention so CI policy docs stay aligned with workflow routing evidence.
 - Added CI routing output docs signal coverage for representative changed-file routing output guidance.
+- Added CI policy suite docs routing signal coverage so bilingual CI policy suite paths stay represented in `ci_policy_sensitive` docs smoke.
 - Added CI guard suite smoke coverage for the PR specs RSpec command and package guard suite composition signals.
 - Added docs-entrypoint guard coverage for `TreeViewTransferDropPositions` and `TreeViewIntegrationHooks` so transfer and integration public API docs signals stay aligned with the manifest.
 - Added CI policy suite and permissions smoke coverage so maintainers can verify read-only workflow permissions and guard group registration through `npm run test:ci-policy`.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2652
Refs #2654

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、PR #2654 で英日 CI policy suite docs 自身が `ci_policy_sensitive` の代表 path に含まれたことを release-facing evidence として追記しました。
- `CHANGELOG.md` の `Unreleased > Tests` に、同じ PR #2654 の docs routing smoke coverage を追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script は変更していません。

## 確認内容

- current `main` で #2654 が merge 済みであることを確認しました。
- compare `main...docs/changelog-ci-policy-suite-routing-evidence`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 2 / deletions 0。
- commit patch は `Unreleased > Documentation` と `Unreleased > Tests` への2行追記のみです。
- PR #2655 head `7da1502f6e58f7eeab501f0648d5258e62f1c968` の GitHub Actions CI #3658 / run `28247134332`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - representative `pr_rails_matrix` jobs: docs-only skip path で success。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
  - `javascript` は `npm run test:docs-entrypoints` success、`test:ci-policy` / `test:js:core` / browser smoke は expected skipped。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。merge済み docs / docs-signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。