### PR TITLE
CI read-only permissions docs signal を追加する

### DIFF
--- a/script/test_ci_policy_permissions_docs_signals.mjs
+++ b/script/test_ci_policy_permissions_docs_signals.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+
+function assertIncludes(source, needle, label) {
+  assert.ok(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const docsSignals = [
+  [
+    "docs/en/ci-policy-suite.md",
+    [
+      "## Read-only workflow permissions",
+      "permissions: contents: read",
+      "GITHUB_TOKEN",
+      "contents: write",
+      "pull-requests: write",
+      "job-level `permissions:` overrides",
+      "CI token-scope evidence",
+      "branch protection",
+      "required checks",
+      "repository settings",
+      "third-party action policy",
+      "release publishing credentials",
+      "update this note and the guard together"
+    ]
+  ],
+  [
+    "docs/ja/ci-policy-suite.md",
+    [
+      "## Read-only workflow permissions",
+      "permissions: contents: read",
+      "GITHUB_TOKEN",
+      "contents: write",
+      "pull-requests: write",
+      "job-level `permissions:` override",
+      "CI token scope の evidence",
+      "branch protection",
+      "required checks",
+      "repository settings",
+      "third-party action policy",
+      "release publishing credential",
+      "このメモと guard を一緒に更新"
+    ]
+  ]
+]
+
+for (const [docsPath, signals] of docsSignals) {
+  const docsSource = readFileSync(docsPath, "utf8")
+
+  for (const signal of signals) {
+    assertIncludes(docsSource, signal, `${docsPath} read-only workflow permissions docs signal`)
+  }
+}
+
+console.log("Checked CI policy read-only workflow permissions docs signals.")

--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -23,6 +23,11 @@ const checks = [
     args: ["script/test_ci_workflow_permissions_signals.mjs"]
   },
   {
+    group: "Workflow permissions docs signals",
+    command: "node",
+    args: ["script/test_ci_policy_permissions_docs_signals.mjs"]
+  },
+  {
     group: "CI observation guidance signals",
     command: "node",
     args: ["script/test_ci_observation_guidance_signals.mjs"]
@@ -224,7 +229,11 @@ function runSelfTest() {
   assert.equal(ambiguous.error, "ambiguous")
   assert.deepEqual(
     ambiguous.matches.map((check) => check.group),
-    ["Workflow changed-file detection signals", "Workflow permissions signals"],
+    [
+      "Workflow changed-file detection signals",
+      "Workflow permissions signals",
+      "Workflow permissions docs signals"
+    ],
     "ambiguous --only should report all matching groups"
   )
 
@@ -235,6 +244,10 @@ function runSelfTest() {
   assert.ok(
     ciPolicyCandidateScriptPaths().includes("script/test_ci_workflow_permissions_signals.mjs"),
     "CI policy candidates should include workflow permissions signals"
+  )
+  assert.ok(
+    ciPolicyCandidateScriptPaths().includes("script/test_ci_policy_permissions_docs_signals.mjs"),
+    "CI policy candidates should include workflow permissions docs signals"
   )
   assert.ok(
     ciPolicyCandidateScriptPaths().includes("script/test_package_lock_dependency_drift.mjs"),

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -172,6 +172,10 @@ const checks = [
 const docsEntrypointScriptExclusions = new Map([
   ["test_ci_policy_docs_routing.mjs", "registered through npm run test:ci-policy"],
   [
+    "test_ci_policy_permissions_docs_signals.mjs",
+    "registered through npm run test:ci-policy"
+  ],
+  [
     "test_development_docs_command_signals.mjs",
     "registered through npm run test:development-docs-commands"
   ],


### PR DESCRIPTION
## 対応 Issue

Closes #2600

## Issue ごとの完了内容

- #2600: 既に main に入っている英日 `docs/*/ci-policy-suite.md` の `Read-only workflow permissions` section を、CI policy suite の lightweight signal として固定しました。
- `permissions: contents: read`、`contents: write` / `pull-requests: write` を要求しないこと、job-level `permissions:` override を避けること、branch protection / required checks / repository settings などが範囲外であることを代表 signal として確認します。

## 変更内容

- `script/test_ci_policy_permissions_docs_signals.mjs` を追加しました。
- `script/test_ci_policy_suite.mjs` に `Workflow permissions docs signals` group を登録しました。
- CI policy suite self-test の候補 script 検出と ambiguous `--only workflow` 期待を、新しい group に合わせて更新しました。
- `script/test_docs_entrypoint_suite.mjs` では、この guard が `npm run test:ci-policy` 経由で登録済みであることを明示し、docs-entrypoint candidate 登録チェックから除外しました。

## 改善カテゴリ

- test
- docs signal hardening
- CI policy guard

## 既存仕様への影響

- `.github/workflows/ci.yml`、workflow permissions、job topology、required checks、branch protection、repository settings、runtime Ruby / JavaScript は変更していません。
- docs 本文も変更せず、既存 docs が drift した時に検出できる guard の追加に閉じています。

## 実施した確認

- Issue #2600 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low` を含む対象 Issue でした。
- 既存 PR #2656 / #2664 が merge 済みで、docs 本文と CHANGELOG evidence は main に入っていることを確認しました。
- Final compare: `ahead_by:3` / `behind_by:0`、changed files は以下の3件のみです。
  - `script/test_ci_policy_permissions_docs_signals.mjs`
  - `script/test_ci_policy_suite.mjs`
  - `script/test_docs_entrypoint_suite.mjs`
- CI run #3684: 初回は `javascript` job 内の docs-entrypoint suite self-test で、追加 guard の登録扱いを検出して failure。
- CI run #3685: success。`changes`, `lint`, `pr_specs`, `javascript`, representative `pr_rails_matrix` lanes が通過しました。
- ローカル checkout / npm 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク評価

low。既存 docs wording を小さな Node smoke で確認するだけで、公開 API、runtime behavior、workflow permissions は変更しません。

## 補足

- review follow-up 対象として確認した open PR は、いずれも visual evidence / human design review 待ちまたは draft first slice で、Quality Fixer が自動修正すべき範囲外でした。

merge は行いません。