### PR TITLE
Release checklist に package-root declaration audit を明記する

### DIFF
--- a/docs/en/release.md
+++ b/docs/en/release.md
@@ -193,6 +193,7 @@ Before release:
   - `app/helpers/tree_view_helper.rb`
   - `app/views/tree_view/_tree_row.html.erb`
   - `app/javascript/tree_view/index.js`
+  - `app/javascript/tree_view/index.d.ts` as the compile-time declaration shipped beside the runtime entrypoint
   - `app/assets/stylesheets/tree_view.scss`
   - `config/importmap.tree_view.rb`
   - `config/public_api_manifest.yml`

--- a/docs/ja/release.md
+++ b/docs/ja/release.md
@@ -193,6 +193,7 @@ release前に確認すること:
   - `app/helpers/tree_view_helper.rb`
   - `app/views/tree_view/_tree_row.html.erb`
   - `app/javascript/tree_view/index.js`
+  - `app/javascript/tree_view/index.d.ts`（runtime entrypoint と一緒に配布する compile-time declaration）
   - `app/assets/stylesheets/tree_view.scss`
   - `config/importmap.tree_view.rb`
   - `config/public_api_manifest.yml`


### PR DESCRIPTION
## 対応 Issue

Closes #1285

## Issue ごとの完了内容

- #1285: current main では `app/javascript/tree_view/index.d.ts` が存在し、`script/check_gem_package_contents.rb` の `JavaScript entrypoints` group でも required packaged path として確認済みでした。残っていた英日 Release docs の gem package checklist に、`index.js` と隣接して配布される compile-time declaration として `app/javascript/tree_view/index.d.ts` を明記しました。

## 変更内容

- `docs/en/release.md` の Gem package checklist に `app/javascript/tree_view/index.d.ts` を追加しました。
- `docs/ja/release.md` に同じ確認項目を同期しました。

## 改善カテゴリ

- docs sync
- package verification evidence
- release checklist hardening

## 既存仕様への影響

なし。runtime JavaScript、TypeScript declaration 本体、package export map、npm publish policy、CI workflow、gemspec は変更していません。

## 実施した確認

- Issue labels を個別確認しました: `status:ready-for-agent`, `agent:planned`, `track:quality`, `risk:medium`。
- current main で `app/javascript/tree_view/index.d.ts` が package contents guard に含まれていることを確認しました。
- `main...docs/1285-package-root-dts-release-checklist` compare は `ahead_by:2` / `behind_by:0` / `status:ahead` です。
- changed files は `docs/en/release.md` と `docs/ja/release.md` の2件だけです。
- ローカル checkout / local docs checks は GitHub HTTPS が `CONNECT tunnel failed, response 403` のため未実行です。PR CI を確認対象にします。

## リスク評価

low。既存の package contents guard と release docs checklist の同期に閉じた docs-only 変更です。

## 補足事項

`script/check_gem_package_contents.rb` は既に `app/javascript/tree_view/index.d.ts` を required packaged path として確認しているため、今回のPRでは checker側を変更していません。