### PR TITLE
CHANGELOG に CI read-only permissions docs evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Release preparation notes:
 - Added pull request changed-file detection and docs-only check retention guidance to CI policy suite docs, covering merge-base / fallback diff routing and package-facing versus repository-only docs boundaries.
 - Added representative routing output guidance to CI policy suite docs so maintainers can map changed-file routing outputs to expected PR checks.
 - Clarified CI policy suite docs self-routing guidance so bilingual CI policy suite notes are represented in `ci_policy_sensitive` checks.
+- Added read-only workflow permissions guidance to CI policy suite docs so maintainers can review `GITHUB_TOKEN` token-scope evidence alongside the permissions guard.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 
 ### Tests


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2600
Refs #2656

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、merge済み PR #2656 で追加された CI policy suite docs の read-only workflow permissions guidance を release-facing evidence として追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- `.github/workflows/ci.yml`、CI policy guard script、package scripts、required checks、branch protection、runtime Ruby / JavaScript は変更していません。
- #2600 の lightweight docs signal / failure-message hardening は Quality/Test lane の残件として扱い、この PR では #2656 の docs本文merge後の CHANGELOG 追従だけに閉じています。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2271: draft mockup first slice / `needs-human` 継続。README / gallery / smoke inventory / browser-capable visual evidence 待ちで既存コメントが十分なため、追加 commit / 重複コメントなし。
  - #2661: script-only quality PR。CI success / comments は Workflow Manager note のみで、Docs Sync Agent の docs-only更新対象外。
- current main で #2656 が merge済みで、英日 `docs/*/ci-policy-suite.md` に `Read-only workflow permissions` section があることを確認しました。
- 重複PR / Issue検索で同じ CHANGELOG 追従PRがないことを確認しました。
- compare `main...docs/changelog-ci-readonly-permissions-evidence`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 1 / deletions 0。
- commit patch は `Unreleased > Documentation` への 1 行追記のみです。
- GitHub Actions CI #3669 / run `28259689399`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` は `npm run test:docs-entrypoints` success、`test:ci-policy` / `test:js:core` / browser smoke は expected skipped。
  - representative `pr_rails_matrix` jobs: docs-only skip path で success。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。merge済み docs-only PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。