### PR TITLE
CHANGELOG に row status docs signal evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Release preparation notes:
 
 ### Tests
 
+- Added row status builder docs signal coverage so grouped option docs keep row disabled, readonly, and disabled-reason builders aligned with the manifest and host-app responsibility boundary.
 - Added helper method manifest-backed docs signal coverage so Public API helper signatures stay aligned with `config/public_api_manifest.yml`.
 - Added docs-entrypoint suite registration and lazy-loading authorization docs signal coverage so manifest-backed public surface guards stay visible through `npm run test:docs-entrypoints`.
 - Added public constants docs signal guard coverage for representative Public API constants so public constants stay aligned with `config/public_api_manifest.yml`.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2658
Refs #2665

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、merge済み PR #2665 で追加された row status builder docs signal coverage を release-facing evidence として追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script、manifest schema、row status rendering は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2271: draft / needs-human 継続。README / gallery / browser-capable visual evidence 待ちのため追加対応なし。
  - #2667: この実行中に merge 済みになったことを確認しました。
- current main で #2665 が merge済みで、`script/test_grouped_option_docs_signals.mjs` に row status builder docs signal coverage が追加されていることを PR metadata から確認しました。
- 重複 PR / Issue 検索で同じ CHANGELOG 追従 PR がないことを確認しました。
- compare `main...docs/changelog-row-status-docs-signal`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 1 / deletions 0。
- commit patch は `Unreleased > Tests` への 1 行追記のみです。
- GitHub Actions CI #3677 / run `28265668944`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` は `npm run test:docs-entrypoints` success、`test:ci-policy` / `test:js:core` / browser smoke は expected skipped。
  - representative `pr_rails_matrix` jobs: docs-only skip path で success。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にしました。

## リスク

low。merge済み quality/docs-signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。