### PR TITLE
docs-entrypoint guard を suite に登録する

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:development-docs-commands": "node script/test_development_docs_command_signals.mjs",
     "test:public-api-manifest-structure": "node script/test_public_api_manifest_structure.mjs",
     "test:docs-i18n": "node script/test_docs_i18n_parity.mjs",
-    "test:docs-entrypoints": "node script/guard_public_api_transfer_integration_signals.mjs && node script/test_docs_entrypoint_suite.mjs",
+    "test:docs-entrypoints": "node script/test_docs_entrypoint_suite.mjs",
     "test:entrypoints": "node script/test_entrypoints.mjs && node script/test_controller_entries_contract.mjs && node script/test_declaration_literal_shapes.mjs && npm run test:docs-entrypoints && npm run test:ci-policy && npm run test:node-version-sources && npm run test:ruby-version-sources",
     "test:js:core": "npm run test:entrypoints && npm test",
     "test:js": "npm run test:js:core && npm run test:browser"

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -315,8 +315,8 @@ const entrypointsScript = packageScript("test:entrypoints")
 const jsCoreScript = packageScript("test:js:core")
 
 const docsEntrypointsSignals = [
-  ["package script runs public API transfer guard", docsEntrypointsScript, "node script/guard_public_api_transfer_integration_signals.mjs"],
   ["package script uses docs entrypoint suite", docsEntrypointsScript, "node script/test_docs_entrypoint_suite.mjs"],
+  ["suite registers public API transfer guard", docsEntrypointSuiteSource, "script/guard_public_api_transfer_integration_signals.mjs"],
   ["suite registers manifest-backed public surface guard", docsEntrypointSuiteSource, "script/test_manifest_backed_public_surface_signals.mjs"],
   ["suite registers controller registration docs signal", docsEntrypointSuiteSource, "script/check_controller_registration_docs_signals.mjs"]
 ]
