### PR TITLE
row_status builder docs signal を grouped option smoke に追加する

### DIFF
--- a/script/test_grouped_option_docs_signals.mjs
+++ b/script/test_grouped_option_docs_signals.mjs
@@ -40,7 +40,9 @@ const groupedOptionSignals = [
   "max_leaf_distance",
   "payload_builder",
   "disabled_reason_builder",
-  "row_readonly_builder"
+  "row_disabled_builder",
+  "row_readonly_builder",
+  "row_disabled_reason_builder"
 ]
 
 assertSignals("config/public_api_manifest.yml", feature, groupedOptionSignals)
@@ -65,6 +67,25 @@ const publicApiDocSignals = [
 
 ;["docs/en/public-api.md", "docs/ja/public-api.md"].forEach((sourcePath) => {
   assertSignals(sourcePath, feature, publicApiDocSignals)
+})
+
+const rowStatusDocSignals = [
+  "row_disabled_builder",
+  "row_readonly_builder",
+  "row_disabled_reason_builder",
+  "tree-view-row--disabled",
+  "tree-view-row--readonly",
+  "data-tree-view-row-disabled-reason",
+  "disabled_builder",
+  "TreeView-owned status data keys",
+  "business rule",
+  "authorization",
+  "action disabling",
+  "disabled reason display"
+]
+
+;["docs/en/row-status.md", "docs/ja/row-status.md"].forEach((sourcePath) => {
+  assertSignals(sourcePath, "RenderState row status docs", rowStatusDocSignals)
 })
 
 assert(


### PR DESCRIPTION
## 対応 Issue 一覧

- Closes #2658

## Issue ごとの完了内容

- #2658: `grouped_option_keys.row_status` の代表 builder と、英日 Row Status docs の row-wide status / selection disabled 差分 / host-app responsibility boundary を既存 docs smoke で確認するようにしました。

## 変更内容

- `script/test_grouped_option_docs_signals.mjs` に `row_disabled_builder` / `row_readonly_builder` / `row_disabled_reason_builder` の manifest-backed signal を追加しました。
- 英日 `docs/*/row-status.md` から、status class / disabled reason data hook / selection disabled builder 差分 / business rule・authorization・action disabling・disabled reason display の host-app responsibility boundary を代表 signal として確認します。

## 改善カテゴリ

- docs signal hardening
- public API docs drift guard
- lightweight test maintenance

## 既存仕様への影響

なし。runtime Ruby / JavaScript、manifest schema、row status rendering、CSS、docs prose、CI workflow、package scripts は変更していません。既存 docs と manifest の代表 signal を smoke で固定するだけです。

## 実施した確認内容

- Issue #2658 の labels を個別確認: `status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low`
- Default PR Check として open PR review follow-up を確認し、既存 human-gated draft PR や green/mergeable PR への重複対応は避けました。
- PR前 compare `main...chore/2658-row-status-docs-signal`: `ahead_by:1` / `behind_by:0` / changed files 1
- 変更ファイル: `script/test_grouped_option_docs_signals.mjs`
- local checkout / local test: GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。1つの Node smoke script に representative signal を追加するだけで、挙動変更や public API 変更はありません。

## 補足事項

- #2660 も ready quality issue として確認しましたが、changed-file routing 本体と大きい既存 policy smoke の期待値更新が必要な別テーマのため、この PR には混ぜていません。
- merge は行いません。