### PR TITLE
gem_package job の install / require smoke signal を追加する

### DIFF
--- a/script/test_ci_workflow_changed_file_detection_signals.mjs
+++ b/script/test_ci_workflow_changed_file_detection_signals.mjs
@@ -378,6 +378,40 @@ javascriptJobNpmScripts.forEach((scriptName) => {
   assertPackageScript(scriptName)
 })
 
+const gemPackageJobSignals = [
+  ["gem build command", "run: gem build tree_view.gemspec"],
+  ["package contents checker command", "run: ruby script/check_gem_package_contents.rb tree_view-*.gem"],
+  ["built gem install smoke command", "run: gem install tree_view-*.gem"],
+  ["built gem require smoke command", 'run: ruby -e "require \'tree_view\'"']
+]
+
+gemPackageJobSignals.forEach(([label, signal]) => {
+  assertIncludes(
+    gemPackageJob,
+    signal,
+    `${workflowPath} jobs.gem_package ${label}`
+  )
+})
+
+assertOrdered(
+  gemPackageJob,
+  "run: gem build tree_view.gemspec",
+  "run: ruby script/check_gem_package_contents.rb tree_view-*.gem",
+  `${workflowPath} jobs.gem_package must build the gem before package contents verification`
+)
+assertOrdered(
+  gemPackageJob,
+  "run: ruby script/check_gem_package_contents.rb tree_view-*.gem",
+  "run: gem install tree_view-*.gem",
+  `${workflowPath} jobs.gem_package must verify package contents before installing the built gem`
+)
+assertOrdered(
+  gemPackageJob,
+  "run: gem install tree_view-*.gem",
+  'run: ruby -e "require \'tree_view\'"',
+  `${workflowPath} jobs.gem_package must install the built gem before the require smoke`
+)
+
 const docsEntrypointsScript = packageScript("test:docs-entrypoints")
 const ciPolicyScript = packageScript("test:ci-policy")
 const entrypointsScript = packageScript("test:entrypoints")
@@ -451,5 +485,6 @@ console.log(`Checked ${prSpecsJobSignals.length} CI pr_specs job representative 
 console.log(`Checked ${matrixFailFastPolicyJobs.length} CI matrix fail-fast policy signals.`)
 console.log(`Checked ${rubyMatrixVersionSignals.length} representative Ruby workflow version signals.`)
 console.log(`Checked ${javascriptJobNpmScripts.length} JavaScript job npm script commands and package.json scripts.`)
+console.log(`Checked ${gemPackageJobSignals.length} gem package build, verification, install, and require smoke signals.`)
 console.log(`Checked ${docsEntrypointsSignals.length} docs-entrypoints package and suite command signals.`)
 console.log(`Checked ${packageGuardSuiteCompositionSignals.length} package guard suite composition signals.`)


### PR DESCRIPTION
## 対応 Issue

Closes #2731

## Issue ごとの完了内容

- #2731: `gem_package` job が `gem build`、package contents check、built gem install、`require "tree_view"` smoke を順番に維持していることを CI policy smoke で確認できるようにしました。

## 変更内容

- `script/test_ci_workflow_changed_file_detection_signals.mjs`
  - `jobs.gem_package` の代表 command signal を追加しました。
  - build → contents check → install → require の順序を `assertOrdered` で軽く固定しました。
  - failure message が `.github/workflows/ci.yml jobs.gem_package` のどの signal 欠落か分かる形にしました。

## 改善カテゴリ

- test
- CI guard coverage
- 小さな内部整理

## 既存仕様への影響

CI workflow behavior、job topology、Ruby versions、branch protection、release automation、gemspec metadata、runtime public API は変更していません。既存 workflow command を守る signal だけを追加しています。

## docs 確認

英日 Release docs は既に package-sensitive PR path と release前確認で `gem install tree_view-*.gem` / `require "tree_view"` を説明しているため、今回の PR では重複追記せず既存 docs を source evidence としました。

## 実施した確認内容

- GitHub connector compare: `main...quality/2731-gem-package-install-require-signal` が `ahead_by:1` / `behind_by:0`
- changed files: `script/test_ci_workflow_changed_file_detection_signals.mjs` 1件のみ
- local clone / local npm execution: GitHub HTTPS が `CONNECT tunnel failed, response 403` のため不可
- PR 作成後に GitHub Actions CI を確認します

## リスク評価

- risk: low
- 既存 CI command の検出と順序確認だけで、実行内容は変えていません。