### PR TITLE
config/importmap.tree_view.rb の docs entrypoint routing を保護する

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -83,6 +83,7 @@ function isDocsEntrypointSensitivePath(file) {
     file === "README.md" ||
     file === "CHANGELOG.md" ||
     file.startsWith("docs/") ||
+    file === "config/importmap.tree_view.rb" ||
     file === "config/public_api_manifest.yml"
   );
 }
@@ -100,6 +101,7 @@ function isCiPolicySensitivePath(file) {
     file === "script/test_ci_workflow_changed_file_detection_signals.mjs" ||
     file === "script/test_ci_workflow_permissions_signals.mjs" ||
     file === "script/test_ci_observation_guidance_signals.mjs" ||
+    file === "script/test_importmap_docs_entrypoint_routing.mjs" ||
     file === "script/test_package_lock_dependency_drift.mjs" ||
     file === "script/test_gemfile_lock_dependency_drift.mjs"
   );

--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -38,6 +38,11 @@ const checks = [
     args: ["script/test_ci_policy_docs_routing.mjs"]
   },
   {
+    group: "Importmap docs entrypoint routing signals",
+    command: "node",
+    args: ["script/test_importmap_docs_entrypoint_routing.mjs"]
+  },
+  {
     group: "Package lock dependency drift",
     command: "node",
     args: ["script/test_package_lock_dependency_drift.mjs"]

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -176,6 +176,10 @@ const docsEntrypointScriptExclusions = new Map([
     "registered through npm run test:ci-policy"
   ],
   [
+    "test_importmap_docs_entrypoint_routing.mjs",
+    "registered through npm run test:ci-policy"
+  ],
+  [
     "test_development_docs_command_signals.mjs",
     "registered through npm run test:development-docs-commands"
   ],

--- a/script/test_importmap_docs_entrypoint_routing.mjs
+++ b/script/test_importmap_docs_entrypoint_routing.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { classifyChangedFiles } from "./ci_changed_files_policy.mjs";
+
+const importmapPath = "config/importmap.tree_view.rb";
+const classification = classifyChangedFiles([importmapPath]);
+
+assert.deepEqual(
+  classification,
+  {
+    docs_only: false,
+    mockups_changed: false,
+    browser_smoke_changed: false,
+    package_sensitive: true,
+    docker_setup_sensitive: false,
+    docs_entrypoint_sensitive: true,
+    ci_policy_sensitive: false
+  },
+  `${importmapPath} changes must run package and docs entrypoint guards without changing workflow topology`
+);
+
+console.log("Checked importmap docs entrypoint routing.");


### PR DESCRIPTION
## 対応 Issue

- Closes #2694

## Issue ごとの完了内容

- #2694
  - `config/importmap.tree_view.rb` 変更時に `docs_entrypoint_sensitive: true` になるよう changed-files policy を更新しました。
  - `package_sensitive: true` は維持し、docs entrypoint guard と package guard の両方が走る routing として明文化しました。
  - importmap pin、JavaScript exports、runtime behavior、CI workflow topology は変更していません。

## 変更内容

- `script/ci_changed_files_policy.mjs`
  - `config/importmap.tree_view.rb` を docs entrypoint sensitive path に追加
  - 新規 guard script を CI policy sensitive path に追加
- `script/test_importmap_docs_entrypoint_routing.mjs`
  - importmap path 単体の classification を代表ケースとして追加
- `script/test_ci_policy_suite.mjs`
  - 新規 routing guard を CI policy suite から実行するよう登録
- `script/test_docs_entrypoint_suite.mjs`
  - 新規 guard script が docs entrypoint suite ではなく `test:ci-policy` 所有であることを明示

## 改善カテゴリ

- CI guard hardening
- test coverage
- docs/package routing の保守性改善

## 既存仕様への影響

- 公開 API、UI、DB、認可、状態遷移、runtime behavior は変更していません。
- CI workflow topology と required checks の構造も変更していません。

## 実施した確認

- GitHub connector 上で `main...fix/2694-importmap-docs-entrypoint-routing` を比較
  - branch は `main` から behind なし
  - 差分は CI policy / docs entrypoint suite ownership に関する意図した 4 ファイルのみ
- PR CI run #3712: success
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success (`test:ci-policy` と `test:js:core` を含む)
  - representative Rails matrix: success
- ローカル checkout はネットワーク制限で取得できなかったため、ローカル test/lint は未実行です。

## リスク評価

- risk: low
- changed-files policy とそのガード登録に閉じた変更で、runtime code には触れていません。

## 補足事項

- #2694 は `track:quality` / `track:docs` の low-risk maintenance CI guard issue として、既存仕様を変えずに routing signal を追加する範囲で対応しました。
