### PR TITLE
CI policy docs signal の trigger / release guard を強化する

### DIFF
--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -87,6 +87,25 @@ const requiredDevelopmentCiPolicySignals = [
   ]
 ]
 
+const requiredReleaseCiPolicySensitiveSignals = [
+  [
+    "docs/en/release.md",
+    [
+      "CI-policy-sensitive docs-only PRs run `npm run test:ci-policy`",
+      "Docs-only PRs that are not docs-entrypoint-sensitive and do not touch mockups, CI-policy-sensitive, or browser-smoke-sensitive paths can skip JavaScript checks entirely",
+      "changed-files policy"
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "CI-policy-sensitive な docs-only PR では `npm run test:ci-policy`",
+      "docs-entrypoint-sensitive でも CI-policy-sensitive でもなく、mockup / browser-smoke path も触らない docs-only PR は JavaScript checks を完全に skip できます",
+      "changed-files policy"
+    ]
+  ]
+]
+
 const requiredWorkflowTriggerSignals = [
   "on:\n  pull_request:",
   "push:\n    branches:\n      - main"
@@ -153,6 +172,14 @@ for (const [docPath, doc, signals] of requiredDevelopmentCiPolicySignals) {
   }
 }
 
+for (const [docPath, doc, signals] of requiredReleaseCiPolicySensitiveSignals) {
+  for (const signal of signals) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: CI policy-sensitive release docs signal ${signal}`)
+    }
+  }
+}
+
 for (const signal of requiredWorkflowTriggerSignals) {
   if (!workflow.includes(signal)) {
     missingSignals.push(`.github/workflows/ci.yml: CI workflow trigger signal ${signal}`)
@@ -172,5 +199,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
 )

--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -2,6 +2,7 @@ import fs from "node:fs"
 
 const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"))
 const readme = fs.readFileSync("README.md", "utf8")
+const workflow = fs.readFileSync(".github/workflows/ci.yml", "utf8")
 const docs = [
   ["docs/en/development.md", fs.readFileSync("docs/en/development.md", "utf8")],
   ["docs/ja/development.md", fs.readFileSync("docs/ja/development.md", "utf8")]
@@ -63,6 +64,34 @@ const requiredReleaseCiPolicySuiteSignals = [
   "node script/test_ci_policy_suite.mjs --self-test"
 ]
 
+const requiredDevelopmentCiPolicySignals = [
+  [
+    "docs/en/development.md",
+    [
+      "Pull requests run the fast Ruby checks and JavaScript checks",
+      "Pushes to `main` also run the broader compatibility and release checks",
+      "changed-files policy",
+      "ci_policy_sensitive",
+      "npm run test:ci-policy"
+    ]
+  ],
+  [
+    "docs/ja/development.md",
+    [
+      "Pull Requestでは、日常的な変更を守る高速なRuby checksとJavaScript checksを実行します",
+      "`main` へのpushでは、より広い互換性確認とrelease向けのchecksも実行します",
+      "changed-files policy",
+      "ci_policy_sensitive",
+      "npm run test:ci-policy"
+    ]
+  ]
+]
+
+const requiredWorkflowTriggerSignals = [
+  "on:\n  pull_request:",
+  "push:\n    branches:\n      - main"
+]
+
 const missingSignals = []
 
 for (const scriptName of requiredMaintenanceScripts) {
@@ -116,6 +145,24 @@ for (const [docPath, doc] of releaseDocs) {
   }
 }
 
+for (const [docPath, doc, signals] of requiredDevelopmentCiPolicySignals) {
+  for (const signal of signals) {
+    if (!doc.includes(signal)) {
+      missingSignals.push(`${docPath}: CI policy trigger/routing signal ${signal}`)
+    }
+  }
+}
+
+for (const signal of requiredWorkflowTriggerSignals) {
+  if (!workflow.includes(signal)) {
+    missingSignals.push(`.github/workflows/ci.yml: CI workflow trigger signal ${signal}`)
+  }
+}
+
+if (workflow.includes("pull_request_target")) {
+  missingSignals.push(".github/workflows/ci.yml: CI workflow must not use pull_request_target for PR checks")
+}
+
 if (missingSignals.length > 0) {
   console.error("[development-docs-command-signals] missing maintenance command signals:")
   for (const signal of missingSignals) {
@@ -125,5 +172,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, and ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals are present in package.json and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
 )

--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -113,6 +113,10 @@ const requiredWorkflowTriggerSignals = [
 
 const missingSignals = []
 
+function docSource(docList, docPath) {
+  return docList.find(([path]) => path === docPath)?.[1]
+}
+
 for (const scriptName of requiredMaintenanceScripts) {
   if (!packageJson.scripts?.[scriptName]) {
     missingSignals.push(`package.json scripts.${scriptName}`)
@@ -164,17 +168,21 @@ for (const [docPath, doc] of releaseDocs) {
   }
 }
 
-for (const [docPath, doc, signals] of requiredDevelopmentCiPolicySignals) {
+for (const [docPath, signals] of requiredDevelopmentCiPolicySignals) {
+  const doc = docSource(docs, docPath)
+
   for (const signal of signals) {
-    if (!doc.includes(signal)) {
+    if (!doc?.includes(signal)) {
       missingSignals.push(`${docPath}: CI policy trigger/routing signal ${signal}`)
     }
   }
 }
 
-for (const [docPath, doc, signals] of requiredReleaseCiPolicySensitiveSignals) {
+for (const [docPath, signals] of requiredReleaseCiPolicySensitiveSignals) {
+  const doc = docSource(releaseDocs, docPath)
+
   for (const signal of signals) {
-    if (!doc.includes(signal)) {
+    if (!doc?.includes(signal)) {
       missingSignals.push(`${docPath}: CI policy-sensitive release docs signal ${signal}`)
     }
   }


### PR DESCRIPTION
## 対応 Issue

- Closes #2572
- Closes #2530

## Issue ごとの完了内容

- #2572: `npm run test:ci-policy` 周辺の Development docs signal と workflow trigger policy を `script/test_development_docs_command_signals.mjs` で確認するようにしました。`pull_request` / `push main` の workflow trigger と、`pull_request_target` を使わない境界を guard します。
- #2530: Release docs の CI-policy-sensitive docs-only PR 説明が落ちないよう、英日 release docs の代表 signal を同じ docs command signal に追加しました。

## 変更内容

- `script/test_development_docs_command_signals.mjs` が `.github/workflows/ci.yml` も読み、CI trigger policy の代表 signalを確認します。
- 英日 Development docs にある `ci_policy_sensitive` / `npm run test:ci-policy` / PR-main push CI 境界の代表 signal を確認します。
- 英日 Release docs にある CI-policy-sensitive docs-only PR と `test:ci-policy` の代表 signal を確認します。

## 改善カテゴリ

- docs signal hardening
- CI policy guard
- lightweight test maintenance

## 既存仕様への影響

なし。CI workflow、changed-files routing、package scripts、runtime Ruby / JavaScript、public API、required checks は変更していません。既存 docs / workflow の代表 signal を smoke で固定するだけです。

## 実施した確認内容

- Issue #2572 / #2530 の labels を個別確認: `status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low`
- 自分の open PR review follow-up を確認し、#2659 は self/status comment のみで追加修正対象外と判断
- 重複 PR 検索: #2572 / #2530 / ci_policy_sensitive release docs signal で open PR なし
- compare `main...chore/2572-ci-policy-doc-signals`: `ahead_by:3` / `behind_by:0` / changed files 1
- PR metadata: open / non-draft / `mergeable:true`
- GitHub Actions CI #3668 / run `28257119889`: success
  - `changes`, `lint`, `pr_specs`, `javascript`: success
  - representative `pr_rails_matrix` 7.0 / 7.2 / 8.0: success
  - `gem_package`, `docker_development_setup`, main-only matrix jobs: expected skipped
- local checkout / local test: GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク評価

low。1つの Node smoke script に representative signal を追加するだけで、挙動変更や workflow 実行条件変更はありません。

## 補足事項

#2660 も近い CI/docs routing issue ですが、`AGENTS.md` / `Product Profile.md` の changed-file routing 本体の判断が絡むため、この PR には混ぜていません。今回の bundle は既存挙動を変えない signal hardening に限定しています。

merge は行いません。