### PR TITLE
Development docs signal で Vitest UI optional command 境界を守る

### DIFF
--- a/script/test_development_docs_command_signals.mjs
+++ b/script/test_development_docs_command_signals.mjs
@@ -34,6 +34,31 @@ const requiredMaintenanceScripts = [
   "test:docs-i18n"
 ]
 
+const optionalLocalCommands = [
+  {
+    scriptName: "test:vitest-ui",
+    command: "npm run test:vitest-ui",
+    docs: [
+      [
+        "docs/en/development.md",
+        [
+          "local Vitest UI",
+          "maintainer convenience command",
+          "not a replacement for CI-oriented `npm test`, `npm run test:js:core`, or `npm run test:js`"
+        ]
+      ],
+      [
+        "docs/ja/development.md",
+        [
+          "ローカルの Vitest UI",
+          "maintainer 向けの便利コマンド",
+          "CI 向けの `npm test`、`npm run test:js:core`、`npm run test:js` の代替ではありません"
+        ]
+      ]
+    ]
+  }
+]
+
 const requiredReadmeDevelopmentCommands = [
   "npm run test:js",
   "npm run test:entrypoints",
@@ -225,6 +250,32 @@ for (const scriptName of requiredMaintenanceScripts) {
   }
 }
 
+for (const optionalCommand of optionalLocalCommands) {
+  if (!packageJson.scripts?.[optionalCommand.scriptName]) {
+    missingSignals.push(`package.json optional local script ${optionalCommand.scriptName}`)
+  }
+
+  if (requiredMaintenanceScripts.includes(optionalCommand.scriptName)) {
+    missingSignals.push(
+      `script/test_development_docs_command_signals.mjs: optional local command ${optionalCommand.scriptName} must not be listed in requiredMaintenanceScripts because it is not a CI/release maintenance guard`
+    )
+  }
+
+  for (const [docPath, signals] of optionalCommand.docs) {
+    const doc = docSource(docs, docPath)
+
+    if (!doc?.includes(optionalCommand.command)) {
+      missingSignals.push(`${docPath}: optional local command ${optionalCommand.command}`)
+    }
+
+    for (const signal of signals) {
+      if (!doc?.includes(signal)) {
+        missingSignals.push(`${docPath}: optional local command boundary signal ${signal}`)
+      }
+    }
+  }
+}
+
 for (const command of requiredReadmeDevelopmentCommands) {
   if (!readme.includes(command)) {
     missingSignals.push(`README.md Development command: ${command}`)
@@ -340,5 +391,5 @@ if (missingSignals.length > 0) {
 }
 
 console.log(
-  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredDevelopmentDocsCommandSignals.length} Development docs command signal groups, ${requiredDocsEntrypointSuiteCommandSignals.length} docs entrypoint suite command signal groups, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredNpmLockfileDriftRecoverySignals.length} npm lockfile drift recovery docs groups, ${requiredManifestStructureDuplicateKeySignals.length} manifest duplicate-key docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
+  `[development-docs-command-signals] ${requiredMaintenanceScripts.length} maintenance commands, ${optionalLocalCommands.length} optional local command boundary signals, ${requiredReadmeDevelopmentCommands.length} README Development commands, ${requiredDockerSetupSignals.length} Docker setup signals, ${requiredDevelopmentDocsCommandSignals.length} Development docs command signal groups, ${requiredDocsEntrypointSuiteCommandSignals.length} docs entrypoint suite command signal groups, ${requiredCiPolicySuiteCommandSignals.length} CI policy suite command signals, ${requiredReleaseCiPolicySuiteSignals.length} release entrypoint signals, ${requiredDevelopmentCiPolicySignals.length} CI policy docs groups, ${requiredNpmLockfileDriftRecoverySignals.length} npm lockfile drift recovery docs groups, ${requiredManifestStructureDuplicateKeySignals.length} manifest duplicate-key docs groups, ${requiredReleaseCiPolicySensitiveSignals.length} release CI policy docs groups, and ${requiredWorkflowTriggerSignals.length} workflow trigger signals are present in package.json, workflow, and docs`
 )


### PR DESCRIPTION
## 対応 Issue

Closes #2807

## Issue ごとの完了内容

- #2807: `npm run test:vitest-ui` を optional local Vitest UI command として扱う代表 signal を `script/test_development_docs_command_signals.mjs` に追加しました。
- `test:vitest-ui` が `requiredMaintenanceScripts` に誤って入った場合に failure として検出できるようにしました。
- 英日 Development docs の optional wording と package script の存在を同じ lightweight signal で確認します。

## 変更内容

- `script/test_development_docs_command_signals.mjs` に `optionalLocalCommands` signal group を追加しました。
- `package.json` に `test:vitest-ui` が存在することを確認します。
- `requiredMaintenanceScripts` には含めないことを確認します。
- `docs/en/development.md` / `docs/ja/development.md` の maintainer convenience / CI replacement ではない boundary wording を確認します。

## 改善カテゴリ

- docs signal hardening
- test guard hardening
- maintenance command boundary guard

## 既存仕様への影響

runtime Ruby / JavaScript、Vitest runner、package scripts、CI workflow、docs prose、public API、DB、認可、外部サービス契約は変更していません。既存 docs と package script の関係を lightweight signal で守るだけです。

## 実施した確認

- Default PR Check: 自作 open PR #2271 を確認しました。draft / design-held / browser-capable visual evidence gate のため、この Quality Fixer 作業では追加 commit していません。
- Issue eligibility: #2807 の `status:ready-for-agent`、`agent:planned`、`track:quality`、`risk:low` を個別確認しました。
- PR #2806 は merge 済みで、英日 Development docs の optional Vitest UI wording が current `main` に入っていることを確認しました。
- branch freshness: `main...quality/2807-vitest-ui-optional-signal` は `ahead_by:1` / `behind_by:0` / `status:ahead` です。
- changed files: `script/test_development_docs_command_signals.mjs` 1件のみです。
- final newline: connector の base64 fetch で末尾 newline を確認しました。
- local checkout / local npm 実行は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実施です。PR CI を確認対象にします。

## リスク評価

low。既存 script の representative signal 追加に限定しており、optional command を CI-required / release-required に昇格していません。

## 補足

- `npm test`、`npm run test:js:core`、`npm run test:js`、CI workflow job topology は変更していません。
- merge は行いません。