### PR TITLE
docs: CI policy main-push default outputs evidence を CHANGELOG に追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Release preparation notes:
 - Clarified empty-state mockup README guidance so hidden-message and permission-hidden row review uses the existing `empty-state.html` entry point without changing authorization policy.
 - Clarified CI policy suite package-sensitive routing guidance for Ruby package and release task paths such as `Gemfile`, `Rakefile`, `tree_view.gemspec`, and package contents verification.
 - Clarified CI policy suite explicit exclusion guidance so candidate guard scripts must be registered in `checks` or carry a reasoned exclusion such as the suite self-test entrypoint.
+- Added CI policy docs release evidence for main-push default outputs, covering package, Docker setup, docs entrypoint, and CI policy confidence lanes without changing pull-request classifier behavior.
 
 ### Tests
 


### PR DESCRIPTION
## 対応 Issue

Closes #2795

## 判定分類

- `docs-sync`
- `code-ahead-of-docs`

## 変更内容

- `CHANGELOG.md` の `Unreleased > Documentation` に、#2794 で入った CI policy main-push default outputs docs / signal hardening の release-facing evidence を 1 行追加しました。
- wording は docs / lightweight signal の同期に限定し、CI workflow や pull-request classifier behavior の変更として読めないようにしています。

## Scope

- docs-only です。
- 変更ファイルは `CHANGELOG.md` 1件のみです。
- `.github/workflows/ci.yml`、`script/ci_changed_files_policy.mjs`、`script/test_ci_policy_docs_routing.mjs`、package scripts、required checks、branch protection、runtime Ruby / JavaScript は変更していません。

## 確認内容

- Default PR Check として self-authored open PR を確認しました。
  - #2271 は draft / design-held / browser-capable visual evidence gate の `needs-human` 継続で、追加修正は行っていません。
- Issue #2795、merged PR #2794、current `CHANGELOG.md` を確認しました。
- PR 作成前 compare: `main...docs/2795-changelog-main-push-defaults` は `ahead_by:1` / `behind_by:0` / changed files 1件 / additions 1 / deletions 0 です。
- commit patch は `Unreleased > Documentation` への1行追加のみです。
- local checkout / local docs checks は GitHub HTTPS と raw fetch が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク

low。merge済み docs / signal PR の release-facing evidence を CHANGELOG に記録するだけです。

merge は行いません。