### PR TITLE
CI concurrency policy を CI policy suite docs に追記する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -34,6 +34,14 @@ For pull requests, the `changes` job fetches the base branch, then tries to find
 
 The resulting file list is passed to `script/ci_changed_files_policy.mjs`, which is the source of truth for the `docs_only`, `package_sensitive`, `docker_setup_sensitive`, `docs_entrypoint_sensitive`, and `ci_policy_sensitive` outputs. `script/test_ci_workflow_changed_file_detection_signals.mjs` protects the workflow command signals; this note explains the maintainer-facing meaning of that routing and does not change the classification logic.
 
+## Pull request run concurrency
+
+The CI workflow uses workflow-level `concurrency` so a newer pull request head can cancel older runs for the same pull request. The group is built from the workflow name, event name, and pull request number or ref, which keeps unrelated pull requests and `main` runs separate.
+
+`cancel-in-progress` is intentionally limited to the `pull_request` event. Pushes to `main` still run to completion so release and package verification evidence is not weakened by a later push. Treat a canceled pull request run as stale-head evidence; review readiness should come from the workflow run for the current head SHA.
+
+`script/test_ci_workflow_changed_file_detection_signals.mjs` protects the representative concurrency signals, including the PR-only cancellation condition and the absence of unconditional `cancel-in-progress: true`. This note explains how maintainers should read that policy; it does not change workflow routing, required checks, branch protection, or CI polling behavior.
+
 ## Representative routing outputs
 
 The changed-file policy exposes representative output flags rather than a full repository inventory. Use these examples as review guidance when reading a pull request's `changes` output:

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -34,6 +34,14 @@ Pull Request では、`changes` job が base branch を fetch し、`origin/${{ 
 
 得られた file list は `script/ci_changed_files_policy.mjs` に渡されます。この script が `docs_only`、`package_sensitive`、`docker_setup_sensitive`、`docs_entrypoint_sensitive`、`ci_policy_sensitive` output の source of truth です。`script/test_ci_workflow_changed_file_detection_signals.mjs` は workflow command signal を守ります。このメモは、その routing の保守者向けの意味を説明するだけで、classification logic は変更しません。
 
+## Pull request run concurrency
+
+CI workflow は workflow-level `concurrency` を使い、同じ Pull Request で head が更新された場合に古い run を cancel できるようにしています。group は workflow 名、event 名、Pull Request number または ref から作られるため、別の Pull Request や `main` run とは分離されます。
+
+`cancel-in-progress` は意図的に `pull_request` event だけに限定しています。`main` への push は最後まで走らせるため、release / package verification evidence を後続 push で弱めません。cancel された Pull Request run は stale head の evidence として扱い、review readiness は current head SHA の workflow run で判断してください。
+
+`script/test_ci_workflow_changed_file_detection_signals.mjs` は、PR-only cancellation 条件と無条件の `cancel-in-progress: true` がないことを含む代表 concurrency signal を守ります。このメモは保守者がその policy をどう読むかを説明するだけで、workflow routing、required checks、branch protection、CI polling behavior は変更しません。
+
 ## Representative routing outputs
 
 changed-file policy は、repository 全体の file inventory ではなく代表的な output flag を公開します。Pull Request の `changes` output を読む時は、次の例を review guidance として扱ってください。


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2483
Refs #2692

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- 英日 `docs/*/ci-policy-suite.md` に `Pull request run concurrency` 節を追加しました。
- PR head 更新時は古い pull request run を cancel できること、`main` push run は release / package verification evidence を弱めないため完走させることを説明しました。
- canceled PR run は stale-head evidence として扱い、current head SHA の workflow run を review readiness の根拠にすることを明記しました。

## Scope

- docs-only です。
- 変更ファイルは以下 2 件のみです。
  - `docs/en/ci-policy-suite.md`
  - `docs/ja/ci-policy-suite.md`
- `.github/workflows/ci.yml`、`script/**`、package scripts、required checks、branch protection、runtime Ruby / JavaScript は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2696 は fresh / green の quality guard PRで、Docs Sync Agentでは追加修正なし。その後 main に mergeされたため、この PR branch は latest main へ載せ直しました。
  - #2271 は draft / design-held / browser-capable visual evidence と mockup inventory 同期待ちで `needs-human` 継続。
- #2692 / #2483 は main に merge済みで、workflow-level concurrency と PR-only cancellation guard が入っていることを確認しました。
- current `AGENTS.md`, `Product Profile.md`, `README.md`, `docs/README.md`, `CHANGELOG.md`, 英日 Release docs / CI policy suite docs を確認しました。
- final compare `main...docs/ci-concurrency-policy-suite`: `ahead_by:3` / `behind_by:0` / changed files 2件 / additions 16 / deletions 0。
- head `7f655bad639ff16b411fb55fec5dc4e679b252cf` の GitHub Actions CI #3715 / run `28293123477`: success。
  - `lint`, `pr_specs`, `gem_package`, `javascript`: success。
  - `javascript` は `npm run test:docs-entrypoints` と `npm run test:ci-policy` success、`test:js:core` / browser smoke は expected skipped。
  - representative Rails lanes は docs-only skip path で success。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。merge済み CI workflow behavior の maintainer-facing docs を補うだけで、CI behavior や guard 実装は変更しません。

merge は行いません。