### PR TITLE
docs: recent docs signal evidence を CHANGELOG に追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,10 +135,16 @@ Release preparation notes:
 - Clarified repository-only maintainer docs routing in CI policy suite docs so AGENTS.md remains CI-policy-sensitive while Product Profile.md stays manual-review routed.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 - Clarified Development docs for temporary docs i18n parity exceptions, including `parityExceptions` metadata and the boundary against permanent single-language docs.
+- Clarified review-gallery visual evidence guidance so gallery previews stay a fast orientation path while merge-grade desktop and narrow viewport evidence is recorded from the target mockup page.
+- Clarified empty-state mockup README guidance so hidden-message and permission-hidden row review uses the existing `empty-state.html` entry point without changing authorization policy.
+- Clarified CI policy suite package-sensitive routing guidance for Ruby package and release task paths such as `Gemfile`, `Rakefile`, `tree_view.gemspec`, and package contents verification.
 
 ### Tests
 
 - Added CI workflow permissions policy smoke coverage so read-only token permissions stay guarded against write-scope drift.
+- Split focused diagnostics, workflow concurrency, and release package contents signal smokes into registered suite groups so maintainers can run the narrow docs or CI guard directly.
+- Added CI policy docs command-surface and docs-entrypoint command-surface smoke coverage so `--list`, `--only`, `--self-test`, and registration guidance stay discoverable.
+- Added CI changed-file routing coverage for workflow package/Docker lanes, package-sensitive Ruby release paths, and gem package install / require smoke evidence.
 - Added CI policy guard evidence for public API manifest structure, Dependabot routing, and browser-smoke routing boundaries so entrypoint and CI policy checks stay aligned.
 - Added Development docs command signal coverage for `npm run test:development-docs-commands` so narrow and suite-level maintainer command checks stay discoverable.
 - Added Public API docs signal coverage for persisted-state setup surface and `initial_expansion` grouped option keys so manifest-backed docs signals stay aligned.


### PR DESCRIPTION
## 対応 Issue / PR

Refs #2720
Refs #2723
Refs #2726
Refs #2728
Refs #2729
Refs #2731
Refs #2734
Refs #2736
Refs #2737
Refs #2738
Refs #2739

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、直近 merge 済みの review-gallery visual evidence 境界、empty-state hidden-message 導線、CI policy suite package-sensitive routing guidance の release-facing evidence を追記しました。
- `Unreleased > Tests` に、focused docs / CI signal smoke 分割、CI / docs suite command-surface guard、workflow package / Docker routing と gem package install / require smoke evidence の追記をまとめました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script、mockup HTML は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2742 は open / non-draft / `mergeable:true`、compare `behind_by:0`、CI #3752 success、review / review thread なしでした。
  - #2271 は draft / design proposal / visual evidence と README・gallery同期待ちの `needs-human` 継続で、追加修正は行っていません。
- current `README.md`, `docs/README.md`, `AGENTS.md`, `Product Profile.md`, `package.json`, CI policy suite docs / suite registration、直近 merged PR を確認しました。
- 重複 open CHANGELOG PR は見当たりませんでした。
- final compare: `main...docs/changelog-recent-docs-signal-evidence-2739` は `ahead_by:1` / `behind_by:0` / changed files 1件 / additions 6 / deletions 0。
- commit patch は `Documentation` と `Tests` への追記のみです。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs / quality PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。