### PR TITLE
CHANGELOG に i18n parity exception guidance を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ Release preparation notes:
 - Added generator specs for persisted state owner concern injection.
 - Added RenderState specs for current node ancestor auto-expansion.
 - Added accessibility semantics integration specs for row ARIA state in static, collapsed, selection, and windowed rendering.
-- Added render traversal regression specs for deep trees, wide trees, collapsed render scope, filtered path trees, sorter call growth, children lookup scope, and max leaf distance behavior.
+- Added render traversal regression specs for deep trees, wide trees, collapsed render scope, filtered trees, sorter call growth, children lookup scope, and max leaf distance behavior.
 - Added specs for TreeView-specific error rescue behavior.
 - Added Ruby and JavaScript specs for client-side toggle mode, mode builders, public API exports, and browser-local descendant visibility updates.
 - Added specs for RenderState internal configuration objects and the consolidated diagnostics entrypoint.
@@ -234,7 +234,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked public JavaScript docs, including controller registration and selection checkbox hook docs.
 - Added gem package verification coverage for manifest-listed package-root JavaScript named exports in packaged `index.js` and `index.d.ts`.
 - Added gem package verification coverage for README-linked render log level docs so the packaged gem keeps the docs reached from README's render logging guidance.
-- Added Ruby version source guard coverage for the Rails 7.1 main-push matrix signal so workflow, Gemfile, and Development docs wording stay aligned.
+- Added Ruby version source guard coverage for the Rails 7.1 main-push matrix signal so workflow, Gemfile, Ruby version, and Development docs wording stay aligned.
 - Added release docs signal coverage for controller registration troubleshooting and public setup generator packaging guidance.
 - Added release and CI docs signal coverage for workflow action major versions, Ruby / Rails release evidence, and gem package install / require checks.
 - Added CI observation guidance signal coverage so maintainers verify GitHub Actions workflow runs when combined status is empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ Release preparation notes:
 - Added read-only workflow permissions guidance to CI policy suite docs so maintainers can review `GITHUB_TOKEN` token-scope evidence alongside the permissions guard.
 - Clarified repository-only maintainer docs routing in CI policy suite docs so AGENTS.md remains CI-policy-sensitive while Product Profile.md stays manual-review routed.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
+- Clarified Development docs for temporary docs i18n parity exceptions, including `parityExceptions` metadata and the boundary against permanent single-language docs.
 
 ### Tests
 
@@ -233,7 +234,7 @@ Release preparation notes:
 - Expanded package contents verification coverage for README-linked public JavaScript docs, including controller registration and selection checkbox hook docs.
 - Added gem package verification coverage for manifest-listed package-root JavaScript named exports in packaged `index.js` and `index.d.ts`.
 - Added gem package verification coverage for README-linked render log level docs so the packaged gem keeps the docs reached from README's render logging guidance.
-- Added Ruby version source guard coverage for the Rails 7.1 main-push matrix signal so workflow, Gemfile, Ruby version, and Development docs wording stay aligned.
+- Added Ruby version source guard coverage for the Rails 7.1 main-push matrix signal so workflow, Gemfile, and Development docs wording stay aligned.
 - Added release docs signal coverage for controller registration troubleshooting and public setup generator packaging guidance.
 - Added release and CI docs signal coverage for workflow action major versions, Ruby / Rails release evidence, and gem package install / require checks.
 - Added CI observation guidance signal coverage so maintainers verify GitHub Actions workflow runs when combined status is empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ Release preparation notes:
 - Added generator specs for persisted state owner concern injection.
 - Added RenderState specs for current node ancestor auto-expansion.
 - Added accessibility semantics integration specs for row ARIA state in static, collapsed, selection, and windowed rendering.
-- Added render traversal regression specs for deep trees, wide trees, collapsed render scope, filtered trees, sorter call growth, children lookup scope, and max leaf distance behavior.
+- Added render traversal regression specs for deep trees, wide trees, collapsed render scope, filtered path trees, sorter call growth, children lookup scope, and max leaf distance behavior.
 - Added specs for TreeView-specific error rescue behavior.
 - Added Ruby and JavaScript specs for client-side toggle mode, mode builders, public API exports, and browser-local descendant visibility updates.
 - Added specs for RenderState internal configuration objects and the consolidated diagnostics entrypoint.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2679
Refs #2684

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、merge済み PR #2684 の docs i18n parity exception guidance を release-facing evidence として追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、docs parity checker、Development docs 本文、public API manifest は変更していません。

## 確認内容

- Default PR Check として open PR を確認しました。
  - #2687: green / `behind_by:0` / review thread なし / review なし。
  - #2271: draft / design-held / browser-capable visual evidence と mockup inventory 同期待ちで `needs-human` 継続。重複コメントや追加修正は行っていません。
- current main の README / AGENTS.md / Product Profile / Development docs / CHANGELOG を確認しました。
- #2684 は merge済みで、英日 `docs/*/development.md` に `parityExceptions` metadata と恒久的な片言語 docs にしない境界が反映済みでした。
- 重複 PR / Issue 検索で同じ CHANGELOG 追従は見つかりませんでした。
- compare `main...docs/changelog-i18n-parity-exception-guidance-fresh`: `ahead_by:3` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 1 / deletions 0。
- 長い `CHANGELOG.md` の connector 全文更新後、commit patch と compare を確認し、意図しない deletion hunk は最終 diff に残していません。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs-only PR の release-facing evidence を CHANGELOG に1行記録するだけです。

merge は行いません。