### PR TITLE
CHANGELOG に Dependabot Bundler package guard evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ Release preparation notes:
 
 - Added Development docs signal coverage for npm lockfile drift recovery guidance so `npm install` / `npm ci` recovery boundaries stay aligned with package metadata drift guidance.
 - Added Development docs signal coverage for public API manifest duplicate-key guard guidance so duplicate YAML key handling stays visible in maintainer docs.
+- Expanded package contents verification coverage for Dependabot Bundler recovery docs so packaged gems keep scoped recovery guidance available.
 - Added row status builder docs signal coverage so grouped option docs keep row disabled, readonly, and disabled-reason builders aligned with the manifest and host-app responsibility boundary.
 - Added repository-only maintainer docs routing signal coverage so CI policy docs keep AGENTS.md and Product Profile.md changed-file guidance aligned.
 - Added helper method manifest-backed docs signal coverage so Public API helper signatures stay aligned with `config/public_api_manifest.yml`.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2508
Refs #2676

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、merge済み PR #2676 の Dependabot Bundler recovery docs package contents guard evidence を追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package checker、Dependabot config、Gemfile / Gemfile.lock、Release docs 本文は変更していません。

## 確認内容

- Default PR Check として open PR を確認しました。
  - #2271: draft / design-human-gated / README・gallery・browser evidence 待ちのため `needs-human` 継続です。
- #2677 は merge済みで、Development docs signal evidence は current `CHANGELOG.md` に反映済みでした。
- #2676 は merge済みですが、Dependabot Bundler recovery docs package guard evidence が current `CHANGELOG.md` の Tests に未反映でした。
- compare `main...docs/changelog-dependabot-bundler-package-guard`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 1 / deletions 0。
- diff は `CHANGELOG.md` の Tests 節へ 1 行追加のみです。
- GitHub Actions CI #3697 / run `28282138404`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` は `npm run test:docs-entrypoints` success、`test:ci-policy` / `test:js:core` / browser smoke は expected skipped。
  - representative `pr_rails_matrix` jobs: docs-only skip path で success。
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: expected skipped。
- local checkout / local docs checks は GitHub HTTPS raw access が 403 のため未実行です。PR CI で確認しました。

## リスク

low。merge済み package guard PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。