### PR TITLE
docs-entrypoint prelude guard を AGENTS に明示する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,8 @@ Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile
 
 For CI policy guard triage, use `node script/test_ci_policy_suite.mjs --list` to see the guard groups that back `npm run test:ci-policy`, then run `node script/test_ci_policy_suite.mjs --only <group-or-index>` when you need one group. Use `node script/test_ci_policy_suite.mjs --self-test` when a CI policy guard script is added, renamed, or moved so registration drift is caught before relying on the full package script.
 
+For docs entrypoint guard triage, `npm run test:docs-entrypoints` currently runs the package-level `script/guard_public_api_transfer_integration_signals.mjs` prelude before `script/test_docs_entrypoint_suite.mjs`. Treat that prelude as an intentional package-level guard until #2574 resolves whether `guard_*` docs signal scripts should move into the suite registration or stay outside it with an explicit exclusion.
+
 Pushes to `main` also run the broader compatibility and release checks:
 
 - Ruby version matrix


### PR DESCRIPTION
## 対応 Issue

Refs #2574

## 判定分類

- `docs-sync`
- `docs-stale`

## 変更内容

- `AGENTS.md` の Testing 節に、現行 `npm run test:docs-entrypoints` が `script/guard_public_api_transfer_integration_signals.mjs` を package-level prelude として実行してから `script/test_docs_entrypoint_suite.mjs` に進むことを明記しました。
- `guard_*` docs signal scripts を suite registration へ移すか、suite 外 prelude として明示的 exclusion に残すかは #2574 の判断対象として残し、この PR では docs の現状説明だけに閉じています。

## Scope

- docs-only です。
- 変更ファイルは `AGENTS.md` 1件のみです。
- `package.json`、`script/test_docs_entrypoint_suite.mjs`、guard script、CI workflow、public API、runtime Ruby / JavaScript は変更していません。

## 確認内容

- 自分が作成した open PR の review follow-up を確認しました。
  - #2656: fresh / CI success / self follow-up comment のみで追加対応なし。
  - #2271: draft first slice / needs-human が既に明記済みのため、重複コメントや追加 commit は避けました。
  - #2657: open / CI success / comments なし。変更内容は script 側であり、Docs Sync Agent の新規 docs-only追従対象からは外しました。
- Issue #2574 と current `package.json` / `script/test_docs_entrypoint_suite.mjs` / `docs/en|ja/development.md` / `AGENTS.md` を確認しました。
- compare `main...docs/2574-docs-entrypoint-prelude`: `ahead_by:1` / `behind_by:0` / changed files `AGENTS.md` 1件 / additions 2 / deletions 0。
- commit patch は Testing 節への 1 paragraph 追加のみです。
- PR #2659 head `8dda798b338cdd7f01e28557907581d94dcd6cd3` の GitHub Actions CI #3663 / run `28253519509`: success。
  - `changes`, `lint`, `pr_specs`, `javascript`: success。
  - `javascript` は `npm run test:ci-policy` success、`npm run test:docs-entrypoints` / `test:js:core` / browser smoke は expected skipped。
  - representative `pr_rails_matrix` jobs: docs-only skip path で success。
  - `gem_package`, `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。repository-only maintainer docs に現行 package script の前段 guard を明示するだけです。#2574 の suite登録方針や script構成は変更しません。

merge は行いません。