### PR TITLE
CI policy docs に main-push default outputs を追記する

### DIFF
--- a/docs/en/ci-policy-suite.md
+++ b/docs/en/ci-policy-suite.md
@@ -44,6 +44,8 @@ For pull requests, the `changes` job fetches the base branch, then tries to find
 
 The resulting file list is passed to `script/ci_changed_files_policy.mjs`, which is the source of truth for the `docs_only`, `package_sensitive`, `docker_setup_sensitive`, `docs_entrypoint_sensitive`, and `ci_policy_sensitive` outputs. `script/test_ci_workflow_changed_file_detection_signals.mjs` protects the workflow command signals; this note explains the maintainer-facing meaning of that routing and does not change the classification logic.
 
+For non-pull-request events such as `main` pushes, the `changes` job does not derive a changed-file list. Before the pull-request diff logic runs, it emits default outputs with `docs_only=false`, `mockups_changed=false`, `browser_smoke_changed=false`, and `package_sensitive`, `docker_setup_sensitive`, `docs_entrypoint_sensitive`, and `ci_policy_sensitive` set to `true`. Treat those defaults as default-branch evidence routing: main-push runs prefer broad package, Docker setup, docs entrypoint, and CI policy confidence over a docs-only shortcut, without changing pull-request classifier behavior.
+
 ## Pull request run concurrency
 
 The CI workflow uses workflow-level `concurrency` so a newer pull request head can cancel older runs for the same pull request. The group is built from the workflow name, event name, and pull request number or ref, which keeps unrelated pull requests and `main` runs separate.

