### PR TITLE
Split focused docs and CI signal smokes

### DIFF
--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -155,7 +155,7 @@ function resolveOnlyGroupResult(groupName) {
   const caseInsensitiveExactMatches = checks.filter(
     (check) => check.group.toLowerCase() === normalizedGroupName
   )
-  if (caseInsensitiveExactMatches.length === 1) return { check: exactMatches[0] }
+  if (caseInsensitiveExactMatches.length === 1) return { check: caseInsensitiveExactMatches[0] }
 
   const partialMatches = checks.filter((check) =>
     check.group.toLowerCase().includes(normalizedGroupName)

--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -18,6 +18,11 @@ const checks = [
     args: ["script/test_ci_workflow_changed_file_detection_signals.mjs"]
   },
   {
+    group: "Workflow concurrency signals",
+    command: "node",
+    args: ["script/test_ci_workflow_concurrency_signals.mjs"]
+  },
+  {
     group: "Workflow permissions signals",
     command: "node",
     args: ["script/test_ci_workflow_permissions_signals.mjs"]
@@ -150,7 +155,7 @@ function resolveOnlyGroupResult(groupName) {
   const caseInsensitiveExactMatches = checks.filter(
     (check) => check.group.toLowerCase() === normalizedGroupName
   )
-  if (caseInsensitiveExactMatches.length === 1) return { check: caseInsensitiveExactMatches[0] }
+  if (caseInsensitiveExactMatches.length === 1) return { check: exactMatches[0] }
 
   const partialMatches = checks.filter((check) =>
     check.group.toLowerCase().includes(normalizedGroupName)
@@ -236,6 +241,7 @@ function runSelfTest() {
     ambiguous.matches.map((check) => check.group),
     [
       "Workflow changed-file detection signals",
+      "Workflow concurrency signals",
       "Workflow permissions signals",
       "Workflow permissions docs signals"
     ],
@@ -245,6 +251,10 @@ function runSelfTest() {
   assert.ok(
     ciPolicyCandidateScriptPaths().includes("script/test_ci_changed_files_policy.mjs"),
     "CI policy candidates should include changed-file policy signals"
+  )
+  assert.ok(
+    ciPolicyCandidateScriptPaths().includes("script/test_ci_workflow_concurrency_signals.mjs"),
+    "CI policy candidates should include workflow concurrency signals"
   )
   assert.ok(
     ciPolicyCandidateScriptPaths().includes("script/test_ci_workflow_permissions_signals.mjs"),

--- a/script/test_ci_workflow_concurrency_signals.mjs
+++ b/script/test_ci_workflow_concurrency_signals.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs"
+
+const workflowPath = ".github/workflows/ci.yml"
+const workflowSource = readFileSync(workflowPath, "utf8")
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+function assertAbsent(source, needle, label) {
+  assert(!source.includes(needle), `${label}: unexpected ${needle}`)
+}
+
+function workflowTopLevelConcurrencyBlock(workflowSource) {
+  const match = workflowSource.match(/^concurrency:\n(?<body>[\s\S]*?)\n\njobs:\n/m)
+
+  assert(
+    match,
+    `${workflowPath} CI concurrency policy must define a top-level concurrency block before jobs`
+  )
+
+  return match.groups.body
+}
+
+function assertWorkflowConcurrencyPolicy(workflowSource) {
+  const concurrencyBlock = workflowTopLevelConcurrencyBlock(workflowSource)
+
+  assertIncludes(
+    concurrencyBlock,
+    "  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}",
+    `${workflowPath} CI concurrency policy group`
+  )
+  assertIncludes(
+    concurrencyBlock,
+    "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+    `${workflowPath} CI concurrency policy pull-request-only cancellation`
+  )
+  assertAbsent(
+    concurrencyBlock,
+    "cancel-in-progress: true",
+    `${workflowPath} CI concurrency policy must not cancel main push runs unconditionally`
+  )
+}
+
+assertWorkflowConcurrencyPolicy(workflowSource)
+
+console.log("Checked CI workflow concurrency policy signals.")

--- a/script/test_diagnostics_docs_signals.mjs
+++ b/script/test_diagnostics_docs_signals.mjs
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const manifest = read("config/public_api_manifest.yml")
+const diagnosticsDocs = [
+  ["docs/en/tree-diagnostics.md", read("docs/en/tree-diagnostics.md")],
+  ["docs/ja/tree-diagnostics.md", read("docs/ja/tree-diagnostics.md")]
+]
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertIncludes(source, needle, label) {
+  assert(source.includes(needle), `${label}: missing ${needle}`)
+}
+
+const diagnosticsManifestSurfaceSignals = [
+  ["diagnostics accepted checks", "diagnostics:"],
+  ["diagnostics accepted checks", "accepted_checks:"],
+  ["diagnostics run options", "run_options:"],
+  ["diagnostics Result surface", "result_surface:"]
+]
+
+const diagnosticsAcceptedCheckSignals = [
+  "node_keys",
+  "dom_ids",
+  "orphans",
+  "cycles"
+]
+
+const diagnosticsRunOptionSignals = [
+  "run_options",
+  "checks",
+  "raise_errors"
+]
+
+const diagnosticsResultSurfaceSignals = [
+  "checks",
+  "errors",
+  "warnings",
+  "success?"
+]
+
+diagnosticsManifestSurfaceSignals.forEach(([label, signal]) => {
+  assertIncludes(manifest, signal, `public API manifest diagnostics surface (${label})`)
+})
+
+diagnosticsAcceptedCheckSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics accepted checks")
+})
+
+diagnosticsRunOptionSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics run options")
+})
+
+diagnosticsResultSurfaceSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest diagnostics Result surface")
+})
+
+diagnosticsDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeView::Diagnostics.run", `${relativePath} diagnostics aggregate entrypoint docs`)
+  assertIncludes(document, "checks:", `${relativePath} diagnostics accepted checks docs`)
+  assertIncludes(document, "raise_errors:", `${relativePath} diagnostics run option docs`)
+  assertIncludes(document, "Result", `${relativePath} diagnostics Result surface docs`)
+
+  diagnosticsAcceptedCheckSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics accepted check docs`)
+  })
+
+  diagnosticsRunOptionSignals.slice(1).forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics run option docs`)
+  })
+
+  diagnosticsResultSurfaceSignals.forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} diagnostics Result reader docs`)
+  })
+
+  assert(
+    /manifest-backed.*diagnostics contract|manifest-backed な diagnostics contract/.test(document),
+    `${relativePath}: diagnostics docs no longer identify the manifest-backed contract boundary`
+  )
+
+  assert(
+    /run option key surface|option key surface/.test(document),
+    `${relativePath}: diagnostics docs no longer identify the run option key surface boundary`
+  )
+
+  assert(
+    /individual error entry internals|warning detail shape|orphan warning semantics|cycle validation policy|個々の error entry 内部|warning detail shape|orphan warning semantics|cycle validation policy/.test(document),
+    `${relativePath}: diagnostics docs no longer keep detailed error and warning shapes outside the manifest schema`
+  )
+})
+
+console.log("Checked diagnostics docs signals.")

--- a/script/test_docs_entrypoint_suite.mjs
+++ b/script/test_docs_entrypoint_suite.mjs
@@ -33,6 +33,11 @@ const checks = [
     args: ["script/test_host_app_extension_diagnostics_signals.mjs"]
   },
   {
+    group: "Diagnostics docs signals",
+    command: "node",
+    args: ["script/test_diagnostics_docs_signals.mjs"]
+  },
+  {
     group: "Development docs Node version signals",
     command: "node",
     args: ["script/test_development_docs_node_version_signals.mjs"]
@@ -81,6 +86,11 @@ const checks = [
     group: "Release docs signals",
     command: "node",
     args: ["script/test_release_docs_signals.mjs"]
+  },
+  {
+    group: "Release package contents signals",
+    command: "node",
+    args: ["script/test_release_package_contents_signals.mjs"]
   },
   {
     group: "README quick start signal",
@@ -414,8 +424,16 @@ function runSelfTest() {
     "docs script registration candidates should include event names public API signals"
   )
   assert.ok(
+    candidatePaths.includes("script/test_diagnostics_docs_signals.mjs"),
+    "docs script registration candidates should include diagnostics docs signals"
+  )
+  assert.ok(
     candidatePaths.includes("script/test_public_api_docs_signals.mjs"),
     "docs script registration candidates should include public API docs signals"
+  )
+  assert.ok(
+    candidatePaths.includes("script/test_release_package_contents_signals.mjs"),
+    "docs script registration candidates should include release package contents signals"
   )
   assert.ok(
     candidatePaths.includes("script/guard_public_api_transfer_integration_signals.mjs"),

--- a/script/test_release_package_contents_signals.mjs
+++ b/script/test_release_package_contents_signals.mjs
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function assertSignals(sourcePath, feature, signals) {
+  const source = read(sourcePath)
+
+  signals.forEach((signal) => {
+    assert(
+      source.includes(signal),
+      `${feature}: ${sourcePath} is missing representative signal ${JSON.stringify(signal)}`
+    )
+  })
+}
+
+const packageContentsVerificationSignals = [
+  [
+    "script/check_gem_package_contents.rb",
+    [
+      "REQUIRED_PACKAGED_PATHS",
+      "INSTALLATION_REQUIRED_SIGNALS",
+      "app/helpers/tree_view_helper.rb",
+      "app/views/tree_view/_tree_row.html.erb",
+      "app/assets/stylesheets/tree_view.scss",
+      "app/javascript/tree_view/index.js",
+      "config/importmap.tree_view.rb",
+      "config/locales/tree_view.toolbar.en.yml",
+      "config/locales/tree_view.toolbar.ja.yml",
+      "config/public_api_manifest.yml",
+      "docs/en/release.md",
+      "docs/ja/release.md",
+      "docs/mockups/review-gallery.html",
+      "EXPECTED_RELEASE_METADATA",
+      "EXPECTED_GEM_METADATA",
+      "homepage_uri",
+      "source_code_uri",
+      "changelog_uri",
+      "bug_tracker_uri",
+      "EXPECTED_PUBLIC_SETUP_GENERATOR",
+      "PUBLIC_SETUP_GENERATOR_SOURCE_SIGNALS",
+      "lib/generators/tree_view/state/install_generator.rb",
+      "lib/generators/tree_view/state/templates/create_tree_view_states.rb",
+      "lib/generators/tree_view/state/templates/tree_view_state.rb",
+      "lib/generators/tree_view/state/templates/tree_view_state_owner.rb",
+      "required_ruby_version",
+      "allowed_push_host",
+      "runtime_dependencies",
+      "Gem package contents verification failed"
+    ]
+  ],
+  [
+    "docs/en/release.md",
+    [
+      "ruby script/check_gem_package_contents.rb tree_view-*.gem",
+      "representative Rails helper, view partial, locale, docs, JavaScript, CSS, importmap, public API manifest, public runtime files, and gem metadata URI surfaces",
+      "required Ruby version, allowed push host, and runtime dependency metadata",
+      "public setup generator files for `tree_view:state:install`",
+      "lib/generators/tree_view/state/install_generator.rb",
+      "lib/generators/tree_view/state/templates/create_tree_view_states.rb",
+      "lib/generators/tree_view/state/templates/tree_view_state.rb",
+      "lib/generators/tree_view/state/templates/tree_view_state_owner.rb",
+      "Public Setup Surface",
+      "Package-sensitive PR paths include `tree_view.gemspec`",
+      ".github/dependabot.yml",
+      "Dependabot configuration changes are package-sensitive",
+      "Rails integration files under `app/helpers/**`, `app/views/**`, `app/assets/**`, and `app/javascript/**`",
+      "`docs_entrypoint_sensitive`",
+      "`package_sensitive`",
+      "`README.md`, `CHANGELOG.md`, `docs/**`, and `config/public_api_manifest.yml`",
+      "docs entrypoint smoke",
+      "config/importmap.tree_view.rb",
+      "config/public_api_manifest.yml",
+      "config/locales/**",
+      "docs/en/release.md",
+      "docs/ja/release.md"
+    ]
+  ],
+  [
+    "docs/ja/release.md",
+    [
+      "ruby script/check_gem_package_contents.rb tree_view-*.gem",
+      "Rails helper / view partial / locale / docs / JavaScript / CSS / importmap / public API manifest / public runtime files / gem metadata URI",
+      "required Ruby version、allowed push host、runtime dependency metadata",
+      "`tree_view:state:install` public setup generator files",
+      "lib/generators/tree_view/state/install_generator.rb",
+      "lib/generators/tree_view/state/templates/create_tree_view_states.rb",
+      "lib/generators/tree_view/state/templates/tree_view_state.rb",
+      "lib/generators/tree_view/state/templates/tree_view_state_owner.rb",
+      "Public Setup Surface",
+      "package-sensitive path には、`tree_view.gemspec`",
+      ".github/dependabot.yml",
+      "Dependabot 設定の変更は dependency automation routing",
+      "Rails integration files である `app/helpers/**`、`app/views/**`、`app/assets/**`、`app/javascript/**`",
+      "`docs_entrypoint_sensitive`",
+      "`package_sensitive`",
+      "`README.md`、`CHANGELOG.md`、`docs/**`、`config/public_api_manifest.yml`",
+      "docs entrypoint smoke",
+      "config/importmap.tree_view.rb",
+      "config/public_api_manifest.yml",
+      "config/locales/**",
+      "docs/en/release.md",
+      "docs/ja/release.md"
+    ]
+  ]
+]
+
+packageContentsVerificationSignals.forEach(([sourcePath, signals]) => {
+  assertSignals(sourcePath, "Gem package release docs category signal", signals)
+})
+
+console.log("Checked release package contents verification signals.")


### PR DESCRIPTION
## 対応 Issue

- Closes #2736
- Closes #2737
- Closes #2738

## Issue ごとの完了内容

- #2736: diagnostics docs / manifest signal を `script/test_diagnostics_docs_signals.mjs` に切り出し、docs entrypoint suite から個別実行できるようにしました。
- #2737: CI workflow concurrency policy signal を `script/test_ci_workflow_concurrency_signals.mjs` に切り出し、CI policy suite から個別実行できるようにしました。
- #2738: release package contents verification signal を `script/test_release_package_contents_signals.mjs` に切り出し、docs entrypoint suite から個別実行できるようにしました。

## 変更内容

- focused smoke script を3本追加
- `script/test_docs_entrypoint_suite.mjs` に diagnostics / release package contents の専用グループを登録
- `script/test_ci_policy_suite.mjs` に workflow concurrency の専用グループを登録
- suite self-test の `--only` case-insensitive exact match が実際の一致候補を返すように修正

## 改善カテゴリ

- test / smoke guard の整理
- 小規模リファクタ
- CI/docs guard の保守性改善

## 既存仕様への影響

- docs 本文、公開 API、runtime、CI workflow、package script の契約は変更していません。
- 追加したのは検査スクリプトと suite 登録のみです。
- 既存の aggregate guard は残しており、今回の変更で検査カバレッジを落としていません。

## 確認内容

- GitHub connector で `main...quality/split-docs-ci-signal-smokes` を比較し、branch は `main` から `behind_by: 0` であることを確認
- 差分が以下の検査ファイルだけであることを確認
  - `script/test_ci_policy_suite.mjs`
  - `script/test_ci_workflow_concurrency_signals.mjs`
  - `script/test_diagnostics_docs_signals.mjs`
  - `script/test_docs_entrypoint_suite.mjs`
  - `script/test_release_package_contents_signals.mjs`
- connector 経由で suite 登録箇所と `--only` 解決ロジックをスポット確認

手元環境から GitHub raw / clone 取得が 403 で制限されたため、ローカルで `npm run test:docs-entrypoints` / `npm run test:ci-policy` は実行できていません。PR CI で確認します。

## リスク評価

- risk: low
- 検査コードのみの追加・登録で、公開挙動や workflow 実行条件は変更していません。

## 補足事項

- 今回は focused guard を追加し、既存 aggregate guard は互換的に残しています。後続で aggregate 側の重複整理を進める場合も、専用スクリプト単位で安全に扱える状態にしています。
