### PR TITLE
npm lockfile drift recovery docs signal を追加する

### DIFF
--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -87,6 +87,31 @@ const requiredDevelopmentCiPolicySignals = [
   ]
 ]
 
+const requiredNpmLockfileDriftRecoverySignals = [
+  [
+    "docs/en/development.md",
+    [
+      "npm lockfile drift guard",
+      "`package-lock.json`",
+      "`package.json`",
+      "dependency or Node engine metadata",
+      "`npm install`",
+      "`npm ci`"
+    ]
+  ],
+  [
+    "docs/ja/development.md",
+    [
+      "npm lockfile drift guard",
+      "`package-lock.json`",
+      "`package.json`",
+      "dependency や Node engine metadata",
+      "`npm install`",
+      "`npm ci`"
+    ]
+  ]
+]
+
 const requiredReleaseCiPolicySensitiveSignals = [
   [
     "docs/en/release.md",
@@ -178,6 +203,16 @@ for (const [docPath, signals] of requiredDevelopmentCiPolicySignals) {
   }
 }
 
+for (const [docPath, signals] of requiredNpmLockfileDriftRecoverySignals) {
+  const doc = docSource(docs, docPath)
+
+  for (const signal of signals) {
+    if (!doc?.includes(signal)) {
+      missingSignals.push(`${docPath}: npm lockfile drift recovery docs signal ${signal}`)
+    }
+  }
+}
+
 for (const [docPath, signals] of requiredReleaseCiPolicySensitiveSignals) {
   const doc = docSource(releaseDocs, docPath)
 
@@ -207,5 +242,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredNpmLockfileDriftRecoverySignals.length} npm lockfile drift recovery docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
 )


### PR DESCRIPTION
## 対応 Issue

Closes #2587

## Issue ごとの完了内容

- #2587: 英日 Development docs に既にある npm / `package-lock.json` drift recovery の reader-facing guidance を、`script/test_development_docs_command_signals.mjs` の lightweight signal で守るようにしました。

## 変更内容

- `script/test_development_docs_command_signals.mjs` に npm lockfile drift recovery の signal group を追加しました。
- 英日 `docs/*/development.md` について、`npm lockfile drift guard`、`package-lock.json` / `package.json`、metadata drift、`npm install`、`npm ci` の代表 wording を確認します。
- failure message は `npm lockfile drift recovery docs signal` と docs path を示す形にしました。

## 改善カテゴリ

- docs signal hardening
- test / CI policy signal
- maintenance guard

## 既存仕様への影響

なし。runtime Ruby / JavaScript、CI workflow、package scripts、dependency metadata、Node / npm policy、`package.json` / `package-lock.json` は変更していません。

## 確認内容

- Default PR Check: self-authored open PR を確認しました。
  - #2672 は self/status comment のみで外部 review follow-up なし。
  - #2271 は browser-capable visual evidence / human gate 待ちで、Quality Fixer が自動解消できる範囲外。
- Issue eligibility: #2587 の `status:ready-for-agent`、`agent:planned`、`track:quality`、`risk:low` を個別確認しました。
- 既存 open PR duplicate: #2587 を閉じる open PR は見つかりませんでした。
- branch freshness: `main...docs/2587-npm-lockfile-drift-recovery` は `ahead_by:1` / `behind_by:0`。
- changed files: `script/test_development_docs_command_signals.mjs` 1件のみ。
- local raw checkout / local npm tests: GitHub raw access が `403` のため未実行です。PR CI を確認します。

## リスク評価

low。既存 docs wording を確認する signal の追加だけで、挙動変更や policy 変更はありません。

## 補足事項

- Planner handoff では dedicated npm recovery docs ではなく、Development docs の focused guidance と lightweight signal に閉じる方針でした。現行 docs に必要な recovery wording は既にあるため、本文 rewrite は避け、signal 追加に絞っています。
- merge は行いません。