--- a/docs/ja/ci-policy-suite.md
+++ b/docs/ja/ci-policy-suite.md
@@ -44,6 +44,8 @@ Pull Request では、`changes` job が base branch を fetch し、`origin/${{ 
 
 得られた file list は `script/ci_changed_files_policy.mjs` に渡されます。この script が `docs_only`、`package_sensitive`、`docker_setup_sensitive`、`docs_entrypoint_sensitive`、`ci_policy_sensitive` output の source of truth です。`script/test_ci_workflow_changed_file_detection_signals.mjs` は workflow command signal を守ります。このメモは、その routing の保守者向けの意味を説明するだけで、classification logic は変更しません。
 
+`main` push など Pull Request ではない event では、`changes` job は changed-file list を作りません。Pull Request 用 diff logic に進む前に、default outputs として `docs_only=false`、`mockups_changed=false`、`browser_smoke_changed=false`、さらに `package_sensitive`、`docker_setup_sensitive`、`docs_entrypoint_sensitive`、`ci_policy_sensitive` を `true` として出力します。これらは default branch evidence routing として扱います。main-push run では docs-only shortcut より、package、Docker setup、docs entrypoint、CI policy の広い confidence lane を優先するためのもので、Pull Request classifier の挙動を変えるものではありません。
+
 ## Pull request run concurrency
 
 CI workflow は workflow-level `concurrency` を使い、同じ Pull Request で head が更新された場合に古い run を cancel できるようにしています。group は workflow 名、event 名、Pull Request number または ref から作られるため、別の Pull Request や `main` run とは分離されます。

--- a/script/test_ci_policy_docs_routing.mjs
+++ b/script/test_ci_policy_docs_routing.mjs
@@ -222,6 +222,47 @@ function assertCiPolicyDocsChangedFileDetectionSignals() {
   }
 }
 
+function assertCiPolicyDocsNonPullRequestDefaultOutputSignals() {
+  const docsSignals = [
+    [
+      "docs/en/ci-policy-suite.md",
+      [
+        "For non-pull-request events such as `main` pushes",
+        "does not derive a changed-file list",
+        "default outputs with `docs_only=false`",
+        "`mockups_changed=false`",
+        "`browser_smoke_changed=false`",
+        "`package_sensitive`, `docker_setup_sensitive`, `docs_entrypoint_sensitive`, and `ci_policy_sensitive` set to `true`",
+        "default-branch evidence routing",
+        "prefer broad package, Docker setup, docs entrypoint, and CI policy confidence over a docs-only shortcut",
+        "without changing pull-request classifier behavior"
+      ]
+    ],
+    [
+      "docs/ja/ci-policy-suite.md",
+      [
+        "`main` push など Pull Request ではない event",
+        "changed-file list を作りません",
+        "default outputs として `docs_only=false`",
+        "`mockups_changed=false`",
+        "`browser_smoke_changed=false`",
+        "`package_sensitive`、`docker_setup_sensitive`、`docs_entrypoint_sensitive`、`ci_policy_sensitive` を `true`",
+        "default branch evidence routing",
+        "docs-only shortcut より、package、Docker setup、docs entrypoint、CI policy の広い confidence lane を優先",
+        "Pull Request classifier の挙動を変えるものではありません"
+      ]
+    ]
+  ]
+
+  for (const [docsPath, signals] of docsSignals) {
+    const docsSource = readFileSync(docsPath, "utf8")
+
+    for (const signal of signals) {
+      assertIncludes(docsSource, signal, `${docsPath} non-pull-request default output docs signal`)
+    }
+  }
+}
+
 function assertCiPolicyDocsTriggerPolicySignals() {
   const docsSignals = [
     [
@@ -538,6 +579,7 @@ assertDependabotLaneSignal()
 assertCiPolicyDocsDependabotSignals()
 assertCiPolicyDocsDockerSetupSignals()
 assertCiPolicyDocsChangedFileDetectionSignals()
+assertCiPolicyDocsNonPullRequestDefaultOutputSignals()
 assertCiPolicyDocsTriggerPolicySignals()
 assertCiPolicyDocsRoutingOutputSignals()
 assertCiPolicyDocsDocsOnlyRetentionSignals()
@@ -550,6 +592,7 @@ console.log("Checked CI policy docs routing guard script routing.")
 console.log("Checked GitHub Actions Dependabot lane config and docs signals.")
 console.log("Checked Docker development setup CI docs signals.")
 console.log("Checked pull request changed-file detection docs signals.")
+console.log("Checked non-pull-request default output docs signals.")
 console.log("Checked workflow trigger policy docs signals.")
 console.log("Checked representative routing output docs signals.")
 console.log("Checked docs-only check retention docs signals.")


### PR DESCRIPTION
## 対応 Issue

Closes #2791

## Issue ごとの完了内容

- #2791: 英日 CI policy suite docs に、Pull Request 以外の event では `changes` job が changed-file list を作らず、main-push 向け default outputs で broad confidence lane を有効化する意図を追記しました。
- #2791: `script/test_ci_policy_docs_routing.mjs` に representative wording guard を追加し、workflow default outputs の docs 説明が落ちた時に CI policy docs signal で検出できるようにしました。

## 変更内容

- `docs/en/ci-policy-suite.md` / `docs/ja/ci-policy-suite.md` に main-push default outputs の短い説明を追加。
- `script/test_ci_policy_docs_routing.mjs` に non-pull-request default output docs signal を追加。
- `.github/workflows/ci.yml`、changed-file classifier、package scripts、required checks、branch protection は変更していません。

## 改善カテゴリ

- docs signal hardening
- CI policy docs guard
- maintenance quality

## 既存仕様への影響

既存仕様への影響はありません。CI workflow behavior、changed-file classifier logic、runtime Ruby / JavaScript、public API、required checks は変更していません。

## 実施した確認

- branch freshness: latest `main` (`abba4366f0d675047e9a65d493b4735575dae5de`) 起点、compare は `ahead_by:3` / `behind_by:0`。
- changed files: `docs/en/ci-policy-suite.md`, `docs/ja/ci-policy-suite.md`, `script/test_ci_policy_docs_routing.mjs`。
- PR #2794 の review submissions / review threads / PR comments を確認し、外部 review follow-up はありませんでした。
- ローカル checkout は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。
- GitHub Actions CI #3787: success on head `5518b1ac03c60cb54d2054c6a8c4903389501cb6`。
  - `changes`: success
  - `pr_specs`: success
  - `lint`: success
  - `javascript`: success（`npm run test:ci-policy`, `npm run test:js:core` 実行）
  - `gem_package`: success
  - `pr_rails_matrix` Rails 7.0 / 7.2 / 8.0: success
  - `ruby_matrix`, `rails_matrix`, `docker_development_setup`: skipped by PR routing

## リスク評価

low。docs と lightweight signal のみの変更で、workflow routing や classifier behavior には触れていません。

## 補足

- main-push の default outputs 自体は既に `script/test_ci_workflow_changed_file_detection_signals.mjs` で守られているため、この PR は docs wording と docs routing guard に閉じています。