### PR TITLE
review gallery の visual evidence 境界を補足する

### DIFF
--- a/docs/mockups/review-gallery.html
+++ b/docs/mockups/review-gallery.html
@@ -57,7 +57,7 @@
 
     <section class="mock-section" aria-labelledby="gallery-usage-heading">
       <h2 id="gallery-usage-heading">How to use this gallery</h2>
-      <ul><li>Start here when a review needs quick side-by-side comparison across the baseline and focused mockup surfaces.</li><li>Use the family index to jump to the first card in a related review path before scanning the full gallery.</li><li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li></ul>
+      <ul><li>Start here when a review needs quick side-by-side comparison across the baseline and focused mockup surfaces.</li><li>Use the family index to jump to the first card in a related review path before scanning the full gallery.</li><li>Treat embedded previews as fast orientation only. Merge-grade visual evidence still comes from opening the target mockup directly in desktop and narrow viewports and recording readability, overlap, and clipping results in the PR discussion.</li><li>Treat final business copy, routes, permissions, and actions as host-app responsibilities. This gallery stays product-neutral on purpose.</li></ul>
       <nav class="mock-gallery-review-paths" aria-labelledby="gallery-review-paths-heading">
         <h2 id="gallery-review-paths-heading">Review paths</h2>
         <p>Choose the review family that matches the question first, then open the linked full mockup when one surface needs deeper inspection.</p>
@@ -141,6 +141,7 @@
     <section class="mock-section" aria-labelledby="comparison-heading">
       <h2 id="comparison-heading">Comparison cues</h2>
       <table class="mock-comparison-table"><thead><tr><th scope="col">Surface</th><th scope="col">Best for</th><th scope="col">Keep outside scope</th></tr></thead><tbody>
+        <tr><td>Gallery preview</td><td>Fast orientation, family routing, and first-pass side-by-side scanning before opening a focused mockup.</td><td>Final visual evidence; record desktop and narrow viewport readability, overlap, and clipping checks from the target full page in the PR discussion.</td></tr>
         <tr><td>Foundation and layout</td><td>Baseline tree structure, first render, table bridge, page context, icon states, and responsive sidebar scans.</td><td>Host-app page IA, saved table state, final row actions, or production responsive breakpoints.</td></tr>
         <tr><td>Interaction and state</td><td>Loading, retry, children pagination, drag/drop, persisted state, Turbo target, and windowed-rendering boundaries.</td><td>Remote fetch behavior, persistence policy, reorder authorization, Turbo responses, or host-app retry copy.</td></tr>
         <tr><td>Accessibility review cues</td><td>Focus-visible samples, table-first ARIA placement, current-row styling, contrast checks, direction stress, and localized-width review.</td><td>Full keyboard model, treegrid promotion, final locale policy, or public styling hook decisions.</td></tr>


### PR DESCRIPTION
## 対応 Issue

Closes #2720

## 判定分類

- `docs-sync`
- `docs-missing`

## 変更内容

- `docs/mockups/review-gallery.html` の `How to use this gallery` に、embedded preview は fast orientation であり、merge-grade visual evidence は対象 mockup を desktop / narrow viewport で直接確認して PR discussion に残すことを追記しました。
- `Comparison cues` に `Gallery preview` 行を追加し、gallery preview と final visual evidence の責務差を明記しました。

## Scope

- docs-only です。
- 変更ファイルは `docs/mockups/review-gallery.html` 1件のみです。
- runtime Ruby / JavaScript、browser smoke inventory、screenshot baseline、mockup implementation、CI workflow は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2721 は review comment / thread なし、CI #3733 success、changed files は script 1件で、Docs Sync の docs-only follow-up対象外でした。その後 main に merge済みです。
  - #2271 は draft / design proposal / browser-capable visual evidence と mockup inventory 同期待ちの `needs-human` 継続で、この PR では触っていません。
- current `README.md`, `docs/README.md`, `AGENTS.md`, `Product Profile.md`, `docs/mockups/README.md`, `docs/mockups/review-gallery.html`, Issue #2720 を確認しました。
- `docs/mockups/README.md` には Visual evidence handoff が既にあり、この PR は gallery 側の入口 copy だけを補います。
- final compare `main...docs/2720-review-gallery-evidence-boundary-v2`: `ahead_by:1` / `behind_by:0` / changed files 1件 / additions 2 / deletions 1。
- PR #2724 は open / non-draft / `mergeable:true`、head `646eb4dbb9a8edbac51b085e0f83f3eb73631037`。
- GitHub Actions CI #3735 / run `28308619222`: success。
  - `changes`, `lint`, `pr_specs`, `gem_package`, `javascript`, representative Rails lanes が success。
  - `javascript` は mockup path 変更として Playwright install と `npm run test:browser` に到達し success。
- local checkout / local browser check は GitHub HTTPS が `CONNECT tunnel failed, response 403`、raw fetch が 403、`gh` CLI なしのため未実行です。PR CI で確認しました。

## リスク

low。static gallery copy のみの補足で、visual evidence policy 自体や browser smoke 実行対象は変えていません。

merge は行いません。