### PR TITLE
docs: CI policy guard script routing を代表表に補足する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -61,12 +61,14 @@ The changed-file policy exposes representative output flags rather than a full r
 | `docs_only` | `README.md`, `docs/**`, `AGENTS.md`, `Product Profile.md` | The pull request is documentation-shaped, although other outputs may still request focused confidence checks. |
 | `package_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `Gemfile`, `Gemfile.lock`, `Rakefile`, `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `app/javascript/**`, `config/public_api_manifest.yml`, `.github/dependabot.yml` | The packaged gem, Ruby package/release wiring, runtime source, or package-facing docs confidence path should run. |
 | `docs_entrypoint_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `config/public_api_manifest.yml` | Docs entrypoint signals should run because reader-facing docs, the release ledger, or public manifest signals changed. |
-| `ci_policy_sensitive` | `AGENTS.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `.github/workflows/ci.yml`, `.github/dependabot.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs` | CI policy guards should run because workflow routing, Dependabot routing, CI policy suite docs, or maintainer policy signals changed. |
+| `ci_policy_sensitive` | `AGENTS.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `.github/workflows/ci.yml`, `.github/dependabot.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_policy_suite.mjs`, `script/test_ci_changed_files_policy.mjs`, focused `script/test_ci_*` guards, lock dependency drift guard scripts | CI policy guards should run because workflow routing, Dependabot routing, CI policy suite docs, maintainer policy signals, or the CI policy guard scripts themselves changed. |
 | `docker_setup_sensitive` | `Dockerfile`, `docker-compose.yml`, `package.json`, `package-lock.json`, `.nvmrc` | Docker-based maintainer setup confidence should run. |
 | `mockups_changed` | `docs/mockups/**` | Static mockup routes changed and may need browser-smoke or gallery review. |
 | `browser_smoke_changed` | `test/browser/**` | Browser smoke definitions changed and should be treated as executable test-surface changes. |
 
 `app/javascript/**` changes remain package-sensitive full JavaScript confidence changes, but they do not set `browser_smoke_changed` by themselves. Keep real-browser smoke routing reserved for changed browser smoke definitions, static mockup routes, or pull requests where maintainers explicitly request browser evidence for an interaction change.
+
+CI policy guard scripts are also CI-policy-sensitive because they define or verify the routing policy. Keep their representative signal in this table broad enough to point maintainers toward `script/test_ci_policy_suite.mjs` and focused `script/test_ci_*` guards, while leaving the executable path list in `script/ci_changed_files_policy.mjs` and `script/test_ci_changed_files_policy.mjs`.
 
 Keep this table representative. Do not turn it into a full changed-file classifier mirror; `script/test_ci_changed_files_policy.mjs` remains the executable fixture source of truth.
 

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -61,12 +61,14 @@ changed-file policy は、repository 全体の file inventory ではなく代表
 | `docs_only` | `README.md`, `docs/**`, `AGENTS.md`, `Product Profile.md` | Pull Request は docs 形状です。ただし、他の output が focused confidence check を要求する場合があります。 |
 | `package_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `Gemfile`, `Gemfile.lock`, `Rakefile`, `tree_view.gemspec`, `script/check_gem_package_contents.rb`, `app/javascript/**`, `config/public_api_manifest.yml`, `.github/dependabot.yml` | packaged gem、Ruby package / release task wiring、runtime source、または package-facing docs confidence path を実行します。 |
 | `docs_entrypoint_sensitive` | `README.md`, `CHANGELOG.md`, `docs/**`, `config/public_api_manifest.yml` | reader-facing docs、release ledger、または public manifest signal が変わったため、docs entrypoint signal を実行します。 |
-| `ci_policy_sensitive` | `AGENTS.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `.github/workflows/ci.yml`, `.github/dependabot.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_changed_files_policy.mjs` | workflow routing、Dependabot routing、CI policy suite docs、または maintainer policy signal が変わったため、CI policy guard を実行します。 |
+| `ci_policy_sensitive` | `AGENTS.md`, `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `.github/workflows/ci.yml`, `.github/dependabot.yml`, `script/ci_changed_files_policy.mjs`, `script/test_ci_policy_suite.mjs`, `script/test_ci_changed_files_policy.mjs`, focused `script/test_ci_*` guards, lock dependency drift guard scripts | workflow routing、Dependabot routing、CI policy suite docs、maintainer policy signal、または CI policy guard scripts 自体が変わったため、CI policy guard を実行します。 |
 | `docker_setup_sensitive` | `Dockerfile`, `docker-compose.yml`, `package.json`, `package-lock.json`, `.nvmrc` | Docker-based maintainer setup confidence を実行します。 |
 | `mockups_changed` | `docs/mockups/**` | static mockup route が変わり、browser-smoke または gallery review が必要になる場合があります。 |
 | `browser_smoke_changed` | `test/browser/**` | browser smoke definition が変わったため、executable test-surface change として扱います。 |
 
 `app/javascript/**` の変更は package-sensitive な full JavaScript confidence change のままですが、それだけでは `browser_smoke_changed` を立てません。real-browser smoke routing は、browser smoke definition の変更、static mockup route、または interaction change に対して maintainer が明示的に browser evidence を求める Pull Request に限定してください。
+
+CI policy guard scripts も、routing policy を定義または検証するため CI-policy-sensitive です。この表では `script/test_ci_policy_suite.mjs` と focused `script/test_ci_*` guards へ保守者を案内できる程度の代表 signal に留め、実行可能な path list は `script/ci_changed_files_policy.mjs` と `script/test_ci_changed_files_policy.mjs` に残してください。
 
 この表は代表例に留めます。full changed-file classifier mirror にはしないでください。executable fixture の source of truth は引き続き `script/test_ci_changed_files_policy.mjs` です。
 

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -292,7 +292,10 @@ function assertCiPolicyDocsRoutingOutputSignals() {
     "docs/ja/ci-policy-suite.md",
     ".github/workflows/ci.yml",
     "script/ci_changed_files_policy.mjs",
+    "script/test_ci_policy_suite.mjs",
     "script/test_ci_changed_files_policy.mjs",
+    "focused `script/test_ci_*` guards",
+    "lock dependency drift guard scripts",
     "Dockerfile",
     "docker-compose.yml",
     "package.json",
@@ -300,6 +303,9 @@ function assertCiPolicyDocsRoutingOutputSignals() {
     ".nvmrc",
     "docs/mockups/**",
     "test/browser/**",
+    "CI policy guard scripts",
+    "routing policy",
+    "full changed-file classifier mirror",
     "executable fixture",
     "source of truth"
   ]
@@ -321,6 +327,24 @@ function assertCiPolicyDocsRoutingOutputSignals() {
       "docs_entrypoint_sensitive",
       "CHANGELOG.md",
       `${docsPath} missing CHANGELOG.md docs-entrypoint routing signal`
+    )
+    assertRoutingOutputRowIncludes(
+      docsSource,
+      "ci_policy_sensitive",
+      "script/test_ci_policy_suite.mjs",
+      `${docsPath} missing CI policy suite routing signal`
+    )
+    assertRoutingOutputRowIncludes(
+      docsSource,
+      "ci_policy_sensitive",
+      "focused `script/test_ci_*` guards",
+      `${docsPath} missing focused CI policy guard routing signal`
+    )
+    assertRoutingOutputRowIncludes(
+      docsSource,
+      "ci_policy_sensitive",
+      "lock dependency drift guard scripts",
+      `${docsPath} missing lock dependency drift guard routing signal`
     )
   }
 }


### PR DESCRIPTION
## 対応 Issue

Closes #2786

## Issue ごとの完了内容

- #2786: 英日 `docs/*/ci-policy-suite.md` の Representative routing outputs で、CI policy guard scripts 自体も `ci_policy_sensitive` に含まれることを補足しました。
- `script/test_ci_policy_docs_routing.mjs` に lightweight signal を追加し、代表表・focused `script/test_ci_*` guards・lock dependency drift guard scripts・full mirror にしない方針が drift したときに検出できるようにしました。

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に、CI policy guard scripts の routing boundary と代表表の非 mirror 方針を補足しました。
- `script/test_ci_policy_docs_routing.mjs` に representative wording / routing row guard を追加しました。
- `script/ci_changed_files_policy.mjs`、`script/test_ci_changed_files_policy.mjs`、`script/test_ci_policy_suite.mjs`、`.github/workflows/ci.yml`、package scripts は変更していません。

## 改善カテゴリ

- docs-sync
- docs-stale
- lightweight docs signal guard

## 既存仕様への影響

なし。CI routing の実装、classifier logic、suite registration、workflow topology、public API は変更していません。

## 実施した確認

- Default PR Check として self-authored open PR を確認しました。
  - #2271 は draft / design proposal / browser-capable visual evidence 待ちの `needs-human` 継続です。
  - #2789 の review comment は lightweight signal 未追加の明確な修正要求として対応しました。
- Issue #2786 のラベルを個別確認し、`status:ready-for-agent`、`agent:planned`、`track:quality`、`risk:low` を満たすことを確認しました。
- final compare: `main...docs/2786-ci-policy-script-routing` は `ahead_by:3` / `behind_by:0` / changed files 3件です。
- PR file list は `docs/en/ci-policy-suite.md`、`docs/ja/ci-policy-suite.md`、`script/test_ci_policy_docs_routing.mjs` です。
- head SHA: `7244d15306d92a61e7a7b9ab9c09689a63e32104`
- GitHub Actions `CI #3782` は success です。
- local checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。connector と PR CI を正本にしています。

## リスク

low。maintainer-facing docs と representative signal の同期に閉じています。

merge は行いません。