### PR TITLE
docs-entrypoint suite command surface の Development docs signal を追加する

### DIFF
--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -84,6 +84,33 @@ const requiredDevelopmentDocsCommandSignals = [
   ]
 ]
 
+const requiredDocsEntrypointSuiteCommandSignals = [
+  [
+    "docs/en/development.md",
+    [
+      "npm run test:docs-entrypoints -- --list",
+      "npm run test:docs-entrypoints -- --only <group-or-index>",
+      "node script/test_docs_entrypoint_suite.mjs --self-test",
+      "Docs entrypoint suite option contract",
+      "Unknown, ambiguous, or out-of-range values exit non-zero",
+      "available groups plus the `--list` hint",
+      "candidate docs entrypoint scripts against the suite's `checks` array and explicit exclusions"
+    ]
+  ],
+  [
+    "docs/ja/development.md",
+    [
+      "npm run test:docs-entrypoints -- --list",
+      "npm run test:docs-entrypoints -- --only <group-or-index>",
+      "node script/test_docs_entrypoint_suite.mjs --self-test",
+      "Docs entrypoint suite option contract",
+      "unknown、ambiguous、範囲外の値は非 0 終了",
+      "available groups と `--list` の案内",
+      "candidate docs entrypoint script が suite の `checks` array または明示的な exclusion"
+    ]
+  ]
+]
+
 const requiredDevelopmentCiPolicySignals = [
   [
     "docs/en/development.md",
@@ -222,6 +249,16 @@ for (const [docPath, signals] of requiredDevelopmentDocsCommandSignals) {
   }
 }
 
+for (const [docPath, signals] of requiredDocsEntrypointSuiteCommandSignals) {
+  const doc = docSource(docs, docPath)
+
+  for (const signal of signals) {
+    if (!doc?.includes(signal)) {
+      missingSignals.push(`${docPath}: docs entrypoint suite command signal ${signal}`)
+    }
+  }
+}
+
 for (const [docPath, doc, registrationSignals] of ciPolicySuiteDocs) {
   for (const signal of requiredCiPolicySuiteCommandSignals) {
     if (!doc.includes(signal)) {
@@ -303,5 +340,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredDevelopmentDocsCommandSignals.length} Development docs command signal groups, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredNpmLockfileDriftRecoverySignals.length} npm lockfile drift recovery docs groups, ${requiredManifestStructureDuplicateKeySignals.length} manifest duplicate-key docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredDevelopmentDocsCommandSignals.length} Development docs command signal groups, ${requiredDocsEntrypointSuiteCommandSignals.length} docs entrypoint suite command signal groups, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredNpmLockfileDriftRecoverySignals.length} npm lockfile drift recovery docs groups, ${requiredManifestStructureDuplicateKeySignals.length} manifest duplicate-key docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
 )


### PR DESCRIPTION
## 対応 Issue

- Closes #2726

## Issue ごとの完了内容

- #2726: 英日 `docs/*/development.md` にある docs-entrypoint suite の targeted-run / self-test / registration guard guidance が静かに落ちないよう、既存の Development docs command signal smoke に代表シグナルを追加しました。

## 変更内容

- `script/test_development_docs_command_signals.mjs`
  - `npm run test:docs-entrypoints -- --list`
  - `npm run test:docs-entrypoints -- --only <group-or-index>`
  - `node script/test_docs_entrypoint_suite.mjs --self-test`
  - `Docs entrypoint suite option contract`
  - unknown / ambiguous / out-of-range guidance
  - candidate docs entrypoint script registration guidance

上記を英日 Development docs の代表シグナルとして確認するようにしました。

## 改善カテゴリ

- test
- docs guard
- CI / maintenance command surface hardening

## 既存仕様への影響

runtime Ruby / JavaScript、public API、docs-entrypoint suite runner behavior、candidate pattern、CI workflow topology、branch protection / required checks は変更していません。既存 docs の代表文言を smoke で守るだけです。

## 実施した確認

- GitHub connector compare: `main...quality/2726-docs-entrypoint-suite-command-signals` は `ahead_by:1` / `behind_by:0`
- changed files: `script/test_development_docs_command_signals.mjs` のみ
- ローカル GitHub 通信は `git ls-remote` が `CONNECT tunnel failed, response 403` で到達不可のため、ローカル `npm run test:development-docs-commands` は未実行です。PR作成後にCIを確認します。

## リスク評価

- risk: low
- 既存docsに含まれる maintainer-facing command surface の確認追加のみです。

## 補足事項

- #2719 は同じ quality/devops 周辺ですが、changed-file classifier の package / Docker routing 方針を扱う別責務のため、このPRでは混ぜていません。