### PR TITLE
Route workflow definitions through package and Docker guards

### DIFF
--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -69,7 +69,7 @@ function isPackageSensitivePath(file) {
     file === "package-lock.json" ||
     file === ".nvmrc" ||
     file === "script/check_gem_package_contents.rb" ||
-    file === ".github/workflows/ci.yml" ||
+    isWorkflowDefinitionPath(file) ||
     file === ".github/dependabot.yml" ||
     file === "config/importmap.tree_view.rb" ||
     file === "config/public_api_manifest.yml" ||
@@ -120,7 +120,7 @@ function isDockerSetupSensitivePath(file) {
     file === "package.json" ||
     file === "package-lock.json" ||
     file === ".nvmrc" ||
-    file === ".github/workflows/ci.yml"
+    isWorkflowDefinitionPath(file)
   );
 }
 

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -8,6 +8,10 @@ const ciPolicyDocsPaths = [
   "docs/en/ci-policy-suite.md",
   "docs/ja/ci-policy-suite.md"
 ]
+const workflowDefinitionPaths = [
+  ".github/workflows/package-verification.yml",
+  ".github/workflows/docker-smoke.yaml"
+]
 const ciPolicyDocsRoutingScriptPath = "script/test_ci_policy_docs_routing.mjs"
 
 const expected = {
@@ -17,6 +21,16 @@ const expected = {
   package_sensitive: true,
   docker_setup_sensitive: false,
   docs_entrypoint_sensitive: true,
+  ci_policy_sensitive: true
+}
+
+const expectedWorkflowDefinitionChange = {
+  docs_only: false,
+  mockups_changed: false,
+  browser_smoke_changed: false,
+  package_sensitive: true,
+  docker_setup_sensitive: true,
+  docs_entrypoint_sensitive: false,
   ci_policy_sensitive: true
 }
 
@@ -344,6 +358,26 @@ for (const docsPath of ciPolicyDocsPaths) {
   )
 }
 
+for (const workflowPath of workflowDefinitionPaths) {
+  assert.deepEqual(
+    classifyChangedFiles([workflowPath]),
+    expectedWorkflowDefinitionChange,
+    `${workflowPath} changes must run package, Docker, and CI policy guards`
+  )
+}
+
+assert.deepEqual(
+  classifyChangedFiles(workflowDefinitionPaths),
+  expectedWorkflowDefinitionChange,
+  "multiple workflow definition changes must keep package, Docker, and CI policy guard routing"
+)
+
+assert.deepEqual(
+  parsePolicyCliOutput(policyCliOutput(`${workflowDefinitionPaths.join("\n")}\n`)),
+  expectedWorkflowDefinitionChange,
+  "changed-file policy CLI must emit package, Docker, and CI policy routing for workflow definition changes"
+)
+
 assert.deepEqual(
   classifyChangedFiles(ciPolicyDocsPaths),
   expected,
@@ -377,6 +411,7 @@ assertCiPolicyDocsDocsOnlyRetentionSignals()
 assertCiPolicyDocsCommandSurfaceSignals()
 
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
+console.log(`Checked ${workflowDefinitionPaths.length} workflow definition package/Docker routing paths.`)
 console.log("Checked CI policy docs routing guard script routing.")
 console.log("Checked GitHub Actions Dependabot lane config and docs signals.")
 console.log("Checked Docker development setup CI docs signals.")

--- a/script/test_ci_policy_permissions_docs_signals.mjs
+++ b/script/test_ci_policy_permissions_docs_signals.mjs
@@ -77,8 +77,11 @@ assertCiPolicyRouting(
 )
 assertCiPolicyRouting(
   ".github/workflows/release.yaml",
-  {},
-  "workflow YAML changes must request the CI policy guard"
+  {
+    package_sensitive: true,
+    docker_setup_sensitive: true
+  },
+  "workflow YAML changes must request package, Docker, and CI policy guards"
 )
 assertCiPolicyRouting(
   ".github/workflows/ci.yml",


### PR DESCRIPTION
## 対応 Issue

- Closes #2719

## Issue ごとの完了内容

- #2719: `.github/workflows/*.yml` / `*.yaml` を package-sensitive / Docker setup-sensitive routing でも扱うようにし、CI policy routing と同じ workflow definition helper に寄せました。

## 変更内容

- `script/ci_changed_files_policy.mjs`
  - `isPackageSensitivePath` と `isDockerSetupSensitivePath` で workflow definition helper を使うように変更しました。
- `script/test_ci_policy_docs_routing.mjs`
  - `.github/workflows/package-verification.yml` と `.github/workflows/docker-smoke.yaml` の代表ケースを追加しました。
  - CLI output でも package / Docker / CI policy routing が揃うことを固定しました。
- `script/test_ci_policy_permissions_docs_signals.mjs`
  - 既存の workflow YAML routing 期待値を、今回の package / Docker routing 方針に合わせました。

## 改善カテゴリ

- test
- CI guard coverage
- 小さな内部整理

## 既存仕様への影響

公開 API、UI、DB、認可、workflow topology、permissions、Dockerfile / docker-compose behavior は変更していません。変更ファイル分類の routing だけを広げています。

## 実施した確認内容

- GitHub connector compare: `main...quality/2719-workflow-package-docker-routing` が `behind_by:0`
- 変更ファイル確認: 意図した 3 ファイルのみ
- GitHub Actions: CI #3742 success

ローカル clone は CONNECT tunnel 403 のため不可でしたが、PR 上の CI で検証済みです。

## リスク評価

- risk: low
- CI changed-file routing の代表 case 追加に閉じており、実行 job の内容や repository settings は変えていません。

## 補足事項

#2718 は既に main にマージ済みで、今回の変更はその helper を package / Docker routing にも使う follow-up です。