### PR TITLE
CI workflow の pull request concurrency policy を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -49,11 +49,22 @@ function assertMatrixFailFastPolicy(jobName, jobSource) {
 }
 
 function workflowTopLevelTriggerBlock(workflowSource) {
-  const match = workflowSource.match(/^on:\n(?<body>[\s\S]*?)\n\njobs:\n/m)
+  const match = workflowSource.match(/^on:\n(?<body>[\s\S]*?)\n\npermissions:\n/m)
 
   assert(
     match,
-    `${workflowPath} CI trigger policy must define a top-level on block before jobs`
+    `${workflowPath} CI trigger policy must define a top-level on block before permissions`
+  )
+
+  return match.groups.body
+}
+
+function workflowTopLevelConcurrencyBlock(workflowSource) {
+  const match = workflowSource.match(/^concurrency:\n(?<body>[\s\S]*?)\n\njobs:\n/m)
+
+  assert(
+    match,
+    `${workflowPath} CI concurrency policy must define a top-level concurrency block before jobs`
   )
 
   return match.groups.body
@@ -86,6 +97,26 @@ function assertWorkflowTriggerPolicy(workflowSource) {
     triggerBlock,
     "pull_request_target",
     `${workflowPath} CI trigger policy privilege boundary trigger`
+  )
+}
+
+function assertWorkflowConcurrencyPolicy(workflowSource) {
+  const concurrencyBlock = workflowTopLevelConcurrencyBlock(workflowSource)
+
+  assertIncludes(
+    concurrencyBlock,
+    "  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}",
+    `${workflowPath} CI concurrency policy group`
+  )
+  assertIncludes(
+    concurrencyBlock,
+    "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+    `${workflowPath} CI concurrency policy pull-request-only cancellation`
+  )
+  assertAbsent(
+    concurrencyBlock,
+    "cancel-in-progress: true",
+    `${workflowPath} CI concurrency policy must not cancel main push runs unconditionally`
   )
 }
 
@@ -129,6 +160,7 @@ function packageScript(scriptName) {
 }
 
 assertWorkflowTriggerPolicy(workflowSource)
+assertWorkflowConcurrencyPolicy(workflowSource)
 
 const changesJob = workflowJobBlock(workflowSource, "changes")
 const lintJob = workflowJobBlock(workflowSource, "lint")
@@ -372,6 +404,7 @@ assertOrdered(
 )
 
 console.log("Checked CI workflow trigger policy signals.")
+console.log("Checked CI workflow concurrency policy signals.")
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)
 console.log(`Checked ${workflowActionMajorSignals.length} workflow action major version signals.`)


### PR DESCRIPTION
## 対応 Issue

Closes #2483

## Issue ごとの完了内容

- #2483: CI workflow に workflow-level `concurrency` を追加し、PR head 更新時の stale run だけを cancel する方針を明示しました。
- `push` on `main` の release / package verification signal を弱めないよう、`cancel-in-progress` は `pull_request` イベントに限定しました。
- 既存 CI policy smoke に concurrency group / cancel 条件の代表 signal を追加しました。

## 変更内容

- `.github/workflows/ci.yml`
  - `concurrency.group` を workflow / event / PR number or ref で構成しました。
  - `cancel-in-progress` を `${{ github.event_name == 'pull_request' }}` に限定しました。
- `script/test_ci_workflow_changed_file_detection_signals.mjs`
  - top-level trigger block と concurrency block を別々に検査するようにしました。
  - PR-only cancellation と unconditional cancellation 不在を確認する guard を追加しました。

## 改善カテゴリ

- CI 改善
- テスト/guard 追加

## 既存仕様への影響

- runtime Ruby / JavaScript、public API、docs routing、changed-files routing、job matrix、Ruby / Node versions、required checks、branch protection、repository settings は変更していません。
- `push` on `main` の CI run は自動 cancel 対象にしていません。

## 実施した確認

- issue #2483 の labels を個別確認: `status:ready-for-agent`, `track:quality`, `agent:planned`, `risk:low`。
- review follow-up 確認: open self PR のうち #2271 は draft / browser evidence held、#2689 は merge済み、今回の実装対象外。
- duplicate PR 検索: #2483 / concurrency の既存 open PR は見当たりませんでした。
- compare `main...fix/2483-ci-concurrency-policy`: `ahead_by:2` / `behind_by:0`。
- changed files は以下2件のみです。
  - `.github/workflows/ci.yml`
  - `script/test_ci_workflow_changed_file_detection_signals.mjs`
- ローカル checkout / local test は GitHub HTTPS 制限 (`CONNECT tunnel failed, response 403`) により未実行です。PR CI を確認対象にします。

## リスク評価

low。変更は workflow-level concurrency と既存 policy smoke の代表 signal に限定しています。主リスクは concurrency group / cancel 条件の誤設定ですが、PR-only cancellation guard で保護しています。

## 補足

- #2688 は Workflow Manager により duplicate として #2483 に集約済みでした。
- merge は行いません。