### PR TITLE
Dependabot Bundler recovery docs の signal guard を追加する

### DIFF
--- a/script/test_docs_entrypoint_signals.mjs
+++ b/script/test_docs_entrypoint_signals.mjs
@@ -270,6 +270,55 @@ const signalGroups = [
     ]
   },
   {
+    feature: "Dependabot Bundler recovery maintainer routing",
+    files: [
+      [
+        "docs/en/README.md",
+        ["dependabot-bundler-recovery.md", "Dependabot Bundler recovery"]
+      ],
+      [
+        "docs/ja/README.md",
+        ["dependabot-bundler-recovery.md", "Dependabot Bundler 復旧手順"]
+      ],
+      [
+        "docs/en/development.md",
+        [
+          "Bundler lockfile drift guard",
+          "Dependabot Bundler recovery",
+          "dependabot-bundler-recovery.md",
+          "@dependabot recreate"
+        ]
+      ],
+      [
+        "docs/ja/development.md",
+        [
+          "Bundler lockfile drift guard",
+          "Dependabot Bundler 復旧手順",
+          "dependabot-bundler-recovery.md",
+          "@dependabot recreate"
+        ]
+      ],
+      [
+        "docs/en/dependabot-bundler-recovery.md",
+        [
+          "Gemfile.lock DEPENDENCIES must match direct Gemfile gem requirements",
+          "lockfile metadata drift",
+          "@dependabot recreate",
+          "Style/RedundantStructKeywordInit"
+        ]
+      ],
+      [
+        "docs/ja/dependabot-bundler-recovery.md",
+        [
+          "Gemfile.lock DEPENDENCIES must match direct Gemfile gem requirements",
+          "lockfile metadata drift",
+          "@dependabot recreate",
+          "Style/RedundantStructKeywordInit"
+        ]
+      ]
+    ]
+  },
+  {
     feature: "Row status and depth label docs boundary",
     files: [
       [


### PR DESCRIPTION
## 対応 Issue

Closes #2507

## Issue ごとの完了内容

- #2507: Dependabot Bundler recovery docs への maintainer 導線が docs entrypoint signal smoke で落ちないよう、既存の `script/test_docs_entrypoint_signals.mjs` に focused signal group を追加しました。

## 変更内容

- `docs/en/README.md` / `docs/ja/README.md` から recovery note へ到達できることを signal 化しました。
- `docs/en/development.md` / `docs/ja/development.md` の Bundler lockfile drift guard から recovery note と `@dependabot recreate` へ到達できることを確認します。
- 英日 `docs/*/dependabot-bundler-recovery.md` が lockfile metadata drift、`@dependabot recreate`、#2150 側の `Style/RedundantStructKeywordInit` 分離を説明し続けることを確認します。

## 改善カテゴリ

- docs signal / smoke guard
- maintenance docs discoverability

## 既存仕様への影響

ありません。runtime Ruby / JavaScript、CI workflow、Dependabot config、Gemfile / Gemfile.lock、package verification には触れていません。

## 確認内容

- Issue 詳細で `status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low` を確認しました。
- PR branch は `main` から `ahead_by:1` / `behind_by:0` です。
- changed files は `script/test_docs_entrypoint_signals.mjs` 1件のみです。
- 追加した各 signal は connector で取得した current main の docs 内容に存在することを確認しました。
- local checkout / local `npm run test:docs-entrypoints -- --only "Docs entrypoint signals"` は GitHub raw/clone が `403` で失敗するため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存 docs の導線を守る smoke signal の追加に限定され、公開挙動や依存関係、release/package guard には影響しません。

## 補足

#2150 の `Style/RedundantStructKeywordInit` baseline cleanup は挙動境界の確認が必要な別 Issue のまま残し、この PR には含めていません。