### PR TITLE
docs: CI policy exclusion evidence を CHANGELOG に追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Release preparation notes:
 - Clarified review-gallery visual evidence guidance so gallery previews stay a fast orientation path while merge-grade desktop and narrow viewport evidence is recorded from the target mockup page.
 - Clarified empty-state mockup README guidance so hidden-message and permission-hidden row review uses the existing `empty-state.html` entry point without changing authorization policy.
 - Clarified CI policy suite package-sensitive routing guidance for Ruby package and release task paths such as `Gemfile`, `Rakefile`, `tree_view.gemspec`, and package contents verification.
+- Clarified CI policy suite explicit exclusion guidance so candidate guard scripts must be registered in `checks` or carry a reasoned exclusion such as the suite self-test entrypoint.
 
 ### Tests
 
@@ -160,6 +161,7 @@ Release preparation notes:
 - Added stylesheet state cue selector source-spec coverage for selected, collapsed, loading, error, disabled-drop, and drop-target cues in the packaged stylesheet.
 - Expanded package contents verification coverage for bilingual CI policy suite docs so packaged gems keep maintainer CI policy guidance available.
 - Consolidated `test:ci-policy` package-script execution around the CI policy suite source of truth while preserving guard registration self-test coverage.
+- Added CI policy suite explicit exclusion self-test coverage so unregistered guard scripts stay classified as registered checks or documented exclusions.
 - Added Docker setup CI docs signal coverage so CI policy docs keep `docker_setup_sensitive`, `docker_development_setup`, Node 22, and `npm ci` guidance aligned.
 - Added CI policy docs signal coverage for pull request changed-file detection and docs-only check retention so CI policy docs stay aligned with workflow routing evidence.
 - Added CI routing output docs signal coverage for representative changed-file routing output guidance.


### PR DESCRIPTION
## 対応 Issue / PR

Related to #2749
Related to #2750

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、CI policy suite の explicit exclusion guidance が `docs/en|ja/ci-policy-suite.md` に同期されたことを追記しました。
- `Unreleased > Tests` に、suite self-test が explicit exclusion reason を代表確認するようになったことを追記しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、docs signal script は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2271 は draft / design proposal / README・gallery・browser evidence 待ちの `needs-human` 継続で、追加修正は行っていません。
- current `README.md`, `docs/README.md`, `AGENTS.md`, `Product Profile.md`, `CHANGELOG.md`, 直近 merged PR #2750 / Issue #2749 を確認しました。
- final compare: `main...docs/changelog-ci-policy-exclusion-evidence` は `ahead_by:1` / `behind_by:0` / changed files 1件 / additions 2 / deletions 0 です。
- GitHub Actions `CI #3758` は success です。
  - `changes`, `lint`, `pr_specs`, `javascript`, `gem_package`, representative Rails 7.0 / 7.2 / 8.0 lanes が success。
  - `javascript` は `npm run test:docs-entrypoints` に到達し success。
  - docs-only PR として representative Rails lanes は expected skip message で完了しました。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。merge済み docs / quality PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。