### PR TITLE
PersistedState / StateStore docs signal を public API smoke に追加する

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -47,6 +47,10 @@ const pathTreeBuilderDocs = [
   ["docs/en/path-tree-builder.md", read("docs/en/path-tree-builder.md")],
   ["docs/ja/path-tree-builder.md", read("docs/ja/path-tree-builder.md")]
 ]
+const persistedStateDocs = [
+  ["docs/en/persisted-state.md", read("docs/en/persisted-state.md")],
+  ["docs/ja/persisted-state.md", read("docs/ja/persisted-state.md")]
+]
 const developmentDocs = [
   ["docs/en/development.md", read("docs/en/development.md")],
   ["docs/ja/development.md", read("docs/ja/development.md")]
@@ -208,6 +212,16 @@ const pathTreeBuilderNodeShapeSignals = [
   "record_node?"
 ]
 
+const persistedStateLifecycleSignals = [
+  "TreeView::PersistedState.from",
+  "TreeView::StateStore",
+  "persisted_state = store.find(",
+  "persisted_state = store.save!(",
+  "persisted_state = store.clear!(",
+  "matching_count = store.prune_count(",
+  "deleted_count = store.prune!("
+]
+
 const publicConstantSignals = [
   "TreeView::Error",
   "TreeView::ConfigurationError",
@@ -219,6 +233,8 @@ const publicConstantSignals = [
   "TreeView::ResourceTableRenderState",
   "TreeView::VisibleRows",
   "TreeView::RenderWindow",
+  "TreeView::PersistedState",
+  "TreeView::StateStore",
   "TreeView::Diagnostics"
 ]
 
@@ -546,6 +562,27 @@ pathTreeBuilderDocs.forEach(([relativePath, document]) => {
   assert(
     /folder key generation strategy|sort algorithm|file-manager behavior|row action design|folder key generation strategy|sort algorithm|file-manager behavior|row action design/.test(document),
     `${relativePath}: PathTreeBuilder docs no longer keep generated-key, sorting, file-manager, and row-action behavior outside the node shape contract`
+  )
+})
+
+persistedStateDocs.forEach(([relativePath, document]) => {
+  persistedStateLifecycleSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} PersistedState / StateStore lifecycle docs`)
+  })
+
+  assert(
+    /storage ownership, authorization, save timing, cleanup policy|実際の保存先、owner model、認可、保存タイミング、cleanup policy/.test(document),
+    `${relativePath}: persisted-state docs no longer keep storage ownership, authorization, and save timing with the host app`
+  )
+
+  assert(
+    /cleanup scheduling, retention selection, authorization, or audit policy|cleanup schedule、retention の選択、authorization、audit policy/.test(document),
+    `${relativePath}: persisted-state docs no longer keep cleanup, retention, authorization, and audit policy with the host app`
+  )
+
+  assert(
+    /does not provide a cleanup rake task or default TTL|cleanup rake task や default TTL を提供しません/.test(document),
+    `${relativePath}: persisted-state docs no longer say TreeView does not own cleanup tasks or default TTL`
   )
 })
 


### PR DESCRIPTION
## 対応 Issue

Closes #2607

## Issue ごとの完了内容

- #2607: `TreeView::PersistedState` / `TreeView::StateStore` の public docs surface について、英日 `persisted-state.md` の lifecycle API と host-app responsibility boundary を `script/test_public_api_docs_signals.mjs` で軽量に guard するようにしました。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に `docs/en/persisted-state.md` / `docs/ja/persisted-state.md` の reader-facing signal collection を追加しました。
- `TreeView::PersistedState.from`、`TreeView::StateStore`、`store.find` / `save!` / `clear!` / `prune_count` / `prune!` の代表 signal を確認します。
- storage ownership、authorization、save timing、cleanup / retention / audit policy、cleanup task / default TTL の host-app boundary が落ちたときに失敗する assertion を追加しました。
- public constants smoke に `TreeView::PersistedState` / `TreeView::StateStore` を含めました。

## 改善カテゴリ

- test
- docs signal guard
- public API docs hardening

## 既存仕様への影響

ありません。runtime Ruby / JavaScript、migration schema、generator output、public API manifest schema、docs prose は変更していません。既存 docs の代表 signal を既存 smoke に接続しただけです。

## 実施した確認

- Issue #2607 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- changed files は `script/test_public_api_docs_signals.mjs` の1件のみ。
- compare `main...test/2607-persisted-state-docs-signal`: `ahead_by:1` / `behind_by:0`。
- ローカル checkout / local test は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 docs の signal guard 追加のみで、挙動変更はありません。

## 補足

#2606 の public setup generator path-level contract、#2608 の localized name helper docs signal とは混ぜていません。merge は行いません。