### PR TITLE
CI policy routing for workflow and permissions docs signal changes

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -52,6 +52,10 @@ function isDocsOnlyPath(file) {
   );
 }
 
+function isWorkflowDefinitionPath(file) {
+  return file.startsWith(".github/workflows/") && (file.endsWith(".yml") || file.endsWith(".yaml"));
+}
+
 function isPackageSensitivePath(file) {
   return (
     file === "README.md" ||
@@ -91,7 +95,7 @@ function isDocsEntrypointSensitivePath(file) {
 function isCiPolicySensitivePath(file) {
   return (
     file === "AGENTS.md" ||
-    file === ".github/workflows/ci.yml" ||
+    isWorkflowDefinitionPath(file) ||
     file === ".github/dependabot.yml" ||
     file === "docs/en/ci-policy-suite.md" ||
     file === "docs/ja/ci-policy-suite.md" ||
@@ -101,6 +105,7 @@ function isCiPolicySensitivePath(file) {
     file === "script/test_ci_policy_docs_routing.mjs" ||
     file === "script/test_ci_workflow_changed_file_detection_signals.mjs" ||
     file === "script/test_ci_workflow_permissions_signals.mjs" ||
+    file === "script/test_ci_policy_permissions_docs_signals.mjs" ||
     file === "script/test_ci_observation_guidance_signals.mjs" ||
     file === "script/test_importmap_docs_entrypoint_routing.mjs" ||
     file === "script/test_package_lock_dependency_drift.mjs" ||

--- a/script/test_ci_policy_permissions_docs_signals.mjs
+++ b/script/test_ci_policy_permissions_docs_signals.mjs
@@ -1,8 +1,26 @@
 import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
+import { classifyChangedFiles } from "./ci_changed_files_policy.mjs"
 
 function assertIncludes(source, needle, label) {
   assert.ok(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+function assertCiPolicyRouting(file, expected, label) {
+  assert.deepEqual(
+    classifyChangedFiles([file]),
+    {
+      docs_only: false,
+      mockups_changed: false,
+      browser_smoke_changed: false,
+      package_sensitive: false,
+      docker_setup_sensitive: false,
+      docs_entrypoint_sensitive: false,
+      ci_policy_sensitive: true,
+      ...expected
+    },
+    label
+  )
 }
 
 const docsSignals = [
@@ -52,4 +70,24 @@ for (const [docsPath, signals] of docsSignals) {
   }
 }
 
+assertCiPolicyRouting(
+  "script/test_ci_policy_permissions_docs_signals.mjs",
+  {},
+  "permissions docs signal guard changes must request the CI policy guard"
+)
+assertCiPolicyRouting(
+  ".github/workflows/release.yaml",
+  {},
+  "workflow YAML changes must request the CI policy guard"
+)
+assertCiPolicyRouting(
+  ".github/workflows/ci.yml",
+  {
+    package_sensitive: true,
+    docker_setup_sensitive: true
+  },
+  "the main CI workflow must keep package, Docker, and CI policy guard routing"
+)
+
 console.log("Checked CI policy read-only workflow permissions docs signals.")
+console.log("Checked CI policy routing for permissions docs signal and workflow changes.")


### PR DESCRIPTION
## 対応 Issue

- Closes #2716
- Closes #2717

## Issue ごとの完了内容

- #2716: `.github/workflows/*.yml` / `.github/workflows/*.yaml` を CI policy-sensitive として扱うようにし、CI workflow 変更時に `test:ci-policy` が走る代表ケースを追加しました。
- #2717: `script/test_ci_policy_permissions_docs_signals.mjs` を CI policy-sensitive path に追加し、この guard 自身の変更でも CI policy guard が走る代表ケースを追加しました。

## 変更内容

- `script/ci_changed_files_policy.mjs`
  - workflow 定義ファイルを判定する小さな helper を追加しました。
  - `.github/workflows/ci.yml` のみだった CI policy routing を `.github/workflows/*.yml` / `*.yaml` に広げました。
  - permissions docs signal guard script を CI policy-sensitive list に追加しました。
- `script/test_ci_policy_permissions_docs_signals.mjs`
  - 既存の docs signal guard に、今回の routing 代表ケースを追加しました。

## 改善カテゴリ

- test
- CI policy guard coverage
- 小さな内部整理

## 既存仕様への影響

公開API、UI、DB、認可、workflow topology、permissions 設定、外部サービス契約は変更していません。変更ファイル分類で `ci_policy_sensitive` が true になる対象を追加するだけで、既存の `.github/workflows/ci.yml` に対する package/Docker routing は維持しています。

## 確認内容

- GitHub connector compare: `main...quality/2716-2717-ci-policy-routing` が `behind_by: 0`、変更ファイルは意図した2ファイルのみ
- 手元 Node 代表確認: permissions docs signal script、workflow `.yaml`、既存 `ci.yml` の分類結果が期待どおり

ローカル `git ls-remote` は CONNECT tunnel 403 のため clone できず、repository 全体の `npm run test:ci-policy` は手元では未実行です。PR作成後にCI状態を確認します。

## リスク評価

- risk: low
- CI policy routing の追加のみで、既存の job 定義や実行コマンドは変更していません。

## 補足事項

3対象repoの確認結果として、`rails_fields_kit` は eligible な ready quality issue なし、既存open PRは browser-capable visual evidence 待ちでした。`rails_table_preferences` の eligible issue は既存コメントどおり browser / large source evidence が必要な停止条件のため、このPRには含めていません。