### PR TITLE
Dependabot Bundler recovery docs を package guard に追加する

### DIFF
--- a/script/check_gem_package_contents.rb
+++ b/script/check_gem_package_contents.rb
@@ -79,6 +79,10 @@ REQUIRED_PACKAGED_PATH_GROUPS = {
     docs/en/development.md
     docs/ja/development.md
   ],
+  "Dependabot Bundler recovery docs" => %w[
+    docs/en/dependabot-bundler-recovery.md
+    docs/ja/dependabot-bundler-recovery.md
+  ],
   "Bilingual CI policy suite docs" => %w[
     docs/en/ci-policy-suite.md
     docs/ja/ci-policy-suite.md


### PR DESCRIPTION
## 対応Issue

- Closes #2508

## Issueごとの完了内容

- #2508: `script/check_gem_package_contents.rb` の `REQUIRED_PACKAGED_PATH_GROUPS` に `Dependabot Bundler recovery docs` group を追加し、`docs/en/dependabot-bundler-recovery.md` と `docs/ja/dependabot-bundler-recovery.md` を代表 package contents guard 対象にしました。

## 変更内容

- Dependabot Bundler recovery docs の英日ファイルを、gem package verification の代表 docs group として明示しました。
- 既存の missing group / missing path failure 表示に乗るため、欠落時には group 名と path が分かります。

## 改善カテゴリ

- test
- docs/package verification guard
- CI/package release evidence hardening

## 既存仕様への影響

- runtime Ruby / JavaScript behavior は変更していません。
- CI workflow、Dependabot config、Gemfile / Gemfile.lock、dependency versions、docs本文、public API、DB、認可は変更していません。
- `docs/**/*` を機械的に列挙するのではなく、Planner handoff どおり recovery docs だけを代表 package evidence として追加しています。

## 実施した確認

- Issue #2508 の labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- `main...chore/2508-dependabot-bundler-package-guard` compare を確認: `ahead_by:1`, `behind_by:0`, changed files は `script/check_gem_package_contents.rb` 1件のみ。
- Connector で更新後の該当箇所を確認し、final newline を落とさない形で更新しました。
- GitHub Actions CI #3693: success。
  - `lint`: success
  - `pr_specs`: success
  - `gem_package`: success（`ruby script/check_gem_package_contents.rb tree_view-*.gem` を含む）
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `javascript`: success（`npm run test:js:core`）

## 未実行の確認

- local checkout / local tests は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。

## リスク評価

low。代表 package contents guard の対象 path 追加だけで、gem contents policy の実行範囲を狭く明確にする変更です。

## 補足

- #2509 は別Issueとして残しました。Release docs wording は既に main に入っていますが、signal guard は別テーマのため、このPRには混ぜていません。

Closes #2508