### PR TITLE
manifest duplicate-key guard の Development docs signal を追加する

### DIFF
--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -112,6 +112,27 @@ const requiredNpmLockfileDriftRecoverySignals = [
   ]
 ]
 
+const requiredManifestStructureDuplicateKeySignals = [
+  [
+    "docs/en/development.md",
+    [
+      "`npm run test:public-api-manifest-structure`",
+      "duplicate-key guardrails",
+      "duplicate YAML keys",
+      "manifest structure smoke"
+    ]
+  ],
+  [
+    "docs/ja/development.md",
+    [
+      "`npm run test:public-api-manifest-structure`",
+      "duplicate-key guardrails",
+      "duplicate YAML keys",
+      "manifest structure"
+    ]
+  ]
+]
+
 const requiredReleaseCiPolicySensitiveSignals = [
   [
     "docs/en/release.md",
@@ -213,6 +234,16 @@ for (const [docPath, signals] of requiredNpmLockfileDriftRecoverySignals) {
   }
 }
 
+for (const [docPath, signals] of requiredManifestStructureDuplicateKeySignals) {
+  const doc = docSource(docs, docPath)
+
+  for (const signal of signals) {
+    if (!doc?.includes(signal)) {
+      missingSignals.push(`${docPath}: manifest duplicate-key docs signal ${signal}`)
+    }
+  }
+}
+
 for (const [docPath, signals] of requiredReleaseCiPolicySensitiveSignals) {
   const doc = docSource(releaseDocs, docPath)
 
@@ -242,5 +273,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredNpmLockfileDriftRecoverySignals.length} npm lockfile drift recovery docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredNpmLockfileDriftRecoverySignals.length} npm lockfile drift recovery docs groups, ${requiredManifestStructureDuplicateKeySignals.length} manifest duplicate-key docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
 )


### PR DESCRIPTION
## 対応 Issue

Closes #2529

## Issue ごとの完了内容

- #2529: 英日 Development docs に既にある `npm run test:public-api-manifest-structure` / duplicate-key guard 説明を、`script/test_development_docs_command_signals.mjs` の lightweight signal で守るようにしました。

## 変更内容

- `script/test_development_docs_command_signals.mjs` に `requiredManifestStructureDuplicateKeySignals` を追加しました。
- 英日 `docs/*/development.md` について、manifest structure smoke、duplicate-key guardrails、duplicate YAML keys の代表 wording を確認します。
- failure message は `manifest duplicate-key docs signal` と docs path を示す形にしました。

## 改善カテゴリ

- docs signal hardening
- test / CI policy signal
- maintenance guard

## 既存仕様への影響

なし。runtime Ruby / JavaScript、public API manifest schema、`config/public_api_manifest.yml`、CI workflow、package scripts、Development docs prose は変更していません。

## 実施した確認内容

- Default PR Check: open PR を確認しました。
  - #2673 は既に merged。
  - #2271 は draft / design-human-gated / browser evidence 待ちで、Quality Fixer が自動解消できる範囲外。
- Issue eligibility: #2529 の `status:ready-for-agent`、`agent:planned`、`track:quality`、`risk:low` を個別確認しました。
- 既存 open PR duplicate: #2529 を閉じる open PR は見つかりませんでした。
- branch freshness: `main...docs/2529-manifest-duplicate-key-signal` は `ahead_by:1` / `behind_by:0`。
- changed files: `script/test_development_docs_command_signals.mjs` 1件のみ。
- local checkout / local npm tests: GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認します。

## リスク評価

low。既存 docs wording を確認する signal の追加だけで、挙動変更や policy 変更はありません。

## 補足事項

- 現行の英日 Development docs には duplicate-key guard の reader-facing wording が既にあるため、docs 本文 rewrite は避け、signal 追加に絞っています。
- merge は行いません。