@@ -347,16 +347,16 @@ packageGuardSuiteCompositionSignals.forEach(([label, source, signal]) => {
 })
 
 assertOrdered(
-  docsEntrypointsScript,
-  "node script/guard_public_api_transfer_integration_signals.mjs",
-  "node script/test_docs_entrypoint_suite.mjs",
-  `${packagePath} scripts.test:docs-entrypoints must run public API transfer guard before docs entrypoint suite`
+  docsEntrypointSuiteSource,
+  "script/test_public_api_docs_signals.mjs",
+  "script/guard_public_api_transfer_integration_signals.mjs",
+  `${docsEntrypointSuitePath} must run public API docs signals before transfer integration signals`
 )
 assertOrdered(
   docsEntrypointSuiteSource,
-  "script/test_public_api_docs_signals.mjs",
+  "script/guard_public_api_transfer_integration_signals.mjs",
   "script/test_manifest_backed_public_surface_signals.mjs",
-  `${docsEntrypointSuitePath} must run public API docs signals before manifest-backed public surface signals`
+  `${docsEntrypointSuitePath} must run transfer integration signals before manifest-backed public surface signals`
 )
 assertOrdered(
   ciPolicyScript,

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -103,6 +103,11 @@ const checks = [
     args: ["script/test_public_api_docs_signals.mjs"]
   },
   {
+    group: "Public API transfer integration signals",
+    command: "node",
+    args: ["script/guard_public_api_transfer_integration_signals.mjs"]
+  },
+  {
     group: "Manifest-backed public surface signals",
     command: "node",
     args: ["script/test_manifest_backed_public_surface_signals.mjs"]
@@ -176,6 +181,7 @@ const docsEntrypointScriptExclusions = new Map([
 
 const docsEntrypointScriptPatterns = [
   /^check_controller_registration_docs_signals\.mjs$/,
+  /^guard_.*signals\.mjs$/,
   /^test_event_names_public_api_signals\.mjs$/,
   /^test_.*docs.*\.mjs$/,
   /^test_.*readme.*signals\.mjs$/,
@@ -324,6 +330,8 @@ function resolveOnlyGroup(groupName) {
 
 function runSelfTest() {
   const availableGroups = formatAvailableGroups()
+  const registeredPaths = registeredNodeScriptPaths()
+  const candidatePaths = docsEntrypointCandidateScriptPaths()
 
   assert.match(
     availableGroups,
@@ -349,6 +357,11 @@ function runSelfTest() {
     resolveOnlyGroupResult("Manifest-backed public surface").check.group,
     "Manifest-backed public surface signals",
     "unique partial --only should resolve the manifest-backed public surface docs signal"
+  )
+  assert.equal(
+    resolveOnlyGroupResult("Public API transfer").check.group,
+    "Public API transfer integration signals",
+    "unique partial --only should resolve the transfer integration guard"
   )
   assert.equal(
     resolveOnlyGroupResult("Event names").check.group,
@@ -380,6 +393,7 @@ function runSelfTest() {
     ambiguous.matches.map((check) => check.group),
     [
       "Public API docs signals",
+      "Public API transfer integration signals",
       "Public API exported controller class docs signals",
       "Public API manifest structure",
       "Public API entrypoint guard signals"
@@ -388,19 +402,27 @@ function runSelfTest() {
   )
 
   assert.ok(
-    docsEntrypointCandidateScriptPaths().includes("script/test_event_names_public_api_signals.mjs"),
+    candidatePaths.includes("script/test_event_names_public_api_signals.mjs"),
     "docs script registration candidates should include event names public API signals"
   )
   assert.ok(
-    docsEntrypointCandidateScriptPaths().includes("script/test_public_api_docs_signals.mjs"),
+    candidatePaths.includes("script/test_public_api_docs_signals.mjs"),
     "docs script registration candidates should include public API docs signals"
   )
   assert.ok(
-    docsEntrypointCandidateScriptPaths().includes("script/check_controller_registration_docs_signals.mjs"),
+    candidatePaths.includes("script/guard_public_api_transfer_integration_signals.mjs"),
+    "docs script registration candidates should include guard-based public API docs signals"
+  )
+  assert.ok(
+    registeredPaths.has("script/guard_public_api_transfer_integration_signals.mjs"),
+    "guard-based public API docs signals should be registered in the suite"
+  )
+  assert.ok(
+    candidatePaths.includes("script/check_controller_registration_docs_signals.mjs"),
     "docs script registration candidates should include controller registration docs signals"
   )
   assert.ok(
-    !docsEntrypointCandidateScriptPaths().includes("script/test_docs_i18n_parity.mjs"),
+    !candidatePaths.includes("script/test_docs_i18n_parity.mjs"),
     "npm-registered docs checks should stay out of direct node script registration candidates"
   )
   assertDocsEntrypointScriptsRegistered()


### PR DESCRIPTION
## 対応 Issue

- Closes #2574

## Issue ごとの完了内容

- #2574: `guard_public_api_transfer_integration_signals.mjs` を docs-entrypoint suite の `checks` 配列へ登録し、`--list` / `--only` / `--self-test` から見える形にしました。
- CI policy smoke も package script 直書き期待ではなく、suite 登録を確認する形へ同期しました。

## 変更内容

- `package.json` の `test:docs-entrypoints` を `node script/test_docs_entrypoint_suite.mjs` に戻し、suite 外 prelude との二重管理を解消しました。
- `script/test_docs_entrypoint_suite.mjs` に `Public API transfer integration signals` group を追加しました。
- `guard_.*signals.mjs` を docs-entrypoint candidate として拾う pattern を追加しました。
- self-test に transfer guard の candidate / registered path と `--only "Public API transfer"` の解決確認を追加しました。
- `Public API` の ambiguous group 期待値を、新しい transfer guard group を含む形に同期しました。
- `script/test_ci_workflow_changed_file_detection_signals.mjs` の代表 signal を、package script prelude ではなく suite registration に合わせました。

## 改善カテゴリ

- test / CI guard hardening
- 小さな内部整理

## 既存仕様への影響

- runtime Ruby / JavaScript behavior、public API manifest schema、manifest content、docs 本文、workflow topology は変更していません。
- docs-entrypoint suite の実行経路を整理するだけで、公開挙動には影響しません。

## 実施した確認

- GitHub connector compare: `main...chore/2574-docs-entrypoint-guard-suite` は `ahead_by:3` / `behind_by:0`。
- changed files は `package.json`, `script/test_docs_entrypoint_suite.mjs`, `script/test_ci_workflow_changed_file_detection_signals.mjs` の3件のみ。
- local `git ls-remote` / raw fetch は GitHub HTTPS `CONNECT tunnel failed, response 403` のため不可。
- CI #3682 success:
  - `lint`, `pr_specs`, `gem_package`, `docker_development_setup`, `javascript`, representative Rails matrix jobs が success。
  - `javascript` job で `npm run test:ci-policy` と `npm run test:js:core` が success。
  - `test:js:core` 内で `npm run test:docs-entrypoints` が実行され、docs-entrypoint suite 32 checks と self-test が success。

## リスク評価

low。Node-only docs/test orchestration の見える化で、guard 内容や公開契約は変更していません。

## 補足

- #2573 はすでに main に入っているため、このPRは current `main` follow-up として作成しています。
- merge は行いません。