### PR TITLE
@vitest/ui のローカル起動導線を明示する

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "test": "vitest run",
+    "test:vitest-ui": "vitest --ui",
     "test:browser": "playwright test",
     "test:ci-policy": "node script/test_ci_policy_suite.mjs --self-test && node script/test_ci_policy_suite.mjs",
     "test:node-version-sources": "node script/test_node_version_sources.mjs",


### PR DESCRIPTION
## 対応 Issue

Closes #2801

## Issue ごとの完了内容

- #2801: `@vitest/ui` を未使用 dependency として削除せず、意図して残す local UI 用 devDependency として `npm run test:vitest-ui` から読めるようにしました。

## 変更内容

- `package.json` に `test:vitest-ui` を追加しました。
- 既存の `npm test` / `test:js:core` / CI 用 script は変更していません。
- `package-lock.json` は変更していません。dependency version や install surface を変えず、用途の明示だけに閉じています。

## 改善カテゴリ

- package hygiene
- dev tooling documentation via package script
- 小さな内部整理

## 既存仕様への影響

runtime Ruby / JavaScript、public API、docs entrypoint suite、CI workflow、Node major、既存 npm scripts の挙動は変更していません。

## 実施した確認

- Issue labels を個別確認: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:low`
- branch freshness: `main...chore/2801-vitest-ui-script` は `ahead_by:1` / `behind_by:0`
- changed files: `package.json` 1件のみ
- JSON parse check: pass
- GitHub Actions `CI #3791`: success
  - `pr_specs`, `lint`, `changes`, `javascript`, `gem_package`, `docker_development_setup`, representative Rails compatibility lanes が success
  - `javascript` job では `npm ci` と `npm run test:js:core` が success
- ローカル checkout / npm install / npm test は、この環境の GitHub / npm registry アクセスが 403 で利用できないため未実行です。

## リスク評価

低リスクです。既存 dependency を残したまま用途を明示するだけで、lockfile・CI・runtime 挙動は変えません。

## 補足事項

- `@vitest/ui` の削除案は lockfile 再生成が必要ですが、この環境では npm registry へのアクセスが 403 で検証できませんでした。そのため、受け入れ条件の keep path を採用しています。