### PR TITLE
Guard importmap setup docs signals

### DIFF
--- a/script/test_manifest_backed_public_surface_signals.mjs
+++ b/script/test_manifest_backed_public_surface_signals.mjs
@@ -160,6 +160,12 @@ const helperMethodDocsSignals = [
   "tree_view_toolbar_action_metadata(render_state, action, ...)"
 ]
 
+const javascriptEntrypointDocsSignals = [
+  "tree_view/index.js",
+  "registerTreeViewControllers(application)",
+  "config/public_api_manifest.yml"
+]
+
 assertAll(manifest, publicConstantSignals, "public API manifest public constants surface")
 assertAll(manifest, localizedNameManifestSignals, "public API manifest localized-name surface")
 assertAll(manifest, setupGeneratorManifestSignals, "public API manifest setup-generator surface")
@@ -182,6 +188,12 @@ assertDocs(
   ["docs/en/public-api.md", "docs/ja/public-api.md"],
   helperMethodDocsSignals,
   "manifest-backed public helper method docs"
+)
+
+assertDocs(
+  ["docs/en/public-api.md", "docs/ja/public-api.md"],
+  javascriptEntrypointDocsSignals,
+  "package-root JavaScript entrypoint docs"
 )
 
 assertDocs(

--- a/script/test_readme_quick_start_signal.mjs
+++ b/script/test_readme_quick_start_signal.mjs
@@ -28,7 +28,36 @@ function assertQuickStartSignal(signal, pattern, message) {
   assert(pattern.test(quickStart), `README.md Quick Start ${signal}: ${message}`)
 }
 
+function assertInstallationSignal(signal, pattern, message) {
+  assert(pattern.test(installation), `README.md Installation ${signal}: ${message}`)
+}
+
+const installation = extractSection(rootReadme, "Installation")
 const quickStart = extractSection(rootReadme, "Quick Start")
+
+assertInstallationSignal(
+  "CSS import",
+  /@import\s+"tree_view";/,
+  "missing the representative stylesheet import"
+)
+
+assertInstallationSignal(
+  "importmap pin",
+  /pin\s+"tree_view",\s+to:\s+"tree_view\/index\.js"/,
+  "missing the package-root importmap pin"
+)
+
+assertInstallationSignal(
+  "package-root JavaScript entrypoint",
+  /tree_view\/index\.js/,
+  "missing the package-root JavaScript entrypoint signal"
+)
+
+assertInstallationSignal(
+  "Public API JavaScript surface link",
+  /Public API JavaScript surface/,
+  "missing the JavaScript surface follow-up link"
+)
 
 assertQuickStartSignal(
   "controller label",


### PR DESCRIPTION
## 対応 Issue

- Closes #2682

## Issue ごとの完了内容

- #2682: README の Installation section にある `pin "tree_view", to: "tree_view/index.js"` / package-root entrypoint signal を `script/test_readme_quick_start_signal.mjs` で guard しました。
- #2682: 英日 Public API docs の JavaScript surface にある `tree_view/index.js` / `registerTreeViewControllers(application)` / manifest reference を `script/test_manifest_backed_public_surface_signals.mjs` で guard しました。

## 変更内容

- README quick start smoke に Installation section 用の focused assertion を追加しました。
- manifest-backed public surface smoke に package-root JavaScript entrypoint docs assertion を追加しました。

## 改善カテゴリ

- docs signal guard
- test hardening
- maintenance quality

## 既存仕様への影響

- Runtime Ruby / JavaScript behavior、public exports、importmap pin 名、package policy、CI workflow は変更していません。
- docs本文は変更せず、既存docsの代表 signal を guard するだけです。

## 実施した確認

- GitHub compare で `main...quality/2682-importmap-setup-signal` が `ahead_by: 2` / `behind_by: 0` であることを確認しました。
- 差分が次の2ファイルだけであることを確認しました。
  - `script/test_readme_quick_start_signal.mjs`
  - `script/test_manifest_backed_public_surface_signals.mjs`
- connector-only 更新後に両ファイルを再取得し、末尾 newline が残っていることを確認しました。

## 未実行の確認

- `npm run test:docs-entrypoints` は未実行です。今回の実行環境では GitHub clone が `CONNECT tunnel failed, response 403` で失敗し、ローカル workspace に repo を展開できませんでした。

## リスク評価

low。既存docsに存在する文字列の lightweight assertion 追加のみで、公開挙動や契約は変更していません。

## 補足

- 既存の package verification は `config/importmap.tree_view.rb` と installation docs の importmap pin signal も確認しているため、このPRでは README / Public API docs 側の docs-entrypoint signal を補強しています。