### PR TITLE
test: guard CI policy suite registration docs signals

### DIFF
--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -374,6 +374,45 @@ function assertCiPolicyDocsCommandSurfaceSignals() {
   }
 }
 
+function assertCiPolicyDocsSuiteRegistrationPolicySignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        "The package script runs the suite self-test first",
+        "then runs the configured CI policy guard groups",
+        "update the suite `checks` array or document an explicit exclusion before relying on CI",
+        "self-test scans candidate scripts",
+        "fails with the missing script path",
+        "Candidate CI policy scripts must either be listed in the `checks` array or named in `ciPolicyScriptExclusions` with a short reason",
+        "Keep exclusions narrow",
+        "this suite's self-test entrypoint, not a direct guard group"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        "package script は先に suite self-test を実行し",
+        "その後に設定済みの CI policy guard group を実行します",
+        "suite の `checks` array を更新するか、明示的な exclusion を残してください",
+        "self-test は candidate script を走査し",
+        "missing script path を表示して失敗します",
+        "Candidate CI policy scripts は、`checks` array に登録するか、短い理由つきで `ciPolicyScriptExclusions` に明示する必要があります",
+        "exclusion は狭く保ってください",
+        "この suite の self-test entrypoint なので除外されています"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} suite registration policy docs signal`)
+    }
+  }
+}
+
 for (const docsPath of ciPolicyDocsPaths) {
   assert.deepEqual(
     classifyChangedFiles([docsPath]),
@@ -433,6 +472,7 @@ assertCiPolicyDocsChangedFileDetectionSignals()
 assertCiPolicyDocsRoutingOutputSignals()
 assertCiPolicyDocsDocsOnlyRetentionSignals()
 assertCiPolicyDocsCommandSurfaceSignals()
+assertCiPolicyDocsSuiteRegistrationPolicySignals()
 
 console.log(`Checked ${ciPolicyDocsPaths.length} CI policy docs routing paths.`)
 console.log(`Checked ${workflowDefinitionPaths.length} workflow definition package/Docker routing paths.`)
@@ -443,3 +483,4 @@ console.log("Checked pull request changed-file detection docs signals.")
 console.log("Checked representative routing output docs signals.")
 console.log("Checked docs-only check retention docs signals.")
 console.log("Checked CI policy docs command surface signals.")
+console.log("Checked CI policy suite registration policy docs signals.")


### PR DESCRIPTION
## 対応 Issue
- Closes #2756

## Issue ごとの完了内容
- #2756: `npm run test:ci-policy` が suite self-test を先に実行すること、candidate CI policy scripts が `checks` array または `ciPolicyScriptExclusions` に明示されるべきこと、missing script path を表示して失敗することを EN/JA docs signal として guard しました。

## 変更内容
- `script/test_ci_policy_docs_routing.mjs` に CI policy suite registration policy の docs signal assertion を追加しました。
- 既存 docs 本文はすでに対象文言を持っていたため、docs 本文・package script・workflow・routing logic は変更していません。

## 改善カテゴリ
- test
- docs signal guard
- CI policy guard

## 既存仕様への影響
- 公開 API、UI、DB、認可、状態遷移、外部サービス契約には影響しません。
- 実行経路や CI policy suite の設定は変更せず、既存 docs signal の退行検知のみを追加しています。

## 実施した確認
- connector 上で main からの差分を確認し、変更ファイルが `script/test_ci_policy_docs_routing.mjs` の 1 ファイルのみであることを確認しました。
- branch freshness: `behind_by: 0`、`ahead_by: 1` を確認しました。
- 更新後ファイルの内容を再取得し、final newline を含むテキストとして確認しました。
- ローカル checkout / test 実行は環境の GitHub 接続制限により未実施です。PR 上の CI で `npm run test:ci-policy` 到達を確認します。

## リスク評価
- risk: low
- 既存 guard script に assertion を追加するだけで、ランタイム挙動や公開仕様は変更しません。

## 補足
- 他 repo / 他 Issue については、既存 open PR の review follow-up と eligible issue を確認し、仕様判断・browser evidence・大きな docs 置換が必要なものは今回の自動修正対象から外しています。