### PR TITLE
CHANGELOG に Development docs signal evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@ Release preparation notes:
 
 ### Tests
 
+- Added Development docs signal coverage for npm lockfile drift recovery guidance so `npm install` / `npm ci` recovery boundaries stay aligned with package metadata drift guidance.
+- Added Development docs signal coverage for public API manifest duplicate-key guard guidance so duplicate YAML key handling stays visible in maintainer docs.
 - Added row status builder docs signal coverage so grouped option docs keep row disabled, readonly, and disabled-reason builders aligned with the manifest and host-app responsibility boundary.
 - Added repository-only maintainer docs routing signal coverage so CI policy docs keep AGENTS.md and Product Profile.md changed-file guidance aligned.
 - Added helper method manifest-backed docs signal coverage so Public API helper signatures stay aligned with `config/public_api_manifest.yml`.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2529
Refs #2587
Refs #2673
Refs #2675

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、merge済み PR #2673 の npm lockfile drift recovery docs signal coverage を release-facing evidence として追記しました。
- 同じく merge済み PR #2675 の public API manifest duplicate-key guard docs signal coverage を追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script、manifest schema、Development docs 本文は変更していません。

## 確認内容

- Default PR Check として open PR を確認しました。
  - #2676: green / `behind_by:0` / Workflow Manager comment あり。quality guard PR で、この Docs Sync run では追加 docs commit 対象外です。
  - #2271: draft / design-human-gated / browser evidence 待ちで `needs-human` 継続です。
- #2673 と #2675 が merge済みで、Development docs command signal coverage が current main に入っていることを確認しました。
- 重複 PR / Issue 検索で同じ CHANGELOG 追従は見つかりませんでした。
- compare `main...docs/changelog-development-docs-signal-evidence-fresh`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 2 / deletions 0。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs-signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。