### PR TITLE
Document package verification entrypoint release signals

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -211,6 +211,12 @@ Before release:
 
 Because `docs/**/*` is packaged, keep package-facing docs independent from repository-only maintainer docs. `Product Profile.md` and `AGENTS.md` stay repository-only; do not add encoded parent-directory links from packaged docs back to those root-only files. The package contents guard reports `Forbidden repository-only root doc links in packaged <path>` when that boundary drifts.
 
+## Package verification signals
+
+The package contents guard also verifies package-root JavaScript entrypoint and importmap signals. Keep `config/public_api_manifest.yml` `javascript_package_root.named_exports` aligned with packaged `app/javascript/tree_view/index.js` and `app/javascript/tree_view/index.d.ts`; when a manifest-listed export is absent, the guard reports `Missing manifest-listed JavaScript package-root named exports in packaged <path>`. This is release evidence only, so do not add or rename public JavaScript exports from this checklist alone.
+
+The same package verification checks that `config/importmap.tree_view.rb` keeps `pin "tree_view", to: "tree_view/index.js"` packaged for host apps that install the gem through importmap. This guards packaging evidence only; importmap setup behavior and public API semantics belong to the PR that intentionally changes those surfaces.
+
 ## Repository
 
 - Confirm `main` is green before tagging.

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -211,6 +211,12 @@ release前に確認すること:
 
 `docs/**/*` は packaged docs としてgemに含まれるため、package-facing docs は repository-only maintainer docs から独立させます。`Product Profile.md` と `AGENTS.md` は repository-only のまま扱い、packaged docs から repository root 専用文書へ戻る encoded parent-directory link を追加しないでください。この境界が崩れると、package contents guard は `Forbidden repository-only root doc links in packaged <path>` として対象 path を報告します。
 
+## Package verification signals
+
+package contents guard は package-root JavaScript entrypoint と importmap の代表 signal も確認します。`config/public_api_manifest.yml` の `javascript_package_root.named_exports` を、packaged `app/javascript/tree_view/index.js` と `app/javascript/tree_view/index.d.ts` にそろえてください。manifest-listed export が欠けた場合、guard は `Missing manifest-listed JavaScript package-root named exports in packaged <path>` を報告します。これは release evidence の確認だけなので、この checklist だけを根拠に public JavaScript export を追加・rename しないでください。
+
+同じ package verification は、importmap で gem を導入する host app 向けに `config/importmap.tree_view.rb` が `pin "tree_view", to: "tree_view/index.js"` を packaged file として維持していることも確認します。これは packaging evidence の guard であり、importmap setup behavior や public API semantics の変更は、その surface を意図的に変更する PR に閉じます。
+
 ## Repository
 
 - `main` がgreenであることを確認する

--- a/script/test_release_docs_signals.mjs
+++ b/script/test_release_docs_signals.mjs
@@ -380,3 +380,51 @@ const releaseNoteCandidateDocs = [
 releaseNoteCandidateDocs.forEach(([sourcePath, signals]) => {
   assertSignals(sourcePath, "Release note candidate docs", signals)
 })
+
+const packageVerificationEntrypointSignals = [
+  [
+    "script/check_gem_package_contents.rb",
+    [
+      "JAVASCRIPT_PACKAGE_ROOT_PATH",
+      "TYPESCRIPT_PACKAGE_ROOT_PATH",
+      "javascript_package_root",
+      "named_exports",
+      "Missing manifest-listed JavaScript package-root named exports in packaged",
+      "importmap_pin_missing",
+      "Missing TreeView importmap pin in config/importmap.tree_view.rb:",
+      "pin \\\"tree_view\\\", to: \\\"tree_view/index.js\\\""
+    ]
+  ],
+  [
+    "docs/en/release.md",
+    [
+      "Package verification signals",
+      "config/public_api_manifest.yml",
+      "javascript_package_root.named_exports",
+      "app/javascript/tree_view/index.js",
+      "app/javascript/tree_view/index.d.ts",
+      "Missing manifest-listed JavaScript package-root named exports in packaged <path>",
+      "do not add or rename public JavaScript exports from this checklist alone",
+      "config/importmap.tree_view.rb",
+      "pin \"tree_view\", to: \"tree_view/index.js\""
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "Package verification signals",
+      "config/public_api_manifest.yml",
+      "javascript_package_root.named_exports",
+      "app/javascript/tree_view/index.js",
+      "app/javascript/tree_view/index.d.ts",
+      "Missing manifest-listed JavaScript package-root named exports in packaged <path>",
+      "public JavaScript export を追加・rename しないでください",
+      "config/importmap.tree_view.rb",
+      "pin \"tree_view\", to: \"tree_view/index.js\""
+    ]
+  ]
+]
+
+packageVerificationEntrypointSignals.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Package verification entrypoint release signal", signals)
+})


### PR DESCRIPTION
## 対応 Issue

- Closes #2699
- Closes #2700

## Issue ごとの完了内容

- #2699: importmap pin の package verification が `config/importmap.tree_view.rb` の `pin "tree_view", to: "tree_view/index.js"` を確認することを release docs に明記し、release docs smoke で同じ代表シグナルを検査するようにしました。
- #2700: manifest-backed package-root named exports guard が `javascript_package_root.named_exports`、`app/javascript/tree_view/index.js`、`app/javascript/tree_view/index.d.ts` を対象にすることを release docs に明記し、release docs smoke で同じ代表シグナルを検査するようにしました。

## 変更内容

- `docs/en/release.md` と `docs/ja/release.md` に `Package verification signals` 節を追加しました。
- `script/test_release_docs_signals.mjs` に package verification entrypoint / importmap の代表シグナル検査を追加しました。

## 改善カテゴリ

- docs
- test / docs smoke
- package verification signal guard

## 既存仕様への影響

- 既存仕様、公開 API、importmap setup behavior、package-root exports は変更していません。
- 既存 guard の検査対象を release docs 上で見える化し、docs smoke で drift を検出するだけの変更です。

## 実施した確認

- GitHub connector で対象 Issue の labels を個別確認しました。
- 自分作成の open PR を確認し、今回対応可能な review follow-up がないことを確認しました。
- `main` から作成したブランチで、差分が `docs/en/release.md`、`docs/ja/release.md`、`script/test_release_docs_signals.mjs` の3ファイルに限定されていることを `main...head` 比較で確認しました。
- この実行環境から GitHub raw / git clone への直接ネットワーク接続が 403 で失敗したため、ローカルのフル `npm run test:docs-entrypoints` は未実行です。PR CI の docs-entrypoint lane で検証してください。

## リスク評価

- risk: low
- 文書と smoke 追加のみで、runtime や CI workflow の挙動は変更しません。

## 補足事項

- #2699 と #2700 はどちらも `script/check_gem_package_contents.rb` に既に存在する package verification guard の release-facing signal を明確化する内容なので、1つの docs/smoke 変更としてまとめています。
