### PR TITLE
test: guard remote-state hook docs signals

### DIFF
--- a/script/test_localized_and_hook_docs_signals.mjs
+++ b/script/test_localized_and_hook_docs_signals.mjs
@@ -29,6 +29,14 @@ const localizedNameDocs = [
   ["docs/en/localized-names.md", read("docs/en/localized-names.md")],
   ["docs/ja/localized-names.md", read("docs/ja/localized-names.md")]
 ]
+const lazyLoadingDocs = [
+  ["docs/en/lazy-loading.md", read("docs/en/lazy-loading.md")],
+  ["docs/ja/lazy-loading.md", read("docs/ja/lazy-loading.md")]
+]
+const jsEventDocs = [
+  ["docs/en/js-events.md", read("docs/en/js-events.md")],
+  ["docs/ja/js-events.md", read("docs/ja/js-events.md")]
+]
 
 const localizedNameManifestSignals = [
   "localized_name_i18n_keys:",
@@ -111,4 +119,63 @@ publicApiDocs.forEach(([relativePath, document]) => {
 
     assertMatches(document, boundary, `${relativePath}: ${name} docs no longer name the host-app responsibility boundary`)
   })
+})
+
+const remoteStateDataHookManifestSignals = [
+  "remote_state_data_hooks:",
+  "lazy_attribute: data-tree-lazy",
+  "children_url_attribute: data-tree-children-url",
+  "loaded_attribute: data-tree-loaded",
+  "remote_state_attribute: data-tree-remote-state"
+]
+
+remoteStateDataHookManifestSignals.forEach((signal) => {
+  assertIncludes(manifest, signal, "public API manifest remote-state DOM hook source")
+})
+
+lazyLoadingDocs.forEach(([relativePath, document]) => {
+  [
+    "data-tree-lazy",
+    "data-tree-children-url",
+    "data-tree-loaded",
+    "data-tree-remote-state"
+  ].forEach((signal) => {
+    assertIncludes(document, signal, `${relativePath} TreeViewRemoteStateDataHooks lazy-loading DOM hook docs`)
+  })
+
+  assertMatches(
+    document,
+    /TreeViewRemoteStateValues\.loading.*\.loaded.*\.error|TreeViewRemoteStateValues\.loading.*\.loaded.*\.error/s,
+    `${relativePath}: Lazy Loading docs no longer name TreeViewRemoteStateValues as common state values`
+  )
+
+  assertMatches(
+    document,
+    /not event names|event 名ではありません/,
+    `${relativePath}: Lazy Loading docs no longer separate remote-state values from event names`
+  )
+
+  assertMatches(
+    document,
+    /TreeViewEventNames\.hostLifecycle\.loading|TreeViewEventNames\.hostLifecycle\.loading/,
+    `${relativePath}: Lazy Loading docs no longer point host apps at hostLifecycle event names`
+  )
+})
+
+jsEventDocs.forEach(([relativePath, document]) => {
+  assertIncludes(document, "TreeViewEventNames.hostLifecycle", `${relativePath} host lifecycle event-name docs`)
+  assertIncludes(document, "TreeViewEventNames.remoteState", `${relativePath} remote-state controller event-name docs`)
+  assertIncludes(document, "TreeViewRemoteStateValues", `${relativePath} remote-state value export docs`)
+
+  assertMatches(
+    document,
+    /host apps dispatching lazy-loading request lifecycle events|lazy-loading request lifecycle event を host app 側で dispatch/,
+    `${relativePath}: JS event docs no longer keep hostLifecycle events host-app-dispatched`
+  )
+
+  assertMatches(
+    document,
+    /TreeView controller-emitted remote-state events|TreeView controller 自身が emit する remote-state event/,
+    `${relativePath}: JS event docs no longer separate controller-emitted remote-state events from host lifecycle events`
+  )
 })


### PR DESCRIPTION
## 対応 Issue

Closes #2763

## Issue ごとの完了内容

- #2763: `TreeViewRemoteStateDataHooks` と `remote_state_data_hooks` の代表 signal を docs smoke で確認する guard を追加しました。
- 英日 Lazy Loading docs の `data-tree-lazy` / `data-tree-children-url` / `data-tree-loaded` / `data-tree-remote-state` が落ちた場合に検出できるようにしました。
- remote-state 周辺の責務差分として、DOM hook、common state value、host lifecycle event、controller-emitted remote-state event の代表 wording を確認するようにしました。

## 変更内容

- `script/test_localized_and_hook_docs_signals.mjs`
  - 英日 `docs/*/lazy-loading.md` と `docs/*/js-events.md` を読み込むように追加
  - manifest の `remote_state_data_hooks` と各 hook attribute の代表 signal を確認
  - Lazy Loading docs の DOM hook 名、`TreeViewRemoteStateValues`、event-name との境界を確認
  - JS Events docs の `TreeViewEventNames.hostLifecycle` / `TreeViewEventNames.remoteState` / `TreeViewRemoteStateValues` の責務差分を確認

## 改善カテゴリ

- docs smoke guard
- public API docs drift detection
- behavior-neutral quality improvement

## 既存仕様への影響

runtime Ruby / JavaScript、public exports、manifest schema、remote-state controller behavior、Lazy Loading / JS Events docs 本文は変更していません。既存 docs の代表 signal を守る test-only 変更です。

## 実施した確認

- connector-only source review
- `main...quality/2763-remote-state-hook-docs-signal`: `ahead_by:1` / `behind_by:0` / `status:ahead`
- changed files: `script/test_localized_and_hook_docs_signals.mjs` 1件のみ

ローカル `npm run test:docs-entrypoints` は、この環境の GitHub HTTPS 接続が `CONNECT tunnel failed, response 403` になるため未実行です。PR CI で確認します。

## リスク評価

- risk: low
- docs smoke の assertion 追加のみで、実行時挙動や公開 API shape は変更しません。

## 補足事項

- `app/javascript/tree_view/index.js` / `index.d.ts` / `config/public_api_manifest.yml` は変更していません。
- public export の追加・rename、TypeScript declaration generator、lazy-loading fetch / Turbo request 実装には広げていません。