### PR TITLE
test: guard workflow concurrency CI policy routing

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -40,7 +40,7 @@ The CI workflow uses workflow-level `concurrency` so a newer pull request head c
 
 `cancel-in-progress` is intentionally limited to the `pull_request` event. Pushes to `main` still run to completion so release and package verification evidence is not weakened by a later push. Treat a canceled pull request run as stale-head evidence; review readiness should come from the workflow run for the current head SHA.
 
-`script/test_ci_workflow_changed_file_detection_signals.mjs` protects the representative concurrency signals, including the PR-only cancellation condition and the absence of unconditional `cancel-in-progress: true`. This note explains how maintainers should read that policy; it does not change workflow routing, required checks, branch protection, or CI polling behavior.
+`script/test_ci_workflow_concurrency_signals.mjs` protects the representative concurrency signals, including the PR-only cancellation condition and the absence of unconditional `cancel-in-progress: true`. This note explains how maintainers should read that policy; it does not change workflow routing, required checks, branch protection, or CI polling behavior.
 
 ## Representative routing outputs
 

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -40,7 +40,7 @@ CI workflow は workflow-level `concurrency` を使い、同じ Pull Request で
 
 `cancel-in-progress` は意図的に `pull_request` event だけに限定しています。`main` への push は最後まで走らせるため、release / package verification evidence を後続 push で弱めません。cancel された Pull Request run は stale head の evidence として扱い、review readiness は current head SHA の workflow run で判断してください。
 
-`script/test_ci_workflow_changed_file_detection_signals.mjs` は、PR-only cancellation 条件と無条件の `cancel-in-progress: true` がないことを含む代表 concurrency signal を守ります。このメモは保守者がその policy をどう読むかを説明するだけで、workflow routing、required checks、branch protection、CI polling behavior は変更しません。
+`script/test_ci_workflow_concurrency_signals.mjs` は、PR-only cancellation 条件と無条件の `cancel-in-progress: true` がないことを含む代表 concurrency signal を守ります。このメモは保守者がその policy をどう読むかを説明するだけで、workflow routing、required checks、branch protection、CI polling behavior は変更しません。
 
 ## Representative routing outputs
 

