### PR TITLE
Strengthen public API docs signal guards

### DIFF
--- a/script/test_public_api_docs_signals.mjs
+++ b/script/test_public_api_docs_signals.mjs
@@ -212,6 +212,48 @@ const pathTreeBuilderNodeShapeSignals = [
   "record_node?"
 ]
 
+const persistedStateInstallGeneratorSignals = [
+  "setup_generators:",
+  "persisted_state_install:",
+  "tree_view:state:install",
+  "OWNER_MODEL",
+  "db/migrate/*_create_tree_view_states.rb",
+  "app/models/tree_view_state.rb",
+  "app/models/concerns/tree_view_state_owner.rb"
+]
+
+const persistedStateInstallDocsSignals = [
+  "tree_view:state:install",
+  "public-setup-surface.md",
+  "bin/rails generate tree_view:state:install User",
+  "db/migrate/*_create_tree_view_states.rb",
+  "app/models/tree_view_state.rb",
+  "app/models/concerns/tree_view_state_owner.rb"
+]
+
+const initialExpansionGroupedOptionSignals = [
+  "grouped_option_keys:",
+  "initial_expansion:",
+  "- default",
+  "- max_depth",
+  "- expanded_keys",
+  "- collapsed_keys",
+  "- current_item",
+  "- current_key",
+  "- auto_expand_ancestors"
+]
+
+const initialExpansionDocsSignals = [
+  "`initial_expansion`",
+  "`default`",
+  "`max_depth`",
+  "`expanded_keys`",
+  "`collapsed_keys`",
+  "`current_item`",
+  "`current_key`",
+  "`auto_expand_ancestors`"
+]
+
 const persistedStateLifecycleSignals = [
   "TreeView::PersistedState.from",
   "TreeView::StateStore",
@@ -272,7 +314,11 @@ const manifestBackedDocsSignalSurfaces = [
   ["diagnostics accepted checks", "accepted_checks:"],
   ["diagnostics run options", "run_options:"],
   ["diagnostics Result surface", "result_surface:"],
-  ["PathTreeBuilder node shapes", "path_tree_builder_node_shapes:"]
+  ["PathTreeBuilder node shapes", "path_tree_builder_node_shapes:"],
+  ["persisted-state install generator", "setup_generators:"],
+  ["persisted-state install generator", "persisted_state_install:"],
+  ["initial_expansion grouped option keys", "grouped_option_keys:"],
+  ["initial_expansion grouped option keys", "initial_expansion:"]
 ]
 
 manifestBackedDocsSignalSurfaces.forEach(([label, manifestNeedle]) => {
@@ -319,6 +365,14 @@ pathTreeBuilderNodeShapeSignals.forEach((signal) => {
   assertIncludes(manifest, signal, "public API manifest PathTreeBuilder node shape surface")
 })
 
+persistedStateInstallGeneratorSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest persisted-state install generator setup surface")
+})
+
+initialExpansionGroupedOptionSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest initial_expansion grouped option key surface")
+})
+
 publicConstantSignals.forEach((signal) => {
   assertIncludes(manifest, signal.replace("TreeView::", "- "), "public API manifest public constants surface")
 })
@@ -341,6 +395,15 @@ publicApiDocs.forEach(([relativePath, document]) => {
   assert(
     /callback arity|return[- ]value|return value|callback arity|戻り値/.test(document),
     `${relativePath}: RenderState callback builder docs no longer mention callback arity or return-value boundary`
+  )
+
+  initialExpansionDocsSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} RenderState initial_expansion grouped option docs`)
+  })
+
+  assert(
+    /flat keyword options.*`initial_expansion:`.*flat keyword options still win|個別 keyword option.*`initial_expansion:`.*優先されるのは個別 keyword option/.test(document),
+    `${relativePath}: initial_expansion docs no longer preserve flat keyword option priority over grouped options`
   )
 
   hostLifecycleSignals.forEach((signal) => {
@@ -566,6 +629,20 @@ pathTreeBuilderDocs.forEach(([relativePath, document]) => {
 })
 
 persistedStateDocs.forEach(([relativePath, document]) => {
+  persistedStateInstallDocsSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} persisted-state install generator setup surface docs`)
+  })
+
+  assert(
+    /generator name, optional owner argument, and generated destination paths|generator 名、任意の owner 引数、生成先 path/.test(document),
+    `${relativePath}: persisted-state docs no longer connect generator docs to the public setup surface contract`
+  )
+
+  assert(
+    /migration schema or generated template contents|migration schema や生成 template 内容/.test(document),
+    `${relativePath}: persisted-state docs no longer keep generated schema and templates outside the path-level setup contract`
+  )
+
   persistedStateLifecycleSignals.forEach((signal) => {
     assertIncludes(document, signal, `${relativePath} PersistedState / StateStore lifecycle docs`)
   })


### PR DESCRIPTION
## 対応 Issue

- Closes #2683
- Closes #2686

## Issue ごとの完了内容

- #2683: persisted-state install generator の public setup surface について、manifest 側の generator 名・optional owner 引数・生成先 path と、persisted-state docs 側の Public Setup Surface 導線・生成先 path・schema/template を固定しない境界文言を docs signal guard で確認するようにしました。
- #2686: `initial_expansion` grouped option keys について、manifest 側の key set と public API docs 側の documented keys / flat keyword option 優先境界を docs signal guard で確認するようにしました。

## 変更内容

- `script/test_public_api_docs_signals.mjs` に、persisted-state install generator setup surface と `initial_expansion` grouped option keys の signal list と assertions を追加しました。
- docs 本文、public API manifest、runtime behavior、UI、API contract は変更していません。

## 改善カテゴリ

- test
- docs signal guard
- release/compatibility drift prevention

## 既存仕様への影響

- 挙動変更なし。
- 公開 API、UI、DB schema、generator 出力、認可、外部サービス契約の変更なし。
- 既存 docs と manifest に既に存在する contract signal を検知対象に追加しただけです。

## 実施した確認

- Issue #2683 / #2686 の labels を個別確認し、`status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low` を満たすことを確認しました。
- 既存 open PR の review follow-up を確認し、今回の品質修正より優先すべき外部 review follow-up がないことを確認しました。
- `main` から branch 作成後、compare で `behind_by: 0` / `ahead_by: 1` を確認しました。
- compare で変更対象が `script/test_public_api_docs_signals.mjs` の 1 ファイルだけであることを確認しました。
- 対象 docs の実文言を connector で確認し、追加した signal が既存 docs / manifest に対応していることを確認しました。

## リスク評価

- risk: low
- 実行時コードや docs 本文を変更しないため、影響範囲は docs signal check の検知範囲追加に限定されます。

## 補足

- この環境から GitHub の clone / raw download は CONNECT 403 で遮断されたため、ローカルで full test command は実行できませんでした。PR CI で script 実行結果を確認します。