### PR TITLE
test: cover CI policy suite routing

### DIFF
--- a/script/test_ci_changed_files_policy.mjs
+++ b/script/test_ci_changed_files_policy.mjs
@@ -7,12 +7,20 @@ const workflowPath = ".github/workflows/ci.yml";
 const packagePath = "package.json";
 const policyCliPath = "script/ci_changed_files_policy.mjs";
 const ciPolicySuitePath = "script/test_ci_policy_suite.mjs";
+const ciPolicySuiteEntrypointExclusion = {
+  path: ciPolicySuitePath,
+  reason: "the suite self-test entrypoint is routed as CI policy-sensitive but is not a direct guard group"
+};
 
 const ciPolicyGuardScriptPaths = [
   "script/test_ci_changed_files_policy.mjs",
   "script/test_ci_workflow_changed_file_detection_signals.mjs",
+  "script/test_ci_workflow_concurrency_signals.mjs",
   "script/test_ci_workflow_permissions_signals.mjs",
+  "script/test_ci_policy_permissions_docs_signals.mjs",
   "script/test_ci_observation_guidance_signals.mjs",
+  "script/test_ci_policy_docs_routing.mjs",
+  "script/test_importmap_docs_entrypoint_routing.mjs",
   "script/test_package_lock_dependency_drift.mjs",
   "script/test_gemfile_lock_dependency_drift.mjs"
 ];
@@ -342,8 +350,48 @@ function assertCiPolicyCommandRunsSuite(ciPolicyCommand, suiteArgs, message) {
   );
 }
 
+function registeredCiPolicySuiteScriptPaths() {
+  const suiteSource = readFileSync(ciPolicySuitePath, "utf8");
+
+  return [
+    ...new Set(
+      [...suiteSource.matchAll(/args: \["(?<scriptPath>script\/[^\"]+\.mjs)"\]/g)]
+        .map((match) => match.groups.scriptPath)
+    )
+  ].sort();
+}
+
+function assertCiPolicySuiteRegisteredScriptsAreRouted() {
+  const missingRoutes = registeredCiPolicySuiteScriptPaths().filter(
+    (scriptPath) => !classifyChangedFiles([scriptPath]).ci_policy_sensitive
+  );
+
+  assert.deepEqual(
+    missingRoutes,
+    [],
+    [
+      "CI policy suite registered guard scripts must be ci_policy_sensitive in script/ci_changed_files_policy.mjs:",
+      ...missingRoutes.map((scriptPath) => `  - ${scriptPath}`),
+      "Add each missing path to isCiPolicySensitivePath(...) so CI policy guard changes run npm run test:ci-policy."
+    ].join("\n")
+  );
+
+  assert.equal(
+    classifyChangedFiles([ciPolicySuiteEntrypointExclusion.path]).ci_policy_sensitive,
+    true,
+    `${ciPolicySuiteEntrypointExclusion.path} must stay ci_policy_sensitive because ${ciPolicySuiteEntrypointExclusion.reason}`
+  );
+}
+
 function assertCiPolicySuiteRegistersGuardScripts() {
   const suiteSource = readFileSync(ciPolicySuitePath, "utf8");
+  const registeredGuardScriptPaths = registeredCiPolicySuiteScriptPaths();
+
+  assertSameMembers(
+    registeredGuardScriptPaths,
+    ciPolicyGuardScriptPaths,
+    `${ciPolicySuitePath} checks array must match this test's CI policy guard script list`
+  );
 
   for (const scriptPath of ciPolicyGuardScriptPaths) {
     assert.match(
@@ -379,6 +427,7 @@ function assertCiPolicyScriptRegistration(packageScripts) {
     `${packagePath} scripts.test:ci-policy must run ${ciPolicySuitePath} so CI policy guard changes validate their own registration`
   );
   assertCiPolicySuiteRegistersGuardScripts();
+  assertCiPolicySuiteRegisteredScriptsAreRouted();
 }
 
 function policyCliOutput(input) {


### PR DESCRIPTION
## 対応 Issue
- Closes #2761

## Issue ごとの完了内容
- #2761: `script/test_ci_policy_suite.mjs` の `checks` に登録された Node guard script が、`script/ci_changed_files_policy.mjs` 上で `ci_policy_sensitive` として扱われることを `script/test_ci_changed_files_policy.mjs` で検証するようにしました。

## 変更内容
- `ciPolicyGuardScriptPaths` を CI policy suite の現在の登録内容に合わせて補完しました。
- suite の `checks` から登録済み script path を読み取り、テスト側の一覧と一致することを検証します。
- 登録済み guard script がすべて `ci_policy_sensitive` にルーティングされることを検証します。
- suite 自身の self-test entrypoint は直接 guard group ではない理由を明示しつつ、引き続き `ci_policy_sensitive` であることを確認します。

## 改善カテゴリ
- テスト追加・改善
- CI ルーティングガードの保守性改善

## 既存仕様への影響
- なし。変更はテストファイルのみで、workflow、package script、CI policy 本体、公開API、UI、DB、認可、外部サービス契約は変更していません。

## 確認内容
- Branch freshness: `main` から `behind_by: 0`、差分は `script/test_ci_changed_files_policy.mjs` のみであることを確認しました。
- ローカル clone は実行環境の CONNECT tunnel 403 で利用できなかったため、PR 作成後に GitHub Actions の結果を確認します。

## リスク評価
- risk: low
- テスト強化のみのため挙動変更リスクは低いです。

## 補足事項
- #2761 の Planner 指示どおり、workflow topology、package scripts、checks 配列の候補/除外ルール、guard script の追加・リネーム・削除には触れていません。