### PR TITLE
AGENTS の docs-entrypoint suite guidance を現状に合わせる

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Docs-only pull requests that touch only `README.md`, `docs/**`, `Product Profile
 
 For CI policy guard triage, use `node script/test_ci_policy_suite.mjs --list` to see the guard groups that back `npm run test:ci-policy`, then run `node script/test_ci_policy_suite.mjs --only <group-or-index>` when you need one group. Use `node script/test_ci_policy_suite.mjs --self-test` when a CI policy guard script is added, renamed, or moved so registration drift is caught before relying on the full package script.
 
-For docs entrypoint guard triage, `npm run test:docs-entrypoints` currently runs the package-level `script/guard_public_api_transfer_integration_signals.mjs` prelude before `script/test_docs_entrypoint_suite.mjs`. Treat that prelude as an intentional package-level guard until #2574 resolves whether `guard_*` docs signal scripts should move into the suite registration or stay outside it with an explicit exclusion.
+For docs entrypoint guard triage, `npm run test:docs-entrypoints` now runs the registered `script/test_docs_entrypoint_suite.mjs` checks directly. Use `npm run test:docs-entrypoints -- --list` to see docs entrypoint groups, `--only <group-or-index>` to run one group, and `node script/test_docs_entrypoint_suite.mjs --self-test` after adding, renaming, or moving a docs signal script so suite registration drift is caught.
 
 Pushes to `main` also run the broader compatibility and release checks:
 


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2574
Refs #2670

## 判定分類

- `docs-stale`
- `docs-sync`

## 変更内容

- `AGENTS.md` の docs entrypoint guard triage 説明を、merge済み #2670 後の現状に合わせました。
- `npm run test:docs-entrypoints` が package-level prelude ではなく、登録済み `script/test_docs_entrypoint_suite.mjs` checks を直接実行することを明記しました。
- `--list` / `--only <group-or-index>` / `--self-test` の使い分けを maintainer entrypoint から辿れるようにしました。

## Scope

- docs-only です。
- 変更ファイルは `AGENTS.md` 1件のみです。
- `package.json`、`script/**`、CI workflow、runtime Ruby / JavaScript、public API docs 本文、CHANGELOG は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2271: draft / needs-human 継続。README / gallery / browser-capable visual evidence 待ちのため追加対応なし。
- #2670 は 2026-06-27T00:10:17Z に merge済みで、`package.json` の `test:docs-entrypoints` は `node script/test_docs_entrypoint_suite.mjs` に戻っています。
- #2671 も merge済みで、CHANGELOG には docs-entrypoint suite registration と CI permissions smoke coverage の Tests evidence が既にあります。
- compare `main...docs/2574-agents-docs-entrypoint-suite`: `ahead_by:1` / `behind_by:0` / changed files `AGENTS.md` 1件 / additions 1 / deletions 1。
- commit patch は stale paragraph 1件の置換のみです。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。repository-only maintainer docs の stale guidance を現行 package script / suite registration に同期するだけです。

merge は行いません。