### PR TITLE
docs: CHANGELOG の docs-entrypoint routing signal を同期する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -52,7 +52,7 @@ The changed-file policy exposes representative output flags rather than a full r
 | --- | --- | --- |
 | `docs_only` | `README.md`, `docs/**`, `AGENTS.md`, `Product Profile.md` | The pull request is documentation-shaped, although other outputs may still request focused confidence checks. |
 | `package_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `Gemfile`, `Gemfile.lock`, `Rakefile`, `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `app/javascript/**`, `config/public_api_manifest.yml`, `.github/dependabot.yml` | The packaged gem, Ruby package/release wiring, runtime source, or package-facing docs confidence path should run. |
-| `docs_entrypoint_sensitive` | `README.md`, `docs/**`, `config/public_api_manifest.yml` | Docs entrypoint signals should run because reader-facing docs or public manifest signals changed. |
+| `docs_entrypoint_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `config/public_api_manifest.yml` | Docs entrypoint signals should run because reader-facing docs, the release ledger, or public manifest signals changed. |
 | `ci_policy_sensitive` | `AGENTS.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `.github/workflows/ci.yml`, `.github/dependabot.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs` | CI policy guards should run because workflow routing, Dependabot routing, CI policy suite docs, or maintainer policy signals changed. |
 | `docker_setup_sensitive` | `Dockerfile`, `docker-compose.yml`, `package.json`, `package-lock.json`, `.nvmrc` | Docker-based maintainer setup confidence should run. |
 | `mockups_changed` | `docs/mockups/**` | Static mockup routes changed and may need browser-smoke or gallery review. |

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -52,7 +52,7 @@ changed-file policy は、repository 全体の file inventory ではなく代表
 | --- | --- | --- |
 | `docs_only` | `README.md`, `docs/**`, `AGENTS.md`, `Product Profile.md` | Pull Request は docs 形状です。ただし、他の output が focused confidence check を要求する場合があります。 |
 | `package_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `Gemfile`, `Gemfile.lock`, `Rakefile`, `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `app/javascript/**`, `config/public_api_manifest.yml`, `.github/dependabot.yml` | packaged gem、Ruby package / release task wiring、runtime source、または package-facing docs confidence path を実行します。 |
-| `docs_entrypoint_sensitive` | `README.md`, `docs/**`, `config/public_api_manifest.yml` | reader-facing docs または public manifest signal が変わったため、docs entrypoint signal を実行します。 |
+| `docs_entrypoint_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `config/public_api_manifest.yml` | reader-facing docs、release ledger、または public manifest signal が変わったため、docs entrypoint signal を実行します。 |
 | `ci_policy_sensitive` | `AGENTS.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `.github/workflows/ci.yml`, `.github/dependabot.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs` | workflow routing、Dependabot routing、CI policy suite docs、または maintainer policy signal が変わったため、CI policy guard を実行します。 |
 | `docker_setup_sensitive` | `Dockerfile`, `docker-compose.yml`, `package.json`, `package-lock.json`, `.nvmrc` | Docker-based maintainer setup confidence を実行します。 |
 | `mockups_changed` | `docs/mockups/**` | static mockup route が変わり、browser-smoke または gallery review が必要になる場合があります。 |

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -77,6 +77,18 @@ function assertIncludes(source, needle, label) {
   assert.ok(source.includes(needle), `${label}: missing ${needle}`)
 }
 
+function routingOutputRow(source, output, label) {
+  const row = source.split(/\r?\n/).find((line) => line.startsWith(`| \`${output}\``))
+
+  assert.ok(row, `${label}: missing ${output} representative routing row`)
+
+  return row
+}
+
+function assertRoutingOutputRowIncludes(source, output, signal, label) {
+  assertIncludes(routingOutputRow(source, output, label), signal, `${label} ${output} representative routing row`)
+}
+
 function assertDependabotLaneSignal() {
   const dependabotSource = readFileSync(dependabotPath, "utf8")
   const githubActionsLane = dependabotUpdateBlock(dependabotSource, "github-actions")
@@ -258,6 +270,13 @@ function assertCiPolicyDocsRoutingOutputSignals() {
     for (const signal of signals) {
       assertIncludes(docsSource, signal, `${docsPath} routing output docs signal`)
     }
+
+    assertRoutingOutputRowIncludes(
+      docsSource,
+      "docs_entrypoint_sensitive",
+      "CHANGELOG.md",
+      `${docsPath} missing CHANGELOG.md docs-entrypoint routing signal`
+    )
   }
 }
 


### PR DESCRIPTION
## 対応 Issue

Closes #2765

## Issue ごとの完了内容

- #2765: 英日 CI policy suite docs の `docs_entrypoint_sensitive` representative path signals に `CHANGELOG.md` を追加し、既存 classifier / fixture が守っている docs-entrypoint routing と docs の代表表を同期しました。

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md`
  - `docs_entrypoint_sensitive` の代表 path signals に `CHANGELOG.md` を追加。
  - maintainer meaning を release ledger も docs entrypoint signal の対象になる説明へ最小同期。
- `script/test_ci_policy_docs_routing.mjs`
  - representative routing table の `docs_entrypoint_sensitive` 行そのものに `CHANGELOG.md` が含まれることを確認する focused guard を追加。
  - 既存の changed-file classifier 挙動や workflow routing は変更していません。

## 改善カテゴリ

- docs
- test / lightweight signal guard
- CI policy docs hardening

## 既存仕様への影響

なし。`.github/workflows/ci.yml`、`script/ci_changed_files_policy.mjs`、package scripts、required checks、branch protection、CHANGELOG release policy は変更していません。

## 実施した確認

- Issue #2765 のラベルを個別確認: `status:ready-for-agent` / `agent:planned` / `track:quality` / `risk:low`。
- self-authored open PR の review follow-up を確認し、今回の機械的修正対象外であることを確認。
- compare `main...docs/2765-changelog-docs-entrypoint-routing`: `ahead_by:3` / `behind_by:0` / changed files 3件。
- connector 経由で更新後の英日 representative table と signal helper / assertion を確認。
- ローカル `npm run test:ci-policy` / focused Node script は、この環境の GitHub HTTPS 取得が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。docs と docs-signal guard のみで、runtime / CI classifier / workflow behavior は変えていません。

## 補足

代表表は full classifier mirror に広げず、Planner handoff の通り `CHANGELOG.md` の同期に留めています。merge は行いません。