### PR TITLE
docs: CI policy suite registration guard evidence を CHANGELOG に追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,7 @@ Release preparation notes:
   - custom checkbox name
   - per-node disabled state
   - disabled reason attributes
+  - initial selected state via `selected_keys`
 - Orphan handling strategies.
 - Optional node key uniqueness validation.
 - Optional DOM ID collision diagnostics via `RenderState#validate_unique_dom_ids!`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ Release preparation notes:
 ### Tests
 
 - Added CI policy suite routing smoke coverage so every registered Node guard script stays classified as `ci_policy_sensitive`.
+- Added CI policy suite registration policy docs signal coverage so self-test ordering and explicit guard-script exclusions stay visible in the bilingual CI policy suite docs.
 - Added CI workflow permissions policy smoke coverage so read-only token permissions stay guarded against write-scope drift.
 - Split focused diagnostics, workflow concurrency, and release package contents signal smokes into registered suite groups so maintainers can run the narrow docs or CI guard directly.
 - Added CI policy docs command-surface and docs-entrypoint command-surface smoke coverage so `--list`, `--only`, `--self-test`, and registration guidance stay discoverable.
@@ -297,7 +298,6 @@ Release preparation notes:
   - custom checkbox name
   - per-node disabled state
   - disabled reason attributes
-  - initial selected state via `selected_keys`
 - Orphan handling strategies.
 - Optional node key uniqueness validation.
 - Optional DOM ID collision diagnostics via `RenderState#validate_unique_dom_ids!`.


### PR DESCRIPTION
## 対応 Issue / PR

Related to #2756
Related to #2769

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Tests` に、CI policy suite registration policy docs signal guard の release-facing evidence を 1 行追加しました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- runtime Ruby / JavaScript、CI workflow、package scripts、guard script、英日 docs 本文は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2271 は draft / design proposal / visual evidence と README・gallery同期待ちの `needs-human` 継続で、追加修正は行っていません。
- recent merged PR #2769 と Issue #2756 を確認しました。
- current `README.md`, `docs/README.md`, `AGENTS.md`, `Product Profile.md`, `CHANGELOG.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md` を確認しました。
- open CHANGELOG PR は見当たりませんでした。
- final compare: `main...docs/changelog-ci-policy-suite-registration-2756` は `ahead_by:2` / `behind_by:0` / changed files 1件 / additions 1 / deletions 0 です。
- GitHub Actions `CI #3771` は success です。
  - `lint`: success
  - `pr_specs`: success
  - `javascript`: success（`npm run test:docs-entrypoints` 到達、`npm run test:ci-policy` / `test:js:core` は routing 上 skip）
  - `gem_package`: success
  - representative Rails 7.0 / 7.2 / 8.0 lanes: docs-only skip message で success
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI で確認しました。

## リスク

low。merge済み quality PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。