### PR TITLE
CHANGELOG に Public API docs signal evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,8 @@ Release preparation notes:
 
 ### Tests
 
+- Added Public API docs signal coverage for persisted-state setup surface and `initial_expansion` grouped option keys so manifest-backed docs signals stay aligned.
+- Added README and Public API docs signal coverage for importmap package-root setup guidance so `tree_view/index.js` and `registerTreeViewControllers(application)` stay aligned.
 - Added Development docs signal coverage for npm lockfile drift recovery guidance so `npm install` / `npm ci` recovery boundaries stay aligned with package metadata drift guidance.
 - Added Development docs signal coverage for public API manifest duplicate-key guard guidance so duplicate YAML key handling stays visible in maintainer docs.
 - Expanded package contents verification coverage for Dependabot Bundler recovery docs so packaged gems keep scoped recovery guidance available.


### PR DESCRIPTION
## 対応 Issue / PR

Closes #2691
Refs #2687
Refs #2690
Refs #2682

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、merge済み #2687 の Public API docs signal guard evidence を追記しました。
- 直近 merge済み #2690 についても、README / Public API docs signal guard evidence が `CHANGELOG.md` に未反映だったため、同じ Tests 節へ 1 行追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、signal script、public API manifest、README、英日 docs 本文は変更していません。

## 確認内容

- Default PR Check として open self PR を確認しました。
  - #2692 は review-held / green の CI workflow guard PRで、Docs Sync Agentでは追加修正なし。その後 main に merge済みとなり、この branch は latest main へ載せ直しました。
  - #2271 は draft / design-held / browser-capable visual evidence と mockup inventory 同期待ちで `needs-human` 継続。重複コメントや追加修正は行っていません。
- current README / docs/README / AGENTS.md / Product Profile / Development docs / CHANGELOG を確認しました。
- #2691 は `status:ready-for-agent`, `track:docs`, `type:docs`, `risk:low` の CHANGELOG-only follow-up と確認しました。
- #2687 と #2690 は merge済みで、対象は docs signal guard の release-facing evidence だけです。
- compare `main...docs/2691-public-api-signal-changelog`: `ahead_by:1` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 2 / deletions 0。
- commit patch は `Unreleased > Tests` 先頭への 2 行追加のみです。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs signal guard PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。