--- a/script/ci_changed_files_policy.mjs
+++ b/script/ci_changed_files_policy.mjs
@@ -104,6 +104,7 @@ function isCiPolicySensitivePath(file) {
     file === "script/test_ci_changed_files_policy.mjs" ||
     file === "script/test_ci_policy_docs_routing.mjs" ||
     file === "script/test_ci_workflow_changed_file_detection_signals.mjs" ||
+    file === "script/test_ci_workflow_concurrency_signals.mjs" ||
     file === "script/test_ci_workflow_permissions_signals.mjs" ||
     file === "script/test_ci_policy_permissions_docs_signals.mjs" ||
     file === "script/test_ci_observation_guidance_signals.mjs" ||

--- a/script/test_ci_workflow_concurrency_signals.mjs
+++ b/script/test_ci_workflow_concurrency_signals.mjs
@@ -1,7 +1,24 @@
+import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
+import { classifyChangedFiles } from "./ci_changed_files_policy.mjs"
 
 const workflowPath = ".github/workflows/ci.yml"
+const concurrencySignalPath = "script/test_ci_workflow_concurrency_signals.mjs"
+const ciPolicyDocsPaths = [
+  "docs/en/ci-policy-suite.md",
+  "docs/ja/ci-policy-suite.md"
+]
 const workflowSource = readFileSync(workflowPath, "utf8")
+
+const expectedCiPolicyScriptChange = {
+  docs_only: false,
+  mockups_changed: false,
+  browser_smoke_changed: false,
+  package_sensitive: false,
+  docker_setup_sensitive: false,
+  docs_entrypoint_sensitive: false,
+  ci_policy_sensitive: true
+}
 
 function assert(condition, message) {
   if (!condition) throw new Error(message)
@@ -26,6 +43,24 @@ function workflowTopLevelConcurrencyBlock(workflowSource) {
   return match.groups.body
 }
 
+function policyCliOutput(input) {
+  return execFileSync(process.execPath, ["script/ci_changed_files_policy.mjs"], {
+    input,
+    encoding: "utf8"
+  })
+}
+
+function parsePolicyCliOutput(output) {
+  return Object.fromEntries(
+    output.trim().split(/\r?\n/).map((line) => {
+      assert(line.match(/^[a-z_]+=(true|false)$/), `policy CLI output must be key=value boolean, got ${line}`)
+      const [key, value] = line.split("=")
+
+      return [key, value === "true"]
+    })
+  )
+}
+
 function assertWorkflowConcurrencyPolicy(workflowSource) {
   const concurrencyBlock = workflowTopLevelConcurrencyBlock(workflowSource)
 
@@ -46,6 +81,57 @@ function assertWorkflowConcurrencyPolicy(workflowSource) {
   )
 }
 
+function assertConcurrencyDocsSignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        "## Pull request run concurrency",
+        concurrencySignalPath,
+        "PR-only cancellation condition",
+        "absence of unconditional `cancel-in-progress: true`",
+        "does not change workflow routing, required checks, branch protection, or CI polling behavior"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        "## Pull request run concurrency",
+        concurrencySignalPath,
+        "PR-only cancellation 条件",
+        "無条件の `cancel-in-progress: true` がないこと",
+        "workflow routing、required checks、branch protection、CI polling behavior は変更しません"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} workflow concurrency docs signal`)
+    }
+  }
+}
+
+function assertConcurrencySignalRouting() {
+  assert.deepEqual(
+    classifyChangedFiles([concurrencySignalPath]),
+    expectedCiPolicyScriptChange,
+    `${concurrencySignalPath} changes must run CI policy guard directly`
+  )
+
+  assert.deepEqual(
+    parsePolicyCliOutput(policyCliOutput(`${concurrencySignalPath}\n`)),
+    expectedCiPolicyScriptChange,
+    "changed-file policy CLI must emit CI policy-sensitive routing for workflow concurrency signal changes"
+  )
+}
+
 assertWorkflowConcurrencyPolicy(workflowSource)
+assertConcurrencyDocsSignals()
+assertConcurrencySignalRouting()
 
 console.log("Checked CI workflow concurrency policy signals.")
+console.log("Checked CI workflow concurrency docs signals.")
+console.log("Checked CI workflow concurrency guard routing.")

--- a/script/test_ci_workflow_concurrency_signals.mjs
+++ b/script/test_ci_workflow_concurrency_signals.mjs
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { classifyChangedFiles } from "./ci_changed_files_policy.mjs"
@@ -20,22 +21,18 @@ const expectedCiPolicyScriptChange = {
   ci_policy_sensitive: true
 }
 
-function assert(condition, message) {
-  if (!condition) throw new Error(message)
-}
-
 function assertIncludes(source, needle, label) {
-  assert(source.includes(needle), `${label}: missing ${needle}`)
+  assert.ok(source.includes(needle), `${label}: missing ${needle}`)
 }
 
 function assertAbsent(source, needle, label) {
-  assert(!source.includes(needle), `${label}: unexpected ${needle}`)
+  assert.ok(!source.includes(needle), `${label}: unexpected ${needle}`)
 }
 
 function workflowTopLevelConcurrencyBlock(workflowSource) {
   const match = workflowSource.match(/^concurrency:\n(?<body>[\s\S]*?)\n\njobs:\n/m)
 
-  assert(
+  assert.ok(
     match,
     `${workflowPath} CI concurrency policy must define a top-level concurrency block before jobs`
   )
@@ -53,7 +50,7 @@ function policyCliOutput(input) {
 function parsePolicyCliOutput(output) {
   return Object.fromEntries(
     output.trim().split(/\r?\n/).map((line) => {
-      assert(line.match(/^[a-z_]+=(true|false)$/), `policy CLI output must be key=value boolean, got ${line}`)
+      assert.match(line, /^[a-z_]+=(true|false)$/, `policy CLI output must be key=value boolean, got ${line}`)
       const [key, value] = line.split("=")
 
       return [key, value === "true"]


### PR DESCRIPTION
## 対応 Issue

- Closes #2740
- Closes #2741

## Issue ごとの完了内容

- #2740: `script/test_ci_workflow_concurrency_signals.mjs` の変更が `ci_policy_sensitive` として routing されるようにし、focused CI policy smoke script が changed-files policy から漏れる状態を代表 guard で検出できるようにしました。
- #2741: 英日 `docs/*/ci-policy-suite.md` の `Pull request run concurrency` section を、focused split 後の `script/test_ci_workflow_concurrency_signals.mjs` と同期しました。

## 変更内容

- `script/ci_changed_files_policy.mjs` に `script/test_ci_workflow_concurrency_signals.mjs` を CI policy sensitive path として追加
- `script/test_ci_workflow_concurrency_signals.mjs` に以下の representative checks を追加
  - concurrency docs が focused script 名を参照すること
  - PR-only cancellation / unconditional cancel absence の docs signal が残ること
  - concurrency signal script 自体の変更が `ci_policy_sensitive` になること
  - CLI output でも同じ routing が出ること
- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` の concurrency guard 参照を旧 changed-file detection script から focused concurrency script に同期

## 改善カテゴリ

- test / smoke guard hardening
- docs drift guard
- CI changed-file routing guard

## 既存仕様への影響

- CI workflow behavior、required checks、branch protection、package scripts、runtime Ruby / JavaScript、public API は変更していません。
- 変更は docs 参照と CI policy guard の代表 signal に閉じています。

## 確認内容

- GitHub compare: `main...quality/2740-ci-policy-script-routing` は `ahead_by: 5` / `behind_by: 0`
- Changed files は以下4件のみ
  - `docs/en/ci-policy-suite.md`
  - `docs/ja/ci-policy-suite.md`
  - `script/ci_changed_files_policy.mjs`
  - `script/test_ci_workflow_concurrency_signals.mjs`
- ローカル `npm run test:ci-policy` は、この実行環境の GitHub HTTPS が `CONNECT tunnel failed, response 403` になるため未実行です。PR CI で確認します。

## リスク評価

- risk: low
- workflow 定義や実際の concurrency policy には触れておらず、変更された smoke script 自体が CI policy lane に乗ることを固定するだけです。

## 補足事項

- #2740 は full changed-file classifier mirror には広げず、今回追加された focused concurrency guard の routing drift を代表確認する first slice に留めています。