### PR TITLE
CHANGELOG に repository-only docs routing evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,11 +132,13 @@ Release preparation notes:
 - Added representative routing output guidance to CI policy suite docs so maintainers can map changed-file routing outputs to expected PR checks.
 - Clarified CI policy suite docs self-routing guidance so bilingual CI policy suite notes are represented in `ci_policy_sensitive` checks.
 - Added read-only workflow permissions guidance to CI policy suite docs so maintainers can review `GITHUB_TOKEN` token-scope evidence alongside the permissions guard.
+- Clarified repository-only maintainer docs routing in CI policy suite docs so AGENTS.md remains CI-policy-sensitive while Product Profile.md stays manual-review routed.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 
 ### Tests
 
 - Added row status builder docs signal coverage so grouped option docs keep row disabled, readonly, and disabled-reason builders aligned with the manifest and host-app responsibility boundary.
+- Added repository-only maintainer docs routing signal coverage so CI policy docs keep AGENTS.md and Product Profile.md changed-file guidance aligned.
 - Added helper method manifest-backed docs signal coverage so Public API helper signatures stay aligned with `config/public_api_manifest.yml`.
 - Added docs-entrypoint suite registration and lazy-loading authorization docs signal coverage so manifest-backed public surface guards stay visible through `npm run test:docs-entrypoints`.
 - Added public constants docs signal guard coverage for representative Public API constants so public constants stay aligned with `config/public_api_manifest.yml`.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2660
Refs #2667

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、merge済み PR #2667 で整理された repository-only maintainer docs routing の release-facing evidence を追記しました。
- `CHANGELOG.md` の `Unreleased > Tests` に、同 PR で追加された routing signal coverage の release-facing evidence を追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script、manifest、AGENTS.md、Product Profile.md は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2668: この実行中に merge 済みになったため、この PR は merge 後の current main (`3d86a141788db78472dfa182a12408f2ecfcf4d0`) から clean branch を作成して差分を載せ直しました。
  - #2271: draft / needs-human 継続。README / gallery / browser-capable visual evidence 待ちのため追加対応なし。
- #2667 が merge済みで、CI policy suite docs と routing signal coverage が更新されていることを PR metadata から確認しました。
- compare `main...docs/changelog-repository-only-routing-evidence`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 2 / deletions 0。
- commit patch は `Unreleased > Documentation` と `Unreleased > Tests` への各 1 行追記のみです。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs / docs-signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。