### PR TITLE
CI policy suite の explicit exclusion signal を補強する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -28,6 +28,8 @@ node script/test_ci_policy_suite.mjs --self-test
 
 When adding or renaming a CI policy guard script, update the suite `checks` array or document an explicit exclusion before relying on CI. The self-test scans candidate scripts, confirms that registered scripts stay visible through the suite, and fails with the missing script path when a candidate is not registered.
 
+Candidate CI policy scripts must either be listed in the `checks` array or named in `ciPolicyScriptExclusions` with a short reason. Keep exclusions narrow: `test_ci_policy_suite.mjs` is excluded because it is this suite's self-test entrypoint, not a direct guard group.
+
 ## Pull request changed-file detection
 
 For pull requests, the `changes` job fetches the base branch, then tries to find a merge base between `origin/${{ github.base_ref }}` and `HEAD`. When the merge base is available, the workflow uses the three-dot diff, `origin/${{ github.base_ref }}...HEAD`, so routing is based on the pull request changes. If the merge base cannot be resolved, it falls back to `git diff --name-only origin/${{ github.base_ref }} HEAD`.

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -28,6 +28,8 @@ node script/test_ci_policy_suite.mjs --self-test
 
 CI policy guard script を追加または rename した場合は、CI に頼る前に suite の `checks` array を更新するか、明示的な exclusion を残してください。self-test は candidate script を走査し、登録済み script が suite から見えることを確認します。未登録 candidate がある場合は missing script path を表示して失敗します。
 
+Candidate CI policy scripts は、`checks` array に登録するか、短い理由つきで `ciPolicyScriptExclusions` に明示する必要があります。exclusion は狭く保ってください。`test_ci_policy_suite.mjs` は direct guard group ではなく、この suite の self-test entrypoint なので除外されています。
+
 ## Pull Request changed-file detection
 
 Pull Request では、`changes` job が base branch を fetch し、`origin/${{ github.base_ref }}` と `HEAD` の merge base を探します。merge base を取得できる場合、workflow は three-dot diff の `origin/${{ github.base_ref }}...HEAD` を使い、Pull Request で変わった file を基準に routing します。merge base を解決できない場合は、fallback として `git diff --name-only origin/${{ github.base_ref }} HEAD` を使います。

--- a/script/test_ci_policy_suite.mjs
+++ b/script/test_ci_policy_suite.mjs
@@ -248,6 +248,11 @@ function runSelfTest() {
     "ambiguous --only should report all matching groups"
   )
 
+  assert.equal(
+    ciPolicyScriptExclusions.get("test_ci_policy_suite.mjs"),
+    "this suite's self-test entrypoint",
+    "the suite entrypoint exclusion should document why it is not a direct guard group"
+  )
   assert.ok(
     ciPolicyCandidateScriptPaths().includes("script/test_ci_changed_files_policy.mjs"),
     "CI policy candidates should include changed-file policy signals"


### PR DESCRIPTION
## 対応 Issue

- Closes #2749

## Issue ごとの完了内容

- #2749: CI policy suite の candidate script 管理について、`checks` array への登録または `ciPolicyScriptExclusions` への理由付き明示除外が必要であることを英日 docs に追記しました。
- #2749: `test_ci_policy_suite.mjs` が direct guard group ではなく suite self-test entrypoint として除外されていることを self-test で代表確認するようにしました。

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` の Registration self-test 節に explicit exclusion policy を追記。
- `script/test_ci_policy_suite.mjs` の `--self-test` に、`test_ci_policy_suite.mjs` の exclusion reason が維持されていることを確認する assertion を追加。

## 改善カテゴリ

- docs
- test
- CI policy guard hardening

## 既存仕様への影響

- runtime Ruby / JavaScript behavior、CI workflow routing、changed-file classifier、package scripts、candidate pattern、exclusion list は変更していません。
- 既存の CI policy suite 実行順と guard group はそのままです。

## 確認内容

- branch freshness: `main...chore/2749-ci-policy-exclusion-signal` は `behind_by:0`、変更ファイルは 3 件のみです。
- connector-only 差分確認: `docs/en/ci-policy-suite.md`、`docs/ja/ci-policy-suite.md`、`script/test_ci_policy_suite.mjs` に限定されていることを確認しました。
- local test: この環境では GitHub HTTPS clone が `CONNECT tunnel failed, response 403` で不可のため未実行です。PR CI の `npm run test:ci-policy` を確認します。

## リスク評価

low。docs と suite self-test の代表 assertion だけで、実行対象の guard script や workflow policy は変えていません。

## 補足事項

- #2743 / #2745 / #2747 は英日 Development docs の大きめの docs patch が必要なため、この connector-only PR には含めていません。
- merge は行いません。