### PR TITLE
CHANGELOG に CI docs signal evidence を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,8 @@ Release preparation notes:
 
 ### Tests
 
+- Added CI policy guard evidence for public API manifest structure, Dependabot routing, and browser-smoke routing boundaries so entrypoint and CI policy checks stay aligned.
+- Added Development docs command signal coverage for `npm run test:development-docs-commands` so narrow and suite-level maintainer command checks stay discoverable.
 - Added Public API docs signal coverage for persisted-state setup surface and `initial_expansion` grouped option keys so manifest-backed docs signals stay aligned.
 - Added README and Public API docs signal coverage for importmap package-root setup guidance so `tree_view/index.js` and `registerTreeViewControllers(application)` stay aligned.
 - Added Development docs signal coverage for npm lockfile drift recovery guidance so `npm install` / `npm ci` recovery boundaries stay aligned with package metadata drift guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Release preparation notes:
 
 ### Tests
 
+- Added CI workflow permissions policy smoke coverage so read-only token permissions stay guarded against write-scope drift.
 - Added CI policy guard evidence for public API manifest structure, Dependabot routing, and browser-smoke routing boundaries so entrypoint and CI policy checks stay aligned.
 - Added Development docs command signal coverage for `npm run test:development-docs-commands` so narrow and suite-level maintainer command checks stay discoverable.
 - Added Public API docs signal coverage for persisted-state setup surface and `initial_expansion` grouped option keys so manifest-backed docs signals stay aligned.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2707
Refs #2711
Refs #2713
Refs #2695
Refs #2697
Refs #2678
Refs #2708
Refs #2712

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、merge済み PR #2707 の CI policy guard evidence を追記しました。
- 同じく merge済み PR #2711 の Development docs command signal coverage を追記しました。
- follow-up として、merge済み PR #2713 の CI workflow permissions policy smoke coverage も同じ Tests 節へ追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script、英日 Development docs 本文は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2715 は open / non-draft / `mergeable:true` で、レビューコメント・review thread はありませんでした。
  - #2271 は draft / design proposal / README・gallery・browser evidence 待ちの `needs-human` 継続で、重複コメントや追加修正は行っていません。
- #2507 は current main で docs本文導線が整合済みで、残件は script / smoke guard 側と確認しました。
- #2336 は current Release docs が PR JavaScript conditional lanes を反映済みと確認しました。
- #2707、#2711、#2713 は merge済みで、対象は release-facing evidence のみです。
- compare `main...docs/changelog-ci-docs-signal-evidence-2711`: `ahead_by:2` / `behind_by:0` / changed files `CHANGELOG.md` 1件 / additions 3 / deletions 0。
- commit patch は `Unreleased > Tests` 先頭への 3 行追加のみです。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs / CI policy signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。