### PR TITLE
CI workflow permissions policy を smoke で守る

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -59,6 +59,17 @@ function workflowTopLevelTriggerBlock(workflowSource) {
   return match.groups.body
 }
 
+function workflowTopLevelPermissionsBlock(workflowSource) {
+  const match = workflowSource.match(/^permissions:\n(?<body>[\s\S]*?)\n\nconcurrency:\n/m)
+
+  assert(
+    match,
+    `${workflowPath} CI permissions policy must define a top-level permissions block before concurrency`
+  )
+
+  return match.groups.body
+}
+
 function workflowTopLevelConcurrencyBlock(workflowSource) {
   const match = workflowSource.match(/^concurrency:\n(?<body>[\s\S]*?)\n\njobs:\n/m)
 
@@ -97,6 +108,31 @@ function assertWorkflowTriggerPolicy(workflowSource) {
     triggerBlock,
     "pull_request_target",
     `${workflowPath} CI trigger policy privilege boundary trigger`
+  )
+}
+
+function assertWorkflowPermissionsPolicy(workflowSource) {
+  const permissionsBlock = workflowTopLevelPermissionsBlock(workflowSource)
+
+  assertIncludes(
+    permissionsBlock,
+    "  contents: read",
+    `${workflowPath} CI permissions policy repository contents token scope`
+  )
+  assertAbsent(
+    permissionsBlock,
+    "contents: write",
+    `${workflowPath} CI permissions policy must not grant repository contents write access`
+  )
+  assertAbsent(
+    permissionsBlock,
+    "write-all",
+    `${workflowPath} CI permissions policy must not use broad write-all access`
+  )
+  assertAbsent(
+    permissionsBlock,
+    "pull-requests: write",
+    `${workflowPath} CI permissions policy must not grant pull request write access`
   )
 }
 
@@ -160,6 +196,7 @@ function packageScript(scriptName) {
 }
 
 assertWorkflowTriggerPolicy(workflowSource)
+assertWorkflowPermissionsPolicy(workflowSource)
 assertWorkflowConcurrencyPolicy(workflowSource)
 
 const changesJob = workflowJobBlock(workflowSource, "changes")
@@ -404,6 +441,7 @@ assertOrdered(
 )
 
 console.log("Checked CI workflow trigger policy signals.")
+console.log("Checked CI workflow permissions policy signals.")
 console.log("Checked CI workflow concurrency policy signals.")
 console.log("Checked CI changed-file detection workflow signals.")
 console.log(`Checked ${Object.keys(nonPullRequestDefaultOutputs).length} non-pull-request workflow default outputs.`)


### PR DESCRIPTION
## 対応 Issue

Closes #2712

## Issue ごとの完了内容

- #2712: `.github/workflows/ci.yml` の top-level `permissions` block が `contents: read` を維持し、`contents: write` / `write-all` / `pull-requests: write` へ広がった場合に既存 CI policy smoke で検出できるようにしました。

## 変更内容

- `script/test_ci_workflow_changed_file_detection_signals.mjs` に top-level permissions block 抽出 helperを追加しました。
- 既存の trigger / concurrency policy guard と同じ流れで `assertWorkflowPermissionsPolicy()` を実行するようにしました。
- smoke 完了ログに permissions policy signal の確認行を追加しました。
- `.github/workflows/ci.yml`、package scripts、CI job topology、required checks は変更していません。

## 改善カテゴリ

- test
- CI policy guard
- security/devops hardening

## 既存仕様への影響

- workflow behavior、runtime Ruby / JavaScript、public API、DB、認可、外部サービス契約は変更していません。
- 既存 workflow の最小権限設定を検知対象に加えた test-only 変更です。

## 実施した確認

- Issue labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`。
- 重複 open PR 検索: #2712 / CI workflow permissions の既存 open PR は見当たりませんでした。
- current main の `.github/workflows/ci.yml`, `script/test_ci_workflow_changed_file_detection_signals.mjs`, `package.json` を確認しました。
- branch freshness: `main...quality/2712-ci-permissions-policy-smoke` は `ahead_by:1` / `behind_by:0` / `status:ahead`。
- PR #2713 は open / non-draft / `mergeable:true`、head `e039bb3c6d637428aa76a93fa744a03f55c4bba4`。
- changed files: `script/test_ci_workflow_changed_file_detection_signals.mjs` のみ。
- GitHub Actions CI #3726 / run `28302171067`: success。
  - `lint`, `pr_specs`, `javascript`, `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0 が success。
  - `javascript` job は `npm run test:ci-policy` と `npm run test:js:core` に到達しました。
  - `gem_package`, `docker_development_setup`, main-only matrix jobs は route policy どおり skipped です。
- local checkout / local tests は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク評価

low。workflow 本体は変更せず、既存の CI policy smoke の代表 signal を増やすだけです。

## 補足事項

- GitHub Actions token permission model の全面設計、SHA pinning / allowed action policy、repository settings / branch protection は非対象です。
- merge は行いません。