### PR TITLE
CI policy docs command surface の smoke guard を追加する

### DIFF
--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -301,6 +301,41 @@ function assertCiPolicyDocsDocsOnlyRetentionSignals() {
   }
 }
 
+function assertCiPolicyDocsCommandSurfaceSignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        "npm run test:ci-policy",
+        "node script/test_ci_policy_suite.mjs --list",
+        "node script/test_ci_policy_suite.mjs --only <group-or-index>",
+        "node script/test_ci_policy_suite.mjs --self-test",
+        "Unknown, ambiguous, or out-of-range values fail and print the available groups plus the `--list` hint",
+        "fails with the missing script path"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        "npm run test:ci-policy",
+        "node script/test_ci_policy_suite.mjs --list",
+        "node script/test_ci_policy_suite.mjs --only <group-or-index>",
+        "node script/test_ci_policy_suite.mjs --self-test",
+        "unknown、ambiguous、範囲外の値は非 0 終了し、available groups と `--list` の案内を表示します",
+        "missing script path を表示して失敗します"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} command surface docs signal`)
+    }
+  }
+}
+
 for (const docsPath of ciPolicyDocsPaths) {
   assert.deepEqual(
     classifyChangedFiles([docsPath]),
@@ -339,6 +374,7 @@ assertCiPolicyDocsDockerSetupSignals()
 assertCiPolicyDocsChangedFileDetectionSignals()
 assertCiPolicyDocsRoutingOutputSignals()
 assertCiPolicyDocsDocsOnlyRetentionSignals()
+assertCiPolicyDocsCommandSurfaceSignals()
 
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
 console.log("Checked CI policy docs routing guard script routing.")
@@ -347,3 +383,4 @@ console.log("Checked Docker development setup CI docs signals.")
 console.log("Checked pull request changed-file detection docs signals.")
 console.log("Checked representative routing output docs signals.")
 console.log("Checked docs-only check retention docs signals.")
+console.log("Checked CI policy docs command surface signals.")


### PR DESCRIPTION
## 対応 Issue

- Closes #2723

## Issue ごとの完了内容

- #2723: 英日 `docs/*/ci-policy-suite.md` の command surface / failure guidance / registration self-test guidance が静かに落ちないよう、既存の docs routing smoke に focused assertion を追加しました。

## 変更内容

- `script/test_ci_policy_docs_routing.mjs` に `assertCiPolicyDocsCommandSurfaceSignals()` を追加
- 英日docsの以下の代表シグナルを確認するようにしました
  - `npm run test:ci-policy`
  - `--list`
  - `--only <group-or-index>`
  - `--self-test`
  - unknown / ambiguous / out-of-range `--only` の failure guidance
  - 未登録 candidate script が missing script path として失敗する registration self-test guidance

## 改善カテゴリ

- test
- docs guard
- CI policy maintenance

## 既存仕様への影響

- runtime behavior、CI workflow topology、changed-file classifier、required checks、branch protection は変更していません。
- docs本文も変更せず、既存docsの保守シグナルをsmokeで守るだけです。

## 実施した確認

- GitHub connector 上で main との差分を確認: `script/test_ci_policy_docs_routing.mjs` のみ、37行追加
- branch freshness 確認: `behind_by: 0`
- ローカルGit通信は `git ls-remote` が `CONNECT tunnel failed, response 403` で到達不可のため、ローカル実行は未実施です。PR作成後のCIで確認します。

## リスク評価

- low。既存docsに含まれる代表文言を確認するsmoke追加のみで、公開挙動やCI構成は変えません。

## 補足

- #2719 は同じ CI policy 周辺ですが、workflow routing classifier の対象拡張を伴うため、このPRでは混ぜず #2723 の docs signal guard に限定します。