### PR TITLE
docs: CI trigger policy evidence を CHANGELOG に追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Release preparation notes:
 - Added representative routing output guidance to CI policy suite docs so maintainers can map changed-file routing outputs to expected PR checks.
 - Clarified CI policy suite docs self-routing guidance so bilingual CI policy suite notes are represented in `ci_policy_sensitive` checks.
 - Added read-only workflow permissions guidance to CI policy suite docs so maintainers can review `GITHUB_TOKEN` token-scope evidence alongside the permissions guard.
+- Added CI workflow trigger policy guidance to CI policy suite docs so maintainers can review `pull_request`, `push main`, and the `pull_request_target` trust boundary without changing workflow triggers.
 - Clarified repository-only maintainer docs routing in CI policy suite docs so AGENTS.md remains CI-policy-sensitive while Product Profile.md stays manual-review routed.
 - Clarified empty-state mockup release evidence for disabled toolbar actions, including the `Current path unavailable` action and host-app-owned reset behavior.
 - Clarified Development docs for temporary docs i18n parity exceptions, including `parityExceptions` metadata and the boundary against permanent single-language docs.


### PR DESCRIPTION
## 対応 Issue

Closes #2784

## 判定分類

- `code-ahead-of-docs`
- `docs-sync`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、CI workflow trigger policy guidance の release-facing evidence を 1 行追加しました。
- `pull_request`、`push main`、`pull_request_target` trust boundary は docs signal で守られていることを、maintenance-only evidence として追えるようにしました。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- `.github/workflows/ci.yml`、`docs/en/ci-policy-suite.md`、`docs/ja/ci-policy-suite.md`、`script/test_ci_policy_docs_routing.mjs`、runtime Ruby / JavaScript は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2271 は draft / design proposal / README・gallery・browser evidence 待ちの `needs-human` 継続で、追加修正は行っていません。
- #2784 の Issue 本文、#2782 の merged 状態、current `CHANGELOG.md` を確認しました。
- open Issue / PR 検索で `CI workflow trigger policy` + `CHANGELOG` の重複がないことを確認しました。
- PR 作成前 compare: `main...docs/2784-changelog-ci-trigger-policy` は `ahead_by:1` / `behind_by:0` / changed files 1件 / additions 1 / deletions 0 です。
- commit patch は `Unreleased > Documentation` への1行追加のみです。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs / quality PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。